### PR TITLE
Heat pump tests

### DIFF
--- a/measure.rb
+++ b/measure.rb
@@ -2309,15 +2309,20 @@ class OSModel
         if heat_pump_values[:heating_efficiency_units] == "HSPF"
           hspf = heat_pump_values[:heating_efficiency_value]
         end
-        num_speeds = get_ashp_num_speeds(seer)
+
+        if load_frac_cool > 0
+          num_speeds = get_ashp_num_speeds_by_seer(seer)
+        else
+          num_speeds = get_ashp_num_speeds_by_hspf(hspf)
+        end
 
         crankcase_kw = 0.02
         crankcase_temp = 55.0
 
         if num_speeds == "1-Speed"
 
-          eers = [0.80 * seer + 1.0]
-          cops = [0.45 * seer - 0.34]
+          eers = [0.80 * seer + 1.00]
+          cops = [0.57 * hspf - 1.30]
           shrs = [0.73]
           fan_power_rated = 0.365
           fan_power_installed = 0.5
@@ -2336,8 +2341,8 @@ class OSModel
 
         elsif num_speeds == "2-Speed"
 
-          eers = [0.78 * seer + 0.6, 0.68 * seer + 1.0]
-          cops = [0.60 * seer - 1.40, 0.50 * seer - 0.94]
+          eers = [0.78 * seer + 0.60, 0.68 * seer + 1.00]
+          cops = [0.60 * hspf - 1.40, 0.17 * hspf - 2.96]
           shrs = [0.71, 0.724]
           capacity_ratios = [0.72, 1.0]
           fan_speed_ratios_cooling = [0.86, 1.0]
@@ -2362,7 +2367,7 @@ class OSModel
         elsif num_speeds == "Variable-Speed"
 
           eers = [0.80 * seer, 0.75 * seer, 0.65 * seer, 0.60 * seer]
-          cops = [0.48 * seer, 0.45 * seer, 0.39 * seer, 0.39 * seer]
+          cops = [0.48 * hspf, 0.45 * hspf, 0.39 * hspf, 0.39 * hspf]
           shrs = [0.84, 0.79, 0.76, 0.77]
           capacity_ratios = [0.49, 0.67, 1.0, 1.2]
           fan_speed_ratios_cooling = [0.7, 0.9, 1.0, 1.26]
@@ -4054,18 +4059,28 @@ def get_ac_num_speeds(seer)
     return "1-Speed"
   elsif seer <= 21
     return "2-Speed"
-  else
+  elsif seer > 21
     return "Variable-Speed"
   end
 end
 
-def get_ashp_num_speeds(seer)
+def get_ashp_num_speeds_by_seer(seer)
   if seer <= 15
-    num_speeds = "1-Speed"
+    return "1-Speed"
   elsif seer <= 21
-    num_speeds = "2-Speed"
-  else
-    num_speeds = "Variable-Speed"
+    return "2-Speed"
+  elsif seer > 21
+    return "Variable-Speed"
+  end
+end
+
+def get_ashp_num_speeds_by_hspf(hspf)
+  if hspf <= 8.5
+    return "1-Speed"
+  elsif hspf <= 9.5
+    return "2-Speed"
+  elsif hspf > 9.5
+    return "Variable-Speed"
   end
 end
 

--- a/measure.rb
+++ b/measure.rb
@@ -2342,7 +2342,7 @@ class OSModel
         elsif num_speeds == "2-Speed"
 
           eers = [0.78 * seer + 0.60, 0.68 * seer + 1.00]
-          cops = [0.60 * hspf - 1.40, 0.17 * hspf - 2.96]
+          cops = [0.60 * hspf - 1.40, 0.50 * hspf - 0.94]
           shrs = [0.71, 0.724]
           capacity_ratios = [0.72, 1.0]
           fan_speed_ratios_cooling = [0.86, 1.0]

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -1060,12 +1060,12 @@ class HPXMLTranslatorTest < MiniTest::Test
 
   def _test_heat_pump_no_heating_or_cooling(xmls, hvac_load_fracs_dir, all_results)
     # Compares either:
-    #   1. Heat pumps without heating and differing cooling efficiencies
-    #   2. Heat pumps without cooling and differing heating efficiencies
-    # to ensure equal heating/cooling energy consumption.
+    #   1. Heat pumps without heating and differing heating efficiencies
+    #   2. Heat pumps without cooling and differing cooling efficiencies
+    # to ensure consistent heating/cooling energy consumption.
     #
     # This means that if we have, e.g., a heat pump used only for heating and where only
-    # the heating efficiency is provided, we can use an arbitrary cooling efficiency
+    # the heating efficiency is provided, an arbitrary cooling efficiency can be used
     # without heating end use results being affected.
     xmls.sort.each do |xml|
       next if not xml.include? hvac_load_fracs_dir

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -68,6 +68,7 @@ class HPXMLTranslatorTest < MiniTest::Test
     _test_multiple_hvac(xmls, hvac_multiple_dir, all_results)
     _test_multiple_water_heaters(xmls, water_heating_multiple_dir, all_results)
     _test_partial_hvac(xmls, hvac_partial_dir, all_results)
+    _test_heat_pump_no_heating_or_cooling(xmls, hvac_load_fracs_dir, all_results)
   end
 
   def test_invalid
@@ -683,7 +684,7 @@ class HPXMLTranslatorTest < MiniTest::Test
           hpxml_value = hp_cap
           query = "SELECT SUM(Value) FROM TabularDataWithStrings WHERE ReportName='ComponentSizingSummary' AND ReportForString='Entire Facility' AND TableName LIKE 'Coil:Cooling:%' AND ColumnName LIKE '%User-Specified%Total Cooling Capacity' AND Units='W'"
           sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'W', 'Btu/hr')
-          if hp_type == "mini-split" or (hp_type == "air-to-air" and get_ashp_num_speeds(hp_seer) == "Variable-Speed")
+          if hp_type == "mini-split" or (hp_type == "air-to-air" and get_ashp_num_speeds_by_seer(hp_seer) == "Variable-Speed")
             cap_adj = 1.20 # TODO: Generalize this
           else
             cap_adj = 1.0
@@ -1052,6 +1053,41 @@ class HPXMLTranslatorTest < MiniTest::Test
         end
 
         assert_in_delta(result_50, result_100 / 2.0, 0.1)
+      end
+      puts "\n"
+    end
+  end
+
+  def _test_heat_pump_no_heating_or_cooling(xmls, hvac_load_fracs_dir, all_results)
+    # Compares either:
+    #   1. Heat pumps without heating and differing cooling efficiencies
+    #   2. Heat pumps without cooling and differing heating efficiencies
+    # to ensure equal heating/cooling energy consumption.
+    #
+    # This means that if we have, e.g., a heat pump used only for heating and where only
+    # the heating efficiency is provided, we can use an arbitrary cooling efficiency
+    # without heating end use results being affected.
+    xmls.sort.each do |xml|
+      next if not xml.include? hvac_load_fracs_dir
+
+      xml_1 = File.absolute_path(xml)
+      xml_2 = File.absolute_path(xml.gsub(".xml", "-diff-efficiency.xml"))
+
+      results_1 = all_results[xml_1]
+      results_2 = all_results[xml_2]
+      next if results_2.nil?
+
+      # Compare results
+      puts "\nResults for #{xml}:"
+      results_1.keys.each do |k|
+        next if not ["Heating", "Cooling"].include? k[1]
+
+        result_1 = results_1[k].to_f
+        result_2 = results_2[k].to_f
+
+        puts "1, 2: #{result_1.round(2)}, #{result_2.round(2)} #{k}"
+
+        assert_in_delta(result_1, result_2, 0.3)
       end
       puts "\n"
     end


### PR DESCRIPTION
Add tests to check that the heating/cooling efficiency input has no impact on simulation results if the heating/cooling load fraction is zero. This means that if a heat pump is only used for heating (or cooling), an arbitrary efficiency can be supplied.