### PR TITLE
Relax validator

### DIFF
--- a/measure.rb
+++ b/measure.rb
@@ -2691,9 +2691,10 @@ class OSModel
         infil_ach50 = air_infiltration_measurement_values[:air_leakage]
       elsif air_infiltration_measurement_values[:house_pressure] == 50 and air_infiltration_measurement_values[:unit_of_measure] == "CFM"
         infil_ach50 = air_infiltration_measurement_values[:air_leakage] * 60.0 / @infilvolume # Convert CFM50 to ACH50
-      else
+      elsif not air_infiltration_measurement_values[:constant_ach_natural].nil?
         infil_const_ach = air_infiltration_measurement_values[:constant_ach_natural]
       end
+      break unless infil_ach50.nil? and infil_const_ach.nil?
     end
 
     vented_attic_sla = nil

--- a/resources/EPvalidator.rb
+++ b/resources/EPvalidator.rb
@@ -49,7 +49,7 @@ class EnergyPlusValidator
 
         "/HPXML/Building/BuildingDetails/ClimateandRiskZones/WeatherStation" => one, # See [WeatherStation]
 
-        "/HPXML/Building/BuildingDetails/Enclosure/AirInfiltration[AirInfiltrationMeasurement[HousePressure=50]/BuildingAirLeakage[UnitofMeasure='ACH' or UnitofMeasure='CFM']/AirLeakage | AirInfiltrationMeasurement/extension/ConstantACHnatural]" => one, # ACH50, CFM50, or constant nACH; see [AirInfiltration]
+        "/HPXML/Building/BuildingDetails/Enclosure/AirInfiltration[AirInfiltrationMeasurement[HousePressure=50]/BuildingAirLeakage[UnitofMeasure='ACH' or UnitofMeasure='CFM']/AirLeakage | AirInfiltrationMeasurement/extension/ConstantACHnatural]" => one_or_more, # ACH50, CFM50, or constant nACH; see [AirInfiltration]
         "/HPXML/Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement/InfiltrationVolume" => zero_or_one, # Assumes InfiltrationVolume = ConditionedVolume if not provided
 
         "/HPXML/Building/BuildingDetails/Enclosure/Attics/Attic[AtticType/Attic[Vented='true']]/VentilationRate[[UnitofMeasure='SLA']/Value | extension/ConstantACHnatural]" => zero_or_one, # SLA or constant nACH; used for vented attic if provided
@@ -154,9 +154,9 @@ class EnergyPlusValidator
         "Thickness" => one,
         "DepthBelowGrade" => one,
         "Insulation/SystemIdentifier" => one, # Required by HPXML schema
-        # Either specify insulation layer R-value and insulation height OR assembly R-value:
-        "DistanceToBottomOfInsulation | Insulation/AssemblyEffectiveRValue" => one,
-        "Insulation/Layer[InstallationType='continuous']/NominalRValue | Insulation/AssemblyEffectiveRValue" => one,
+        # At minimum, specify insulation layer R-value and insulation height OR assembly R-value:
+        "DistanceToBottomOfInsulation | Insulation/AssemblyEffectiveRValue" => one_or_more,
+        "Insulation/Layer[InstallationType='continuous']/NominalRValue | Insulation/AssemblyEffectiveRValue" => one_or_more,
       },
 
       # [FrameFloor]
@@ -389,13 +389,13 @@ class EnergyPlusValidator
 
       ## [MechVentType=HRV]
       "/HPXML/Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan[UsedForWholeBuildingVentilation='true'][FanType='heat recovery ventilator']" => {
-        "[SensibleRecoveryEfficiency | AdjustedSensibleRecoveryEfficiency]" => one,
+        "[SensibleRecoveryEfficiency | AdjustedSensibleRecoveryEfficiency]" => one_or_more,
       },
 
       ## [MechVentType=ERV]
       "/HPXML/Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan[UsedForWholeBuildingVentilation='true'][FanType='energy recovery ventilator']" => {
-        "[TotalRecoveryEfficiency | AdjustedTotalRecoveryEfficiency]" => one,
-        "[SensibleRecoveryEfficiency | AdjustedSensibleRecoveryEfficiency]" => one,
+        "[TotalRecoveryEfficiency | AdjustedTotalRecoveryEfficiency]" => one_or_more,
+        "[SensibleRecoveryEfficiency | AdjustedSensibleRecoveryEfficiency]" => one_or_more,
       },
 
       ## [MechVentType=CFIS]
@@ -418,7 +418,7 @@ class EnergyPlusValidator
         "[FuelType='natural gas' or FuelType='fuel oil' or FuelType='propane' or FuelType='electricity']" => one, # If not electricity, see [WHType=FuelTank]
         "TankVolume" => one,
         "HeatingCapacity" => one,
-        "[EnergyFactor | UniformEnergyFactor]" => one,
+        "[EnergyFactor | UniformEnergyFactor]" => one_or_more,
         "WaterHeaterInsulation/Jacket/JacketRValue" => zero_or_one, # Capable to model tank wrap insulation
       },
 
@@ -431,14 +431,14 @@ class EnergyPlusValidator
       "/HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem[WaterHeaterType='instantaneous water heater']" => {
         "[FuelType='natural gas' or FuelType='fuel oil' or FuelType='propane' or FuelType='electricity']" => one,
         "PerformanceAdjustment" => zero_or_one, # Uses ERI assumption for tankless cycling derate if not provided
-        "[EnergyFactor | UniformEnergyFactor]" => one,
+        "[EnergyFactor | UniformEnergyFactor]" => one_or_more,
       },
 
       ## [WHType=HeatPump]
       "/HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem[WaterHeaterType='heat pump water heater']" => {
         "[FuelType='electricity']" => one,
         "TankVolume" => one,
-        "[EnergyFactor | UniformEnergyFactor]" => one,
+        "[EnergyFactor | UniformEnergyFactor]" => one_or_more,
         "WaterHeaterInsulation/Jacket/JacketRValue" => zero_or_one, # Capable to model tank wrap insulation
       },
 
@@ -506,7 +506,7 @@ class EnergyPlusValidator
       "/HPXML/Building/BuildingDetails/Appliances/ClothesWasher" => {
         "SystemIdentifier" => one, # Required by HPXML schema
         "[Location='living space' or Location='basement - conditioned' or Location='basement - unconditioned' or Location='garage']" => one,
-        "[ModifiedEnergyFactor | IntegratedModifiedEnergyFactor]" => one,
+        "[ModifiedEnergyFactor | IntegratedModifiedEnergyFactor]" => one_or_more,
         "RatedAnnualkWh" => one,
         "LabelElectricRate" => one,
         "LabelGasRate" => one,
@@ -519,14 +519,14 @@ class EnergyPlusValidator
         "SystemIdentifier" => one, # Required by HPXML schema
         "[Location='living space' or Location='basement - conditioned' or Location='basement - unconditioned' or Location='garage']" => one,
         "[FuelType='natural gas' or FuelType='fuel oil' or FuelType='propane' or FuelType='electricity']" => one,
-        "[EnergyFactor | CombinedEnergyFactor]" => one,
+        "[EnergyFactor | CombinedEnergyFactor]" => one_or_more,
         "[ControlType='timer' or ControlType='moisture']" => one,
       },
 
       # [Dishwasher]
       "/HPXML/Building/BuildingDetails/Appliances/Dishwasher" => {
         "SystemIdentifier" => one, # Required by HPXML schema
-        "[EnergyFactor | RatedAnnualkWh]" => one,
+        "[EnergyFactor | RatedAnnualkWh]" => one_or_more,
         "PlaceSettingCapacity" => one,
       },
 


### PR DESCRIPTION
Relax validator so that it no longer errors out if additional/extra information is provided. For example, now allows both water heater EF and UEF to be provided without erroring out.

TODO:
- [ ] Test