### PR TITLE
Autosized baseboard bugfix

### DIFF
--- a/resources/hvac_sizing.rb
+++ b/resources/hvac_sizing.rb
@@ -2802,9 +2802,11 @@ class HVACSizing
         if not ratedCFMperTonHeating.nil?
           hvac.RatedCFMperTonHeating = ratedCFMperTonHeating.split(",").map(&:to_f)
         end
+      end
 
-        hvac.HeatingLoadFraction = get_feature(runner, equip, Constants.SizingInfoHVACFracHeatLoadServed, 'double')
-        return nil if hvac.HeatingLoadFraction.nil?
+      heatingLoadFraction = get_feature(runner, equip, Constants.SizingInfoHVACFracHeatLoadServed, 'double', false)
+      if not heatingLoadFraction.nil?
+        hvac.HeatingLoadFraction = heatingLoadFraction
       end
 
       if equip.is_a? OpenStudio::Model::ZoneHVACBaseboardConvectiveElectric


### PR DESCRIPTION
Fixes heating capacity/energy for autosized electric baseboard runs. Updated tests to check that autosized hvac systems have E+ capacities > 0 (previous tests only checked hardsized hvac systems).

@joseph-robertson 