### PR TITLE
Allow HVAC HeatingCapacity/CoolingCapacity to be zero

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1722,6 +1722,7 @@ def get_hpxml_file_heating_systems_values(hpxml_file, heating_systems_values)
     heating_systems_values[0][:heating_capacity] = -1
   elsif hpxml_file.include? '-zero-heat.xml' and not heating_systems_values.nil? and heating_systems_values.size > 0
     heating_systems_values[0][:fraction_heat_load_served] = 0
+    heating_systems_values[0][:heating_capacity] = 0
   elsif hpxml_file.include? 'hvac_multiple' and not heating_systems_values.nil? and heating_systems_values.size > 0
     heating_systems_values[0][:heating_capacity] /= 3.0
     heating_systems_values[0][:fraction_heat_load_served] = 0.333
@@ -1811,6 +1812,7 @@ def get_hpxml_file_cooling_systems_values(hpxml_file, cooling_systems_values)
     cooling_systems_values[0][:cooling_capacity] = -1
   elsif hpxml_file.include? '-zero-cool.xml' and not cooling_systems_values.nil? and cooling_systems_values.size > 0
     cooling_systems_values[0][:fraction_cool_load_served] = 0
+    cooling_systems_values[0][:cooling_capacity] = 0
   elsif hpxml_file.include? 'hvac_multiple' and not cooling_systems_values.nil? and cooling_systems_values.size > 0
     cooling_systems_values[0][:cooling_capacity] /= 3.0
     cooling_systems_values[0][:fraction_cool_load_served] = 0.333
@@ -1837,7 +1839,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heating_capacity => 42000,
                            :cooling_capacity => 48000,
                            :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 120000,
+                           :backup_heating_capacity => 34121,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
                            :fraction_cool_load_served => 1,
@@ -1854,7 +1856,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heating_capacity => 42000,
                            :cooling_capacity => 48000,
                            :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 120000,
+                           :backup_heating_capacity => 34121,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
                            :fraction_cool_load_served => 1,
@@ -1868,7 +1870,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heating_capacity => 42000,
                            :cooling_capacity => 48000,
                            :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 120000,
+                           :backup_heating_capacity => 34121,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
                            :fraction_cool_load_served => 1,
@@ -1882,7 +1884,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heating_capacity => 42000,
                            :cooling_capacity => 48000,
                            :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 120000,
+                           :backup_heating_capacity => 34121,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
                            :fraction_cool_load_served => 1,
@@ -1896,7 +1898,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heating_capacity => 52000,
                            :cooling_capacity => 48000,
                            :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 120000,
+                           :backup_heating_capacity => 34121,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 1,
                            :fraction_cool_load_served => 1,
@@ -1939,7 +1941,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heating_capacity => 4800,
                            :cooling_capacity => 4800,
                            :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 12000,
+                           :backup_heating_capacity => 3412,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 0.1,
                            :fraction_cool_load_served => 0.2,
@@ -1952,7 +1954,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heating_capacity => 4800,
                            :cooling_capacity => 4800,
                            :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 12000,
+                           :backup_heating_capacity => 3412,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 0.1,
                            :fraction_cool_load_served => 0.2,
@@ -1964,7 +1966,7 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
                            :heating_capacity => 4800,
                            :cooling_capacity => 4800,
                            :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 12000,
+                           :backup_heating_capacity => 3412,
                            :backup_heating_efficiency_percent => 1.0,
                            :fraction_heat_load_served => 0.1,
                            :fraction_cool_load_served => 0.2,
@@ -1981,10 +1983,16 @@ def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
   elsif hpxml_file.include? '-zero-heat-cool.xml' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
     heat_pumps_values[0][:fraction_heat_load_served] = 0
     heat_pumps_values[0][:fraction_cool_load_served] = 0
+    heat_pumps_values[0][:heating_capacity] = 0
+    heat_pumps_values[0][:backup_heating_capacity] = 0
+    heat_pumps_values[0][:cooling_capacity] = 0
   elsif hpxml_file.include? '-zero-heat.xml' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
     heat_pumps_values[0][:fraction_heat_load_served] = 0
+    heat_pumps_values[0][:heating_capacity] = 0
+    heat_pumps_values[0][:backup_heating_capacity] = 0
   elsif hpxml_file.include? '-zero-cool.xml' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
     heat_pumps_values[0][:fraction_cool_load_served] = 0
+    heat_pumps_values[0][:cooling_capacity] = 0
   elsif hpxml_file.include? 'hvac_multiple' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
     heat_pumps_values[0][:cooling_capacity] /= 3.0
     heat_pumps_values[0][:heating_capacity] /= 3.0

--- a/resources/hvac.rb
+++ b/resources/hvac.rb
@@ -37,18 +37,18 @@ class HVAC
     clg_coil_stage_data[0].remove
     clg_coil.setName(obj_name + " clg coil")
     if capacity != Constants.SizingAuto
-      clg_coil.setRatedTotalCoolingCapacity(UnitConversions.convert(capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      clg_coil.setRatedTotalCoolingCapacity(UnitConversions.convert([capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     clg_coil.setRatedSensibleHeatRatio(shrs_rated_gross[0])
-    clg_coil.setRatedCOP(OpenStudio::OptionalDouble.new(1.0 / cooling_eirs[0]))
-    clg_coil.setRatedEvaporatorFanPowerPerVolumeFlowRate(OpenStudio::OptionalDouble.new(fan_power_rated / UnitConversions.convert(1.0, "cfm", "m^3/s")))
-    clg_coil.setNominalTimeForCondensateRemovalToBegin(OpenStudio::OptionalDouble.new(1000.0))
-    clg_coil.setRatioOfInitialMoistureEvaporationRateAndSteadyStateLatentCapacity(OpenStudio::OptionalDouble.new(1.5))
-    clg_coil.setMaximumCyclingRate(OpenStudio::OptionalDouble.new(3.0))
-    clg_coil.setLatentCapacityTimeConstant(OpenStudio::OptionalDouble.new(45.0))
+    clg_coil.setRatedCOP(1.0 / cooling_eirs[0])
+    clg_coil.setRatedEvaporatorFanPowerPerVolumeFlowRate(fan_power_rated / UnitConversions.convert(1.0, "cfm", "m^3/s"))
+    clg_coil.setNominalTimeForCondensateRemovalToBegin(1000.0)
+    clg_coil.setRatioOfInitialMoistureEvaporationRateAndSteadyStateLatentCapacity(1.5)
+    clg_coil.setMaximumCyclingRate(3.0)
+    clg_coil.setLatentCapacityTimeConstant(45.0)
     clg_coil.setCondenserType("AirCooled")
-    clg_coil.setCrankcaseHeaterCapacity(OpenStudio::OptionalDouble.new(UnitConversions.convert(crankcase_kw, "kW", "W")))
-    clg_coil.setMaximumOutdoorDryBulbTemperatureForCrankcaseHeaterOperation(OpenStudio::OptionalDouble.new(UnitConversions.convert(crankcase_temp, "F", "C")))
+    clg_coil.setCrankcaseHeaterCapacity(UnitConversions.convert(crankcase_kw, "kW", "W"))
+    clg_coil.setMaximumOutdoorDryBulbTemperatureForCrankcaseHeaterOperation(UnitConversions.convert(crankcase_temp, "F", "C"))
     hvac_map[sys_id] << clg_coil
 
     # _processSystemFan
@@ -403,7 +403,7 @@ class HVAC
     htg_coil_stage_data[0].remove
     htg_coil.setName(obj_name + " htg coil")
     if heat_pump_capacity_heat != Constants.SizingAuto
-      htg_coil.setRatedTotalHeatingCapacity(UnitConversions.convert(heat_pump_capacity_heat, "Btu/hr", "W")) # Used by HVACSizing measure
+      htg_coil.setRatedTotalHeatingCapacity(UnitConversions.convert([heat_pump_capacity_heat, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     htg_coil.setRatedCOP(1.0 / heating_eirs[0])
     htg_coil.setRatedSupplyFanPowerPerVolumeFlowRate(fan_power_rated / UnitConversions.convert(1.0, "cfm", "m^3/s"))
@@ -424,7 +424,7 @@ class HVAC
     htg_supp_coil.setName(obj_name + " supp htg coil")
     htg_supp_coil.setEfficiency(supplemental_efficiency)
     if supplemental_capacity != Constants.SizingAuto
-      htg_supp_coil.setNominalCapacity(UnitConversions.convert(supplemental_capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      htg_supp_coil.setNominalCapacity(UnitConversions.convert([supplemental_capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     hvac_map[sys_id] << htg_supp_coil
 
@@ -432,15 +432,15 @@ class HVAC
     clg_coil_stage_data[0].remove
     clg_coil.setName(obj_name + " clg coil")
     if heat_pump_capacity_cool != Constants.SizingAuto
-      clg_coil.setRatedTotalCoolingCapacity(UnitConversions.convert(heat_pump_capacity_cool, "Btu/hr", "W")) # Used by HVACSizing measure
+      clg_coil.setRatedTotalCoolingCapacity(UnitConversions.convert([heat_pump_capacity_cool, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     clg_coil.setRatedSensibleHeatRatio(shrs_rated_gross[0])
-    clg_coil.setRatedCOP(OpenStudio::OptionalDouble.new(1.0 / cooling_eirs[0]))
-    clg_coil.setRatedEvaporatorFanPowerPerVolumeFlowRate(OpenStudio::OptionalDouble.new(fan_power_rated / UnitConversions.convert(1.0, "cfm", "m^3/s")))
-    clg_coil.setNominalTimeForCondensateRemovalToBegin(OpenStudio::OptionalDouble.new(1000.0))
-    clg_coil.setRatioOfInitialMoistureEvaporationRateAndSteadyStateLatentCapacity(OpenStudio::OptionalDouble.new(1.5))
-    clg_coil.setMaximumCyclingRate(OpenStudio::OptionalDouble.new(3.0))
-    clg_coil.setLatentCapacityTimeConstant(OpenStudio::OptionalDouble.new(45.0))
+    clg_coil.setRatedCOP(1.0 / cooling_eirs[0])
+    clg_coil.setRatedEvaporatorFanPowerPerVolumeFlowRate(fan_power_rated / UnitConversions.convert(1.0, "cfm", "m^3/s"))
+    clg_coil.setNominalTimeForCondensateRemovalToBegin(1000.0)
+    clg_coil.setRatioOfInitialMoistureEvaporationRateAndSteadyStateLatentCapacity(1.5)
+    clg_coil.setMaximumCyclingRate(3.0)
+    clg_coil.setLatentCapacityTimeConstant(45.0)
     clg_coil.setCondenserType("AirCooled")
     hvac_map[sys_id] << clg_coil
 
@@ -583,7 +583,7 @@ class HVAC
     htg_supp_coil.setName(obj_name + " supp htg coil")
     htg_supp_coil.setEfficiency(supplemental_efficiency)
     if supplemental_capacity != Constants.SizingAuto
-      htg_supp_coil.setNominalCapacity(UnitConversions.convert(supplemental_capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      htg_supp_coil.setNominalCapacity(UnitConversions.convert([supplemental_capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     hvac_map[sys_id] << htg_supp_coil
 
@@ -753,7 +753,7 @@ class HVAC
     htg_supp_coil.setName(obj_name + " supp htg coil")
     htg_supp_coil.setEfficiency(supplemental_efficiency)
     if supplemental_capacity != Constants.SizingAuto
-      htg_supp_coil.setNominalCapacity(UnitConversions.convert(supplemental_capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      htg_supp_coil.setNominalCapacity(UnitConversions.convert([supplemental_capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
 
     clg_coil = OpenStudio::Model::CoilCoolingDXMultiSpeed.new(model)
@@ -954,7 +954,7 @@ class HVAC
     htg_supp_coil.setName(obj_name + " supp htg coil")
     htg_supp_coil.setEfficiency(supplemental_efficiency)
     if supplemental_capacity != Constants.SizingAuto
-      htg_supp_coil.setNominalCapacity(UnitConversions.convert(supplemental_capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      htg_supp_coil.setNominalCapacity(UnitConversions.convert([supplemental_capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     hvac_map[sys_id] << htg_supp_coil
 
@@ -1077,7 +1077,7 @@ class HVAC
       program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
       program.setName(obj_name + " pan heater program")
       if heat_pump_capacity != Constants.SizingAuto
-        num_outdoor_units = (UnitConversions.convert(heat_pump_capacity, "Btu/hr", "ton") / 1.5).ceil # Assume 1.5 tons max per outdoor unit
+        num_outdoor_units = (UnitConversions.convert([heat_pump_capacity, Constants.small].max, "Btu/hr", "ton") / 1.5).ceil # Assume 1.5 tons max per outdoor unit
       else
         num_outdoor_units = 2
       end
@@ -1249,7 +1249,7 @@ class HVAC
     htg_coil = OpenStudio::Model::CoilHeatingWaterToAirHeatPumpEquationFit.new(model)
     htg_coil.setName(obj_name + " htg coil")
     if heat_pump_capacity_heat != Constants.SizingAuto
-      htg_coil.setRatedHeatingCapacity(OpenStudio::OptionalDouble.new(UnitConversions.convert(heat_pump_capacity_heat, "Btu/hr", "W"))) # Used by HVACSizing measure
+      htg_coil.setRatedHeatingCapacity(UnitConversions.convert([heat_pump_capacity_heat, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     htg_coil.setRatedHeatingCoefficientofPerformance(1.0 / heatingEIR)
     htg_coil.setHeatingCapacityCoefficient1(gshp_HEAT_CAP_fT_coeff[0])
@@ -1268,14 +1268,14 @@ class HVAC
     htg_supp_coil.setName(obj_name + " supp htg coil")
     htg_supp_coil.setEfficiency(supplemental_efficiency)
     if supplemental_capacity != Constants.SizingAuto
-      htg_supp_coil.setNominalCapacity(UnitConversions.convert(supplemental_capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      htg_supp_coil.setNominalCapacity(UnitConversions.convert([supplemental_capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     hvac_map[sys_id] << htg_supp_coil
 
     clg_coil = OpenStudio::Model::CoilCoolingWaterToAirHeatPumpEquationFit.new(model)
     clg_coil.setName(obj_name + " clg coil")
     if heat_pump_capacity_cool != Constants.SizingAuto
-      clg_coil.setRatedTotalCoolingCapacity(UnitConversions.convert(heat_pump_capacity_cool, "Btu/hr", "W")) # Used by HVACSizing measure
+      clg_coil.setRatedTotalCoolingCapacity(UnitConversions.convert([heat_pump_capacity_cool, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     clg_coil.setRatedCoolingCoefficientofPerformance(1.0 / coolingEIR)
     clg_coil.setTotalCoolingCapacityCoefficient1(gshp_COOL_CAP_fT_coeff[0])
@@ -1403,14 +1403,14 @@ class HVAC
     clg_coil = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model, model.alwaysOnDiscreteSchedule, roomac_cap_ft_curve, roomac_cap_fff_curve, roomac_eir_ft_curve, roomcac_eir_fff_curve, roomac_plf_fplr_curve)
     clg_coil.setName(obj_name + " #{control_zone.name} clg coil")
     if capacity != Constants.SizingAuto
-      clg_coil.setRatedTotalCoolingCapacity(UnitConversions.convert(capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      clg_coil.setRatedTotalCoolingCapacity(UnitConversions.convert([capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     clg_coil.setRatedSensibleHeatRatio(shr)
-    clg_coil.setRatedCOP(OpenStudio::OptionalDouble.new(UnitConversions.convert(eer, "Btu/hr", "W")))
-    clg_coil.setRatedEvaporatorFanPowerPerVolumeFlowRate(OpenStudio::OptionalDouble.new(773.3))
-    clg_coil.setEvaporativeCondenserEffectiveness(OpenStudio::OptionalDouble.new(0.9))
-    clg_coil.setMaximumOutdoorDryBulbTemperatureForCrankcaseHeaterOperation(OpenStudio::OptionalDouble.new(10))
-    clg_coil.setBasinHeaterSetpointTemperature(OpenStudio::OptionalDouble.new(2))
+    clg_coil.setRatedCOP(UnitConversions.convert(eer, "Btu/hr", "W"))
+    clg_coil.setRatedEvaporatorFanPowerPerVolumeFlowRate(773.3)
+    clg_coil.setEvaporativeCondenserEffectiveness(0.9)
+    clg_coil.setMaximumOutdoorDryBulbTemperatureForCrankcaseHeaterOperation(10)
+    clg_coil.setBasinHeaterSetpointTemperature(2)
     hvac_map[sys_id] << clg_coil
 
     fan = OpenStudio::Model::FanOnOff.new(model, model.alwaysOnDiscreteSchedule)
@@ -1468,7 +1468,7 @@ class HVAC
     end
     htg_coil.setName(obj_name + " htg coil")
     if capacity != Constants.SizingAuto
-      htg_coil.setNominalCapacity(UnitConversions.convert(capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      htg_coil.setNominalCapacity(UnitConversions.convert([capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     hvac_map[sys_id] << htg_coil
 
@@ -1654,7 +1654,7 @@ class HVAC
     boiler.setName(obj_name)
     boiler.setFuelType(HelperMethods.eplus_fuel_map(fuel_type))
     if capacity != Constants.SizingAuto
-      boiler.setNominalCapacity(UnitConversions.convert(capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      boiler.setNominalCapacity(UnitConversions.convert([capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     if system_type == Constants.BoilerTypeCondensing
       # Convert Rated Efficiency at 80F and 1.0PLR where the performance curves are derived from to Design condition as input
@@ -1719,7 +1719,7 @@ class HVAC
     baseboard_coil = OpenStudio::Model::CoilHeatingWaterBaseboard.new(model)
     baseboard_coil.setName(obj_name + " #{control_zone.name} htg coil")
     if capacity != Constants.SizingAuto
-      baseboard_coil.setHeatingDesignCapacity(UnitConversions.convert(capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      baseboard_coil.setHeatingDesignCapacity(UnitConversions.convert([capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     baseboard_coil.setConvergenceTolerance(0.001)
     hvac_map[sys_id] << baseboard_coil
@@ -1759,7 +1759,7 @@ class HVAC
     baseboard_heater = OpenStudio::Model::ZoneHVACBaseboardConvectiveElectric.new(model)
     baseboard_heater.setName(obj_name + " #{control_zone.name}")
     if capacity != Constants.SizingAuto
-      baseboard_heater.setNominalCapacity(UnitConversions.convert(capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      baseboard_heater.setNominalCapacity(UnitConversions.convert([capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     baseboard_heater.setEfficiency(efficiency)
     hvac_map[sys_id] << baseboard_heater
@@ -1804,7 +1804,7 @@ class HVAC
     end
     htg_coil.setName(obj_name + " #{control_zone.name} htg coil")
     if capacity != Constants.SizingAuto
-      htg_coil.setNominalCapacity(UnitConversions.convert(capacity, "Btu/hr", "W")) # Used by HVACSizing measure
+      htg_coil.setNominalCapacity(UnitConversions.convert([capacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
     end
     hvac_map[sys_id] << htg_coil
 
@@ -3795,7 +3795,7 @@ class HVAC
                                                                            cool_plf_fplr_curve,
                                                                            const_biquadratic)
       if outputCapacity != Constants.SizingAuto
-        stage_data.setGrossRatedTotalCoolingCapacity(UnitConversions.convert(outputCapacity, "Btu/hr", "W")) # Used by HVACSizing measure
+        stage_data.setGrossRatedTotalCoolingCapacity(UnitConversions.convert([outputCapacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
       end
       stage_data.setGrossRatedSensibleHeatRatio(shrs_rated_gross[speed])
       stage_data.setGrossRatedCoolingCOP(1.0 / cooling_eirs[speed])
@@ -3831,7 +3831,7 @@ class HVAC
                                                                            hp_heat_plf_fplr_curve,
                                                                            const_biquadratic)
       if outputCapacity != Constants.SizingAuto
-        stage_data.setGrossRatedHeatingCapacity(UnitConversions.convert(outputCapacity, "Btu/hr", "W")) # Used by HVACSizing measure
+        stage_data.setGrossRatedHeatingCapacity(UnitConversions.convert([outputCapacity, Constants.small].max, "Btu/hr", "W")) # Used by HVACSizing measure
       end
       stage_data.setGrossRatedHeatingCOP(1.0 / heating_eirs[speed])
       stage_data.setRatedWasteHeatFractionofPowerInput(0.2)

--- a/resources/hvac_sizing.rb
+++ b/resources/hvac_sizing.rb
@@ -1734,7 +1734,7 @@ class HVACSizing
         return nil if hvac_final_values.nil?
       end
 
-      hvac_final_values.Heat_Capacity = hvac_final_values.Cool_Capacity + hvac.HeatingCapacityOffset
+      hvac_final_values.Heat_Capacity = [hvac_final_values.Cool_Capacity + hvac.HeatingCapacityOffset, Constants.small].max
       hvac_final_values.Heat_Capacity_Supp = hvac_final_values.Heat_Load
 
       hvac_final_values.Heat_Airflow = hvac.HeatingCFMs[-1] * UnitConversions.convert(hvac_final_values.Heat_Capacity, "Btu/hr", "ton") # Maximum air flow under heating operation
@@ -1947,7 +1947,7 @@ class HVACSizing
       if hvac.has_type(Constants.ObjectNameAirSourceHeatPump)
         hvac_final_values.Heat_Capacity = hvac_final_values.Cool_Capacity
       elsif hvac.has_type(Constants.ObjectNameMiniSplitHeatPump)
-        hvac_final_values.Heat_Capacity = hvac_final_values.Cool_Capacity + hvac.HeatingCapacityOffset
+        hvac_final_values.Heat_Capacity = [hvac_final_values.Cool_Capacity + hvac.HeatingCapacityOffset, Constants.small].max
       end
     else
       cfm_Btu = hvac_final_values.Cool_Airflow / hvac_final_values.Cool_Capacity
@@ -1964,7 +1964,7 @@ class HVACSizing
         hvac_final_values.Heat_Capacity = hvac_final_values.Cool_Capacity
       elsif hvac.has_type(Constants.ObjectNameMiniSplitHeatPump)
         hvac_final_values.Cool_Airflow = hvac.CoolingCFMs[-1] * UnitConversions.convert(hvac_final_values.Cool_Capacity, "Btu/hr", "ton")
-        hvac_final_values.Heat_Capacity = hvac_final_values.Cool_Capacity + hvac.HeatingCapacityOffset
+        hvac_final_values.Heat_Capacity = [hvac_final_values.Cool_Capacity + hvac.HeatingCapacityOffset, Constants.small].max
       end
     end
 

--- a/tests/base-dhw-desuperheater-gshp.xml
+++ b/tests/base-dhw-desuperheater-gshp.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-1-speed-17F.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-1-speed-17F.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-1-speed-shr.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-1-speed-shr.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-1-speed.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-1-speed.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-2-speed-17F.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-2-speed-17F.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-2-speed-shr.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-2-speed-shr.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-2-speed.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-2-speed.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-var-speed-17F.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-var-speed-17F.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-var-speed-shr.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-var-speed-shr.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-air-to-air-heat-pump-var-speed.xml
+++ b/tests/base-hvac-air-to-air-heat-pump-var-speed.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
+++ b/tests/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
@@ -256,7 +256,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-ground-to-air-heat-pump-shr.xml
+++ b/tests/base-hvac-ground-to-air-heat-pump-shr.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-ground-to-air-heat-pump.xml
+++ b/tests/base-hvac-ground-to-air-heat-pump.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-mini-split-heat-pump-ducted-17F.xml
+++ b/tests/base-hvac-mini-split-heat-pump-ducted-17F.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-mini-split-heat-pump-ducted-shr.xml
+++ b/tests/base-hvac-mini-split-heat-pump-ducted-shr.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-mini-split-heat-pump-ducted.xml
+++ b/tests/base-hvac-mini-split-heat-pump-ducted.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-mini-split-heat-pump-ductless.xml
+++ b/tests/base-hvac-mini-split-heat-pump-ductless.xml
@@ -243,7 +243,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/base-hvac-multiple.xml
+++ b/tests/base-hvac-multiple.xml
@@ -366,7 +366,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -390,7 +390,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -413,7 +413,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/cfis/base-hvac-air-to-air-heat-pump-1-speed-cfis.xml
+++ b/tests/cfis/base-hvac-air-to-air-heat-pump-1-speed-cfis.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/cfis/base-hvac-air-to-air-heat-pump-2-speed-cfis.xml
+++ b/tests/cfis/base-hvac-air-to-air-heat-pump-2-speed-cfis.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/cfis/base-hvac-air-to-air-heat-pump-var-speed-cfis.xml
+++ b/tests/cfis/base-hvac-air-to-air-heat-pump-var-speed-cfis.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/cfis/base-hvac-ground-to-air-heat-pump-cfis.xml
+++ b/tests/cfis/base-hvac-ground-to-air-heat-pump-cfis.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -716,18 +716,20 @@ class HPXMLTranslatorTest < MiniTest::Test
     has_multispeed_dx_heating_coil = false # FIXME: Remove this when https://github.com/NREL/EnergyPlus/issues/7381 is fixed
     has_gshp_coil = false # FIXME: Remove this when https://github.com/NREL/EnergyPlus/issues/7381 is fixed
     bldg_details.elements.each('Systems/HVAC/HVACPlant/HeatingSystem') do |htg_sys|
-      htg_cap = 0 if htg_cap.nil?
       htg_sys_cap = Float(XMLHelper.get_value(htg_sys, "HeatingCapacity"))
-      htg_cap += htg_sys_cap if htg_sys_cap > 0
+      if htg_sys_cap > 0
+        htg_cap = 0 if htg_cap.nil?
+        htg_cap += htg_sys_cap
+      end
     end
     bldg_details.elements.each('Systems/HVAC/HVACPlant/CoolingSystem') do |clg_sys|
-      clg_cap = 0 if clg_cap.nil?
       clg_sys_cap = Float(XMLHelper.get_value(clg_sys, "CoolingCapacity"))
-      clg_cap += clg_sys_cap if clg_sys_cap > 0
+      if clg_sys_cap > 0
+        clg_cap = 0 if clg_cap.nil?
+        clg_cap += clg_sys_cap
+      end
     end
     bldg_details.elements.each('Systems/HVAC/HVACPlant/HeatPump') do |hp|
-      htg_cap = 0 if htg_cap.nil?
-      clg_cap = 0 if clg_cap.nil?
       hp_type = XMLHelper.get_value(hp, "HeatPumpType")
       hp_cap_clg = Float(XMLHelper.get_value(hp, "CoolingCapacity"))
       hp_cap_htg = Float(XMLHelper.get_value(hp, "HeatingCapacity"))
@@ -736,9 +738,18 @@ class HPXMLTranslatorTest < MiniTest::Test
         hp_cap_htg *= 1.20 # TODO: Generalize this
       end
       supp_hp_cap = XMLHelper.get_value(hp, "BackupHeatingCapacity").to_f
-      clg_cap += hp_cap_clg if hp_cap_clg > 0
-      htg_cap += hp_cap_htg if hp_cap_htg > 0
-      htg_cap += supp_hp_cap if supp_hp_cap > 0
+      if hp_cap_clg > 0
+        clg_cap = 0 if clg_cap.nil?
+        clg_cap += hp_cap_clg
+      end
+      if hp_cap_htg > 0
+        htg_cap = 0 if htg_cap.nil?
+        htg_cap += hp_cap_htg
+      end
+      if supp_hp_cap > 0
+        htg_cap = 0 if htg_cap.nil?
+        htg_cap += supp_hp_cap
+      end
       if XMLHelper.get_value(hp, "AnnualCoolingEfficiency[Units='SEER']/Value").to_f > 15
         has_multispeed_dx_heating_coil = true
       end

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -836,12 +836,12 @@ class HPXMLTranslatorTest < MiniTest::Test
 
       # Add any combi water heating energy use
       query = "SELECT SUM(ABS(VariableValue)/1000000000) FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableType='Sum' AND VariableName='#{OutputVars.WaterHeatingCombiBoilerHeatExchanger.values[0][0]}' AND ReportingFrequency='Run Period' AND VariableUnits='J')"
-      combi_hx_load = sqlFile.execAndReturnFirstDouble(query).get
+      combi_hx_load = sqlFile.execAndReturnFirstDouble(query).get.round(2)
       query = "SELECT SUM(ABS(VariableValue)/1000000000) FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableType='Sum' AND VariableName='#{OutputVars.WaterHeatingCombiBoiler.values[0][0]}' AND ReportingFrequency='Run Period' AND VariableUnits='J')"
-      combi_htg_load = sqlFile.execAndReturnFirstDouble(query).get
+      combi_htg_load = sqlFile.execAndReturnFirstDouble(query).get.round(2)
       if combi_htg_load > 0 and combi_hx_load > 0
         results.keys.each do |k|
-          next unless k[1] == "Heating" and k[3] == "GJ"
+          next unless k[0] != "Load" and k[1] == "Heating" and k[3] == "GJ"
 
           water_heater_energy += (results[k] * combi_hx_load / combi_htg_load)
         end

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -289,7 +289,7 @@ class HPXMLTranslatorTest < MiniTest::Test
     query = "SELECT SUM(Value)/1000000000 FROM ReportData WHERE ReportDataDictionaryIndex IN (SELECT ReportDataDictionaryIndex FROM ReportDataDictionary WHERE Name='Cooling Coil Crankcase Heater Electric Energy')"
     sql_value = sqlFile.execAndReturnFirstDouble(query)
     if sql_value.is_initialized
-      cooling_crankcase = sql_value.get
+      cooling_crankcase = sql_value.get.round(2)
       if cooling_crankcase > 0
         results[["Electricity", "Cooling", "General", "GJ"]] -= cooling_crankcase
         results[["Electricity", "Cooling", "Crankcase", "GJ"]] = cooling_crankcase
@@ -298,7 +298,7 @@ class HPXMLTranslatorTest < MiniTest::Test
     query = "SELECT SUM(Value)/1000000000 FROM ReportData WHERE ReportDataDictionaryIndex IN (SELECT ReportDataDictionaryIndex FROM ReportDataDictionary WHERE Name='Heating Coil Crankcase Heater Electric Energy')"
     sql_value = sqlFile.execAndReturnFirstDouble(query)
     if sql_value.is_initialized
-      heating_crankcase = sql_value.get
+      heating_crankcase = sql_value.get.round(2)
       if heating_crankcase > 0
         results[["Electricity", "Heating", "General", "GJ"]] -= heating_crankcase
         results[["Electricity", "Heating", "Crankcase", "GJ"]] = heating_crankcase
@@ -307,7 +307,7 @@ class HPXMLTranslatorTest < MiniTest::Test
     query = "SELECT SUM(Value)/1000000000 FROM ReportData WHERE ReportDataDictionaryIndex IN (SELECT ReportDataDictionaryIndex FROM ReportDataDictionary WHERE Name='Heating Coil Defrost Electric Energy')"
     sql_value = sqlFile.execAndReturnFirstDouble(query)
     if sql_value.is_initialized
-      heating_defrost = sql_value.get
+      heating_defrost = sql_value.get.round(2)
       if heating_defrost > 0
         results[["Electricity", "Heating", "General", "GJ"]] -= heating_defrost
         results[["Electricity", "Heating", "Defrost", "GJ"]] = heating_defrost
@@ -316,17 +316,17 @@ class HPXMLTranslatorTest < MiniTest::Test
 
     # Obtain HVAC capacities
     query = "SELECT SUM(Value) FROM ComponentSizes WHERE (CompType LIKE 'Coil:Heating:%' OR CompType LIKE 'Boiler:%' OR CompType LIKE 'ZONEHVAC:BASEBOARD:%') AND Description LIKE '%User-Specified%Capacity' AND Description NOT LIKE '%Supplemental%' AND Units='W'"
-    results[["Capacity", "Heating", "General", "W"]] = sqlFile.execAndReturnFirstDouble(query).get
+    results[["Capacity", "Heating", "General", "W"]] = sqlFile.execAndReturnFirstDouble(query).get.round(2)
 
     query = "SELECT SUM(Value) FROM ComponentSizes WHERE CompType LIKE 'Coil:Cooling:%' AND Description LIKE '%User-Specified%Total%Capacity' AND Units='W'"
-    results[["Capacity", "Cooling", "General", "W"]] = sqlFile.execAndReturnFirstDouble(query).get
+    results[["Capacity", "Cooling", "General", "W"]] = sqlFile.execAndReturnFirstDouble(query).get.round(2)
 
     # Obtain Heating/Cooling loads
     query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnergyMeters' AND ReportForString='Entire Facility' AND TableName='Annual and Peak Values - Other' AND RowName='Heating:EnergyTransfer' AND ColumnName='Annual Value' AND Units='GJ'"
-    results[["Load", "Heating", "General", "J"]] = sqlFile.execAndReturnFirstDouble(query).get
+    results[["Load", "Heating", "General", "GJ"]] = sqlFile.execAndReturnFirstDouble(query).get.round(2)
 
     query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnergyMeters' AND ReportForString='Entire Facility' AND TableName='Annual and Peak Values - Other' AND RowName='Cooling:EnergyTransfer' AND ColumnName='Annual Value' AND Units='GJ'"
-    results[["Load", "Cooling", "General", "J"]] = sqlFile.execAndReturnFirstDouble(query).get
+    results[["Load", "Cooling", "General", "GJ"]] = sqlFile.execAndReturnFirstDouble(query).get.round(2)
 
     sqlFile.close
 

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -748,7 +748,9 @@ class HPXMLTranslatorTest < MiniTest::Test
     end
     if not clg_cap.nil?
       sql_value = UnitConversions.convert(results[["Capacity", "Cooling", "General", "W"]], 'W', 'Btu/hr')
-      if clg_cap > 0
+      if clg_cap == 0
+        assert_operator(sql_value, :<, 1)
+      elsif clg_cap > 0
         assert_in_epsilon(clg_cap, sql_value, 0.01)
       else # autosized
         assert_operator(sql_value, :>, 1)
@@ -756,7 +758,9 @@ class HPXMLTranslatorTest < MiniTest::Test
     end
     if not htg_cap.nil? and not (has_multispeed_dx_heating_coil or has_gshp_coil)
       sql_value = UnitConversions.convert(results[["Capacity", "Heating", "General", "W"]], 'W', 'Btu/hr')
-      if htg_cap > 0
+      if htg_cap == 0
+        assert_operator(sql_value, :<, 1)
+      elsif htg_cap > 0
         assert_in_epsilon(htg_cap, sql_value, 0.01)
       else # autosized
         assert_operator(sql_value, :>, 1)

--- a/tests/hvac_base/base-hvac-air-to-air-heat-pump-1-speed-base.xml
+++ b/tests/hvac_base/base-hvac-air-to-air-heat-pump-1-speed-base.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_base/base-hvac-air-to-air-heat-pump-2-speed-base.xml
+++ b/tests/hvac_base/base-hvac-air-to-air-heat-pump-2-speed-base.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_base/base-hvac-air-to-air-heat-pump-var-speed-base.xml
+++ b/tests/hvac_base/base-hvac-air-to-air-heat-pump-var-speed-base.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_base/base-hvac-ground-to-air-heat-pump-base.xml
+++ b/tests/hvac_base/base-hvac-ground-to-air-heat-pump-base.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_base/base-hvac-mini-split-heat-pump-ducted-base.xml
+++ b/tests/hvac_base/base-hvac-mini-split-heat-pump-ducted-base.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_base/base-hvac-mini-split-heat-pump-ductless-base.xml
+++ b/tests/hvac_base/base-hvac-mini-split-heat-pump-ductless-base.xml
@@ -243,7 +243,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-cool.xml
@@ -238,13 +238,13 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <HeatingCapacity>42000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-heat-cool.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>42000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-1-speed-zero-heat.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>42000.0</HeatingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
               <CoolingCapacity>48000.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-cool.xml
@@ -238,13 +238,13 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <HeatingCapacity>42000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-heat-cool.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>42000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-2-speed-zero-heat.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>42000.0</HeatingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
               <CoolingCapacity>48000.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-cool.xml
@@ -238,13 +238,13 @@
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <HeatingCapacity>42000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-heat-cool.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>42000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-air-to-air-heat-pump-var-speed-zero-heat.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>air-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>42000.0</HeatingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
               <CoolingCapacity>48000.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-cool.xml
@@ -238,13 +238,13 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <HeatingCapacity>42000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-heat-cool.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>42000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-ground-to-air-heat-pump-zero-heat.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>42000.0</HeatingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
               <CoolingCapacity>48000.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-cool.xml
@@ -238,13 +238,13 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <HeatingCapacity>52000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-heat-cool.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>52000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ducted-zero-heat.xml
@@ -237,14 +237,14 @@
               <DistributionSystem idref='HVACDistribution'/>
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>52000.0</HeatingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
               <CoolingCapacity>48000.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-cool.xml
@@ -237,13 +237,13 @@
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <HeatingCapacity>52000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-heat-cool.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-heat-cool.xml
@@ -236,14 +236,14 @@
               <SystemIdentifier id='HeatPump'/>
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>52000.0</HeatingCapacity>
-              <CoolingCapacity>48000.0</CoolingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
+              <CoolingCapacity>0.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-heat.xml
+++ b/tests/hvac_load_fracs/base-hvac-mini-split-heat-pump-ductless-zero-heat.xml
@@ -236,14 +236,14 @@
               <SystemIdentifier id='HeatPump'/>
               <HeatPumpType>mini-split</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
-              <HeatingCapacity>52000.0</HeatingCapacity>
+              <HeatingCapacity>0.0</HeatingCapacity>
               <CoolingCapacity>48000.0</CoolingCapacity>
               <BackupSystemFuel>electricity</BackupSystemFuel>
               <BackupAnnualHeatingEfficiency>
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>0.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-1-speed-x3.xml
+++ b/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-1-speed-x3.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -268,7 +268,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -292,7 +292,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-2-speed-x3.xml
+++ b/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-2-speed-x3.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -268,7 +268,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -292,7 +292,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-var-speed-x3.xml
+++ b/tests/hvac_multiple/base-hvac-air-to-air-heat-pump-var-speed-x3.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -268,7 +268,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -292,7 +292,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_multiple/base-hvac-ground-to-air-heat-pump-x3.xml
+++ b/tests/hvac_multiple/base-hvac-ground-to-air-heat-pump-x3.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -268,7 +268,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -292,7 +292,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_multiple/base-hvac-mini-split-heat-pump-ducted-x3.xml
+++ b/tests/hvac_multiple/base-hvac-mini-split-heat-pump-ducted-x3.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -268,7 +268,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -292,7 +292,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_multiple/base-hvac-mini-split-heat-pump-ductless-x3.xml
+++ b/tests/hvac_multiple/base-hvac-mini-split-heat-pump-ductless-x3.xml
@@ -243,7 +243,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -266,7 +266,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -289,7 +289,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_partial/base-hvac-air-to-air-heat-pump-1-speed-33percent.xml
+++ b/tests/hvac_partial/base-hvac-air-to-air-heat-pump-1-speed-33percent.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_partial/base-hvac-air-to-air-heat-pump-2-speed-33percent.xml
+++ b/tests/hvac_partial/base-hvac-air-to-air-heat-pump-2-speed-33percent.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_partial/base-hvac-air-to-air-heat-pump-var-speed-33percent.xml
+++ b/tests/hvac_partial/base-hvac-air-to-air-heat-pump-var-speed-33percent.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_partial/base-hvac-ground-to-air-heat-pump-33percent.xml
+++ b/tests/hvac_partial/base-hvac-ground-to-air-heat-pump-33percent.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_partial/base-hvac-mini-split-heat-pump-ducted-33percent.xml
+++ b/tests/hvac_partial/base-hvac-mini-split-heat-pump-ducted-33percent.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/hvac_partial/base-hvac-mini-split-heat-pump-ductless-33percent.xml
+++ b/tests/hvac_partial/base-hvac-mini-split-heat-pump-ductless-33percent.xml
@@ -243,7 +243,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>40000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>11373.666666666666</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.333</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities.xml
+++ b/tests/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities2.xml
+++ b/tests/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities2.xml
@@ -244,7 +244,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities3.xml
+++ b/tests/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities3.xml
@@ -245,7 +245,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>120000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>34121.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/invalid_files/hvac-distribution-multiple-attached-cooling.xml
+++ b/tests/invalid_files/hvac-distribution-multiple-attached-cooling.xml
@@ -366,7 +366,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -390,7 +390,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -413,7 +413,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/invalid_files/hvac-distribution-multiple-attached-heating.xml
+++ b/tests/invalid_files/hvac-distribution-multiple-attached-heating.xml
@@ -366,7 +366,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -390,7 +390,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -413,7 +413,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>

--- a/tests/invalid_files/hvac-frac-load-served.xml
+++ b/tests/invalid_files/hvac-frac-load-served.xml
@@ -366,7 +366,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -390,7 +390,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
@@ -413,7 +413,7 @@
                 <Units>Percent</Units>
                 <Value>1.0</Value>
               </BackupAnnualHeatingEfficiency>
-              <BackupHeatingCapacity>12000.0</BackupHeatingCapacity>
+              <BackupHeatingCapacity>3412.0</BackupHeatingCapacity>
               <FractionHeatLoadServed>0.1</FractionHeatLoadServed>
               <FractionCoolLoadServed>0.2</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>


### PR DESCRIPTION
Allow HVAC `HeatingCapacity` and `CoolingCapacity` to be zero. Updated tests. Changed heat pump supplemental heating capacities to be more representative.

Also removed uses of OpenStudio::OptionalDouble.new, which are no longer needed in the latest OS SDK.

