### PR TITLE
Mechanical Ventilation

### DIFF
--- a/measure.rb
+++ b/measure.rb
@@ -2736,12 +2736,16 @@ class OSModel
       fan_type = XMLHelper.get_value(whole_house_fan, "FanType")
       if fan_type == "supply only"
         mech_vent_type = Constants.VentTypeSupply
+        num_fans = 1.0
       elsif fan_type == "exhaust only"
         mech_vent_type = Constants.VentTypeExhaust
+        num_fans = 1.0
       elsif fan_type == "central fan integrated supply"
         mech_vent_type = Constants.VentTypeCFIS
+        num_fans = 1.0
       elsif ["balanced", "energy recovery ventilator", "heat recovery ventilator"].include? fan_type
         mech_vent_type = Constants.VentTypeBalanced
+        num_fans = 2.0
       end
       mech_vent_total_efficiency = 0.0
       mech_vent_sensible_efficiency = 0.0
@@ -2753,7 +2757,7 @@ class OSModel
       end
       mech_vent_cfm = Float(XMLHelper.get_value(whole_house_fan, "RatedFlowRate"))
       mech_vent_w = Float(XMLHelper.get_value(whole_house_fan, "FanPower"))
-      mech_vent_fan_power = mech_vent_w / mech_vent_cfm
+      mech_vent_fan_power = mech_vent_w / mech_vent_cfm / num_fans
     end
     mech_vent_ashrae_std = '2013'
     mech_vent_infil_credit = true

--- a/resources/airflow.rb
+++ b/resources/airflow.rb
@@ -733,12 +733,16 @@ class Airflow
     # Fraction of fan heat that goes to the space
     if mech_vent.type == Constants.VentTypeExhaust
       frac_fan_heat = 0.0 # Fan heat does not enter space
+      num_fans = 1
     elsif mech_vent.type == Constants.VentTypeSupply or mech_vent.type == Constants.VentTypeCFIS
       frac_fan_heat = 1.0 # Fan heat does enter space
+      num_fans = 1
     elsif mech_vent.type == Constants.VentTypeBalanced
       frac_fan_heat = 0.5 # Assumes supply fan heat enters space
+      num_fans = 2
     else
       frac_fan_heat = 0.0
+      num_fans = 0
     end
 
     # Get the clothes washer so we can use the day shift for the clothes dryer
@@ -847,7 +851,7 @@ class Airflow
     unit.additionalProperties.setFeature(Constants.SizingInfoMechVentApparentSensibleEffectiveness, apparent_sensible_effectiveness.to_f)
     unit.additionalProperties.setFeature(Constants.SizingInfoMechVentWholeHouseRate, whole_house_vent_rate.to_f)
 
-    mv_output = MechanicalVentilationOutput.new(frac_fan_heat, whole_house_vent_rate, bathroom_hour_avg_exhaust, range_hood_hour_avg_exhaust, spot_fan_power, latent_effectiveness, sensible_effectiveness, dryer_exhaust_day_shift, has_dryer)
+    mv_output = MechanicalVentilationOutput.new(frac_fan_heat, num_fans, whole_house_vent_rate, bathroom_hour_avg_exhaust, range_hood_hour_avg_exhaust, spot_fan_power, latent_effectiveness, sensible_effectiveness, dryer_exhaust_day_shift, has_dryer)
     return true, mv_output
   end
 
@@ -1803,21 +1807,19 @@ class Airflow
 
       supply_fan = OpenStudio::Model::FanOnOff.new(model)
       supply_fan.setName(obj_name_mech_vent + " erv supply fan")
-      supply_fan.setFanEfficiency(UnitConversions.convert(300.0 / mech_vent.fan_power, "cfm", "m^3/s"))
-      supply_fan.setPressureRise(300.0)
+      supply_fan.setFanEfficiency(1)
+      supply_fan.setPressureRise(0)
       supply_fan.setMaximumFlowRate(balanced_flow_rate)
       supply_fan.setMotorEfficiency(1)
       supply_fan.setMotorInAirstreamFraction(1)
-      supply_fan.setEndUseSubcategory(Constants.EndUseMechVentFan)
 
       exhaust_fan = OpenStudio::Model::FanOnOff.new(model)
       exhaust_fan.setName(obj_name_mech_vent + " erv exhaust fan")
-      exhaust_fan.setFanEfficiency(UnitConversions.convert(300.0 / mech_vent.fan_power, "cfm", "m^3/s"))
-      exhaust_fan.setPressureRise(300.0)
+      exhaust_fan.setFanEfficiency(1)
+      exhaust_fan.setPressureRise(0)
       exhaust_fan.setMaximumFlowRate(balanced_flow_rate)
       exhaust_fan.setMotorEfficiency(1)
       exhaust_fan.setMotorInAirstreamFraction(0)
-      exhaust_fan.setEndUseSubcategory(Constants.EndUseMechVentFan)
 
       erv_controller = OpenStudio::Model::ZoneHVACEnergyRecoveryVentilatorController.new(model)
       erv_controller.setName(obj_name_mech_vent + " erv controller")
@@ -2007,7 +2009,6 @@ class Airflow
       infil_program.addLine("Set Qin = QhpwhIn+QductsIn")
       infil_program.addLine("Set Qu = (@Abs (Qout-Qin))")
       infil_program.addLine("Set Qb = QWHV + (@Min Qout Qin)")
-      infil_program.addLine("Set #{whole_house_fan_actuator.name} = 0")
     else
       if mech_vent.type == Constants.VentTypeExhaust
         infil_program.addLine("Set Qout = QWHV+Qrange+Qbath+Qdryer+QhpwhOut+QductsOut")
@@ -2020,14 +2021,14 @@ class Airflow
         infil_program.addLine("Set Qu = @Abs (Qout- Qin)")
         infil_program.addLine("Set Qb = (@Min Qout Qin)")
       end
-      if mech_vent.type != Constants.VentTypeCFIS
-        if mech_vent.fan_power !=  0
-          infil_program.addLine("Set faneff_wh = #{UnitConversions.convert(300.0 / mech_vent.fan_power, "cfm", "m^3/s")}")
-        else
-          infil_program.addLine("Set faneff_wh = 1")
-        end
-        infil_program.addLine("Set #{whole_house_fan_actuator.name} = (QWHV*300)/faneff_wh")
+    end
+    if mech_vent.type != Constants.VentTypeCFIS
+      if mech_vent.fan_power != 0
+        infil_program.addLine("Set faneff_wh = #{UnitConversions.convert(300.0 / mech_vent.fan_power, "cfm", "m^3/s")}")
+      else
+        infil_program.addLine("Set faneff_wh = 1")
       end
+      infil_program.addLine("Set #{whole_house_fan_actuator.name} = (QWHV*300)/faneff_wh*#{mv_output.num_fans}")
     end
 
     if mv_output.spot_fan_power != 0
@@ -2380,8 +2381,9 @@ class MechanicalVentilation
 end
 
 class MechanicalVentilationOutput
-  def initialize(frac_fan_heat, whole_house_vent_rate, bathroom_hour_avg_exhaust, range_hood_hour_avg_exhaust, spot_fan_power, latent_effectiveness, sensible_effectiveness, dryer_exhaust_day_shift, has_dryer)
+  def initialize(frac_fan_heat, num_fans, whole_house_vent_rate, bathroom_hour_avg_exhaust, range_hood_hour_avg_exhaust, spot_fan_power, latent_effectiveness, sensible_effectiveness, dryer_exhaust_day_shift, has_dryer)
     @frac_fan_heat = frac_fan_heat
+    @num_fans = num_fans
     @whole_house_vent_rate = whole_house_vent_rate
     @bathroom_hour_avg_exhaust = bathroom_hour_avg_exhaust
     @range_hood_hour_avg_exhaust = range_hood_hour_avg_exhaust
@@ -2391,7 +2393,7 @@ class MechanicalVentilationOutput
     @dryer_exhaust_day_shift = dryer_exhaust_day_shift
     @has_dryer = has_dryer
   end
-  attr_accessor(:frac_fan_heat, :whole_house_vent_rate, :bathroom_hour_avg_exhaust, :range_hood_hour_avg_exhaust, :spot_fan_power, :latent_effectiveness, :sensible_effectiveness, :dryer_exhaust_day_shift, :has_dryer)
+  attr_accessor(:frac_fan_heat, :num_fans, :whole_house_vent_rate, :bathroom_hour_avg_exhaust, :range_hood_hour_avg_exhaust, :spot_fan_power, :latent_effectiveness, :sensible_effectiveness, :dryer_exhaust_day_shift, :has_dryer)
 end
 
 class CFISOutput

--- a/resources/unit_conversions.rb
+++ b/resources/unit_conversions.rb
@@ -33,6 +33,8 @@ class UnitConversions
       return x * 3412.141633127942
     elsif from == 'kwh' and to == 'j'
       return x * 3600000.0
+    elsif from == 'wh' and to == 'gj'
+      return x * 0.0000036
     elsif from == 'kwh' and to == 'therm'
       return x / 29.307107017222222
     elsif from == 'kwh' and to == 'wh'

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -6,8 +6,6 @@ require 'fileutils'
 require 'json'
 require 'rexml/document'
 require 'rexml/xpath'
-require 'parallel'
-require 'etc'
 require_relative '../resources/constants'
 require_relative '../resources/meta_measure'
 require_relative '../resources/unit_conversions'
@@ -41,64 +39,28 @@ class HPXMLTranslatorTest < MiniTest::Test
       end
     end
 
-    num_proc = Parallel.processor_count - 1
-    if ENV['CI']
-      num_proc = 1 # Use 1 cpu on CircleCI
-    end
-
-    # Override to only use 1 processor for now; for some reason, simulations
-    # are giving different results when using multiple processors.
-    num_proc = 1 #
-
     # Test simulations (in parallel)
     puts "Running #{xmls.size} HPXML files..."
-    if Process.respond_to?(:fork) # e.g., most Unix systems
-
-      # Setup IO.pipe to communicate output from child processes to this parent process
-      readers, writers = {}, {}
-      xmls.each do |xml|
-        readers[xml], writers[xml] = IO.pipe
-      end
-
-      # Do runs in separate processes
-      Parallel.map(xmls, in_processes: num_proc) do |xml|
-        rundir, sim_time, workflow_time = _run_xml(xml, this_dir, args.dup, Parallel.worker_number)
-        sim_results = _get_results(rundir, sim_time, workflow_time)
-        writers[xml].puts(Marshal.dump(sim_results)) # Provide output data to parent process
-      end
-
-      # Retrieve output data from child processes
-      all_results = {}
-      readers.each do |xml, reader|
-        writers[xml].close
-        all_results[xml] = Marshal.load(reader.read)
-      end
-
-    else # e.g., Windows
-
-      # Do runs in separate threads
-      all_results = {}
-      Parallel.map(xmls, in_threads: num_proc) do |xml|
-        rundir, sim_time, workflow_time = _run_xml(xml, this_dir, args.dup, Parallel.worker_number)
-        all_results[xml] = _get_results(rundir, sim_time, workflow_time)
-      end
-
+    all_results = {}
+    xmls.each do |xml|
+      all_results[xml] = _run_xml(xml, this_dir, args.dup)
     end
 
     _write_summary_results(results_dir, all_results)
+
+    # Cross simulation tests
     _test_dse(xmls, dse_dir, all_results)
-    _test_cfis(xmls, cfis_dir, all_results)
   end
 
-  def _run_xml(xml, this_dir, args, worker_num)
+  def _run_xml(xml, this_dir, args)
     print "Testing #{File.basename(xml)}...\n"
-    rundir = File.join(this_dir, "run#{worker_num}")
+    rundir = File.join(this_dir, "run")
     args['epw_output_path'] = File.absolute_path(File.join(rundir, "in.epw"))
     args['osm_output_path'] = File.absolute_path(File.join(rundir, "in.osm"))
     args['hpxml_path'] = xml
     _test_schema_validation(this_dir, xml)
-    sim_time, workflow_time = _test_simulation(args, this_dir, rundir)
-    return rundir, sim_time, workflow_time
+    results = _test_simulation(args, this_dir, rundir)
+    return results
   end
 
   def _get_results(rundir, sim_time, workflow_time)
@@ -244,13 +206,15 @@ class HPXMLTranslatorTest < MiniTest::Test
     workflow_time = (Time.now - workflow_start).round(1)
     puts "Completed #{File.basename(args['hpxml_path'])} simulation in #{sim_time}, workflow in #{workflow_time}s."
 
-    # Verify simulation outputs
-    _verify_simulation_outputs(rundir, args['hpxml_path'])
+    results = _get_results(rundir, sim_time, workflow_time)
 
-    return sim_time, workflow_time
+    # Verify simulation outputs
+    _verify_simulation_outputs(rundir, args['hpxml_path'], results)
+
+    return results
   end
 
-  def _verify_simulation_outputs(rundir, hpxml_path)
+  def _verify_simulation_outputs(rundir, hpxml_path, results)
     sql_path = File.join(rundir, "eplusout.sql")
     assert(File.exists? sql_path)
 
@@ -412,6 +376,30 @@ class HPXMLTranslatorTest < MiniTest::Test
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
     end
 
+    # Mechanical Ventilation
+    mv = bldg_details.elements["Systems/MechanicalVentilation/VentilationFans/VentilationFan[UsedForWholeBuildingVentilation='true']"]
+    if not mv.nil?
+      found_mv_energy = false
+      results.keys.each do |k|
+        next if k[0] != 'Electricity' or k[1] != 'Interior Equipment' or k[2] != Constants.EndUseMechVentFan
+
+        found_mv_energy = true
+        if XMLHelper.has_element(mv, "AttachedToHVACDistributionSystem")
+          # CFIS, check for positive mech vent energy
+          assert_operator(results[k], :>, 0)
+        else
+          # Supply, exhaust, ERV, HRV, etc., check for appropriate mech vent energy
+          fan_w = Float(XMLHelper.get_value(mv, "FanPower"))
+          hrs_per_day = Float(XMLHelper.get_value(mv, "HoursInOperation"))
+          fan_kwhs = UnitConversions.convert(fan_w * hrs_per_day * 365.0, 'Wh', 'GJ')
+          assert_in_delta(fan_kwhs, results[k], 0.1)
+        end
+      end
+      if not found_mv_energy
+        flunk "Could not find mechanical ventilation energy for #{hpxml_path}."
+      end
+    end
+
     sqlFile.close
   end
 
@@ -505,28 +493,6 @@ class HPXMLTranslatorTest < MiniTest::Test
         assert_in_epsilon(dse_expect, dse_actual, 0.025)
       end
       puts "\n"
-    end
-  end
-
-  def _test_cfis(xmls, cfis_dir, all_results)
-    # Verify non-zero mechanical ventilation energy.
-    xmls.sort.each do |xml|
-      next if not xml.include? cfis_dir
-
-      xml_cfis = File.absolute_path(xml)
-      results_cfis = all_results[xml_cfis]
-
-      # Verify results
-      puts "\nResults for #{File.basename(xml)}:"
-      found_mv = false
-      results_cfis.keys.each do |k|
-        next if k[0] != 'Electricity' or k[2] != Constants.EndUseMechVentFan
-
-        found_mv = true
-        puts "CFIS: #{results_cfis[k].round(2)} #{k}"
-        assert_operator(results_cfis[k], :>, 0)
-      end
-      assert(found_mv)
     end
   end
 


### PR DESCRIPTION
Change mech vent energy so that it's always under Interior Equipment in the E+ output. (Previously it would show up under Fans for ERVs, etc.)

Fixed double energy use for ERVs, etc. Added mech vent tests.