### PR TITLE
Interior Shading

### DIFF
--- a/hpxml_schemas/BaseElements.xsd
+++ b/hpxml_schemas/BaseElements.xsd
@@ -4395,7 +4395,8 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 				type="WindowThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
 			<xs:element minOccurs="0" name="InteriorShading" type="InteriorShading"/>
-			<xs:element minOccurs="0" name="InteriorShadingFactor" type="Fraction"/>
+			<xs:element minOccurs="0" name="InteriorShadingFactorSummer" type="Fraction"/>
+			<xs:element minOccurs="0" name="InteriorShadingFactorWinter" type="Fraction"/>
 			<xs:element minOccurs="0" name="ExteriorShading" type="ExteriorShading"/>
 			<xs:element minOccurs="0" name="Overhangs">
 				<xs:complexType>

--- a/resources/EPvalidator.rb
+++ b/resources/EPvalidator.rb
@@ -194,10 +194,10 @@ class EnergyPlusValidator
         "Azimuth" => one,
         "UFactor" => one,
         "SHGC" => one,
+        "InteriorShadingFactorSummer" => zero_or_one, # Uses ERI assumption if not provided
+        "InteriorShadingFactorWinter" => zero_or_one, # Uses ERI assumption if not provided
         "Overhangs" => zero_or_one, # See [WindowOverhang]
         "AttachedToWall" => one,
-        "extension/InteriorShadingFactorSummer" => zero_or_one, # Uses ERI assumption if not provided
-        "extension/InteriorShadingFactorWinter" => zero_or_one, # Uses ERI assumption if not provided
       },
 
       ## [WindowOverhang]

--- a/resources/hpxml.rb
+++ b/resources/hpxml.rb
@@ -706,6 +706,8 @@ class HPXML
     XMLHelper.add_element(window, "Azimuth", Integer(azimuth))
     XMLHelper.add_element(window, "UFactor", Float(ufactor))
     XMLHelper.add_element(window, "SHGC", Float(shgc))
+    XMLHelper.add_element(window, "InteriorShadingFactorSummer", Float(interior_shading_factor_summer)) unless interior_shading_factor_summer.nil?
+    XMLHelper.add_element(window, "InteriorShadingFactorWinter", Float(interior_shading_factor_winter)) unless interior_shading_factor_winter.nil?
     if not overhangs_depth.nil? or not overhangs_distance_to_top_of_window.nil? or not overhangs_distance_to_bottom_of_window.nil?
       overhangs = XMLHelper.add_element(window, "Overhangs")
       XMLHelper.add_element(overhangs, "Depth", Float(overhangs_depth))
@@ -714,9 +716,7 @@ class HPXML
     end
     attached_to_wall = XMLHelper.add_element(window, "AttachedToWall")
     XMLHelper.add_attribute(attached_to_wall, "idref", wall_idref)
-    HPXML.add_extension(parent: window,
-                        extensions: { "InteriorShadingFactorSummer": to_float_or_nil(interior_shading_factor_summer),
-                                      "InteriorShadingFactorWinter": to_float_or_nil(interior_shading_factor_winter) })
+
     return window
   end
 
@@ -739,13 +739,13 @@ class HPXML
              :gas_fill => XMLHelper.get_value(window, "GasFill"),
              :ufactor => to_float_or_nil(XMLHelper.get_value(window, "UFactor")),
              :shgc => to_float_or_nil(XMLHelper.get_value(window, "SHGC")),
+             :interior_shading_factor_summer => to_float_or_nil(XMLHelper.get_value(window, "InteriorShadingFactorSummer")),
+             :interior_shading_factor_winter => to_float_or_nil(XMLHelper.get_value(window, "InteriorShadingFactorWinter")),
              :exterior_shading => XMLHelper.get_value(window, "ExteriorShading"),
              :overhangs_depth => to_float_or_nil(XMLHelper.get_value(window, "Overhangs/Depth")),
              :overhangs_distance_to_top_of_window => to_float_or_nil(XMLHelper.get_value(window, "Overhangs/DistanceToTopOfWindow")),
              :overhangs_distance_to_bottom_of_window => to_float_or_nil(XMLHelper.get_value(window, "Overhangs/DistanceToBottomOfWindow")),
-             :wall_idref => HPXML.get_idref(window, "AttachedToWall"),
-             :interior_shading_factor_summer => to_float_or_nil(XMLHelper.get_value(window, "extension/InteriorShadingFactorSummer")),
-             :interior_shading_factor_winter => to_float_or_nil(XMLHelper.get_value(window, "extension/InteriorShadingFactorWinter")) }
+             :wall_idref => HPXML.get_idref(window, "AttachedToWall") }
   end
 
   def self.add_skylight(hpxml:,

--- a/tests/base-enclosure-windows-interior-shading.xml
+++ b/tests/base-enclosure-windows-interior-shading.xml
@@ -185,11 +185,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
+            <InteriorShadingFactorSummer>0.7</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>0.85</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>0.7</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>0.85</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -197,11 +195,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
+            <InteriorShadingFactorSummer>0.01</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>0.99</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>0.01</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>0.99</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -209,11 +205,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
+            <InteriorShadingFactorSummer>0.99</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>0.01</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>0.99</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>0.01</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -221,11 +215,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
+            <InteriorShadingFactorSummer>0.85</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>0.7</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>0.85</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>0.7</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>


### PR DESCRIPTION
Uses HPXML v3 proposed fields `InteriorShadingFractionSummer` and `InteriorShadingFractionWinter` to remove use of extension.