### PR TITLE
Heat Pump backup, take 2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1628,6 +1628,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heat_pump_type => "air-to-air",
                            :heat_pump_fuel => "electricity",
                            :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
                            :backup_heating_capacity => 120000,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
@@ -1640,6 +1641,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heat_pump_type => "air-to-air",
                            :heat_pump_fuel => "electricity",
                            :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
                            :backup_heating_capacity => 120000,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
@@ -1652,6 +1654,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heat_pump_type => "air-to-air",
                            :heat_pump_fuel => "electricity",
                            :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
                            :backup_heating_capacity => 120000,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
@@ -1664,6 +1667,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heat_pump_type => "ground-to-air",
                            :heat_pump_fuel => "electricity",
                            :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
                            :backup_heating_capacity => 120000,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
@@ -1676,6 +1680,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heat_pump_type => "mini-split",
                            :heat_pump_fuel => "electricity",
                            :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
                            :backup_heating_capacity => 120000,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
@@ -1685,13 +1690,14 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
   elsif ['base-hvac-mini-split-heat-pump-ductless.xml'].include? hpxml_file
     heat_pumps_values[0][:distribution_system_idref] = nil
   elsif ['base-hvac-mini-split-heat-pump-ductless-no-backup.xml'].include? hpxml_file
-    heat_pumps_values[0][:backup_heating_capacity] = 0
+    heat_pumps_values[0][:backup_heating_fuel] = nil
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
     heat_pumps_values << { :id => "HeatPump",
                            :distribution_system_idref => "HVACDistribution5",
                            :heat_pump_type => "air-to-air",
                            :heat_pump_fuel => "electricity",
                            :cooling_capacity => 4800,
+                           :backup_heating_fuel => "electricity",
                            :backup_heating_capacity => 12000,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 0.1,
@@ -1703,6 +1709,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heat_pump_type => "ground-to-air",
                            :heat_pump_fuel => "electricity",
                            :cooling_capacity => 4800,
+                           :backup_heating_fuel => "electricity",
                            :backup_heating_capacity => 12000,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 0.1,
@@ -1713,6 +1720,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heat_pump_type => "mini-split",
                            :heat_pump_fuel => "electricity",
                            :cooling_capacity => 4800,
+                           :backup_heating_fuel => "electricity",
                            :backup_heating_capacity => 12000,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 0.1,

--- a/measure.rb
+++ b/measure.rb
@@ -2161,12 +2161,17 @@ class OSModel
       sequential_load_frac_cool = load_frac_cool / @total_frac_remaining_cool_load_served # Fraction of remaining load served by this system
       @total_frac_remaining_cool_load_served -= load_frac_cool
 
-      backup_heat_capacity_btuh = heat_pump_values[:backup_heating_capacity]
-      if backup_heat_capacity_btuh < 0
-        backup_heat_capacity_btuh = Constants.SizingAuto
+      backup_heat_fuel = heat_pump_values[:backup_heating_fuel]
+      if not backup_heat_fuel.nil?
+        backup_heat_capacity_btuh = heat_pump_values[:backup_heating_capacity]
+        if backup_heat_capacity_btuh < 0
+          backup_heat_capacity_btuh = Constants.SizingAuto
+        end
+        backup_heat_efficiency = heat_pump_values[:backup_heating_efficiency_percent]
+      else
+        backup_heat_capacity_btuh = 0.0
+        backup_heat_efficiency = 1.0
       end
-
-      backup_heat_efficiency = heat_pump_values[:backup_heating_efficiency_percent]
 
       dse_heat, dse_cool, has_dse = get_dse(building, heat_pump_values)
       if dse_heat != dse_cool

--- a/resources/EPvalidator.rb
+++ b/resources/EPvalidator.rb
@@ -277,7 +277,7 @@ class EnergyPlusValidator
         "ElectricAuxiliaryEnergy" => zero_or_one, # If not provided, uses 301 defaults for furnace/boiler and zero for other heating systems
       },
 
-      ## [CoolingSystem]
+      # [CoolingSystem]
       "/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem" => {
         "SystemIdentifier" => one, # Required by HPXML schema
         "../../HVACControl" => one, # See [HVACControl]
@@ -300,15 +300,14 @@ class EnergyPlusValidator
         "AnnualCoolingEfficiency[Units='EER']/Value" => one,
       },
 
-      ## [HeatPump]
+      # [HeatPump]
       "/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump" => {
         "SystemIdentifier" => one, # Required by HPXML schema
         "../../HVACControl" => one, # See [HVACControl]
         "[HeatPumpType='air-to-air' or HeatPumpType='mini-split' or HeatPumpType='ground-to-air']" => one, # See [HeatPumpType=ASHP] or [HeatPumpType=MSHP] or [HeatPumpType=GSHP]
         "[HeatPumpFuel='electricity']" => one,
         "CoolingCapacity" => one, # Use -1 for autosizing
-        "BackupAnnualHeatingEfficiency[Units='Percent']/Value" => one,
-        "BackupHeatingCapacity" => one, # Use -1 for autosizing
+        "[BackupSystemFuel='electricity']" => zero_or_one, # See [HeatPumpBackup]
         "FractionHeatLoadServed" => one, # Must sum to <= 1 across all HeatPumps and HeatingSystems
         "FractionCoolLoadServed" => one, # Must sum to <= 1 across all HeatPumps and CoolingSystems
       },
@@ -335,6 +334,12 @@ class EnergyPlusValidator
         "DistributionSystem" => one,
         "AnnualCoolingEfficiency[Units='EER']/Value" => one,
         "AnnualHeatingEfficiency[Units='COP']/Value" => one,
+      },
+
+      ## [HeatPumpBackup]
+      "/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump[BackupSystemFuel]" => {
+        "BackupAnnualHeatingEfficiency[Units='Percent']/Value" => one,
+        "BackupHeatingCapacity" => one, # Use -1 for autosizing
       },
 
       # [HVACControl]

--- a/resources/hpxml.rb
+++ b/resources/hpxml.rb
@@ -954,8 +954,9 @@ class HPXML
                          heat_pump_fuel:,
                          heating_capacity: nil,
                          cooling_capacity:,
-                         backup_heating_capacity:,
-                         backup_heating_efficiency_percent:,
+                         backup_heating_fuel: nil,
+                         backup_heating_capacity: nil,
+                         backup_heating_efficiency_percent: nil,
                          fraction_heat_load_served:,
                          fraction_cool_load_served:,
                          heating_efficiency_percent: nil,
@@ -979,10 +980,13 @@ class HPXML
     XMLHelper.add_element(heat_pump, "HeatPumpFuel", heat_pump_fuel)
     XMLHelper.add_element(heat_pump, "HeatingCapacity", Float(heating_capacity)) unless heating_capacity.nil?
     XMLHelper.add_element(heat_pump, "CoolingCapacity", Float(cooling_capacity))
-    backup_eff = XMLHelper.add_element(heat_pump, "BackupAnnualHeatingEfficiency")
-    XMLHelper.add_element(backup_eff, "Units", "Percent")
-    XMLHelper.add_element(backup_eff, "Value", Float(backup_heating_efficiency_percent))
-    XMLHelper.add_element(heat_pump, "BackupHeatingCapacity", Float(backup_heating_capacity)) unless backup_heating_capacity.nil?
+    if not backup_heating_fuel.nil?
+      XMLHelper.add_element(heat_pump, "BackupSystemFuel", backup_heating_fuel)
+      backup_eff = XMLHelper.add_element(heat_pump, "BackupAnnualHeatingEfficiency")
+      XMLHelper.add_element(backup_eff, "Units", "Percent")
+      XMLHelper.add_element(backup_eff, "Value", Float(backup_heating_efficiency_percent))
+      XMLHelper.add_element(heat_pump, "BackupHeatingCapacity", Float(backup_heating_capacity))
+    end
     XMLHelper.add_element(heat_pump, "FractionHeatLoadServed", Float(fraction_heat_load_served))
     XMLHelper.add_element(heat_pump, "FractionCoolLoadServed", Float(fraction_cool_load_served))
     efficiencies = { "kW/ton" => cooling_efficiency_kw_per_ton,
@@ -1021,6 +1025,7 @@ class HPXML
              :heat_pump_fuel => XMLHelper.get_value(heat_pump, "HeatPumpFuel"),
              :heating_capacity => to_float_or_nil(XMLHelper.get_value(heat_pump, "HeatingCapacity")),
              :cooling_capacity => to_float_or_nil(XMLHelper.get_value(heat_pump, "CoolingCapacity")),
+             :backup_heating_fuel => XMLHelper.get_value(heat_pump, "BackupSystemFuel"),
              :backup_heating_capacity => to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupHeatingCapacity")),
              :backup_heating_efficiency_percent => to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='Percent']/Value")),
              :fraction_heat_load_served => to_float_or_nil(XMLHelper.get_value(heat_pump, "FractionHeatLoadServed")),

--- a/tests/base-hvac-air-to-air-heat-pump-1-speed.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-1-speed.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/base-hvac-air-to-air-heat-pump-2-speed.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-2-speed.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/base-hvac-air-to-air-heat-pump-var-speed.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-var-speed.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/base-hvac-ground-to-air-heat-pump.xml
+++ b/tests/base-hvac-ground-to-air-heat-pump.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/base-hvac-mini-split-heat-pump-ducted.xml
+++ b/tests/base-hvac-mini-split-heat-pump-ducted.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/base-hvac-mini-split-heat-pump-ductless-no-backup.xml
+++ b/tests/base-hvac-mini-split-heat-pump-ductless-no-backup.xml
@@ -238,11 +238,6 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
-              <BackupAnnualHeatingEfficiency>
-                <Units>Percent</Units>
-                <Value>1.0</Value>
-              </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-mini-split-heat-pump-ductless.xml
+++ b/tests/base-hvac-mini-split-heat-pump-ductless.xml
@@ -238,6 +238,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/base-hvac-multiple.xml
+++ b/tests/base-hvac-multiple.xml
@@ -361,6 +361,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -383,6 +384,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -404,6 +406,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/cfis/base-hvac-air-to-air-heat-pump-1-speed-cfis.xml
+++ b/tests/cfis/base-hvac-air-to-air-heat-pump-1-speed-cfis.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/cfis/base-hvac-air-to-air-heat-pump-2-speed-cfis.xml
+++ b/tests/cfis/base-hvac-air-to-air-heat-pump-2-speed-cfis.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/cfis/base-hvac-air-to-air-heat-pump-var-speed-cfis.xml
+++ b/tests/cfis/base-hvac-air-to-air-heat-pump-var-speed-cfis.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/cfis/base-hvac-ground-to-air-heat-pump-cfis.xml
+++ b/tests/cfis/base-hvac-ground-to-air-heat-pump-cfis.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-1-speed-autosize.xml
+++ b/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-1-speed-autosize.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>-1.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-2-speed-autosize.xml
+++ b/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-2-speed-autosize.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>-1.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-var-speed-autosize.xml
+++ b/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-var-speed-autosize.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>-1.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_autosizing/base-hvac-ground-to-air-heat-pump-autosize.xml
+++ b/tests/hvac_autosizing/base-hvac-ground-to-air-heat-pump-autosize.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>-1.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_autosizing/base-hvac-mini-split-heat-pump-ducted-autosize.xml
+++ b/tests/hvac_autosizing/base-hvac-mini-split-heat-pump-ducted-autosize.xml
@@ -239,6 +239,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>-1.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_autosizing/base-hvac-mini-split-heat-pump-ductless-autosize.xml
+++ b/tests/hvac_autosizing/base-hvac-mini-split-heat-pump-ductless-autosize.xml
@@ -238,6 +238,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>-1.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_base/base-hvac-air-to-air-heat-pump-1-speed-base.xml
+++ b/tests/hvac_base/base-hvac-air-to-air-heat-pump-1-speed-base.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_base/base-hvac-air-to-air-heat-pump-2-speed-base.xml
+++ b/tests/hvac_base/base-hvac-air-to-air-heat-pump-2-speed-base.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_base/base-hvac-air-to-air-heat-pump-var-speed-base.xml
+++ b/tests/hvac_base/base-hvac-air-to-air-heat-pump-var-speed-base.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_base/base-hvac-ground-to-air-heat-pump-base.xml
+++ b/tests/hvac_base/base-hvac-ground-to-air-heat-pump-base.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_base/base-hvac-mini-split-heat-pump-ducted-base.xml
+++ b/tests/hvac_base/base-hvac-mini-split-heat-pump-ducted-base.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_base/base-hvac-mini-split-heat-pump-ductless-base.xml
+++ b/tests/hvac_base/base-hvac-mini-split-heat-pump-ductless-base.xml
@@ -205,6 +205,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_dse/base-hvac-air-to-air-heat-pump-1-speed-dse-0.8.xml
+++ b/tests/hvac_dse/base-hvac-air-to-air-heat-pump-1-speed-dse-0.8.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_dse/base-hvac-air-to-air-heat-pump-2-speed-dse-0.8.xml
+++ b/tests/hvac_dse/base-hvac-air-to-air-heat-pump-2-speed-dse-0.8.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_dse/base-hvac-air-to-air-heat-pump-var-speed-dse-0.8.xml
+++ b/tests/hvac_dse/base-hvac-air-to-air-heat-pump-var-speed-dse-0.8.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_dse/base-hvac-ground-to-air-heat-pump-dse-0.8.xml
+++ b/tests/hvac_dse/base-hvac-ground-to-air-heat-pump-dse-0.8.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_dse/base-hvac-mini-split-heat-pump-ducted-dse-0.8.xml
+++ b/tests/hvac_dse/base-hvac-mini-split-heat-pump-ducted-dse-0.8.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-heat-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-heat.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-heat-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-heat.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-heat-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-heat.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-heat-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-heat.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-heat-cool.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-heat.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-cool.xml
@@ -205,6 +205,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-heat-cool.xml
@@ -205,6 +205,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-heat.xml
@@ -205,6 +205,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-1-speed-x3.xml
+++ b/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-1-speed-x3.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -228,6 +229,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -250,6 +252,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-2-speed-x3.xml
+++ b/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-2-speed-x3.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -228,6 +229,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -250,6 +252,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-var-speed-x3.xml
+++ b/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-var-speed-x3.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -228,6 +229,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -250,6 +252,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_multiple/base-hvac-ground-to-air-heat-pump-x3.xml
+++ b/tests/hvac_multiple/base-hvac-ground-to-air-heat-pump-x3.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -228,6 +229,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -250,6 +252,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_multiple/base-hvac-mini-split-heat-pump-ducted-x3.xml
+++ b/tests/hvac_multiple/base-hvac-mini-split-heat-pump-ducted-x3.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -228,6 +229,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -250,6 +252,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_multiple/base-hvac-mini-split-heat-pump-ductless-x3.xml
+++ b/tests/hvac_multiple/base-hvac-mini-split-heat-pump-ductless-x3.xml
@@ -205,6 +205,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -226,6 +227,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -247,6 +249,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>16000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_partial/base-hvac-air-to-air-heat-pump-1-speed-50percent.xml
+++ b/tests/hvac_partial/base-hvac-air-to-air-heat-pump-1-speed-50percent.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>24000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_partial/base-hvac-air-to-air-heat-pump-2-speed-50percent.xml
+++ b/tests/hvac_partial/base-hvac-air-to-air-heat-pump-2-speed-50percent.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>24000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_partial/base-hvac-air-to-air-heat-pump-var-speed-50percent.xml
+++ b/tests/hvac_partial/base-hvac-air-to-air-heat-pump-var-speed-50percent.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>24000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_partial/base-hvac-ground-to-air-heat-pump-50percent.xml
+++ b/tests/hvac_partial/base-hvac-ground-to-air-heat-pump-50percent.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>24000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_partial/base-hvac-mini-split-heat-pump-ducted-50percent.xml
+++ b/tests/hvac_partial/base-hvac-mini-split-heat-pump-ducted-50percent.xml
@@ -206,6 +206,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>24000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/hvac_partial/base-hvac-mini-split-heat-pump-ductless-50percent.xml
+++ b/tests/hvac_partial/base-hvac-mini-split-heat-pump-ductless-50percent.xml
@@ -205,6 +205,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>24000.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/invalid_files/hvac-distribution-multiple-attached-cooling.xml
+++ b/tests/invalid_files/hvac-distribution-multiple-attached-cooling.xml
@@ -361,6 +361,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -383,6 +384,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -404,6 +406,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/invalid_files/hvac-distribution-multiple-attached-heating.xml
+++ b/tests/invalid_files/hvac-distribution-multiple-attached-heating.xml
@@ -361,6 +361,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -383,6 +384,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -404,6 +406,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>

--- a/tests/invalid_files/hvac-frac-load-served.xml
+++ b/tests/invalid_files/hvac-frac-load-served.xml
@@ -361,6 +361,7 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -383,6 +384,7 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
@@ -404,6 +406,7 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <CoolingCapacity>4800.0</CoolingCapacity>
+              <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>


### PR DESCRIPTION
Allow heat pump backup to more easily not be specified (for systems w/o backup). Driven off presence of `BackupSystemFuel` element.