### PR TITLE
Unconditioned basement thermal boundary

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -150,6 +150,7 @@ def create_hpxmls
     'base-foundation-unconditioned-basement.xml' => 'base.xml',
     'base-foundation-unconditioned-basement-assembly-r.xml' => 'base-foundation-unconditioned-basement.xml',
     'base-foundation-unconditioned-basement-above-grade.xml' => 'base-foundation-unconditioned-basement.xml',
+    'base-foundation-unconditioned-basement-wall-insulation.xml' => 'base-foundation-unconditioned-basement.xml',
     'base-foundation-unvented-crawlspace.xml' => 'base.xml',
     'base-foundation-vented-crawlspace.xml' => 'base.xml',
     'base-foundation-walkout-basement.xml' => 'base.xml',
@@ -809,6 +810,14 @@ def get_hpxml_file_foundation_values(hpxml_file, foundation_values)
     foundation_values = { :id => "VentedCrawlspace",
                           :foundation_type => "VentedCrawlspace",
                           :vented_crawlspace_sla => 0.00667 }
+  elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
+    foundation_values = { :id => "UnconditionedBasement",
+                          :foundation_type => "UnconditionedBasement",
+                          :unconditioned_basement_thermal_boundary => "frame floor" }
+  elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
+    foundation_values = { :id => "UnconditionedBasement",
+                          :foundation_type => "UnconditionedBasement",
+                          :unconditioned_basement_thermal_boundary => "foundation wall" }
   end
   return foundation_values
 end
@@ -896,6 +905,11 @@ def get_hpxml_file_rim_joists_values(hpxml_file, rim_joists_values)
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     for i in 0..rim_joists_values.size - 1
       rim_joists_values[i][:interior_adjacent_to] = "basement - unconditioned"
+      rim_joists_values[i][:insulation_assembly_r_value] = 2.3
+    end
+  elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
+    for i in 0..rim_joists_values.size - 1
+      rim_joists_values[i][:insulation_assembly_r_value] = 23.0
     end
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
     for i in 0..rim_joists_values.size - 1
@@ -1111,7 +1125,11 @@ def get_hpxml_file_foundation_walls_values(hpxml_file, foundation_walls_values)
                                  :insulation_r_value => 8.9 }]
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     foundation_walls_values[0][:interior_adjacent_to] = "basement - unconditioned"
+    foundation_walls_values[0][:insulation_distance_to_bottom] = 0
+    foundation_walls_values[0][:insulation_r_value] = 0
+  elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
     foundation_walls_values[0][:insulation_distance_to_bottom] = 4
+    foundation_walls_values[0][:insulation_r_value] = 8.9
   elsif ['base-foundation-unconditioned-basement-assembly-r.xml'].include? hpxml_file
     foundation_walls_values[0][:insulation_distance_to_bottom] = nil
     foundation_walls_values[0][:insulation_r_value] = nil
@@ -1270,6 +1288,8 @@ def get_hpxml_file_framefloors_values(hpxml_file, framefloors_values)
                             :interior_adjacent_to => "living space",
                             :area => 1350,
                             :insulation_assembly_r_value => 18.7 }
+  elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
+    framefloors_values[0][:insulation_assembly_r_value] = 2.1
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
     framefloors_values << { :id => "FloorAboveUnventedCrawl",
                             :exterior_adjacent_to => "crawlspace - unvented",

--- a/Rakefile
+++ b/Rakefile
@@ -1165,8 +1165,8 @@ def get_hpxml_file_foundation_walls_values(hpxml_file, foundation_walls_values)
                                  :area => 600,
                                  :thickness => 8,
                                  :depth_below_grade => 3,
-                                 :insulation_distance_to_bottom => 4,
-                                 :insulation_r_value => 8.9 }
+                                 :insulation_distance_to_bottom => 0,
+                                 :insulation_r_value => 0 }
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml'].include? hpxml_file
     foundation_walls_values = []
@@ -1289,7 +1289,7 @@ def get_hpxml_file_framefloors_values(hpxml_file, framefloors_values)
                             :area => 1350,
                             :insulation_assembly_r_value => 18.7 }
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    framefloors_values[0][:insulation_assembly_r_value] = 2.1
+    framefloors_values[1][:insulation_assembly_r_value] = 2.1
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
     framefloors_values << { :id => "FloorAboveUnventedCrawl",
                             :exterior_adjacent_to => "crawlspace - unvented",

--- a/resources/EPvalidator.rb
+++ b/resources/EPvalidator.rb
@@ -53,8 +53,6 @@ class EnergyPlusValidator
         "/HPXML/Building/BuildingDetails/Enclosure/AirInfiltration[AirInfiltrationMeasurement[HousePressure=50]/BuildingAirLeakage[UnitofMeasure='ACH' or UnitofMeasure='CFM']/AirLeakage | AirInfiltrationMeasurement/extension/ConstantACHnatural]" => one, # ACH50, CFM50, or constant nACH; see [AirInfiltration]
         "/HPXML/Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement/InfiltrationVolume" => zero_or_one, # Assumes InfiltrationVolume = ConditionedVolume if not provided
 
-        "/HPXML/Building/BuildingDetails/Enclosure/Attics/Attic[AtticType/Attic[Vented='true']]/VentilationRate[[UnitofMeasure='SLA']/Value | extension/ConstantACHnatural]" => zero_or_one, # SLA or constant nACH; used for vented attic if provided
-        "/HPXML/Building/BuildingDetails/Enclosure/Foundations/Foundation[FoundationType/Crawlspace[Vented='true']]/VentilationRate[UnitofMeasure='SLA']/Value" => zero_or_one, # SLA; used for vented crawlspace if provided
         "/HPXML/Building/BuildingDetails/Enclosure/Roofs/Roof" => zero_or_more, # See [Roof]
         "/HPXML/Building/BuildingDetails/Enclosure/Walls/Wall" => one_or_more, # See [Wall]
         "/HPXML/Building/BuildingDetails/Enclosure/RimJoists/RimJoist" => zero_or_more, # See [RimJoist]
@@ -118,7 +116,7 @@ class EnergyPlusValidator
       # [Roof]
       "/HPXML/Building/BuildingDetails/Enclosure/Roofs/Roof" => {
         "SystemIdentifier" => one, # Required by HPXML schema
-        "[InteriorAdjacentTo='attic - vented' or InteriorAdjacentTo='attic - unvented' or InteriorAdjacentTo='living space' or InteriorAdjacentTo='garage']" => one,
+        "[InteriorAdjacentTo='attic - vented' or InteriorAdjacentTo='attic - unvented' or InteriorAdjacentTo='living space' or InteriorAdjacentTo='garage']" => one, # See [VentedAttic]
         "Area" => one,
         "Azimuth" => zero_or_one,
         "SolarAbsorptance" => one,
@@ -127,6 +125,11 @@ class EnergyPlusValidator
         "RadiantBarrier" => one,
         "Insulation/SystemIdentifier" => one, # Required by HPXML schema
         "Insulation/AssemblyEffectiveRValue" => one,
+      },
+
+      ## [VentedAttic]
+      "/HPXML/Building/BuildingDetails/Enclosure/Roofs/Roof[InteriorAdjacentTo='attic - vented']" => {
+        "../../Attics/Attic[AtticType/Attic[Vented='true']]/VentilationRate[[UnitofMeasure='SLA']/Value | extension/ConstantACHnatural]" => zero_or_one,
       },
 
       # [Wall]
@@ -160,7 +163,7 @@ class EnergyPlusValidator
       "/HPXML/Building/BuildingDetails/Enclosure/FoundationWalls/FoundationWall" => {
         "SystemIdentifier" => one, # Required by HPXML schema
         "[ExteriorAdjacentTo='ground' or ExteriorAdjacentTo='basement - conditioned' or ExteriorAdjacentTo='basement - unconditioned' or ExteriorAdjacentTo='crawlspace - vented' or ExteriorAdjacentTo='crawlspace - unvented' or ExteriorAdjacentTo='garage' or ExteriorAdjacentTo='other housing unit']" => one,
-        "[InteriorAdjacentTo='basement - conditioned' or InteriorAdjacentTo='basement - unconditioned' or InteriorAdjacentTo='crawlspace - vented' or InteriorAdjacentTo='crawlspace - unvented' or InteriorAdjacentTo='garage']" => one,
+        "[InteriorAdjacentTo='basement - conditioned' or InteriorAdjacentTo='basement - unconditioned' or InteriorAdjacentTo='crawlspace - vented' or InteriorAdjacentTo='crawlspace - unvented' or InteriorAdjacentTo='garage']" => one, # See [VentedCrawlspace]
         "Height" => one,
         "Area" => one,
         "Azimuth" => zero_or_one,
@@ -170,6 +173,11 @@ class EnergyPlusValidator
         # Either specify insulation layer R-value and insulation height OR assembly R-value:
         "DistanceToBottomOfInsulation | Insulation/AssemblyEffectiveRValue" => one,
         "Insulation/Layer[InstallationType='continuous']/NominalRValue | Insulation/AssemblyEffectiveRValue" => one,
+      },
+
+      ## [VentedCrawlspace]
+      "/HPXML/Building/BuildingDetails/Enclosure/FoundationWalls/FoundationWall[InteriorAdjacentTo='crawlspace - vented']" => {
+        "../../Foundations/Foundation[FoundationType/Crawlspace[Vented='true']]/VentilationRate[UnitofMeasure='SLA']/Value" => zero_or_one,
       },
 
       # [FrameFloor]

--- a/resources/hpxml.rb
+++ b/resources/hpxml.rb
@@ -444,6 +444,7 @@ class HPXML
                           id:,
                           foundation_type:,
                           vented_crawlspace_sla: nil,
+                          unconditioned_basement_thermal_boundary: nil,
                           **remainder)
     foundations = XMLHelper.create_elements_as_needed(hpxml, ["Building", "BuildingDetails", "Enclosure", "Foundations"])
     foundation = XMLHelper.add_element(foundations, "Foundation")
@@ -459,6 +460,7 @@ class HPXML
       elsif foundation_type == "UnconditionedBasement"
         basement = XMLHelper.add_element(foundation_type_e, "Basement")
         XMLHelper.add_element(basement, "Conditioned", false)
+        XMLHelper.add_element(foundation, "ThermalBoundary", unconditioned_basement_thermal_boundary)
       elsif foundation_type == "VentedCrawlspace"
         crawlspace = XMLHelper.add_element(foundation_type_e, "Crawlspace")
         XMLHelper.add_element(crawlspace, "Vented", true)

--- a/resources/hpxml.rb
+++ b/resources/hpxml.rb
@@ -489,6 +489,7 @@ class HPXML
       foundation_type = "SlabOnGrade"
     elsif XMLHelper.has_element(foundation, "FoundationType/Basement[Conditioned='false']")
       foundation_type = "UnconditionedBasement"
+      unconditioned_basement_thermal_boundary = XMLHelper.get_value(foundation, "ThermalBoundary")
     elsif XMLHelper.has_element(foundation, "FoundationType/Basement[Conditioned='true']")
       foundation_type = "ConditionedBasement"
     elsif XMLHelper.has_element(foundation, "FoundationType/Crawlspace[Vented='false']")
@@ -502,7 +503,8 @@ class HPXML
 
     return { :id => HPXML.get_id(foundation),
              :foundation_type => foundation_type,
-             :vented_crawlspace_sla => vented_crawlspace_sla }
+             :vented_crawlspace_sla => vented_crawlspace_sla,
+             :unconditioned_basement_thermal_boundary => unconditioned_basement_thermal_boundary }
   end
 
   def self.add_roof(hpxml:,

--- a/tests/base-foundation-multiple.xml
+++ b/tests/base-foundation-multiple.xml
@@ -184,12 +184,12 @@
             <Area>600.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>3.0</DepthBelowGrade>
-            <DistanceToBottomOfInsulation>4.0</DistanceToBottomOfInsulation>
+            <DistanceToBottomOfInsulation>0.0</DistanceToBottomOfInsulation>
             <Insulation>
               <SystemIdentifier id='FoundationWallCrawlspaceInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
-                <NominalRValue>8.9</NominalRValue>
+                <NominalRValue>0.0</NominalRValue>
               </Layer>
             </Insulation>
           </FoundationWall>

--- a/tests/base-foundation-multiple.xml
+++ b/tests/base-foundation-multiple.xml
@@ -57,6 +57,17 @@
             <InfiltrationVolume>10800.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>
         </AirInfiltration>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='UnconditionedBasement'/>
+            <FoundationType>
+              <Basement>
+                <Conditioned>false</Conditioned>
+              </Basement>
+            </FoundationType>
+            <ThermalBoundary>frame floor</ThermalBoundary>
+          </Foundation>
+        </Foundations>
         <Roofs>
           <Roof>
             <SystemIdentifier id='Roof'/>
@@ -82,7 +93,7 @@
             <Emittance>0.92</Emittance>
             <Insulation>
               <SystemIdentifier id='RimJoistFoundationInsulation'/>
-              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
             </Insulation>
           </RimJoist>
           <RimJoist>
@@ -139,12 +150,12 @@
             <Area>600.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
-            <DistanceToBottomOfInsulation>4.0</DistanceToBottomOfInsulation>
+            <DistanceToBottomOfInsulation>0.0</DistanceToBottomOfInsulation>
             <Insulation>
               <SystemIdentifier id='FoundationWallInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
-                <NominalRValue>8.9</NominalRValue>
+                <NominalRValue>0.0</NominalRValue>
               </Layer>
             </Insulation>
           </FoundationWall>

--- a/tests/base-foundation-unconditioned-basement-above-grade.xml
+++ b/tests/base-foundation-unconditioned-basement-above-grade.xml
@@ -57,6 +57,17 @@
             <InfiltrationVolume>10800.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>
         </AirInfiltration>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='UnconditionedBasement'/>
+            <FoundationType>
+              <Basement>
+                <Conditioned>false</Conditioned>
+              </Basement>
+            </FoundationType>
+            <ThermalBoundary>frame floor</ThermalBoundary>
+          </Foundation>
+        </Foundations>
         <Roofs>
           <Roof>
             <SystemIdentifier id='Roof'/>
@@ -82,7 +93,7 @@
             <Emittance>0.92</Emittance>
             <Insulation>
               <SystemIdentifier id='RimJoistFoundationInsulation'/>
-              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
             </Insulation>
           </RimJoist>
         </RimJoists>
@@ -127,12 +138,12 @@
             <Area>1200.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>4.0</DepthBelowGrade>
-            <DistanceToBottomOfInsulation>4.0</DistanceToBottomOfInsulation>
+            <DistanceToBottomOfInsulation>0.0</DistanceToBottomOfInsulation>
             <Insulation>
               <SystemIdentifier id='FoundationWallInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
-                <NominalRValue>8.9</NominalRValue>
+                <NominalRValue>0.0</NominalRValue>
               </Layer>
             </Insulation>
           </FoundationWall>

--- a/tests/base-foundation-unconditioned-basement-assembly-r.xml
+++ b/tests/base-foundation-unconditioned-basement-assembly-r.xml
@@ -57,6 +57,17 @@
             <InfiltrationVolume>10800.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>
         </AirInfiltration>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='UnconditionedBasement'/>
+            <FoundationType>
+              <Basement>
+                <Conditioned>false</Conditioned>
+              </Basement>
+            </FoundationType>
+            <ThermalBoundary>frame floor</ThermalBoundary>
+          </Foundation>
+        </Foundations>
         <Roofs>
           <Roof>
             <SystemIdentifier id='Roof'/>
@@ -82,7 +93,7 @@
             <Emittance>0.92</Emittance>
             <Insulation>
               <SystemIdentifier id='RimJoistFoundationInsulation'/>
-              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
             </Insulation>
           </RimJoist>
         </RimJoists>

--- a/tests/base-foundation-unconditioned-basement-wall-insulation.xml
+++ b/tests/base-foundation-unconditioned-basement-wall-insulation.xml
@@ -3,7 +3,7 @@
   <XMLTransactionHeaderInformation>
     <XMLType>HPXML</XMLType>
     <XMLGeneratedBy>Rakefile</XMLGeneratedBy>
-    <CreatedDateAndTime>2019-05-03T09:27:22-06:00</CreatedDateAndTime>
+    <CreatedDateAndTime>2019-11-18T15:32:23-07:00</CreatedDateAndTime>
     <Transaction>create</Transaction>
   </XMLTransactionHeaderInformation>
   <SoftwareInfo>
@@ -65,7 +65,7 @@
                 <Conditioned>false</Conditioned>
               </Basement>
             </FoundationType>
-            <ThermalBoundary>frame floor</ThermalBoundary>
+            <ThermalBoundary>foundation wall</ThermalBoundary>
           </Foundation>
         </Foundations>
         <Roofs>
@@ -93,7 +93,7 @@
             <Emittance>0.92</Emittance>
             <Insulation>
               <SystemIdentifier id='RimJoistFoundationInsulation'/>
-              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </RimJoist>
         </RimJoists>
@@ -138,12 +138,12 @@
             <Area>1200.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
-            <DistanceToBottomOfInsulation>0.0</DistanceToBottomOfInsulation>
+            <DistanceToBottomOfInsulation>4.0</DistanceToBottomOfInsulation>
             <Insulation>
               <SystemIdentifier id='FoundationWallInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
-                <NominalRValue>0.0</NominalRValue>
+                <NominalRValue>8.9</NominalRValue>
               </Layer>
             </Insulation>
           </FoundationWall>
@@ -156,7 +156,7 @@
             <Area>1350.0</Area>
             <Insulation>
               <SystemIdentifier id='FloorBelowAtticInsulation'/>
-              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
           </FrameFloor>
           <FrameFloor>

--- a/tests/base-foundation-unconditioned-basement-wall-insulation.xml
+++ b/tests/base-foundation-unconditioned-basement-wall-insulation.xml
@@ -156,7 +156,7 @@
             <Area>1350.0</Area>
             <Insulation>
               <SystemIdentifier id='FloorBelowAtticInsulation'/>
-              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
             </Insulation>
           </FrameFloor>
           <FrameFloor>
@@ -166,7 +166,7 @@
             <Area>1350.0</Area>
             <Insulation>
               <SystemIdentifier id='FloorAboveUncondBasementInsulation'/>
-              <AssemblyEffectiveRValue>18.7</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
           </FrameFloor>
         </FrameFloors>

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -46,7 +46,7 @@ class HPXMLTranslatorTest < MiniTest::Test
 
     xmls = []
     test_dirs.each do |test_dir|
-      Dir["#{test_dir}/base*.xml"].sort.each do |xml|
+      Dir["#{test_dir}/base*unconditioned-basement*.xml"].sort.each do |xml|
         xmls << File.absolute_path(xml)
       end
     end

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -46,7 +46,7 @@ class HPXMLTranslatorTest < MiniTest::Test
 
     xmls = []
     test_dirs.each do |test_dir|
-      Dir["#{test_dir}/base*unconditioned-basement*.xml"].sort.each do |xml|
+      Dir["#{test_dir}/base*.xml"].sort.each do |xml|
         xmls << File.absolute_path(xml)
       end
     end

--- a/tests/hvac_autosizing/base-foundation-unconditioned-basement-autosize.xml
+++ b/tests/hvac_autosizing/base-foundation-unconditioned-basement-autosize.xml
@@ -57,6 +57,17 @@
             <InfiltrationVolume>10800.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>
         </AirInfiltration>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='UnconditionedBasement'/>
+            <FoundationType>
+              <Basement>
+                <Conditioned>false</Conditioned>
+              </Basement>
+            </FoundationType>
+            <ThermalBoundary>frame floor</ThermalBoundary>
+          </Foundation>
+        </Foundations>
         <Roofs>
           <Roof>
             <SystemIdentifier id='Roof'/>
@@ -82,7 +93,7 @@
             <Emittance>0.92</Emittance>
             <Insulation>
               <SystemIdentifier id='RimJoistFoundationInsulation'/>
-              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
             </Insulation>
           </RimJoist>
         </RimJoists>
@@ -127,12 +138,12 @@
             <Area>1200.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
-            <DistanceToBottomOfInsulation>4.0</DistanceToBottomOfInsulation>
+            <DistanceToBottomOfInsulation>0.0</DistanceToBottomOfInsulation>
             <Insulation>
               <SystemIdentifier id='FoundationWallInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
-                <NominalRValue>8.9</NominalRValue>
+                <NominalRValue>0.0</NominalRValue>
               </Layer>
             </Insulation>
           </FoundationWall>


### PR DESCRIPTION
Updates hpxml.rb to allow thermal boundary to be specified for an unconditioned basement. Not used for simulation, but can be used in upstream rulesets.