### PR TITLE
Addresses runtime performance

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1566,22 +1566,7 @@ def get_hpxml_file_windows_values(hpxml_file, windows_values, walls_values, foun
         windows_values << windows_values[n - 1].dup
         windows_values[-1][:id] += i.to_s
         windows_values[-1][:wall_idref] += i.to_s
-        if i < 4
-          # nop
-        elsif i < 7 # Move to another Wall
-          new_idref = "WallAtticGable#{i}"
-          area_adjustments << [windows_values[-1][:wall_idref], new_idref, windows_values[-1][:area]]
-          windows_values[-1][:wall_idref] = new_idref
-        else # Move to a FoundationWall
-          new_idref = "FoundationWall#{i}"
-          area_adjustments << [windows_values[-1][:wall_idref], new_idref, windows_values[-1][:area]]
-          windows_values[-1][:wall_idref] = new_idref
-        end
       end
-    end
-    # Moved subsurface; preserve original net wall areas
-    area_adjustments.each do |area_adjustment|
-      update_areas(area_adjustment[0], area_adjustment[1], area_adjustment[2], walls_values, foundation_walls_values)
     end
   end
   return windows_values
@@ -1647,22 +1632,7 @@ def get_hpxml_file_doors_values(hpxml_file, doors_values, walls_values, foundati
         doors_values << doors_values[n - 1].dup
         doors_values[-1][:id] += i.to_s
         doors_values[-1][:wall_idref] += i.to_s
-        if i < 4
-          # nop
-        elsif i < 7 # Move to another Wall
-          new_idref = "WallAtticGable#{i}"
-          area_adjustments << [doors_values[-1][:wall_idref], new_idref, doors_values[-1][:area]]
-          doors_values[-1][:wall_idref] = new_idref
-        else # Move to a FoundationWall
-          new_idref = "FoundationWall#{i}"
-          area_adjustments << [doors_values[-1][:wall_idref], new_idref, doors_values[-1][:area]]
-          doors_values[-1][:wall_idref] = new_idref
-        end
       end
-    end
-    # Moved subsurface; preserve original net wall areas
-    area_adjustments.each do |area_adjustment|
-      update_areas(area_adjustment[0], area_adjustment[1], area_adjustment[2], walls_values, foundation_walls_values)
     end
   end
   return doors_values
@@ -3131,14 +3101,4 @@ def get_hpxml_file_misc_load_schedule_values(hpxml_file, misc_load_schedule_valu
                                   :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0" }
   end
   return misc_load_schedule_values
-end
-
-def update_areas(old_idref, new_idref, area, walls_values1, walls_values2)
-  (walls_values1 + walls_values2).each do |walls_values|
-    if walls_values[:id] == old_idref
-      walls_values[:area] -= area
-    elsif walls_values[:id] == new_idref
-      walls_values[:area] += area
-    end
-  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1076,6 +1076,7 @@ def get_hpxml_file_walls_values(hpxml_file, walls_values)
     walls_values[-1][:area] *= 0.65
     walls_values[-1][:id] += "Adiabatic"
     walls_values[-1][:exterior_adjacent_to] = "other housing unit"
+    walls_values[-1][:insulation_assembly_r_value] = 4
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..walls_values.size
       walls_values[n - 1][:area] /= 10.0

--- a/Rakefile
+++ b/Rakefile
@@ -1072,8 +1072,8 @@ def get_hpxml_file_walls_values(hpxml_file, walls_values)
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
     walls_values.delete_at(1)
     walls_values << walls_values[0].dup
-    walls_values[0][:area] *= 0.25
-    walls_values[-1][:area] *= 0.75
+    walls_values[0][:area] *= 0.35
+    walls_values[-1][:area] *= 0.65
     walls_values[-1][:id] += "Adiabatic"
     walls_values[-1][:exterior_adjacent_to] = "other housing unit"
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file

--- a/Rakefile
+++ b/Rakefile
@@ -906,7 +906,7 @@ def get_hpxml_file_rim_joists_values(hpxml_file, rim_joists_values)
                            :area => 81,
                            :solar_absorptance => 0.7,
                            :emittance => 0.92,
-                           :insulation_assembly_r_value => 23.0 }
+                           :insulation_assembly_r_value => 2.3 }
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
     rim_joists_values << { :id => "RimJoist2ndStory",
                            :exterior_adjacent_to => "outside",

--- a/Rakefile
+++ b/Rakefile
@@ -477,9 +477,9 @@ def create_hpxmls
         foundation_walls_values = get_hpxml_file_foundation_walls_values(hpxml_file, foundation_walls_values)
         framefloors_values = get_hpxml_file_framefloors_values(hpxml_file, framefloors_values)
         slabs_values = get_hpxml_file_slabs_values(hpxml_file, slabs_values)
-        windows_values = get_hpxml_file_windows_values(hpxml_file, windows_values, walls_values, foundation_walls_values)
+        windows_values = get_hpxml_file_windows_values(hpxml_file, windows_values)
         skylights_values = get_hpxml_file_skylights_values(hpxml_file, skylights_values)
-        doors_values = get_hpxml_file_doors_values(hpxml_file, doors_values, walls_values, foundation_walls_values)
+        doors_values = get_hpxml_file_doors_values(hpxml_file, doors_values)
         heating_systems_values = get_hpxml_file_heating_systems_values(hpxml_file, heating_systems_values)
         cooling_systems_values = get_hpxml_file_cooling_systems_values(hpxml_file, cooling_systems_values)
         heat_pumps_values = get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
@@ -1433,7 +1433,7 @@ def get_hpxml_file_slabs_values(hpxml_file, slabs_values)
   return slabs_values
 end
 
-def get_hpxml_file_windows_values(hpxml_file, windows_values, walls_values, foundation_walls_values)
+def get_hpxml_file_windows_values(hpxml_file, windows_values)
   if ['base.xml'].include? hpxml_file
     windows_values = [{ :id => "WindowNorth",
                         :area => 54,
@@ -1604,7 +1604,7 @@ def get_hpxml_file_skylights_values(hpxml_file, skylights_values)
   return skylights_values
 end
 
-def get_hpxml_file_doors_values(hpxml_file, doors_values, walls_values, foundation_walls_values)
+def get_hpxml_file_doors_values(hpxml_file, doors_values)
   if ['base.xml'].include? hpxml_file
     doors_values = [{ :id => "DoorNorth",
                       :wall_idref => "Wall",

--- a/Rakefile
+++ b/Rakefile
@@ -130,6 +130,7 @@ def create_hpxmls
     'base-enclosure-no-natural-ventilation.xml' => 'base.xml',
     'base-enclosure-overhangs.xml' => 'base.xml',
     'base-enclosure-skylights.xml' => 'base.xml',
+    'base-enclosure-split-surfaces.xml' => 'base-enclosure-skylights.xml',
     'base-enclosure-walltype-cmu.xml' => 'base.xml',
     'base-enclosure-walltype-doublestud.xml' => 'base.xml',
     'base-enclosure-walltype-icf.xml' => 'base.xml',
@@ -859,6 +860,14 @@ def get_hpxml_file_roofs_values(hpxml_file, roofs_values)
                       :insulation_assembly_r_value => 2.3 }
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
     roofs_values = []
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..roofs_values.size
+      roofs_values[n - 1][:area] /= 10.0
+      for i in 2..10
+        roofs_values << roofs_values[n - 1].dup
+        roofs_values[-1][:id] += i.to_s
+      end
+    end
   end
   return roofs_values
 end
@@ -906,6 +915,14 @@ def get_hpxml_file_rim_joists_values(hpxml_file, rim_joists_values)
                            :solar_absorptance => 0.7,
                            :emittance => 0.92,
                            :insulation_assembly_r_value => 23.0 }
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..rim_joists_values.size
+      rim_joists_values[n - 1][:area] /= 10.0
+      for i in 2..10
+        rim_joists_values << rim_joists_values[n - 1].dup
+        rim_joists_values[-1][:id] += i.to_s
+      end
+    end
   end
   return rim_joists_values
 end
@@ -1059,6 +1076,14 @@ def get_hpxml_file_walls_values(hpxml_file, walls_values)
     walls_values[-1][:area] *= 0.75
     walls_values[-1][:id] += "Adiabatic"
     walls_values[-1][:exterior_adjacent_to] = "other housing unit"
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..walls_values.size
+      walls_values[n - 1][:area] /= 10.0
+      for i in 2..10
+        walls_values << walls_values[n - 1].dup
+        walls_values[-1][:id] += i.to_s
+      end
+    end
   end
   return walls_values
 end
@@ -1191,6 +1216,14 @@ def get_hpxml_file_foundation_walls_values(hpxml_file, foundation_walls_values)
                                  :depth_below_grade => 3,
                                  :insulation_distance_to_bottom => 4,
                                  :insulation_r_value => 8.9 }]
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..foundation_walls_values.size
+      foundation_walls_values[n - 1][:area] /= 10.0
+      for i in 2..10
+        foundation_walls_values << foundation_walls_values[n - 1].dup
+        foundation_walls_values[-1][:id] += i.to_s
+      end
+    end
   end
   return foundation_walls_values
 end
@@ -1263,6 +1296,14 @@ def get_hpxml_file_framefloors_values(hpxml_file, framefloors_values)
                             :interior_adjacent_to => "living space",
                             :area => 1350,
                             :insulation_assembly_r_value => 2.1 }]
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..framefloors_values.size
+      framefloors_values[n - 1][:area] /= 10.0
+      for i in 2..10
+        framefloors_values << framefloors_values[n - 1].dup
+        framefloors_values[-1][:id] += i.to_s
+      end
+    end
   end
   return framefloors_values
 end
@@ -1378,6 +1419,15 @@ def get_hpxml_file_slabs_values(hpxml_file, slabs_values)
                       :under_slab_insulation_r_value => 0,
                       :carpet_fraction => 0,
                       :carpet_r_value => 0 }]
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..slabs_values.size
+      slabs_values[n - 1][:area] /= 10.0
+      slabs_values[n - 1][:exposed_perimeter] /= 10.0
+      for i in 2..10
+        slabs_values << slabs_values[n - 1].dup
+        slabs_values[-1][:id] += i.to_s
+      end
+    end
   end
   return slabs_values
 end
@@ -1508,6 +1558,15 @@ def get_hpxml_file_windows_values(hpxml_file, windows_values)
                         :wall_idref => "FoundationWall" }
   elsif ['invalid_files/unattached-window.xml'].include? hpxml_file
     windows_values[0][:wall_idref] = "foobar"
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..windows_values.size
+      windows_values[n - 1][:area] /= 10.0
+      for i in 2..10
+        windows_values << windows_values[n - 1].dup
+        windows_values[-1][:id] += i.to_s
+        windows_values[-1][:wall_idref] += i.to_s
+      end
+    end
   end
   return windows_values
 end
@@ -1530,6 +1589,15 @@ def get_hpxml_file_skylights_values(hpxml_file, skylights_values)
     skylights_values[0][:area] = 4000
   elsif ['invalid_files/unattached-skylight.xml'].include? hpxml_file
     skylights_values[0][:roof_idref] = "foobar"
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..skylights_values.size
+      skylights_values[n - 1][:area] /= 10.0
+      for i in 2..10
+        skylights_values << skylights_values[n - 1].dup
+        skylights_values[-1][:id] += i.to_s
+        skylights_values[-1][:roof_idref] += i.to_s
+      end
+    end
   end
   return skylights_values
 end
@@ -1555,6 +1623,15 @@ def get_hpxml_file_doors_values(hpxml_file, doors_values)
                       :r_value => 4.4 }
   elsif ['invalid_files/unattached-door.xml'].include? hpxml_file
     doors_values[0][:wall_idref] = "foobar"
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..doors_values.size
+      doors_values[n - 1][:area] /= 10.0
+      for i in 2..10
+        doors_values << doors_values[n - 1].dup
+        doors_values[-1][:id] += i.to_s
+        doors_values[-1][:wall_idref] += i.to_s
+      end
+    end
   end
   return doors_values
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1564,7 +1564,7 @@ def get_hpxml_file_windows_values(hpxml_file, windows_values)
       for i in 2..10
         windows_values << windows_values[n - 1].dup
         windows_values[-1][:id] += i.to_s
-        windows_values[-1][:wall_idref] += i.to_s
+        windows_values[-1][:wall_idref] += i.to_s if i % 2 == 0
       end
     end
   end
@@ -1595,7 +1595,7 @@ def get_hpxml_file_skylights_values(hpxml_file, skylights_values)
       for i in 2..10
         skylights_values << skylights_values[n - 1].dup
         skylights_values[-1][:id] += i.to_s
-        skylights_values[-1][:roof_idref] += i.to_s
+        skylights_values[-1][:roof_idref] += i.to_s if i % 2 == 0
       end
     end
   end
@@ -1629,7 +1629,7 @@ def get_hpxml_file_doors_values(hpxml_file, doors_values)
       for i in 2..10
         doors_values << doors_values[n - 1].dup
         doors_values[-1][:id] += i.to_s
-        doors_values[-1][:wall_idref] += i.to_s
+        doors_values[-1][:wall_idref] += i.to_s if i % 2 == 0
       end
     end
   end

--- a/measure.rb
+++ b/measure.rb
@@ -988,7 +988,9 @@ class OSModel
   def self.net_surface_area(gross_area, surface_id, azimuth, surface_type)
     net_area = gross_area
     if not @subsurface_areas_by_surface[surface_id].nil?
-      if not @subsurface_areas_by_surface[surface_id][azimuth].nil?
+      if azimuth.nil?
+        net_area -= @subsurface_areas_by_surface[surface_id].values.inject(:+)
+      elsif not @subsurface_areas_by_surface[surface_id][azimuth].nil?
         net_area -= @subsurface_areas_by_surface[surface_id][azimuth]
       end
     end
@@ -1013,7 +1015,7 @@ class OSModel
     if num_occ > 0
       occ_gain, hrs_per_day, sens_frac, lat_frac = Geometry.get_occupancy_default_values()
       weekday_sch = "1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 0.88310, 0.40861, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.29498, 0.55310, 0.89693, 0.89693, 0.89693, 1.00000, 1.00000, 1.00000" # TODO: Normalize schedule based on hrs_per_day
-      weekday_sch_sum = weekday_sch.split(",").map(&:to_f).inject { |sum, n| sum + n }
+      weekday_sch_sum = weekday_sch.split(",").map(&:to_f).inject(:+)
       if (weekday_sch_sum - hrs_per_day).abs > 0.1
         runner.registerError("Occupancy schedule inconsistent with hrs_per_day.")
         return false
@@ -1435,9 +1437,9 @@ class OSModel
         slab_exp_perims[slab] = slab_values[:exposed_perimeter]
         slab_areas[slab] = slab_values[:area]
       end
-      total_slab_exp_perim = slab_exp_perims.values.inject(0, :+)
-      total_slab_area = slab_areas.values.inject(0, :+)
-      total_fnd_wall_length = fnd_wall_lengths.values.inject(0, :+)
+      total_slab_exp_perim = slab_exp_perims.values.inject(:+)
+      total_slab_area = slab_areas.values.inject(:+)
+      total_fnd_wall_length = fnd_wall_lengths.values.inject(:+)
 
       no_wall_slab_exp_perim = {}
 
@@ -2868,7 +2870,7 @@ class OSModel
     medium_cfm = 3000.0
     weekday_sch = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
     weekend_sch = weekday_sch
-    hrs_per_day = weekday_sch.inject { |sum, n| sum + n }
+    hrs_per_day = weekday_sch.inject(:+)
 
     cfm_per_w = ceiling_fan_values[:efficiency]
     if cfm_per_w.nil?

--- a/measure.rb
+++ b/measure.rb
@@ -989,7 +989,7 @@ class OSModel
     net_area = gross_area
     if not @subsurface_areas_by_surface[surface_id].nil?
       if azimuth.nil?
-        net_area -= @subsurface_areas_by_surface[surface_id].values.inject(:+)
+        net_area -= @subsurface_areas_by_surface[surface_id].values.inject(0, :+)
       elsif not @subsurface_areas_by_surface[surface_id][azimuth].nil?
         net_area -= @subsurface_areas_by_surface[surface_id][azimuth]
       end
@@ -1015,7 +1015,7 @@ class OSModel
     if num_occ > 0
       occ_gain, hrs_per_day, sens_frac, lat_frac = Geometry.get_occupancy_default_values()
       weekday_sch = "1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 0.88310, 0.40861, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.29498, 0.55310, 0.89693, 0.89693, 0.89693, 1.00000, 1.00000, 1.00000" # TODO: Normalize schedule based on hrs_per_day
-      weekday_sch_sum = weekday_sch.split(",").map(&:to_f).inject(:+)
+      weekday_sch_sum = weekday_sch.split(",").map(&:to_f).inject(0, :+)
       if (weekday_sch_sum - hrs_per_day).abs > 0.1
         runner.registerError("Occupancy schedule inconsistent with hrs_per_day.")
         return false
@@ -1437,9 +1437,9 @@ class OSModel
         slab_exp_perims[slab] = slab_values[:exposed_perimeter]
         slab_areas[slab] = slab_values[:area]
       end
-      total_slab_exp_perim = slab_exp_perims.values.inject(:+)
-      total_slab_area = slab_areas.values.inject(:+)
-      total_fnd_wall_length = fnd_wall_lengths.values.inject(:+)
+      total_slab_exp_perim = slab_exp_perims.values.inject(0, :+)
+      total_slab_area = slab_areas.values.inject(0, :+)
+      total_fnd_wall_length = fnd_wall_lengths.values.inject(0, :+)
 
       no_wall_slab_exp_perim = {}
 
@@ -2870,7 +2870,7 @@ class OSModel
     medium_cfm = 3000.0
     weekday_sch = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
     weekend_sch = weekday_sch
-    hrs_per_day = weekday_sch.inject(:+)
+    hrs_per_day = weekday_sch.inject(0, :+)
 
     cfm_per_w = ceiling_fan_values[:efficiency]
     if cfm_per_w.nil?

--- a/measure.rb
+++ b/measure.rb
@@ -763,7 +763,7 @@ class OSModel
         else
           vf = vf_map_cb[from_surface][to_surface]
         end
-        next if vf < 0.01 # TODO: Review
+        next if vf < 0.01 # TODO: Remove this when https://github.com/NREL/OpenStudio/issues/3737 is resolved
 
         os_vf = OpenStudio::Model::ViewFactor.new(from_surface, to_surface, vf)
         zone_prop = @living_zone.getZonePropertyUserViewFactorsBySurfaceName

--- a/measure.rb
+++ b/measure.rb
@@ -985,10 +985,12 @@ class OSModel
     return OpenStudio::reverse(add_floor_polygon(x, y, z))
   end
 
-  def self.net_surface_area(gross_area, surface_id, surface_type)
+  def self.net_surface_area(gross_area, surface_id, azimuth, surface_type)
     net_area = gross_area
-    if @subsurface_areas_by_surface.keys.include? surface_id
-      net_area -= @subsurface_areas_by_surface[surface_id]
+    if not @subsurface_areas_by_surface[surface_id].nil?
+      if not @subsurface_areas_by_surface[surface_id][azimuth].nil?
+        net_area -= @subsurface_areas_by_surface[surface_id][azimuth]
+      end
     end
 
     if net_area < 0
@@ -1027,7 +1029,7 @@ class OSModel
 
   def self.calc_subsurface_areas_by_surface(building)
     # Returns a hash with the amount of subsurface (window/skylight/door)
-    # area for each surface. Used to convert gross surface area to net surface
+    # area by azimuth for each surface. Used to convert gross surface area to net surface
     # area for a given surface.
     subsurface_areas = {}
 
@@ -1035,24 +1037,30 @@ class OSModel
     building.elements.each("BuildingDetails/Enclosure/Windows/Window") do |window|
       window_values = HPXML.get_window_values(window: window)
       wall_id = window_values[:wall_idref]
-      subsurface_areas[wall_id] = 0.0 if subsurface_areas[wall_id].nil?
-      subsurface_areas[wall_id] += window_values[:area]
+      azimuth = window_values[:azimuth]
+      subsurface_areas[wall_id] = {} if subsurface_areas[wall_id].nil?
+      subsurface_areas[wall_id][azimuth] = 0 if subsurface_areas[wall_id][azimuth].nil?
+      subsurface_areas[wall_id][azimuth] += window_values[:area]
     end
 
     # Skylights
     building.elements.each("BuildingDetails/Enclosure/Skylights/Skylight") do |skylight|
       skylight_values = HPXML.get_skylight_values(skylight: skylight)
       roof_id = skylight_values[:roof_idref]
-      subsurface_areas[roof_id] = 0.0 if subsurface_areas[roof_id].nil?
-      subsurface_areas[roof_id] += skylight_values[:area]
+      azimuth = skylight_values[:azimuth]
+      subsurface_areas[roof_id] = {} if subsurface_areas[roof_id].nil?
+      subsurface_areas[roof_id][azimuth] = 0 if subsurface_areas[roof_id][azimuth].nil?
+      subsurface_areas[roof_id][azimuth] += skylight_values[:area]
     end
 
     # Doors
     building.elements.each("BuildingDetails/Enclosure/Doors/Door") do |door|
       door_values = HPXML.get_door_values(door: door)
       wall_id = door_values[:wall_idref]
-      subsurface_areas[wall_id] = 0.0 if subsurface_areas[wall_id].nil?
-      subsurface_areas[wall_id] += door_values[:area]
+      azimuth = door_values[:azimuth]
+      subsurface_areas[wall_id] = {} if subsurface_areas[wall_id].nil?
+      subsurface_areas[wall_id][azimuth] = 0 if subsurface_areas[wall_id][azimuth].nil?
+      subsurface_areas[wall_id][azimuth] += door_values[:area]
     end
 
     return subsurface_areas
@@ -1060,7 +1068,7 @@ class OSModel
 
   def self.get_default_azimuths(building)
     azimuth_counts = {}
-    building.elements.each("BuildingDetails/Enclosure//Azimuth") do |azimuth|
+    building.elements.each("BuildingDetails/Enclosure/*/*/Azimuth") do |azimuth|
       az = Integer(azimuth.text)
       azimuth_counts[az] = 0 if azimuth_counts[az].nil?
       azimuth_counts[az] += 1
@@ -1111,11 +1119,11 @@ class OSModel
       surfaces = []
 
       azimuths.each do |azimuth|
-        net_area = net_surface_area(roof_values[:area], roof_values[:id], "Roof")
+        net_area = net_surface_area(roof_values[:area] / azimuths.size, roof_values[:id], azimuth, "Roof")
         next if net_area < 0.1
 
         width = Math::sqrt(net_area)
-        length = (net_area / width) / azimuths.size
+        length = net_area / width
         tilt = roof_values[:pitch] / 12.0
         z_origin = @walls_top + 0.5 * Math.sin(Math.atan(tilt)) * width
 
@@ -1200,11 +1208,11 @@ class OSModel
       surfaces = []
 
       azimuths.each do |azimuth|
-        net_area = net_surface_area(wall_values[:area], wall_values[:id], "Wall")
+        net_area = net_surface_area(wall_values[:area] / azimuths.size, wall_values[:id], azimuth, "Wall")
         next if net_area < 0.1
 
         height = 8.0 * @ncfl_ag
-        length = (net_area / height) / azimuths.size
+        length = net_area / height
         z_origin = @foundation_top
 
         surface = OpenStudio::Model::Surface.new(add_wall_polygon(length, height, z_origin, azimuth), model)
@@ -1500,7 +1508,7 @@ class OSModel
         next unless fnd_wall_values[:exterior_adjacent_to] != "ground"
 
         ag_height = fnd_wall_values[:height] - fnd_wall_values[:depth_below_grade]
-        ag_net_area = net_surface_area(fnd_wall_values[:area], fnd_wall_values[:id], "Wall") * ag_height / fnd_wall_values[:height]
+        ag_net_area = net_surface_area(fnd_wall_values[:area], fnd_wall_values[:id], fnd_wall_values[:azimuth], "Wall") * ag_height / fnd_wall_values[:height]
         next if ag_net_area < 0.1
 
         length = ag_net_area / ag_height
@@ -1548,7 +1556,7 @@ class OSModel
   def self.add_foundation_wall(runner, model, spaces, fnd_wall_values, slab_frac,
                                total_fnd_wall_length, total_slab_exp_perim, kiva_foundation)
 
-    net_area = net_surface_area(fnd_wall_values[:area], fnd_wall_values[:id], "Wall") * slab_frac
+    net_area = net_surface_area(fnd_wall_values[:area], fnd_wall_values[:id], fnd_wall_values[:azimuth], "Wall") * slab_frac
     gross_area = fnd_wall_values[:area] * slab_frac
     height = fnd_wall_values[:height]
     height_ag = height - fnd_wall_values[:depth_below_grade]

--- a/measure.rb
+++ b/measure.rb
@@ -223,10 +223,6 @@ end
 
 class OSModel
   def self.create(hpxml_doc, runner, model, weather, map_tsv_dir)
-    # Simulation parameters
-    success = add_simulation_params(runner, model)
-    return false if not success
-
     hpxml = hpxml_doc.elements["HPXML"]
     hpxml_values = HPXML.get_hpxml_values(hpxml: hpxml)
     building = hpxml_doc.elements["/HPXML/Building"]
@@ -234,6 +230,9 @@ class OSModel
 
     @eri_version = hpxml_values[:eri_calculation_version]
     fail "Could not find ERI Version" if @eri_version.nil?
+
+    success = collapse_like_surfaces(enclosure)
+    return false if not success
 
     # Global variables
     construction_values = HPXML.get_building_construction_values(building_construction: building.elements["BuildingDetails/BuildingSummary/BuildingConstruction"])
@@ -272,6 +271,11 @@ class OSModel
     if not construction_values[:use_only_ideal_air_system].nil?
       @use_only_ideal_air = construction_values[:use_only_ideal_air_system]
     end
+
+    # Simulation parameters
+
+    success = add_simulation_params(runner, model)
+    return false if not success
 
     # Geometry/Envelope
 
@@ -341,6 +345,120 @@ class OSModel
   end
 
   private
+
+  def self.collapse_like_surfaces(enclosure)
+    # Collapses like surfaces into a single surface with, e.g.,
+    # aggregate surface area.
+    surf_types = ['Roofs/Roof',
+                  'Walls/Wall',
+                  'RimJoists/RimJoist',
+                  'FoundationWalls/FoundationWall',
+                  'FrameFloors/FrameFloor',
+                  'Slabs/Slab']
+
+    subsurf_types = ['Windows/Window',
+                     'Skylights/Skylight',
+                     'Doors/Door']
+
+    keys_to_ignore = [:id,
+                      :insulation_id,
+                      :perimeter_insulation_id,
+                      :under_slab_insulation_id,
+                      :area,
+                      :exposed_perimeter]
+
+    # Populate surf_type_values
+    surf_type_values = {} # Surface values (hashes)
+    surfs = {} # Surface objects
+    (surf_types + subsurf_types).each do |surf_type|
+      surf_type_values[surf_type] = []
+      enclosure.elements.each(surf_type) do |surf|
+        if surf_type == 'Roofs/Roof'
+          surf_type_values[surf_type] << HPXML.get_roof_values(roof: surf)
+        elsif surf_type == 'Walls/Wall'
+          surf_type_values[surf_type] << HPXML.get_wall_values(wall: surf)
+        elsif surf_type == 'RimJoists/RimJoist'
+          surf_type_values[surf_type] << HPXML.get_rim_joist_values(rim_joist: surf)
+        elsif surf_type == 'FoundationWalls/FoundationWall'
+          surf_type_values[surf_type] << HPXML.get_foundation_wall_values(foundation_wall: surf)
+        elsif surf_type == 'FrameFloors/FrameFloor'
+          surf_type_values[surf_type] << HPXML.get_framefloor_values(framefloor: surf)
+        elsif surf_type == 'Slabs/Slab'
+          surf_type_values[surf_type] << HPXML.get_slab_values(slab: surf)
+        elsif surf_type == 'Windows/Window'
+          surf_type_values[surf_type] << HPXML.get_window_values(window: surf)
+        elsif surf_type == 'Skylights/Skylight'
+          surf_type_values[surf_type] << HPXML.get_skylight_values(skylight: surf)
+        elsif surf_type == 'Doors/Door'
+          surf_type_values[surf_type] << HPXML.get_door_values(door: surf)
+        end
+        surfs[surf_type_values[surf_type][-1][:id]] = surf
+      end
+    end
+
+    # Look for pairs of surfaces that can be collapsed
+    (surf_types + subsurf_types).each do |surf_type|
+      for i in 0..surf_type_values[surf_type].size - 1
+        surf_values = surf_type_values[surf_type][i]
+        next if surf_values.nil?
+
+        surf = surfs[surf_values[:id]]
+
+        for j in (surf_type_values[surf_type].size - 1).downto(i + 1)
+          surf_values2 = surf_type_values[surf_type][j]
+          next if surf_values2.nil?
+
+          surf2 = surfs[surf_values2[:id]]
+
+          next if surf_values.nil? or surf_values2.nil?
+          next unless surf_values.keys.sort == surf_values2.keys.sort
+
+          match = true
+          surf_values.keys.each do |key|
+            next if keys_to_ignore.include? key
+            next if surf_type == 'FoundationWalls/FoundationWall' and key == :azimuth # Azimuth of foundation walls is irrelevant
+            next if surf_values[key] == surf_values2[key]
+
+            match = false
+          end
+          next unless match
+
+          # Update Area/ExposedPerimeter
+          if not surf_values[:area].nil?
+            surf_values[:area] += surf_values2[:area]
+            surf.elements["Area"].text = surf_values[:area]
+          end
+          if not surf_values[:exposed_perimeter].nil?
+            surf_values[:exposed_perimeter] += surf_values2[:exposed_perimeter]
+            surf.elements["ExposedPerimeter"].text = surf_values[:exposed_perimeter]
+          end
+
+          # Update subsurface idrefs as appropriate
+          if surf_types.include? surf_type
+            subsurf_types.each do |subsurf_type|
+              surf_type_values[subsurf_type].each do |subsurf_values|
+                subsurf = surfs[subsurf_values[:id]]
+                if subsurf_values[:wall_idref] == surf_values2[:id]
+                  subsurf_values[:wall_idref] = surf_values[:id]
+                  subsurf.elements["AttachedToWall"].attributes["idref"] = surf_values[:id]
+                end
+                if subsurf_values[:roof_idref] == surf_values2[:id]
+                  subsurf_values[:roof_idref] = surf_values[:id]
+                  subsurf.elements["AttachedToRoof"].attributes["idref"] = surf_values[:id]
+                end
+              end
+            end
+          end
+
+          # Remove old surface
+          surf2.parent.elements.delete surf2
+          surf_type_values[surf_type].delete_at(j)
+        end
+      end
+    end
+
+    return true
+  end
 
   def self.add_simulation_params(runner, model)
     sim = model.getSimulationControl

--- a/resources/hpxml.rb
+++ b/resources/hpxml.rb
@@ -273,8 +273,6 @@ class HPXML
               surf_type_values[surf_type][-1][:exterior_adjacent_to] = parent_surf_values[:exterior_adjacent_to]
             end
           end
-          fail "Could not obtain parent surface interior adjacent to." if surf_type_values[surf_type][-1][:interior_adjacent_to].nil?
-          fail "Could not obtain parent surface exterior adjacent to." if surf_type_values[surf_type][-1][:exterior_adjacent_to].nil?
         end
 
         surfs[surf_type_values[surf_type][-1][:id]] = surf

--- a/resources/hpxml.rb
+++ b/resources/hpxml.rb
@@ -257,6 +257,26 @@ class HPXML
         elsif surf_type == 'Door'
           surf_type_values[surf_type] << HPXML.get_door_values(door: surf)
         end
+
+        # Add parent wall/roof AdjacentTo values to hash so that they're included in the logic
+        # regarding whether a pair of surfaces can be collapsed.
+        if ['Window', 'Skylight', 'Door'].include? surf_type
+          parent_id = surf_type_values[surf_type][-1][:wall_idref]
+          if parent_id.nil?
+            parent_id = surf_type_values[surf_type][-1][:roof_idref]
+          end
+          ['Wall', 'FoundationWall', 'Roof'].each do |parent_surf_type|
+            surf_type_values[parent_surf_type].each do |parent_surf_values|
+              next unless parent_surf_values[:id] == parent_id
+
+              surf_type_values[surf_type][-1][:interior_adjacent_to] = parent_surf_values[:interior_adjacent_to]
+              surf_type_values[surf_type][-1][:exterior_adjacent_to] = parent_surf_values[:exterior_adjacent_to]
+            end
+          end
+          fail "Could not obtain parent surface interior adjacent to." if surf_type_values[surf_type][-1][:interior_adjacent_to].nil?
+          fail "Could not obtain parent surface exterior adjacent to." if surf_type_values[surf_type][-1][:exterior_adjacent_to].nil?
+        end
+
         surfs[surf_type_values[surf_type][-1][:id]] = surf
       end
     end

--- a/tests/base-enclosure-adiabatic-surfaces.xml
+++ b/tests/base-enclosure-adiabatic-surfaces.xml
@@ -85,7 +85,7 @@
             <Emittance>0.92</Emittance>
             <Insulation>
               <SystemIdentifier id='WallAdiabaticInsulation'/>
-              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
         </Walls>

--- a/tests/base-enclosure-adiabatic-surfaces.xml
+++ b/tests/base-enclosure-adiabatic-surfaces.xml
@@ -65,7 +65,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>300.0</Area>
+            <Area>420.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -80,7 +80,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>900.0</Area>
+            <Area>780.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>

--- a/tests/base-enclosure-split-surfaces.xml
+++ b/tests/base-enclosure-split-surfaces.xml
@@ -379,7 +379,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>94.0</Area>
+            <Area>120.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -394,7 +394,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>94.0</Area>
+            <Area>120.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -409,7 +409,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>94.0</Area>
+            <Area>120.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -424,7 +424,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>94.0</Area>
+            <Area>120.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -439,7 +439,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>94.0</Area>
+            <Area>120.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -454,7 +454,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>94.0</Area>
+            <Area>120.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -469,7 +469,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>94.0</Area>
+            <Area>120.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -514,7 +514,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>55.0</Area>
+            <Area>29.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -529,7 +529,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>55.0</Area>
+            <Area>29.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -544,7 +544,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>55.0</Area>
+            <Area>29.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -721,7 +721,7 @@
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>146.0</Area>
+            <Area>120.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
@@ -738,7 +738,7 @@
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>146.0</Area>
+            <Area>120.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
@@ -755,7 +755,7 @@
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>146.0</Area>
+            <Area>120.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
@@ -772,7 +772,7 @@
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>146.0</Area>
+            <Area>120.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
@@ -1214,7 +1214,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable4'/>
+            <AttachedToWall idref='Wall4'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth5'/>
@@ -1222,7 +1222,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable5'/>
+            <AttachedToWall idref='Wall5'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth6'/>
@@ -1230,7 +1230,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable6'/>
+            <AttachedToWall idref='Wall6'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth7'/>
@@ -1238,7 +1238,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall7'/>
+            <AttachedToWall idref='Wall7'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth8'/>
@@ -1246,7 +1246,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall8'/>
+            <AttachedToWall idref='Wall8'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth9'/>
@@ -1254,7 +1254,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall9'/>
+            <AttachedToWall idref='Wall9'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth10'/>
@@ -1262,7 +1262,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall10'/>
+            <AttachedToWall idref='Wall10'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth2'/>
@@ -1286,7 +1286,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable4'/>
+            <AttachedToWall idref='Wall4'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth5'/>
@@ -1294,7 +1294,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable5'/>
+            <AttachedToWall idref='Wall5'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth6'/>
@@ -1302,7 +1302,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable6'/>
+            <AttachedToWall idref='Wall6'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth7'/>
@@ -1310,7 +1310,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall7'/>
+            <AttachedToWall idref='Wall7'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth8'/>
@@ -1318,7 +1318,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall8'/>
+            <AttachedToWall idref='Wall8'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth9'/>
@@ -1326,7 +1326,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall9'/>
+            <AttachedToWall idref='Wall9'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth10'/>
@@ -1334,7 +1334,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall10'/>
+            <AttachedToWall idref='Wall10'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast2'/>
@@ -1358,7 +1358,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable4'/>
+            <AttachedToWall idref='Wall4'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast5'/>
@@ -1366,7 +1366,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable5'/>
+            <AttachedToWall idref='Wall5'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast6'/>
@@ -1374,7 +1374,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable6'/>
+            <AttachedToWall idref='Wall6'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast7'/>
@@ -1382,7 +1382,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall7'/>
+            <AttachedToWall idref='Wall7'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast8'/>
@@ -1390,7 +1390,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall8'/>
+            <AttachedToWall idref='Wall8'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast9'/>
@@ -1398,7 +1398,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall9'/>
+            <AttachedToWall idref='Wall9'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast10'/>
@@ -1406,7 +1406,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall10'/>
+            <AttachedToWall idref='Wall10'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest2'/>
@@ -1430,7 +1430,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable4'/>
+            <AttachedToWall idref='Wall4'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest5'/>
@@ -1438,7 +1438,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable5'/>
+            <AttachedToWall idref='Wall5'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest6'/>
@@ -1446,7 +1446,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='WallAtticGable6'/>
+            <AttachedToWall idref='Wall6'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest7'/>
@@ -1454,7 +1454,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall7'/>
+            <AttachedToWall idref='Wall7'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest8'/>
@@ -1462,7 +1462,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall8'/>
+            <AttachedToWall idref='Wall8'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest9'/>
@@ -1470,7 +1470,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall9'/>
+            <AttachedToWall idref='Wall9'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest10'/>
@@ -1478,7 +1478,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='FoundationWall10'/>
+            <AttachedToWall idref='Wall10'/>
           </Window>
         </Windows>
         <Skylights>
@@ -1674,49 +1674,49 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth4'/>
-            <AttachedToWall idref='WallAtticGable4'/>
+            <AttachedToWall idref='Wall4'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth5'/>
-            <AttachedToWall idref='WallAtticGable5'/>
+            <AttachedToWall idref='Wall5'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth6'/>
-            <AttachedToWall idref='WallAtticGable6'/>
+            <AttachedToWall idref='Wall6'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth7'/>
-            <AttachedToWall idref='FoundationWall7'/>
+            <AttachedToWall idref='Wall7'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth8'/>
-            <AttachedToWall idref='FoundationWall8'/>
+            <AttachedToWall idref='Wall8'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth9'/>
-            <AttachedToWall idref='FoundationWall9'/>
+            <AttachedToWall idref='Wall9'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth10'/>
-            <AttachedToWall idref='FoundationWall10'/>
+            <AttachedToWall idref='Wall10'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
@@ -1737,49 +1737,49 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth4'/>
-            <AttachedToWall idref='WallAtticGable4'/>
+            <AttachedToWall idref='Wall4'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth5'/>
-            <AttachedToWall idref='WallAtticGable5'/>
+            <AttachedToWall idref='Wall5'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth6'/>
-            <AttachedToWall idref='WallAtticGable6'/>
+            <AttachedToWall idref='Wall6'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth7'/>
-            <AttachedToWall idref='FoundationWall7'/>
+            <AttachedToWall idref='Wall7'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth8'/>
-            <AttachedToWall idref='FoundationWall8'/>
+            <AttachedToWall idref='Wall8'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth9'/>
-            <AttachedToWall idref='FoundationWall9'/>
+            <AttachedToWall idref='Wall9'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth10'/>
-            <AttachedToWall idref='FoundationWall10'/>
+            <AttachedToWall idref='Wall10'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>

--- a/tests/base-enclosure-split-surfaces.xml
+++ b/tests/base-enclosure-split-surfaces.xml
@@ -1,0 +1,1981 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<HPXML xmlns='http://hpxmlonline.com/2019/10' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://hpxmlonline.com/2019/10' schemaVersion='3.0'>
+  <XMLTransactionHeaderInformation>
+    <XMLType>HPXML</XMLType>
+    <XMLGeneratedBy>Rakefile</XMLGeneratedBy>
+    <CreatedDateAndTime>2019-10-24T15:44:20-06:00</CreatedDateAndTime>
+    <Transaction>create</Transaction>
+  </XMLTransactionHeaderInformation>
+  <SoftwareInfo>
+    <extension>
+      <ERICalculation>
+        <Version>2014AEG</Version>
+      </ERICalculation>
+    </extension>
+  </SoftwareInfo>
+  <Building>
+    <BuildingID id='MyBuilding'/>
+    <ProjectStatus>
+      <EventType>proposed workscope</EventType>
+    </ProjectStatus>
+    <BuildingDetails>
+      <BuildingSummary>
+        <Site>
+          <FuelTypesAvailable>
+            <Fuel>electricity</Fuel>
+            <Fuel>natural gas</Fuel>
+          </FuelTypesAvailable>
+        </Site>
+        <BuildingConstruction>
+          <NumberofConditionedFloors>2</NumberofConditionedFloors>
+          <NumberofConditionedFloorsAboveGrade>1</NumberofConditionedFloorsAboveGrade>
+          <NumberofBedrooms>3</NumberofBedrooms>
+          <ConditionedFloorArea>2700.0</ConditionedFloorArea>
+          <ConditionedBuildingVolume>21600.0</ConditionedBuildingVolume>
+        </BuildingConstruction>
+      </BuildingSummary>
+      <ClimateandRiskZones>
+        <ClimateZoneIECC>
+          <Year>2006</Year>
+          <ClimateZone>5B</ClimateZone>
+        </ClimateZoneIECC>
+        <WeatherStation>
+          <SystemIdentifier id='WeatherStation'/>
+          <Name>Denver, CO</Name>
+          <WMO>725650</WMO>
+        </WeatherStation>
+      </ClimateandRiskZones>
+      <Enclosure>
+        <AirInfiltration>
+          <AirInfiltrationMeasurement>
+            <SystemIdentifier id='InfiltrationMeasurement'/>
+            <HousePressure>50.0</HousePressure>
+            <BuildingAirLeakage>
+              <UnitofMeasure>ACH</UnitofMeasure>
+              <AirLeakage>3.0</AirLeakage>
+            </BuildingAirLeakage>
+            <InfiltrationVolume>21600.0</InfiltrationVolume>
+          </AirInfiltrationMeasurement>
+        </AirInfiltration>
+        <Roofs>
+          <Roof>
+            <SystemIdentifier id='Roof'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='RoofInsulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof2'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof2Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof3'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof3Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof4'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof4Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof5'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof5Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof6'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof6Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof7'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof7Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof8'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof8Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof9'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof9Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof10'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>151.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof10Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+        </Roofs>
+        <RimJoists>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundationInsulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation2'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation2Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation3'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation3Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation4'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation4Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation5'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation5Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation6'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation6Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation7'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation7Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation8'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation8Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation9'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation9Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation10'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>11.6</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundation10Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+        </RimJoists>
+        <Walls>
+          <Wall>
+            <SystemIdentifier id='Wall'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallInsulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGableInsulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall2'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall2Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall3'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall3Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall4'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall4Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall5'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall5Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall6'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall6Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall7'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall7Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall8'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall8Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall9'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall9Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall10'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>120.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall10Insulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable2'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable2Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable3'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable3Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable4'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable4Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable5'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable5Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable6'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable6Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable7'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable7Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable8'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable8Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable9'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable9Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable10'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>29.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGable10Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+        </Walls>
+        <FoundationWalls>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWallInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall2'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall2Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall3'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall3Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall4'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall4Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall5'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall5Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall6'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall6Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall7'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall7Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall8'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall8Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall9'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall9Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall10'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall10Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+        </FoundationWalls>
+        <FrameFloors>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAtticInsulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic2'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic2Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic3'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic3Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic4'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic4Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic5'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic5Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic6'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic6Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic7'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic7Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic8'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic8Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic9'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic9Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic10'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAttic10Insulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+        </FrameFloors>
+        <Slabs>
+          <Slab>
+            <SystemIdentifier id='Slab'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='SlabPerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='SlabUnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab2'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab2PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab2UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab3'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab3PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab3UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab4'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab4PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab4UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab5'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab5PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab5UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab6'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab6PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab6UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab7'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab7PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab7UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab8'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab8PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab8UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab9'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab9PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab9UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab10'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>135.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>15.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab10PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab10UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+        </Slabs>
+        <Windows>
+          <Window>
+            <SystemIdentifier id='WindowNorth'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth2'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall2'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth3'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth4'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall4'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth5'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall5'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth6'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall6'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth7'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall7'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth8'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall8'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth9'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall9'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowNorth10'/>
+            <Area>5.4</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall10'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth2'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall2'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth3'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth4'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall4'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth5'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall5'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth6'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall6'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth7'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall7'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth8'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall8'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth9'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall9'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth10'/>
+            <Area>5.4</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall10'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast2'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall2'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast3'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast4'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall4'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast5'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall5'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast6'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall6'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast7'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall7'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast8'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall8'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast9'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall9'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast10'/>
+            <Area>3.6</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall10'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest2'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall2'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest3'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest4'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall4'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest5'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall5'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest6'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall6'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest7'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall7'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest8'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall8'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest9'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall9'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest10'/>
+            <Area>3.6</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToWall idref='Wall10'/>
+          </Window>
+        </Windows>
+        <Skylights>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth2'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof2'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth3'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof3'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth4'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof4'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth5'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof5'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth6'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof6'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth7'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof7'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth8'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof8'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth9'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof9'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightNorth10'/>
+            <Area>1.5</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <AttachedToRoof idref='Roof10'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth2'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof2'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth3'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof3'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth4'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof4'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth5'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof5'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth6'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof6'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth7'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof7'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth8'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof8'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth9'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof9'/>
+          </Skylight>
+          <Skylight>
+            <SystemIdentifier id='SkylightSouth10'/>
+            <Area>1.5</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.35</UFactor>
+            <SHGC>0.47</SHGC>
+            <AttachedToRoof idref='Roof10'/>
+          </Skylight>
+        </Skylights>
+        <Doors>
+          <Door>
+            <SystemIdentifier id='DoorNorth'/>
+            <AttachedToWall idref='Wall'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth'/>
+            <AttachedToWall idref='Wall'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth2'/>
+            <AttachedToWall idref='Wall2'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth3'/>
+            <AttachedToWall idref='Wall3'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth4'/>
+            <AttachedToWall idref='Wall4'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth5'/>
+            <AttachedToWall idref='Wall5'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth6'/>
+            <AttachedToWall idref='Wall6'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth7'/>
+            <AttachedToWall idref='Wall7'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth8'/>
+            <AttachedToWall idref='Wall8'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth9'/>
+            <AttachedToWall idref='Wall9'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorNorth10'/>
+            <AttachedToWall idref='Wall10'/>
+            <Area>4.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth2'/>
+            <AttachedToWall idref='Wall2'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth3'/>
+            <AttachedToWall idref='Wall3'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth4'/>
+            <AttachedToWall idref='Wall4'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth5'/>
+            <AttachedToWall idref='Wall5'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth6'/>
+            <AttachedToWall idref='Wall6'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth7'/>
+            <AttachedToWall idref='Wall7'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth8'/>
+            <AttachedToWall idref='Wall8'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth9'/>
+            <AttachedToWall idref='Wall9'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth10'/>
+            <AttachedToWall idref='Wall10'/>
+            <Area>4.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+        </Doors>
+      </Enclosure>
+      <Systems>
+        <HVAC>
+          <HVACPlant>
+            <HeatingSystem>
+              <SystemIdentifier id='HeatingSystem'/>
+              <DistributionSystem idref='HVACDistribution'/>
+              <HeatingSystemType>
+                <Furnace/>
+              </HeatingSystemType>
+              <HeatingSystemFuel>natural gas</HeatingSystemFuel>
+              <HeatingCapacity>64000.0</HeatingCapacity>
+              <AnnualHeatingEfficiency>
+                <Units>AFUE</Units>
+                <Value>0.92</Value>
+              </AnnualHeatingEfficiency>
+              <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
+            </HeatingSystem>
+            <CoolingSystem>
+              <SystemIdentifier id='CoolingSystem'/>
+              <DistributionSystem idref='HVACDistribution'/>
+              <CoolingSystemType>central air conditioner</CoolingSystemType>
+              <CoolingSystemFuel>electricity</CoolingSystemFuel>
+              <CoolingCapacity>48000.0</CoolingCapacity>
+              <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
+              <AnnualCoolingEfficiency>
+                <Units>SEER</Units>
+                <Value>13.0</Value>
+              </AnnualCoolingEfficiency>
+            </CoolingSystem>
+          </HVACPlant>
+          <HVACControl>
+            <SystemIdentifier id='HVACControl'/>
+            <ControlType>manual thermostat</ControlType>
+          </HVACControl>
+          <HVACDistribution>
+            <SystemIdentifier id='HVACDistribution'/>
+            <DistributionSystemType>
+              <AirDistribution>
+                <DuctLeakageMeasurement>
+                  <DuctType>supply</DuctType>
+                  <DuctLeakage>
+                    <Units>CFM25</Units>
+                    <Value>75.0</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <DuctLeakageMeasurement>
+                  <DuctType>return</DuctType>
+                  <DuctLeakage>
+                    <Units>CFM25</Units>
+                    <Value>25.0</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <Ducts>
+                  <DuctType>supply</DuctType>
+                  <DuctInsulationRValue>4.0</DuctInsulationRValue>
+                  <DuctLocation>attic - unvented</DuctLocation>
+                  <DuctSurfaceArea>150.0</DuctSurfaceArea>
+                </Ducts>
+                <Ducts>
+                  <DuctType>return</DuctType>
+                  <DuctInsulationRValue>0.0</DuctInsulationRValue>
+                  <DuctLocation>attic - unvented</DuctLocation>
+                  <DuctSurfaceArea>50.0</DuctSurfaceArea>
+                </Ducts>
+              </AirDistribution>
+            </DistributionSystemType>
+          </HVACDistribution>
+        </HVAC>
+        <WaterHeating>
+          <WaterHeatingSystem>
+            <SystemIdentifier id='WaterHeater'/>
+            <FuelType>electricity</FuelType>
+            <WaterHeaterType>storage water heater</WaterHeaterType>
+            <Location>living space</Location>
+            <TankVolume>40.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <HeatingCapacity>18767.0</HeatingCapacity>
+            <EnergyFactor>0.95</EnergyFactor>
+          </WaterHeatingSystem>
+          <HotWaterDistribution>
+            <SystemIdentifier id='HotWaterDstribution'/>
+            <SystemType>
+              <Standard>
+                <PipingLength>50.0</PipingLength>
+              </Standard>
+            </SystemType>
+            <PipeInsulation>
+              <PipeRValue>0.0</PipeRValue>
+            </PipeInsulation>
+          </HotWaterDistribution>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture'/>
+            <WaterFixtureType>shower head</WaterFixtureType>
+            <LowFlow>true</LowFlow>
+          </WaterFixture>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture2'/>
+            <WaterFixtureType>faucet</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+        </WaterHeating>
+      </Systems>
+      <Appliances>
+        <ClothesWasher>
+          <SystemIdentifier id='ClothesWasher'/>
+          <Location>living space</Location>
+          <ModifiedEnergyFactor>0.8</ModifiedEnergyFactor>
+          <RatedAnnualkWh>700.0</RatedAnnualkWh>
+          <LabelElectricRate>0.1</LabelElectricRate>
+          <LabelGasRate>0.6</LabelGasRate>
+          <LabelAnnualGasCost>25.0</LabelAnnualGasCost>
+          <Capacity>3.0</Capacity>
+        </ClothesWasher>
+        <ClothesDryer>
+          <SystemIdentifier id='ClothesDryer'/>
+          <Location>living space</Location>
+          <FuelType>electricity</FuelType>
+          <EnergyFactor>2.95</EnergyFactor>
+          <ControlType>timer</ControlType>
+        </ClothesDryer>
+        <Dishwasher>
+          <SystemIdentifier id='Dishwasher'/>
+          <RatedAnnualkWh>450.0</RatedAnnualkWh>
+          <PlaceSettingCapacity>12</PlaceSettingCapacity>
+        </Dishwasher>
+        <Refrigerator>
+          <SystemIdentifier id='Refrigerator'/>
+          <Location>living space</Location>
+          <RatedAnnualkWh>650.0</RatedAnnualkWh>
+        </Refrigerator>
+        <CookingRange>
+          <SystemIdentifier id='Range'/>
+          <FuelType>electricity</FuelType>
+          <IsInduction>false</IsInduction>
+        </CookingRange>
+        <Oven>
+          <SystemIdentifier id='Oven'/>
+          <IsConvection>false</IsConvection>
+        </Oven>
+      </Appliances>
+      <Lighting>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierI_Interior'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.5</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier I</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierI_Exterior'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.5</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier I</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierI_Garage'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.5</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier I</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierII_Interior'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.25</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier II</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierII_Exterior'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.25</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier II</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierII_Garage'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.25</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier II</ThirdPartyCertification>
+        </LightingGroup>
+      </Lighting>
+      <MiscLoads>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoadMisc'/>
+          <PlugLoadType>other</PlugLoadType>
+        </PlugLoad>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoadMisc2'/>
+          <PlugLoadType>TV other</PlugLoadType>
+        </PlugLoad>
+      </MiscLoads>
+    </BuildingDetails>
+  </Building>
+</HPXML>

--- a/tests/base-enclosure-split-surfaces.xml
+++ b/tests/base-enclosure-split-surfaces.xml
@@ -1206,7 +1206,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall3'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth4'/>
@@ -1222,7 +1222,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall5'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth6'/>
@@ -1238,7 +1238,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall7'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth8'/>
@@ -1254,7 +1254,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall9'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth10'/>
@@ -1278,7 +1278,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall3'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth4'/>
@@ -1294,7 +1294,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall5'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth6'/>
@@ -1310,7 +1310,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall7'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth8'/>
@@ -1326,7 +1326,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall9'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth10'/>
@@ -1350,7 +1350,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall3'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast4'/>
@@ -1366,7 +1366,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall5'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast6'/>
@@ -1382,7 +1382,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall7'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast8'/>
@@ -1398,7 +1398,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall9'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast10'/>
@@ -1422,7 +1422,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall3'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest4'/>
@@ -1438,7 +1438,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall5'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest6'/>
@@ -1454,7 +1454,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall7'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest8'/>
@@ -1470,7 +1470,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall9'/>
+            <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest10'/>
@@ -1512,7 +1512,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToRoof idref='Roof3'/>
+            <AttachedToRoof idref='Roof'/>
           </Skylight>
           <Skylight>
             <SystemIdentifier id='SkylightNorth4'/>
@@ -1528,7 +1528,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToRoof idref='Roof5'/>
+            <AttachedToRoof idref='Roof'/>
           </Skylight>
           <Skylight>
             <SystemIdentifier id='SkylightNorth6'/>
@@ -1544,7 +1544,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToRoof idref='Roof7'/>
+            <AttachedToRoof idref='Roof'/>
           </Skylight>
           <Skylight>
             <SystemIdentifier id='SkylightNorth8'/>
@@ -1560,7 +1560,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToRoof idref='Roof9'/>
+            <AttachedToRoof idref='Roof'/>
           </Skylight>
           <Skylight>
             <SystemIdentifier id='SkylightNorth10'/>
@@ -1584,7 +1584,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.35</UFactor>
             <SHGC>0.47</SHGC>
-            <AttachedToRoof idref='Roof3'/>
+            <AttachedToRoof idref='Roof'/>
           </Skylight>
           <Skylight>
             <SystemIdentifier id='SkylightSouth4'/>
@@ -1600,7 +1600,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.35</UFactor>
             <SHGC>0.47</SHGC>
-            <AttachedToRoof idref='Roof5'/>
+            <AttachedToRoof idref='Roof'/>
           </Skylight>
           <Skylight>
             <SystemIdentifier id='SkylightSouth6'/>
@@ -1616,7 +1616,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.35</UFactor>
             <SHGC>0.47</SHGC>
-            <AttachedToRoof idref='Roof7'/>
+            <AttachedToRoof idref='Roof'/>
           </Skylight>
           <Skylight>
             <SystemIdentifier id='SkylightSouth8'/>
@@ -1632,7 +1632,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.35</UFactor>
             <SHGC>0.47</SHGC>
-            <AttachedToRoof idref='Roof9'/>
+            <AttachedToRoof idref='Roof'/>
           </Skylight>
           <Skylight>
             <SystemIdentifier id='SkylightSouth10'/>
@@ -1667,7 +1667,7 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth3'/>
-            <AttachedToWall idref='Wall3'/>
+            <AttachedToWall idref='Wall'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
@@ -1681,7 +1681,7 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth5'/>
-            <AttachedToWall idref='Wall5'/>
+            <AttachedToWall idref='Wall'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
@@ -1695,7 +1695,7 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth7'/>
-            <AttachedToWall idref='Wall7'/>
+            <AttachedToWall idref='Wall'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
@@ -1709,7 +1709,7 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth9'/>
-            <AttachedToWall idref='Wall9'/>
+            <AttachedToWall idref='Wall'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
@@ -1730,7 +1730,7 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth3'/>
-            <AttachedToWall idref='Wall3'/>
+            <AttachedToWall idref='Wall'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
@@ -1744,7 +1744,7 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth5'/>
-            <AttachedToWall idref='Wall5'/>
+            <AttachedToWall idref='Wall'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
@@ -1758,7 +1758,7 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth7'/>
-            <AttachedToWall idref='Wall7'/>
+            <AttachedToWall idref='Wall'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
@@ -1772,7 +1772,7 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth9'/>
-            <AttachedToWall idref='Wall9'/>
+            <AttachedToWall idref='Wall'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>

--- a/tests/base-enclosure-split-surfaces.xml
+++ b/tests/base-enclosure-split-surfaces.xml
@@ -379,7 +379,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>94.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -394,7 +394,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>94.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -409,7 +409,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>94.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -424,7 +424,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>94.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -439,7 +439,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>94.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -454,7 +454,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>94.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -469,7 +469,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>94.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -514,7 +514,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>29.0</Area>
+            <Area>55.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -529,7 +529,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>29.0</Area>
+            <Area>55.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -544,7 +544,7 @@
             <WallType>
               <WoodStud/>
             </WallType>
-            <Area>29.0</Area>
+            <Area>55.0</Area>
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
@@ -721,7 +721,7 @@
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>120.0</Area>
+            <Area>146.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
@@ -738,7 +738,7 @@
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>120.0</Area>
+            <Area>146.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
@@ -755,7 +755,7 @@
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>120.0</Area>
+            <Area>146.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
@@ -772,7 +772,7 @@
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>120.0</Area>
+            <Area>146.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
@@ -1206,7 +1206,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='Wall3'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth4'/>
@@ -1214,7 +1214,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall4'/>
+            <AttachedToWall idref='WallAtticGable4'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth5'/>
@@ -1222,7 +1222,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='WallAtticGable5'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth6'/>
@@ -1230,7 +1230,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall6'/>
+            <AttachedToWall idref='WallAtticGable6'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth7'/>
@@ -1238,7 +1238,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall7'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth8'/>
@@ -1246,7 +1246,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall8'/>
+            <AttachedToWall idref='FoundationWall8'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth9'/>
@@ -1254,7 +1254,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall9'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowNorth10'/>
@@ -1262,7 +1262,7 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall10'/>
+            <AttachedToWall idref='FoundationWall10'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth2'/>
@@ -1278,7 +1278,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='Wall3'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth4'/>
@@ -1286,7 +1286,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall4'/>
+            <AttachedToWall idref='WallAtticGable4'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth5'/>
@@ -1294,7 +1294,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='WallAtticGable5'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth6'/>
@@ -1302,7 +1302,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall6'/>
+            <AttachedToWall idref='WallAtticGable6'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth7'/>
@@ -1310,7 +1310,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall7'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth8'/>
@@ -1318,7 +1318,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall8'/>
+            <AttachedToWall idref='FoundationWall8'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth9'/>
@@ -1326,7 +1326,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall9'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth10'/>
@@ -1334,7 +1334,7 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall10'/>
+            <AttachedToWall idref='FoundationWall10'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast2'/>
@@ -1350,7 +1350,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='Wall3'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast4'/>
@@ -1358,7 +1358,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall4'/>
+            <AttachedToWall idref='WallAtticGable4'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast5'/>
@@ -1366,7 +1366,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='WallAtticGable5'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast6'/>
@@ -1374,7 +1374,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall6'/>
+            <AttachedToWall idref='WallAtticGable6'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast7'/>
@@ -1382,7 +1382,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall7'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast8'/>
@@ -1390,7 +1390,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall8'/>
+            <AttachedToWall idref='FoundationWall8'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast9'/>
@@ -1398,7 +1398,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall9'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast10'/>
@@ -1406,7 +1406,7 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall10'/>
+            <AttachedToWall idref='FoundationWall10'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest2'/>
@@ -1422,7 +1422,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='Wall3'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest4'/>
@@ -1430,7 +1430,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall4'/>
+            <AttachedToWall idref='WallAtticGable4'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest5'/>
@@ -1438,7 +1438,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='WallAtticGable5'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest6'/>
@@ -1446,7 +1446,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall6'/>
+            <AttachedToWall idref='WallAtticGable6'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest7'/>
@@ -1454,7 +1454,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall7'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest8'/>
@@ -1462,7 +1462,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall8'/>
+            <AttachedToWall idref='FoundationWall8'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest9'/>
@@ -1470,7 +1470,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall9'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest10'/>
@@ -1478,7 +1478,7 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
-            <AttachedToWall idref='Wall10'/>
+            <AttachedToWall idref='FoundationWall10'/>
           </Window>
         </Windows>
         <Skylights>
@@ -1667,56 +1667,56 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth3'/>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='Wall3'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth4'/>
-            <AttachedToWall idref='Wall4'/>
+            <AttachedToWall idref='WallAtticGable4'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth5'/>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='WallAtticGable5'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth6'/>
-            <AttachedToWall idref='Wall6'/>
+            <AttachedToWall idref='WallAtticGable6'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth7'/>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall7'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth8'/>
-            <AttachedToWall idref='Wall8'/>
+            <AttachedToWall idref='FoundationWall8'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth9'/>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall9'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorNorth10'/>
-            <AttachedToWall idref='Wall10'/>
+            <AttachedToWall idref='FoundationWall10'/>
             <Area>4.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
@@ -1730,56 +1730,56 @@
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth3'/>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='Wall3'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth4'/>
-            <AttachedToWall idref='Wall4'/>
+            <AttachedToWall idref='WallAtticGable4'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth5'/>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='WallAtticGable5'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth6'/>
-            <AttachedToWall idref='Wall6'/>
+            <AttachedToWall idref='WallAtticGable6'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth7'/>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall7'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth8'/>
-            <AttachedToWall idref='Wall8'/>
+            <AttachedToWall idref='FoundationWall8'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth9'/>
-            <AttachedToWall idref='Wall'/>
+            <AttachedToWall idref='FoundationWall9'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
             <SystemIdentifier id='DoorSouth10'/>
-            <AttachedToWall idref='Wall10'/>
+            <AttachedToWall idref='FoundationWall10'/>
             <Area>4.0</Area>
             <Azimuth>180</Azimuth>
             <RValue>4.4</RValue>

--- a/tests/base-foundation-multiple.xml
+++ b/tests/base-foundation-multiple.xml
@@ -94,7 +94,7 @@
             <Emittance>0.92</Emittance>
             <Insulation>
               <SystemIdentifier id='RimJoistCrawlspaceInsulation'/>
-              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
             </Insulation>
           </RimJoist>
         </RimJoists>

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -435,8 +435,6 @@ class HPXMLTranslatorTest < MiniTest::Test
   end
 
   def _verify_simulation_outputs(runner, rundir, hpxml_path, results)
-    return if hpxml_path.include? "base-enclosure-split-surfaces.xml"
-
     # Check that eplusout.err has no lines that include "Blank Schedule Type Limits Name input"
     File.readlines(File.join(rundir, "eplusout.err")).each do |err_line|
       next if err_line.include? 'Schedule:Constant="ALWAYS ON CONTINUOUS", Blank Schedule Type Limits Name input'
@@ -468,8 +466,11 @@ class HPXMLTranslatorTest < MiniTest::Test
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
     end
 
+    enclosure = bldg_details.elements["Enclosure"]
+    HPXML.collapse_enclosure(enclosure)
+
     # Enclosure Roofs
-    bldg_details.elements.each('Enclosure/Roofs/Roof') do |roof|
+    enclosure.elements.each('Roofs/Roof') do |roof|
       roof_id = roof.elements["SystemIdentifier"].attributes["id"].upcase
 
       # R-value
@@ -480,7 +481,7 @@ class HPXMLTranslatorTest < MiniTest::Test
 
       # Net area
       hpxml_value = Float(XMLHelper.get_value(roof, 'Area'))
-      bldg_details.elements.each('Enclosure/Skylights/Skylight') do |subsurface|
+      enclosure.elements.each('Skylights/Skylight') do |subsurface|
         next if subsurface.elements["AttachedToRoof"].attributes["idref"].upcase != roof_id
 
         hpxml_value -= Float(XMLHelper.get_value(subsurface, 'Area'))
@@ -539,9 +540,9 @@ class HPXMLTranslatorTest < MiniTest::Test
     end
 
     # Enclosure Foundation Slabs
-    num_slabs = bldg_details.elements['count(Enclosure/Slabs/Slab)']
+    num_slabs = enclosure.elements['count(Slabs/Slab)']
     if num_slabs <= 1 and num_kiva_instances <= 1 # The slab surfaces may be combined in these situations, so skip tests
-      bldg_details.elements.each('Enclosure/Slabs/Slab') do |slab|
+      enclosure.elements.each('Slabs/Slab') do |slab|
         slab_id = slab.elements["SystemIdentifier"].attributes["id"].upcase
 
         # Exposed Area
@@ -558,12 +559,8 @@ class HPXMLTranslatorTest < MiniTest::Test
     end
 
     # Enclosure Walls/RimJoists/FoundationWalls
-    bldg_details.elements.each('Enclosure/Walls/Wall[ExteriorAdjacentTo="outside"] | Enclosure/RimJoists/RimJoist[ExteriorAdjacentTo="outside"] | Enclosure/FoundationWalls/FoundationWall[ExteriorAdjacentTo="ground"]') do |wall|
+    enclosure.elements.each('Walls/Wall[ExteriorAdjacentTo="outside"] | RimJoists/RimJoist[ExteriorAdjacentTo="outside"] | FoundationWalls/FoundationWall[ExteriorAdjacentTo="ground"]') do |wall|
       wall_id = wall.elements["SystemIdentifier"].attributes["id"].upcase
-
-      # This case is complicated because two foundation walls are collapsed into one model wall
-      # so we need to skip some tests.
-      is_complex_fnd_wall = (XMLHelper.get_value(wall, "ExteriorAdjacentTo") == "ground" and hpxml_path.include? "base-foundation-complex.xml")
 
       # R-value
       if XMLHelper.has_element(wall, 'Insulation/AssemblyEffectiveRValue') and not hpxml_path.include? "base-foundation-unconditioned-basement-assembly-r.xml" # This file uses Foundation:Kiva for insulation, so skip it
@@ -575,7 +572,7 @@ class HPXMLTranslatorTest < MiniTest::Test
 
       # Net area
       hpxml_value = Float(XMLHelper.get_value(wall, 'Area'))
-      bldg_details.elements.each('Enclosure/Windows/Window | Enclosure/Doors/Door') do |subsurface|
+      enclosure.elements.each('Windows/Window | Doors/Door') do |subsurface|
         next if subsurface.elements["AttachedToWall"].attributes["idref"].upcase != wall_id
 
         hpxml_value -= Float(XMLHelper.get_value(subsurface, 'Area'))
@@ -583,7 +580,7 @@ class HPXMLTranslatorTest < MiniTest::Test
       if XMLHelper.get_value(wall, "ExteriorAdjacentTo") == "ground"
         # Calculate total length of walls
         wall_total_length = 0
-        bldg_details.elements.each('Enclosure/FoundationWalls/FoundationWall[ExteriorAdjacentTo="ground"]') do |fwall|
+        enclosure.elements.each('FoundationWalls/FoundationWall[ExteriorAdjacentTo="ground"]') do |fwall|
           next unless XMLHelper.get_value(wall, "InteriorAdjacentTo") == XMLHelper.get_value(fwall, "InteriorAdjacentTo")
 
           wall_total_length += Float(XMLHelper.get_value(fwall, "Area")) / Float(XMLHelper.get_value(fwall, "Height"))
@@ -591,7 +588,7 @@ class HPXMLTranslatorTest < MiniTest::Test
 
         # Calculate total slab exposed perimeter
         slab_exposed_length = 0
-        bldg_details.elements.each('Enclosure/Slabs/Slab') do |slab|
+        enclosure.elements.each('Slabs/Slab') do |slab|
           next unless XMLHelper.get_value(wall, "InteriorAdjacentTo") == XMLHelper.get_value(slab, "InteriorAdjacentTo")
 
           slab_exposed_length += Float(XMLHelper.get_value(slab, "ExposedPerimeter"))
@@ -602,11 +599,9 @@ class HPXMLTranslatorTest < MiniTest::Test
           hpxml_value *= (slab_exposed_length / wall_total_length)
         end
       end
-      if not is_complex_fnd_wall
-        query = "SELECT SUM(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{wall_id}' OR RowName LIKE '#{wall_id}:%' OR RowName LIKE '#{wall_id} %') AND ColumnName='Net Area' AND Units='m2'"
-        sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'm^2', 'ft^2')
-        assert_in_epsilon(hpxml_value, sql_value, 0.01)
-      end
+      query = "SELECT SUM(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{wall_id}' OR RowName LIKE '#{wall_id}:%' OR RowName LIKE '#{wall_id} %') AND ColumnName='Net Area' AND Units='m2'"
+      sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'm^2', 'ft^2')
+      assert_in_epsilon(hpxml_value, sql_value, 0.01)
 
       # Solar absorptance
       if XMLHelper.has_element(wall, 'SolarAbsorptance')
@@ -617,11 +612,9 @@ class HPXMLTranslatorTest < MiniTest::Test
       end
 
       # Tilt
-      if not is_complex_fnd_wall
-        query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{wall_id}' OR RowName LIKE '#{wall_id}:%') AND ColumnName='Tilt' AND Units='deg'"
-        sql_value = sqlFile.execAndReturnFirstDouble(query).get
-        assert_in_epsilon(90.0, sql_value, 0.01)
-      end
+      query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{wall_id}' OR RowName LIKE '#{wall_id}:%') AND ColumnName='Tilt' AND Units='deg'"
+      sql_value = sqlFile.execAndReturnFirstDouble(query).get
+      assert_in_epsilon(90.0, sql_value, 0.01)
 
       # Azimuth
       if XMLHelper.has_element(wall, 'Azimuth')
@@ -635,7 +628,7 @@ class HPXMLTranslatorTest < MiniTest::Test
     # TODO: Enclosure FrameFloors
 
     # Enclosure Windows/Skylights
-    bldg_details.elements.each('Enclosure/Windows/Window | Enclosure/Skylights/Skylight') do |subsurface|
+    enclosure.elements.each('Windows/Window | Skylights/Skylight') do |subsurface|
       subsurface_id = subsurface.elements["SystemIdentifier"].attributes["id"].upcase
 
       # Area
@@ -666,7 +659,7 @@ class HPXMLTranslatorTest < MiniTest::Test
         assert_in_epsilon(90.0, sql_value, 0.01)
       elsif XMLHelper.has_element(subsurface, "AttachedToRoof")
         hpxml_value = nil
-        bldg_details.elements.each('Enclosure/Roofs/Roof') do |roof|
+        enclosure.elements.each('Roofs/Roof') do |roof|
           next if roof.elements["SystemIdentifier"].attributes["id"] != subsurface.elements["AttachedToRoof"].attributes["idref"]
 
           hpxml_value = UnitConversions.convert(Math.atan(Float(XMLHelper.get_value(roof, "Pitch")) / 12.0), "rad", "deg")
@@ -680,7 +673,7 @@ class HPXMLTranslatorTest < MiniTest::Test
     end
 
     # Enclosure Doors
-    bldg_details.elements.each('Enclosure/Doors/Door') do |door|
+    enclosure.elements.each('Doors/Door') do |door|
       door_id = door.elements["SystemIdentifier"].attributes["id"].upcase
 
       # Area


### PR DESCRIPTION
Some buildings with large numbers of surfaces (e.g., windows, skylights, walls) are seeing significant runtime regressions due to exponentially increasing runtime in the OpenStudio SDK's ViewFactor class.

This PR addresses the issue by:
1. Automatically identifying and collapsing like surfaces (e.g., individual windows with all the same properties other than area).
2. Refactoring the code that generates view factors.
3. Eliminating view factors with small values. (When OpenStudio performance is improved, this threshold should be relaxed a bit.)
