### PR TITLE
Reducing HPWH number of nodes from 12 to 6

### DIFF
--- a/resources/waterheater.rb
+++ b/resources/waterheater.rb
@@ -84,9 +84,6 @@ class Waterheater
     int_factor = 1.0 # unitless
     temp_depress = 0.0 # F
     ducting = "none"
-    
-    #Code for testing out the number of nodes
-    reduced_nodes = true #Reduced nodes = true gives a 6 node tank instead of 12
 
     # Based on Ecotope lab testing of most recent AO Smith HPWHs (series HPTU)
     if vol <= 58
@@ -296,11 +293,7 @@ class Waterheater
     else
       tank.setAmbientTemperatureSchedule(hpwh_tamb)
     end
-    if reduced_nodes
-      tank.setNumberofNodes(6)
-    else
-      tank.setNumberofNodes(12)
-    end
+    tank.setNumberofNodes(6)
     tank.setAdditionalDestratificationConductivity(0)
     tank.setNode1AdditionalLossCoefficient(0)
     tank.setNode2AdditionalLossCoefficient(0)

--- a/resources/waterheater.rb
+++ b/resources/waterheater.rb
@@ -84,6 +84,9 @@ class Waterheater
     int_factor = 1.0 # unitless
     temp_depress = 0.0 # F
     ducting = "none"
+    
+    #Code for testing out the number of nodes
+    reduced_nodes = true #Reduced nodes = true gives a 6 node tank instead of 12
 
     # Based on Ecotope lab testing of most recent AO Smith HPWHs (series HPTU)
     if vol <= 58
@@ -293,7 +296,11 @@ class Waterheater
     else
       tank.setAmbientTemperatureSchedule(hpwh_tamb)
     end
-    tank.setNumberofNodes(12)
+    if reduced_nodes
+      tank.setNumberofNodes(6)
+    else
+      tank.setNumberofNodes(12)
+    end
     tank.setAdditionalDestratificationConductivity(0)
     tank.setNode1AdditionalLossCoefficient(0)
     tank.setNode2AdditionalLossCoefficient(0)


### PR DESCRIPTION
When we made the change to use the AO Smith control logic, changing from 12 nodes to 6 became a bit easier so it's now pretty much a 1 line change. I did run some simulations comparing the lab data for a simulated use test, Energy consumption difference between E+ 9.2 and the lab data is 13%, compared to 4% for version 8.2 compared to lab data. Reducing to 6 nodes changed the discrepency to 11%. It looks like with the latest version of E+, the HPWH needs to run longer to reheat the tank. I'm comfortable with this level of discrepancy across versions.

![image](https://user-images.githubusercontent.com/8376057/67887206-7b686b00-fb10-11e9-96d0-886fb5b0524b.png)
