### PR TITLE
Code cleanup & performance improvements

### DIFF
--- a/measure.rb
+++ b/measure.rb
@@ -114,8 +114,7 @@ class HPXMLTranslator < OpenStudio::Measure::ModelMeasure
       hpxml_path = File.expand_path(File.join(File.dirname(__FILE__), hpxml_path))
     end
     unless File.exists?(hpxml_path) and hpxml_path.downcase.end_with? ".xml"
-      runner.registerError("'#{hpxml_path}' does not exist or is not an .xml file.")
-      return false
+      fail "'#{hpxml_path}' does not exist or is not an .xml file."
     end
 
     hpxml_doc = XMLHelper.parse_file(hpxml_path)
@@ -138,8 +137,7 @@ class HPXMLTranslator < OpenStudio::Measure::ModelMeasure
       if not epw_path.nil?
         epw_path = File.join(weather_dir, epw_path)
         if not File.exists?(epw_path)
-          runner.registerError("'#{epw_path}' could not be found.")
-          return false
+          fail "'#{epw_path}' could not be found."
         end
       else
         weather_wmo = climate_and_risk_zones_values[:weather_station_wmo]
@@ -148,14 +146,13 @@ class HPXMLTranslator < OpenStudio::Measure::ModelMeasure
 
           epw_path = File.join(weather_dir, row["filename"])
           if not File.exists?(epw_path)
-            runner.registerError("'#{epw_path}' could not be found.")
-            return false
+            fail "'#{epw_path}' could not be found."
           end
+
           break
         end
         if epw_path.nil?
-          runner.registerError("Weather station WMO '#{weather_wmo}' could not be found in weather/data.csv.")
-          return false
+          fail "Weather station WMO '#{weather_wmo}' could not be found in weather/data.csv."
         end
       end
       cache_path = epw_path.gsub('.epw', '.cache')
@@ -165,11 +162,6 @@ class HPXMLTranslator < OpenStudio::Measure::ModelMeasure
         epw_file = OpenStudio::EpwFile.new(epw_path)
         OpenStudio::Model::WeatherFile.setWeatherFile(model, epw_file)
         weather = WeatherProcess.new(model, runner)
-        if weather.error? or weather.data.WSF.nil?
-          runner.registerError("Could not successfully process weather file.")
-          return false
-        end
-
         File.open(cache_path, "wb") do |file|
           Marshal.dump(weather, file)
         end
@@ -179,19 +171,17 @@ class HPXMLTranslator < OpenStudio::Measure::ModelMeasure
       end
 
       # Apply Location to obtain weather data
-      success, weather = Location.apply(model, runner, epw_path, "NA", "NA")
-      return false if not success
+      weather = Location.apply(model, runner, epw_path, "NA", "NA")
 
       # Create OpenStudio model
-      if not OSModel.create(hpxml_doc, runner, model, weather, map_tsv_dir, hpxml_path)
-        runner.registerError("Unsuccessful creation of OpenStudio model.")
-        return false
-      end
+      OSModel.create(hpxml_doc, runner, model, weather, map_tsv_dir, hpxml_path)
     rescue Exception => e
       if skip_validation
         # Something went wrong, check for invalid HPXML file now. This was previously
         # skipped to reduce runtime (see https://github.com/NREL/OpenStudio-ERI/issues/47).
-        validate_hpxml(runner, hpxml_path, hpxml_doc, schemas_dir)
+        if not validate_hpxml(runner, hpxml_path, hpxml_doc, schemas_dir)
+          return false
+        end
       end
 
       # Report exception
@@ -208,20 +198,19 @@ class HPXMLTranslator < OpenStudio::Measure::ModelMeasure
   end
 
   def validate_hpxml(runner, hpxml_path, hpxml_doc, schemas_dir)
-    is_valid = true
-
     if schemas_dir.is_initialized
       schemas_dir = schemas_dir.get
       unless (Pathname.new schemas_dir).absolute?
         schemas_dir = File.expand_path(File.join(File.dirname(__FILE__), schemas_dir))
       end
       unless Dir.exists?(schemas_dir)
-        runner.registerError("'#{schemas_dir}' does not exist.")
-        return false
+        fail "'#{schemas_dir}' does not exist."
       end
     else
       schemas_dir = nil
     end
+
+    is_valid = true
 
     # Validate input HPXML against schema
     if not schemas_dir.nil?
@@ -301,79 +290,49 @@ class OSModel
 
     # Simulation parameters
 
-    success = add_simulation_params(runner, model)
-    return false if not success
+    add_simulation_params(model)
 
     # Geometry/Envelope
 
-    spaces = {}
-    success = add_geometry_envelope(runner, model, building, weather, spaces)
-    return false if not success
+    spaces = add_geometry_envelope(runner, model, building, weather)
 
     # Bedrooms, Occupants
 
-    success = add_num_occupants(model, building, runner)
-    return false if not success
+    add_num_occupants(model, building, runner)
 
     # HVAC
 
     @total_frac_remaining_heat_load_served = 1.0
     @total_frac_remaining_cool_load_served = 1.0
 
-    success = add_cooling_system(runner, model, building)
-    return false if not success
-
-    success = add_heating_system(runner, model, building)
-    return false if not success
-
-    success = add_heat_pump(runner, model, building, weather)
-    return false if not success
-
-    success = add_residual_hvac(runner, model, building)
-    return false if not success
-
-    success = add_setpoints(runner, model, building, weather)
-    return false if not success
-
-    success = add_ceiling_fans(runner, model, building, weather)
-    return false if not success
+    add_cooling_system(runner, model, building)
+    add_heating_system(runner, model, building)
+    add_heat_pump(runner, model, building, weather)
+    add_residual_hvac(runner, model, building)
+    add_setpoints(runner, model, building, weather)
+    add_ceiling_fans(runner, model, building, weather)
 
     # Hot Water
 
-    success = add_hot_water_and_appliances(runner, model, building, weather, spaces)
-    return false if not success
+    add_hot_water_and_appliances(runner, model, building, weather, spaces)
 
     # Plug Loads & Lighting
 
-    success = add_mels(runner, model, building, spaces)
-    return false if not success
-
-    success = add_lighting(runner, model, building, weather, spaces)
-    return false if not success
+    add_mels(runner, model, building, spaces)
+    add_lighting(runner, model, building, weather, spaces)
 
     # Other
 
-    success = add_airflow(runner, model, building, weather, spaces)
-    return false if not success
-
-    success = add_hvac_sizing(runner, model, weather)
-    return false if not success
-
-    success = add_fuel_heating_eae(runner, model, building)
-    return false if not success
-
-    success = add_photovoltaics(runner, model, building)
-    return false if not success
-
-    success = add_outputs(runner, model, map_tsv_dir)
-    return false if not success
-
-    return true
+    add_airflow(runner, model, building, weather, spaces)
+    add_hvac_sizing(runner, model, weather)
+    add_fuel_heating_eae(runner, model, building)
+    add_photovoltaics(runner, model, building)
+    add_outputs(runner, model, map_tsv_dir)
   end
 
   private
 
-  def self.add_simulation_params(runner, model)
+  def self.add_simulation_params(model)
     sim = model.getSimulationControl
     sim.setRunSimulationforSizingPeriods(false)
 
@@ -395,66 +354,36 @@ class OSModel
 
     convlim = model.getConvergenceLimits
     convlim.setMinimumSystemTimestep(0)
-
-    return true
   end
 
-  def self.add_geometry_envelope(runner, model, building, weather, spaces)
+  def self.add_geometry_envelope(runner, model, building, weather)
+    spaces = {}
     @foundation_top, @walls_top = get_foundation_and_walls_top(building)
 
-    heating_season, cooling_season = HVAC.calc_heating_and_cooling_seasons(model, weather, runner)
-    return false if heating_season.nil? or cooling_season.nil?
+    heating_season, cooling_season = HVAC.calc_heating_and_cooling_seasons(model, weather)
 
-    success = add_roofs(runner, model, building, spaces)
-    return false if not success
-
-    success = add_walls(runner, model, building, spaces)
-    return false if not success
-
-    success = add_rim_joists(runner, model, building, spaces)
-    return false if not success
-
-    success = add_framefloors(runner, model, building, spaces)
-    return false if not success
-
-    success = add_foundation_walls_slabs(runner, model, building, spaces)
-    return false if not success
-
-    success = add_windows(runner, model, building, spaces, weather, cooling_season)
-    return false if not success
-
-    success = add_doors(runner, model, building, spaces)
-    return false if not success
-
-    success = add_skylights(runner, model, building, spaces, weather, cooling_season)
-    return false if not success
-
-    success = add_conditioned_floor_area(runner, model, building, spaces)
-    return false if not success
+    add_roofs(runner, model, building, spaces)
+    add_walls(runner, model, building, spaces)
+    add_rim_joists(runner, model, building, spaces)
+    add_framefloors(runner, model, building, spaces)
+    add_foundation_walls_slabs(runner, model, building, spaces)
+    add_windows(runner, model, building, spaces, weather, cooling_season)
+    add_doors(runner, model, building, spaces)
+    add_skylights(runner, model, building, spaces, weather, cooling_season)
+    add_conditioned_floor_area(runner, model, building, spaces)
 
     # update living space/zone global variable
     @living_space = get_space_of_type(spaces, Constants.SpaceTypeLiving)
     @living_zone = @living_space.thermalZone.get
 
-    success = add_thermal_mass(runner, model, building)
-    return false if not success
+    add_thermal_mass(runner, model, building)
+    modify_cond_basement_surface_properties(runner, model)
+    assign_view_factor(runner, model)
+    check_for_errors(runner, model)
+    set_zone_volumes(runner, model, building)
+    explode_surfaces(runner, model, building)
 
-    success = modify_cond_basement_surface_properties(runner, model)
-    return false if not success
-
-    success = assign_view_factor(runner, model)
-    return false if not success
-
-    success = check_for_errors(runner, model)
-    return false if not success
-
-    success = set_zone_volumes(runner, model, building)
-    return false if not success
-
-    success = explode_surfaces(runner, model, building)
-    return false if not success
-
-    return true
+    return spaces
   end
 
   def self.set_zone_volumes(runner, model, building)
@@ -523,8 +452,6 @@ class OSModel
     if zones_updated != thermal_zones.size
       fail "Unhandled volume calculations for thermal zones."
     end
-
-    return true
   end
 
   def self.explode_surfaces(runner, model, building)
@@ -573,8 +500,7 @@ class OSModel
     end
     explode_distance = max_azimuth_length / (2.0 * Math.tan(UnitConversions.convert(180.0 / nsides, "deg", "rad")))
 
-    success = add_neighbors(runner, model, building, max_azimuth_length)
-    return false if not success
+    add_neighbors(runner, model, building, max_azimuth_length)
 
     # Initial distance of shifts at 90-degrees to horizontal outward
     azimuth_side_shifts = {}
@@ -592,8 +518,7 @@ class OSModel
         distance = shading_surface.additionalProperties.getFeatureAsDouble("Distance").get
 
         unless azimuth_lengths.keys.include? azimuth
-          runner.registerError("A neighbor building has an azimuth (#{azimuth}) not equal to the azimuth of any wall.")
-          return false
+          fail "A neighbor building has an azimuth (#{azimuth}) not equal to the azimuth of any wall."
         end
 
         # Push out horizontally
@@ -666,8 +591,6 @@ class OSModel
 
       surfaces_moved << surface
     end
-
-    return true
   end
 
   def self.check_for_errors(runner, model)
@@ -699,24 +622,18 @@ class OSModel
       end
 
       if n_floors == 0
-        runner.registerError("'#{zone.name}' must have at least one floor surface.")
-        return false
+        fail "'#{zone.name}' must have at least one floor surface."
       end
       if n_roofceilings == 0
-        runner.registerError("'#{zone.name}' must have at least one roof/ceiling surface.")
-        return false
+        fail "'#{zone.name}' must have at least one roof/ceiling surface."
       end
       if n_walls == 0 and not [Constants.SpaceTypeUnventedAttic, Constants.SpaceTypeVentedAttic].include? zone.name.to_s
-        runner.registerError("'#{zone.name}' must have at least one wall surface.")
-        return false
+        fail "'#{zone.name}' must have at least one wall surface."
       end
       if n_exteriors == 0
-        runner.registerError("'#{zone.name}' must have at least one surface adjacent to outside/ground.")
-        return false
+        fail "'#{zone.name}' must have at least one surface adjacent to outside/ground."
       end
     end
-
-    return true
   end
 
   def self.modify_cond_basement_surface_properties(runner, model)
@@ -750,7 +667,6 @@ class OSModel
       innermost_material.setSolarAbsorptance(0.0)
       innermost_material.setVisibleAbsorptance(0.0)
     end
-    return true
   end
 
   def self.assign_view_factor(runner, model)
@@ -801,8 +717,6 @@ class OSModel
         zone_prop.addViewFactor(os_vf)
       end
     end
-
-    return true
   end
 
   def self.calc_approximate_view_factor(runner, model, all_surfaces)
@@ -1045,16 +959,13 @@ class OSModel
       weekday_sch = "1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 0.88310, 0.40861, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.29498, 0.55310, 0.89693, 0.89693, 0.89693, 1.00000, 1.00000, 1.00000" # TODO: Normalize schedule based on hrs_per_day
       weekday_sch_sum = weekday_sch.split(",").map(&:to_f).inject(0, :+)
       if (weekday_sch_sum - hrs_per_day).abs > 0.1
-        runner.registerError("Occupancy schedule inconsistent with hrs_per_day.")
-        return false
+        fail "Occupancy schedule inconsistent with hrs_per_day."
       end
+
       weekend_sch = weekday_sch
       monthly_sch = "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0"
-      success = Geometry.process_occupants(model, runner, num_occ, occ_gain, sens_frac, lat_frac, weekday_sch, weekend_sch, monthly_sch, @cfa, @nbeds, @living_space)
-      return false if not success
+      Geometry.process_occupants(model, num_occ, occ_gain, sens_frac, lat_frac, weekday_sch, weekend_sch, monthly_sch, @cfa, @nbeds, @living_space)
     end
-
-    return true
   end
 
   def self.calc_subsurface_areas_by_surface(building)
@@ -1210,19 +1121,15 @@ class OSModel
 
       install_grade = 1
 
-      success = Constructions.apply_closed_cavity_roof(runner, model, surfaces, "#{roof_values[:id]} construction",
-                                                       cavity_r, install_grade,
-                                                       constr_set.stud.thick_in,
-                                                       true, constr_set.framing_factor,
-                                                       constr_set.drywall_thick_in,
-                                                       constr_set.osb_thick_in, constr_set.rigid_r,
-                                                       constr_set.exterior_material, has_radiant_barrier)
-      return false if not success
-
+      Constructions.apply_closed_cavity_roof(model, surfaces, "#{roof_values[:id]} construction",
+                                             cavity_r, install_grade,
+                                             constr_set.stud.thick_in,
+                                             true, constr_set.framing_factor,
+                                             constr_set.drywall_thick_in,
+                                             constr_set.osb_thick_in, constr_set.rigid_r,
+                                             constr_set.exterior_material, has_radiant_barrier)
       check_surface_assembly_rvalue(runner, surfaces, film_r, assembly_r, match)
     end
-
-    return true
   end
 
   def self.add_walls(runner, model, building, spaces)
@@ -1291,12 +1198,9 @@ class OSModel
         mat_ext_finish = nil
       end
 
-      success = apply_wall_construction(runner, model, surfaces, wall_values[:id], wall_values[:wall_type], wall_values[:insulation_assembly_r_value],
-                                        drywall_thick_in, film_r, mat_ext_finish)
-      return false if not success
+      apply_wall_construction(runner, model, surfaces, wall_values[:id], wall_values[:wall_type], wall_values[:insulation_assembly_r_value],
+                              drywall_thick_in, film_r, mat_ext_finish)
     end
-
-    return true
   end
 
   def self.add_rim_joists(runner, model, building, spaces)
@@ -1369,16 +1273,12 @@ class OSModel
       match, constr_set, cavity_r = pick_wood_stud_construction_set(assembly_r, constr_sets, film_r, rim_joist_values[:id])
       install_grade = 1
 
-      success = Constructions.apply_rim_joist(runner, model, surfaces, "#{rim_joist_values[:id]} construction",
-                                              cavity_r, install_grade, constr_set.framing_factor,
-                                              constr_set.drywall_thick_in, constr_set.osb_thick_in,
-                                              constr_set.rigid_r, constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_rim_joist(model, surfaces, "#{rim_joist_values[:id]} construction",
+                                    cavity_r, install_grade, constr_set.framing_factor,
+                                    constr_set.drywall_thick_in, constr_set.osb_thick_in,
+                                    constr_set.rigid_r, constr_set.exterior_material)
       check_surface_assembly_rvalue(runner, surfaces, film_r, assembly_r, match)
     end
-
-    return true
   end
 
   def self.add_framefloors(runner, model, building, spaces)
@@ -1424,17 +1324,13 @@ class OSModel
       install_grade = 1
 
       # Floor
-      success = Constructions.apply_floor(runner, model, [surface], "#{framefloor_values[:id]} construction",
-                                          cavity_r, install_grade,
-                                          constr_set.framing_factor, constr_set.stud.thick_in,
-                                          constr_set.osb_thick_in, constr_set.rigid_r,
-                                          mat_floor_covering, constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_floor(model, [surface], "#{framefloor_values[:id]} construction",
+                                cavity_r, install_grade,
+                                constr_set.framing_factor, constr_set.stud.thick_in,
+                                constr_set.osb_thick_in, constr_set.rigid_r,
+                                mat_floor_covering, constr_set.exterior_material)
       check_surface_assembly_rvalue(runner, [surface], film_r, assembly_r, match)
     end
-
-    return true
   end
 
   def self.add_foundation_walls_slabs(runner, model, building, spaces)
@@ -1508,7 +1404,6 @@ class OSModel
           fnd_wall_values = fnd_walls_values[fnd_wall]
           kiva_foundation = add_foundation_wall(runner, model, spaces, fnd_wall_values, slab_frac,
                                                 total_fnd_wall_length, total_slab_exp_perim)
-          return false if kiva_foundation.nil?
         end
 
         # Add single combined foundation slab surface (for similar surfaces)
@@ -1535,7 +1430,6 @@ class OSModel
         end
         kiva_foundation = add_foundation_slab(runner, model, spaces, slab_values, slab_exp_perim,
                                               slab_area, z_origin, kiva_foundation)
-        return false if kiva_foundation.nil?
       end
 
       # For each slab, create a no-wall Kiva slab instance if needed.
@@ -1547,7 +1441,6 @@ class OSModel
         slab_area = total_slab_area * no_wall_slab_exp_perim[slab] / total_slab_exp_perim
         kiva_foundation = add_foundation_slab(runner, model, spaces, slab_values, no_wall_slab_exp_perim[slab],
                                               slab_area, z_origin, nil)
-        return false if kiva_foundation.nil?
       end
 
       # Interzonal foundation wall surfaces
@@ -1598,9 +1491,8 @@ class OSModel
         end
         mat_ext_finish = nil
 
-        success = apply_wall_construction(runner, model, [surface], fnd_wall_values[:id], wall_type, assembly_r,
-                                          drywall_thick_in, film_r, mat_ext_finish)
-        return false if not success
+        apply_wall_construction(runner, model, [surface], fnd_wall_values[:id], wall_type, assembly_r,
+                                drywall_thick_in, film_r, mat_ext_finish)
       end
     end
   end
@@ -1677,13 +1569,11 @@ class OSModel
       rigid_r = fnd_wall_values[:insulation_r_value]
     end
 
-    success = Constructions.apply_foundation_wall(runner, model, [surface], "#{fnd_wall_values[:id]} construction",
-                                                  rigid_height, cavity_r, install_grade,
-                                                  cavity_depth_in, filled_cavity, framing_factor,
-                                                  rigid_r, drywall_thick_in, concrete_thick_in,
-                                                  height, height_ag)
-    return nil if not success
-
+    Constructions.apply_foundation_wall(model, [surface], "#{fnd_wall_values[:id]} construction",
+                                        rigid_height, cavity_r, install_grade,
+                                        cavity_depth_in, filled_cavity, framing_factor,
+                                        rigid_r, drywall_thick_in, concrete_thick_in,
+                                        height, height_ag)
     if not assembly_r.nil?
       check_surface_assembly_rvalue(runner, [surface], film_r, assembly_r, match)
     end
@@ -1741,12 +1631,10 @@ class OSModel
                                          slab_values[:carpet_r_value])
     end
 
-    success = Constructions.apply_foundation_slab(runner, model, surface, "#{slab_values[:id]} construction",
-                                                  slab_under_r, slab_under_width, slab_gap_r, slab_perim_r,
-                                                  slab_perim_depth, slab_whole_r, slab_values[:thickness],
-                                                  slab_exp_perim, mat_carpet, kiva_foundation)
-    return nil if not success
-
+    Constructions.apply_foundation_slab(model, surface, "#{slab_values[:id]} construction",
+                                        slab_under_r, slab_under_width, slab_gap_r, slab_perim_r,
+                                        slab_perim_depth, slab_whole_r, slab_values[:thickness],
+                                        slab_exp_perim, mat_carpet, kiva_foundation)
     # FIXME: Temporary code for sizing
     surface.additionalProperties.setFeature(Constants.SizingInfoSlabRvalue, 10.0)
 
@@ -1754,7 +1642,6 @@ class OSModel
   end
 
   def self.add_conditioned_floor_area(runner, model, building, spaces)
-    # FIXME: Simplify this.
     # TODO: Use HPXML values not Model values
     cfa = @cfa.round(1)
 
@@ -1774,7 +1661,7 @@ class OSModel
     end
 
     addtl_cfa = cfa - model_cfa
-    return true unless addtl_cfa > 0
+    return unless addtl_cfa > 0
 
     conditioned_floor_width = Math::sqrt(addtl_cfa)
     conditioned_floor_length = addtl_cfa / conditioned_floor_width
@@ -1807,28 +1694,21 @@ class OSModel
     end
 
     # Apply Construction
-    success = apply_adiabatic_construction(runner, model, [floor_surface, ceiling_surface], "floor")
-    return false if not success
-
-    return true
+    apply_adiabatic_construction(runner, model, [floor_surface, ceiling_surface], "floor")
   end
 
   def self.add_thermal_mass(runner, model, building)
     drywall_thick_in = 0.5
     partition_frac_of_cfa = 1.0 # Ratio of partition wall area to conditioned floor area
     basement_frac_of_cfa = (@cfa - @cfa_ag) / @cfa
-    success = Constructions.apply_partition_walls(runner, model, "PartitionWallConstruction", drywall_thick_in, partition_frac_of_cfa,
-                                                  basement_frac_of_cfa, @cond_bsmnt_surfaces, @living_space)
-    return false if not success
+    Constructions.apply_partition_walls(model, "PartitionWallConstruction", drywall_thick_in, partition_frac_of_cfa,
+                                        basement_frac_of_cfa, @cond_bsmnt_surfaces, @living_space)
 
     mass_lb_per_sqft = 8.0
     density_lb_per_cuft = 40.0
     mat = BaseMaterial.Wood
-    success = Constructions.apply_furniture(runner, model, mass_lb_per_sqft, density_lb_per_cuft, mat,
-                                            basement_frac_of_cfa, @cond_bsmnt_surfaces, @living_space)
-    return false if not success
-
-    return true
+    Constructions.apply_furniture(model, mass_lb_per_sqft, density_lb_per_cuft, mat,
+                                  basement_frac_of_cfa, @cond_bsmnt_surfaces, @living_space)
   end
 
   def self.add_neighbors(runner, model, building, length)
@@ -1870,8 +1750,6 @@ class OSModel
         shading_surface.setShadingSurfaceGroup(shading_surface_group)
       end
     end
-
-    return true
   end
 
   def self.add_windows(runner, model, building, spaces, weather, cooling_season)
@@ -1935,17 +1813,13 @@ class OSModel
       if not window_values[:interior_shading_factor_winter].nil?
         heat_shade_mult = window_values[:interior_shading_factor_winter]
       end
-      success = Constructions.apply_window(runner, model, [sub_surface],
-                                           "WindowConstruction",
-                                           weather, cooling_season, ufactor, shgc,
-                                           heat_shade_mult, cool_shade_mult)
-      return false if not success
+      Constructions.apply_window(model, [sub_surface],
+                                 "WindowConstruction",
+                                 weather, cooling_season, ufactor, shgc,
+                                 heat_shade_mult, cool_shade_mult)
     end
 
-    success = apply_adiabatic_construction(runner, model, surfaces, "wall")
-    return false if not success
-
-    return true
+    apply_adiabatic_construction(runner, model, surfaces, "wall")
   end
 
   def self.add_skylights(runner, model, building, spaces, weather, cooling_season)
@@ -2000,17 +1874,13 @@ class OSModel
       shgc = skylight_values[:shgc]
       cool_shade_mult = 1.0
       heat_shade_mult = 1.0
-      success = Constructions.apply_skylight(runner, model, [sub_surface],
-                                             "SkylightConstruction",
-                                             weather, cooling_season, ufactor, shgc,
-                                             heat_shade_mult, cool_shade_mult)
-      return false if not success
+      Constructions.apply_skylight(model, [sub_surface],
+                                   "SkylightConstruction",
+                                   weather, cooling_season, ufactor, shgc,
+                                   heat_shade_mult, cool_shade_mult)
     end
 
-    success = apply_adiabatic_construction(runner, model, surfaces, "roof")
-    return false if not success
-
-    return true
+    apply_adiabatic_construction(runner, model, surfaces, "roof")
   end
 
   def self.add_doors(runner, model, building, spaces)
@@ -2049,14 +1919,10 @@ class OSModel
       # Apply construction
       ufactor = 1.0 / door_values[:r_value]
 
-      success = Constructions.apply_door(runner, model, [sub_surface], "Door", ufactor)
-      return false if not success
+      Constructions.apply_door(model, [sub_surface], "Door", ufactor)
     end
 
-    success = apply_adiabatic_construction(runner, model, surfaces, "wall")
-    return false if not success
-
-    return true
+    apply_adiabatic_construction(runner, model, surfaces, "wall")
   end
 
   def self.apply_adiabatic_construction(runner, model, surfaces, type)
@@ -2065,29 +1931,18 @@ class OSModel
     # adiabatic or surface net area is near zero.
 
     if type == "wall"
-
-      success = Constructions.apply_wood_stud_wall(runner, model, surfaces, "AdiabaticWallConstruction",
-                                                   0, 1, 3.5, true, 0.1, 0.5, 0, 999,
-                                                   Material.ExtFinishStuccoMedDark)
-      return false if not success
-
+      Constructions.apply_wood_stud_wall(model, surfaces, "AdiabaticWallConstruction",
+                                         0, 1, 3.5, true, 0.1, 0.5, 0, 999,
+                                         Material.ExtFinishStuccoMedDark)
     elsif type == "floor"
-
-      success = Constructions.apply_floor(runner, model, surfaces, "AdiabaticFloorConstruction",
-                                          0, 1, 0.07, 5.5, 0.75, 999,
-                                          Material.FloorWood, Material.CoveringBare)
-      return false if not success
-
+      Constructions.apply_floor(model, surfaces, "AdiabaticFloorConstruction",
+                                0, 1, 0.07, 5.5, 0.75, 999,
+                                Material.FloorWood, Material.CoveringBare)
     elsif type == "roof"
-
-      success = Constructions.apply_open_cavity_roof(runner, model, surfaces, "AdiabaticRoofConstruction",
-                                                     0, 1, 7.25, 0.07, 7.25, 0.75, 999,
-                                                     Material.RoofingAsphaltShinglesMed, false)
-      return false if not success
-
+      Constructions.apply_open_cavity_roof(model, surfaces, "AdiabaticRoofConstruction",
+                                           0, 1, 7.25, 0.07, 7.25, 0.75, 999,
+                                           Material.RoofingAsphaltShinglesMed, false)
     end
-
-    return true
   end
 
   def self.add_hot_water_and_appliances(runner, model, building, weather, spaces)
@@ -2267,12 +2122,10 @@ class OSModel
           capacity_kbtuh = water_heating_system_values[:heating_capacity] / 1000.0
           oncycle_power = 0.0
           offcycle_power = 0.0
-          success = Waterheater.apply_tank(model, runner, space, to_beopt_fuel(fuel),
-                                           capacity_kbtuh, tank_vol, ef, re, setpoint_temp,
-                                           oncycle_power, offcycle_power, ec_adj,
-                                           @nbeds, @dhw_map, sys_id, desuperheater_clg_coil, jacket_r)
-          return false if not success
-
+          Waterheater.apply_tank(model, space, to_beopt_fuel(fuel),
+                                 capacity_kbtuh, tank_vol, ef, re, setpoint_temp,
+                                 oncycle_power, offcycle_power, ec_adj,
+                                 @nbeds, @dhw_map, sys_id, desuperheater_clg_coil, jacket_r)
         elsif wh_type == "instantaneous water heater"
 
           cycling_derate = water_heating_system_values[:performance_adjustment]
@@ -2283,19 +2136,15 @@ class OSModel
           capacity_kbtuh = 100000000.0
           oncycle_power = 0.0
           offcycle_power = 0.0
-          success = Waterheater.apply_tankless(model, runner, space, to_beopt_fuel(fuel),
-                                               capacity_kbtuh, ef, cycling_derate,
-                                               setpoint_temp, oncycle_power, offcycle_power, ec_adj,
-                                               @nbeds, @dhw_map, sys_id, desuperheater_clg_coil)
-          return false if not success
-
+          Waterheater.apply_tankless(model, space, to_beopt_fuel(fuel),
+                                     capacity_kbtuh, ef, cycling_derate,
+                                     setpoint_temp, oncycle_power, offcycle_power, ec_adj,
+                                     @nbeds, @dhw_map, sys_id, desuperheater_clg_coil)
         elsif wh_type == "heat pump water heater"
 
           tank_vol = water_heating_system_values[:tank_volume]
-          success = Waterheater.apply_heatpump(model, runner, space, weather, setpoint_temp, tank_vol, ef, ec_adj,
-                                               @nbeds, @dhw_map, sys_id, jacket_r)
-          return false if not success
-
+          Waterheater.apply_heatpump(model, runner, space, weather, setpoint_temp, tank_vol, ef, ec_adj,
+                                     @nbeds, @dhw_map, sys_id, jacket_r)
         elsif wh_type == "space-heating boiler with storage tank" or wh_type == "space-heating boiler with tankless coil"
           # Check tank type to default tank volume for tankless coil
           combi_sys_id_list << sys_id
@@ -2312,45 +2161,38 @@ class OSModel
           capacity_kbtuh = 0.0
           oncycle_power = 0.0
           offcycle_power = 0.0
-          success = Waterheater.apply_indirect(model, runner, space, capacity_kbtuh,
-                                               water_heating_system_values[:tank_volume], setpoint_temp, oncycle_power,
-                                               offcycle_power, ec_adj, @nbeds, boiler_sys['boiler'],
-                                               boiler_sys['plant_loop'], boiler_fuel_type,
-                                               @dhw_map, sys_id, wh_type, jacket_r, standby_loss)
-          return false if not success
-
+          Waterheater.apply_indirect(model, runner, space, capacity_kbtuh,
+                                     water_heating_system_values[:tank_volume], setpoint_temp, oncycle_power,
+                                     offcycle_power, ec_adj, @nbeds, boiler_sys['boiler'],
+                                     boiler_sys['plant_loop'], boiler_fuel_type,
+                                     @dhw_map, sys_id, wh_type, jacket_r, standby_loss)
         else
-
           fail "Unhandled water heater (#{wh_type})."
-
         end
         dhw_loop_fracs[sys_id] = dhw_load_frac
       end
     end
     wh_setpoint = Waterheater.get_default_hot_water_temperature(@eri_version)
-    success = HotWaterAndAppliances.apply(model, runner, weather, @living_space,
-                                          @cfa, @nbeds, @ncfl, @has_uncond_bsmnt, wh_setpoint,
-                                          cw_mef, cw_ler, cw_elec_rate, cw_gas_rate,
-                                          cw_agc, cw_cap, cw_space, cd_fuel, cd_ef, cd_control,
-                                          cd_space, dw_ef, dw_cap, fridge_annual_kwh, fridge_space,
-                                          cook_fuel_type, cook_is_induction, oven_is_convection,
-                                          has_low_flow_fixtures, dist_type, pipe_r,
-                                          std_pipe_length, recirc_loop_length,
-                                          recirc_branch_length, recirc_control_type,
-                                          recirc_pump_power, dwhr_present,
-                                          dwhr_facilities_connected, dwhr_is_equal_flow,
-                                          dwhr_efficiency, dhw_loop_fracs, @eri_version,
-                                          @dhw_map, @hpxml_path)
-    return false if not success
+    HotWaterAndAppliances.apply(model, weather, @living_space,
+                                @cfa, @nbeds, @ncfl, @has_uncond_bsmnt, wh_setpoint,
+                                cw_mef, cw_ler, cw_elec_rate, cw_gas_rate,
+                                cw_agc, cw_cap, cw_space, cd_fuel, cd_ef, cd_control,
+                                cd_space, dw_ef, dw_cap, fridge_annual_kwh, fridge_space,
+                                cook_fuel_type, cook_is_induction, oven_is_convection,
+                                has_low_flow_fixtures, dist_type, pipe_r,
+                                std_pipe_length, recirc_loop_length,
+                                recirc_branch_length, recirc_control_type,
+                                recirc_pump_power, dwhr_present,
+                                dwhr_facilities_connected, dwhr_is_equal_flow,
+                                dwhr_efficiency, dhw_loop_fracs, @eri_version,
+                                @dhw_map, @hpxml_path)
 
     # Add combi-system EMS program with water use equipment information
     @dhw_map.keys.each do |sys_id|
       next unless combi_sys_id_list.include? sys_id
 
-      Waterheater.apply_combi_system_EMS(model, runner, sys_id, @dhw_map)
+      Waterheater.apply_combi_system_EMS(model, sys_id, @dhw_map)
     end
-
-    return true
   end
 
   def self.get_desuperheatercoil(hvac_map, relatedhvac, wh_id)
@@ -2373,7 +2215,7 @@ class OSModel
   end
 
   def self.add_cooling_system(runner, model, building)
-    return true if @use_only_ideal_air
+    return if @use_only_ideal_air
 
     building.elements.each("BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem") do |clgsys|
       cooling_system_values = HPXML.get_cooling_system_values(cooling_system: clgsys)
@@ -2416,13 +2258,11 @@ class OSModel
           end
           fan_power_installed = get_fan_power_installed(seer)
           airflow_rate = cooling_system_values[:cooling_cfm] # Hidden feature; used only for HERS DSE test
-          success = HVAC.apply_central_ac_1speed(model, runner, seer, shrs,
-                                                 fan_power_installed, crankcase_kw, crankcase_temp,
-                                                 cool_capacity_btuh, airflow_rate, load_frac,
-                                                 sequential_load_frac, @living_zone,
-                                                 @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_central_ac_1speed(model, runner, seer, shrs,
+                                       fan_power_installed, crankcase_kw, crankcase_temp,
+                                       cool_capacity_btuh, airflow_rate, load_frac,
+                                       sequential_load_frac, @living_zone,
+                                       @hvac_map, sys_id)
         elsif num_speeds == "2-Speed"
 
           if cooling_system_values[:cooling_shr].nil?
@@ -2432,13 +2272,11 @@ class OSModel
             shrs = [cooling_system_values[:cooling_shr] - 0.02, cooling_system_values[:cooling_shr]]
           end
           fan_power_installed = get_fan_power_installed(seer)
-          success = HVAC.apply_central_ac_2speed(model, runner, seer, shrs,
-                                                 fan_power_installed, crankcase_kw, crankcase_temp,
-                                                 cool_capacity_btuh, load_frac,
-                                                 sequential_load_frac, @living_zone,
-                                                 @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_central_ac_2speed(model, runner, seer, shrs,
+                                       fan_power_installed, crankcase_kw, crankcase_temp,
+                                       cool_capacity_btuh, load_frac,
+                                       sequential_load_frac, @living_zone,
+                                       @hvac_map, sys_id)
         elsif num_speeds == "Variable-Speed"
 
           if cooling_system_values[:cooling_shr].nil?
@@ -2448,13 +2286,11 @@ class OSModel
             shrs = var_sp_shr_mult.map { |m| cooling_system_values[:cooling_shr] * m }
           end
           fan_power_installed = get_fan_power_installed(seer)
-          success = HVAC.apply_central_ac_4speed(model, runner, seer, shrs,
-                                                 fan_power_installed, crankcase_kw, crankcase_temp,
-                                                 cool_capacity_btuh, load_frac,
-                                                 sequential_load_frac, @living_zone,
-                                                 @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_central_ac_4speed(model, runner, seer, shrs,
+                                       fan_power_installed, crankcase_kw, crankcase_temp,
+                                       cool_capacity_btuh, load_frac,
+                                       sequential_load_frac, @living_zone,
+                                       @hvac_map, sys_id)
         else
 
           fail "Unexpected number of speeds (#{num_speeds}) for cooling system."
@@ -2472,28 +2308,22 @@ class OSModel
         end
 
         airflow_rate = 350.0
-        success = HVAC.apply_room_ac(model, runner, eer, shr,
-                                     airflow_rate, cool_capacity_btuh, load_frac,
-                                     sequential_load_frac, @living_zone,
-                                     @hvac_map, sys_id)
-        return false if not success
-
+        HVAC.apply_room_ac(model, runner, eer, shr,
+                           airflow_rate, cool_capacity_btuh, load_frac,
+                           sequential_load_frac, @living_zone,
+                           @hvac_map, sys_id)
       elsif clg_type == "evaporative cooler"
 
         is_ducted = XMLHelper.has_element(clgsys, "DistributionSystem")
-        success = HVAC.apply_evaporative_cooler(model, runner, load_frac,
-                                                sequential_load_frac, @living_zone,
-                                                @hvac_map, sys_id, is_ducted)
-        return false if not success
-
+        HVAC.apply_evaporative_cooler(model, runner, load_frac,
+                                      sequential_load_frac, @living_zone,
+                                      @hvac_map, sys_id, is_ducted)
       end
     end
-
-    return true
   end
 
   def self.add_heating_system(runner, model, building)
-    return true if @use_only_ideal_air
+    return if @use_only_ideal_air
 
     # We need to process furnaces attached to ACs before any other heating system
     # such that the sequential load heating fraction is properly applied.
@@ -2537,25 +2367,21 @@ class OSModel
           afue = heating_system_values[:heating_efficiency_afue]
           fan_power = 0.5 # For fuel furnaces, will be overridden by EAE later
           airflow_rate = heating_system_values[:heating_cfm] # Hidden feature; used only for HERS DSE test
-          success = HVAC.apply_furnace(model, runner, fuel, afue,
-                                       heat_capacity_btuh, airflow_rate, fan_power,
-                                       load_frac, sequential_load_frac,
-                                       attached_clg_system, @living_zone,
-                                       @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_furnace(model, runner, fuel, afue,
+                             heat_capacity_btuh, airflow_rate, fan_power,
+                             load_frac, sequential_load_frac,
+                             attached_clg_system, @living_zone,
+                             @hvac_map, sys_id)
         elsif htg_type == "WallFurnace"
 
           afue = heating_system_values[:heating_efficiency_afue]
           fan_power = 0.0
           airflow_rate = 0.0
-          success = HVAC.apply_unit_heater(model, runner, fuel,
-                                           afue, heat_capacity_btuh, fan_power,
-                                           airflow_rate, load_frac,
-                                           sequential_load_frac, @living_zone,
-                                           @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_unit_heater(model, runner, fuel,
+                                 afue, heat_capacity_btuh, fan_power,
+                                 airflow_rate, load_frac,
+                                 sequential_load_frac, @living_zone,
+                                 @hvac_map, sys_id)
         elsif htg_type == "Boiler"
 
           system_type = Constants.BoilerTypeForcedDraft
@@ -2566,43 +2392,35 @@ class OSModel
           oat_hwst_high = nil
           oat_hwst_low = nil
           design_temp = 180.0
-          success = HVAC.apply_boiler(model, runner, fuel, system_type, afue,
-                                      oat_reset_enabled, oat_high, oat_low, oat_hwst_high, oat_hwst_low,
-                                      heat_capacity_btuh, design_temp, load_frac,
-                                      sequential_load_frac, @living_zone,
-                                      @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_boiler(model, runner, fuel, system_type, afue,
+                            oat_reset_enabled, oat_high, oat_low, oat_hwst_high, oat_hwst_low,
+                            heat_capacity_btuh, design_temp, load_frac,
+                            sequential_load_frac, @living_zone,
+                            @hvac_map, sys_id)
         elsif htg_type == "ElectricResistance"
 
           efficiency = heating_system_values[:heating_efficiency_percent]
-          success = HVAC.apply_electric_baseboard(model, runner, efficiency,
-                                                  heat_capacity_btuh, load_frac,
-                                                  sequential_load_frac, @living_zone,
-                                                  @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_electric_baseboard(model, runner, efficiency,
+                                        heat_capacity_btuh, load_frac,
+                                        sequential_load_frac, @living_zone,
+                                        @hvac_map, sys_id)
         elsif htg_type == "Stove" or htg_type == "PortableHeater"
 
           efficiency = heating_system_values[:heating_efficiency_percent]
           airflow_rate = 125.0 # cfm/ton; doesn't affect energy consumption
           fan_power = 0.5 # For fuel equipment, will be overridden by EAE later
-          success = HVAC.apply_unit_heater(model, runner, fuel,
-                                           efficiency, heat_capacity_btuh, fan_power,
-                                           airflow_rate, load_frac,
-                                           sequential_load_frac, @living_zone,
-                                           @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_unit_heater(model, runner, fuel,
+                                 efficiency, heat_capacity_btuh, fan_power,
+                                 airflow_rate, load_frac,
+                                 sequential_load_frac, @living_zone,
+                                 @hvac_map, sys_id)
         end
       end
     end
-
-    return true
   end
 
   def self.add_heat_pump(runner, model, building, weather)
-    return true if @use_only_ideal_air
+    return if @use_only_ideal_air
 
     building.elements.each("BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |hp|
       heat_pump_values = HPXML.get_heat_pump_values(heat_pump: hp)
@@ -2623,14 +2441,12 @@ class OSModel
 
       # Heating and cooling capacity must either both be Autosized or Fixed
       if (cool_capacity_btuh == Constants.SizingAuto) ^ (heat_capacity_btuh == Constants.SizingAuto)
-        runner.registerError("HeatPump '#{heat_pump_values[:id]}' CoolingCapacity and HeatingCapacity must either both be auto-sized or fixed-sized.")
-        return false
+        fail "HeatPump '#{heat_pump_values[:id]}' CoolingCapacity and HeatingCapacity must either both be auto-sized or fixed-sized."
       end
 
       heat_capacity_btuh_17F = heat_pump_values[:heating_capacity_17F]
       if heat_capacity_btuh == Constants.SizingAuto and not heat_capacity_btuh_17F.nil?
-        runner.registerError("HeatPump '#{heat_pump_values[:id]}' has HeatingCapacity17F provided but heating capacity is auto-sized.")
-        return false
+        fail "HeatPump '#{heat_pump_values[:id]}' has HeatingCapacity17F provided but heating capacity is auto-sized."
       end
 
       load_frac_heat = heat_pump_values[:fraction_heat_load_served]
@@ -2661,8 +2477,7 @@ class OSModel
 
         # Heating and backup heating capacity must either both be Autosized or Fixed
         if (backup_heat_capacity_btuh == Constants.SizingAuto) ^ (heat_capacity_btuh == Constants.SizingAuto)
-          runner.registerError("HeatPump '#{heat_pump_values[:id]}' BackupHeatingCapacity and HeatingCapacity must either both be auto-sized or fixed-sized.")
-          return false
+          fail "HeatPump '#{heat_pump_values[:id]}' BackupHeatingCapacity and HeatingCapacity must either both be auto-sized or fixed-sized."
         end
 
         if not heat_pump_values[:backup_heating_efficiency_percent].nil?
@@ -2715,15 +2530,13 @@ class OSModel
           end
 
           fan_power_installed = get_fan_power_installed(seer)
-          success = HVAC.apply_central_ashp_1speed(model, runner, seer, hspf, shrs,
-                                                   fan_power_installed, hp_compressor_min_temp, crankcase_kw, crankcase_temp,
-                                                   cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
-                                                   backup_heat_fuel, backup_heat_efficiency, backup_heat_capacity_btuh, supp_htg_max_outdoor_temp,
-                                                   load_frac_heat, load_frac_cool,
-                                                   sequential_load_frac_heat, sequential_load_frac_cool,
-                                                   @living_zone, @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_central_ashp_1speed(model, runner, seer, hspf, shrs,
+                                         fan_power_installed, hp_compressor_min_temp, crankcase_kw, crankcase_temp,
+                                         cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
+                                         backup_heat_fuel, backup_heat_efficiency, backup_heat_capacity_btuh, supp_htg_max_outdoor_temp,
+                                         load_frac_heat, load_frac_cool,
+                                         sequential_load_frac_heat, sequential_load_frac_cool,
+                                         @living_zone, @hvac_map, sys_id)
         elsif num_speeds == "2-Speed"
 
           if heat_pump_values[:cooling_shr].nil?
@@ -2733,15 +2546,13 @@ class OSModel
             shrs = [heat_pump_values[:cooling_shr] - 0.014, heat_pump_values[:cooling_shr]]
           end
           fan_power_installed = get_fan_power_installed(seer)
-          success = HVAC.apply_central_ashp_2speed(model, runner, seer, hspf, shrs,
-                                                   fan_power_installed, hp_compressor_min_temp, crankcase_kw, crankcase_temp,
-                                                   cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
-                                                   backup_heat_fuel, backup_heat_efficiency, backup_heat_capacity_btuh, supp_htg_max_outdoor_temp,
-                                                   load_frac_heat, load_frac_cool,
-                                                   sequential_load_frac_heat, sequential_load_frac_cool,
-                                                   @living_zone, @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_central_ashp_2speed(model, runner, seer, hspf, shrs,
+                                         fan_power_installed, hp_compressor_min_temp, crankcase_kw, crankcase_temp,
+                                         cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
+                                         backup_heat_fuel, backup_heat_efficiency, backup_heat_capacity_btuh, supp_htg_max_outdoor_temp,
+                                         load_frac_heat, load_frac_cool,
+                                         sequential_load_frac_heat, sequential_load_frac_cool,
+                                         @living_zone, @hvac_map, sys_id)
         elsif num_speeds == "Variable-Speed"
 
           if heat_pump_values[:cooling_shr].nil?
@@ -2751,15 +2562,13 @@ class OSModel
             shrs = var_sp_shr_mult.map { |m| heat_pump_values[:cooling_shr] * m }
           end
           fan_power_installed = get_fan_power_installed(seer)
-          success = HVAC.apply_central_ashp_4speed(model, runner, seer, hspf, shrs,
-                                                   fan_power_installed, hp_compressor_min_temp, crankcase_kw, crankcase_temp,
-                                                   cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
-                                                   backup_heat_fuel, backup_heat_efficiency, backup_heat_capacity_btuh, supp_htg_max_outdoor_temp,
-                                                   load_frac_heat, load_frac_cool,
-                                                   sequential_load_frac_heat, sequential_load_frac_cool,
-                                                   @living_zone, @hvac_map, sys_id)
-          return false if not success
-
+          HVAC.apply_central_ashp_4speed(model, runner, seer, hspf, shrs,
+                                         fan_power_installed, hp_compressor_min_temp, crankcase_kw, crankcase_temp,
+                                         cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
+                                         backup_heat_fuel, backup_heat_efficiency, backup_heat_capacity_btuh, supp_htg_max_outdoor_temp,
+                                         load_frac_heat, load_frac_cool,
+                                         sequential_load_frac_heat, sequential_load_frac_cool,
+                                         @living_zone, @hvac_map, sys_id)
         else
 
           fail "Unexpected number of speeds (#{num_speeds}) for heat pump system."
@@ -2802,20 +2611,18 @@ class OSModel
         pan_heater_power = 0.0
         fan_power = 0.07
         is_ducted = XMLHelper.has_element(hp, "DistributionSystem")
-        success = HVAC.apply_mshp(model, runner, seer, hspf, shr,
-                                  min_cooling_capacity, max_cooling_capacity,
-                                  min_cooling_airflow_rate, max_cooling_airflow_rate,
-                                  min_heating_capacity, max_heating_capacity,
-                                  min_heating_airflow_rate, max_heating_airflow_rate,
-                                  heating_capacity_offset, cap_retention_frac,
-                                  cap_retention_temp, pan_heater_power, fan_power,
-                                  is_ducted, cool_capacity_btuh, hp_compressor_min_temp,
-                                  backup_heat_fuel, backup_heat_efficiency, backup_heat_capacity_btuh,
-                                  supp_htg_max_outdoor_temp, load_frac_heat, load_frac_cool,
-                                  sequential_load_frac_heat, sequential_load_frac_cool,
-                                  @living_zone, @hvac_map, sys_id)
-        return false if not success
-
+        HVAC.apply_mshp(model, runner, seer, hspf, shr,
+                        min_cooling_capacity, max_cooling_capacity,
+                        min_cooling_airflow_rate, max_cooling_airflow_rate,
+                        min_heating_capacity, max_heating_capacity,
+                        min_heating_airflow_rate, max_heating_airflow_rate,
+                        heating_capacity_offset, cap_retention_frac,
+                        cap_retention_temp, pan_heater_power, fan_power,
+                        is_ducted, cool_capacity_btuh, hp_compressor_min_temp,
+                        backup_heat_fuel, backup_heat_efficiency, backup_heat_capacity_btuh,
+                        supp_htg_max_outdoor_temp, load_frac_heat, load_frac_cool,
+                        sequential_load_frac_heat, sequential_load_frac_cool,
+                        @living_zone, @hvac_map, sys_id)
       elsif hp_type == "ground-to-air"
 
         eer = heat_pump_values[:cooling_efficiency_eer]
@@ -2841,32 +2648,26 @@ class OSModel
         u_tube_leg_spacing = 0.9661
         u_tube_spacing_type = "b"
         fan_power = 0.5
-        success = HVAC.apply_gshp(model, runner, weather, cop, eer, shr,
-                                  ground_conductivity, grout_conductivity,
-                                  bore_config, bore_holes, bore_depth,
-                                  bore_spacing, bore_diameter, pipe_size,
-                                  ground_diffusivity, fluid_type, frac_glycol,
-                                  design_delta_t, pump_head,
-                                  u_tube_leg_spacing, u_tube_spacing_type,
-                                  fan_power, cool_capacity_btuh, heat_capacity_btuh,
-                                  backup_heat_efficiency, backup_heat_capacity_btuh,
-                                  load_frac_heat, load_frac_cool,
-                                  sequential_load_frac_heat, sequential_load_frac_cool,
-                                  @living_zone, @hvac_map, sys_id)
-        return false if not success
-
+        HVAC.apply_gshp(model, runner, weather, cop, eer, shr,
+                        ground_conductivity, grout_conductivity,
+                        bore_config, bore_holes, bore_depth,
+                        bore_spacing, bore_diameter, pipe_size,
+                        ground_diffusivity, fluid_type, frac_glycol,
+                        design_delta_t, pump_head,
+                        u_tube_leg_spacing, u_tube_spacing_type,
+                        fan_power, cool_capacity_btuh, heat_capacity_btuh,
+                        backup_heat_efficiency, backup_heat_capacity_btuh,
+                        load_frac_heat, load_frac_cool,
+                        sequential_load_frac_heat, sequential_load_frac_cool,
+                        @living_zone, @hvac_map, sys_id)
       end
     end
-
-    return true
   end
 
   def self.add_residual_hvac(runner, model, building)
     if @use_only_ideal_air
-      success = HVAC.apply_ideal_air_loads(model, runner, 1, 1, @living_zone)
-      return false if not success
-
-      return true
+      HVAC.apply_ideal_air_loads(model, runner, 1, 1, @living_zone)
+      return
     end
 
     # Adds an ideal air system to meet either:
@@ -2888,17 +2689,14 @@ class OSModel
       sequential_heat_load_frac = 0 # no heating system, don't add ideal air for heating either
     end
     if sequential_heat_load_frac > 0 or sequential_cool_load_frac > 0
-      success = HVAC.apply_ideal_air_loads(model, runner, sequential_cool_load_frac, sequential_heat_load_frac,
-                                           @living_zone)
-      return false if not success
+      HVAC.apply_ideal_air_loads(model, runner, sequential_cool_load_frac, sequential_heat_load_frac,
+                                 @living_zone)
     end
-
-    return true
   end
 
   def self.add_setpoints(runner, model, building, weather)
     hvac_control_values = HPXML.get_hvac_control_values(hvac_control: building.elements["BuildingDetails/Systems/HVAC/HVACControl"])
-    return true if hvac_control_values.nil?
+    return if hvac_control_values.nil?
 
     # Base heating setpoint
     htg_setpoint = hvac_control_values[:heating_setpoint_temp]
@@ -2920,10 +2718,9 @@ class OSModel
     htg_use_auto_season = false
     htg_season_start_month = 1
     htg_season_end_month = 12
-    success = HVAC.apply_heating_setpoints(model, runner, weather, htg_weekday_setpoints, htg_weekend_setpoints,
-                                           htg_use_auto_season, htg_season_start_month, htg_season_end_month,
-                                           @living_zone)
-    return false if not success
+    HVAC.apply_heating_setpoints(model, runner, weather, htg_weekday_setpoints, htg_weekend_setpoints,
+                                 htg_use_auto_season, htg_season_start_month, htg_season_end_month,
+                                 @living_zone)
 
     # Base cooling setpoint
     clg_setpoint = hvac_control_values[:cooling_setpoint_temp]
@@ -2955,17 +2752,14 @@ class OSModel
     clg_use_auto_season = false
     clg_season_start_month = 1
     clg_season_end_month = 12
-    success = HVAC.apply_cooling_setpoints(model, runner, weather, clg_weekday_setpoints, clg_weekend_setpoints,
-                                           clg_use_auto_season, clg_season_start_month, clg_season_end_month,
-                                           @living_zone)
-    return false if not success
-
-    return true
+    HVAC.apply_cooling_setpoints(model, runner, weather, clg_weekday_setpoints, clg_weekend_setpoints,
+                                 clg_use_auto_season, clg_season_start_month, clg_season_end_month,
+                                 @living_zone)
   end
 
   def self.add_ceiling_fans(runner, model, building, weather)
     ceiling_fan_values = HPXML.get_ceiling_fan_values(ceiling_fan: building.elements["BuildingDetails/Lighting/CeilingFan"])
-    return true if ceiling_fan_values.nil?
+    return if ceiling_fan_values.nil?
 
     monthly_sch = HVAC.get_ceiling_fan_operation_months(weather)
     medium_cfm = 3000.0
@@ -2985,11 +2779,8 @@ class OSModel
     annual_kwh = UnitConversions.convert(quantity * medium_cfm / cfm_per_w * hrs_per_day * 365.0, "Wh", "kWh")
     annual_kwh *= monthly_sch.inject(:+) / 12.0
 
-    success = HVAC.apply_ceiling_fans(model, runner, annual_kwh, weekday_sch, weekend_sch, monthly_sch,
-                                      @cfa, @living_space)
-    return false if not success
-
-    return true
+    HVAC.apply_ceiling_fans(model, runner, annual_kwh, weekday_sch, weekend_sch, monthly_sch,
+                            @cfa, @living_space)
   end
 
   def self.check_distribution_system(building, system_values)
@@ -3078,17 +2869,14 @@ class OSModel
       tv_annual_kwh = 0
     end
 
-    success, sch = MiscLoads.apply_plug(model, runner, misc_annual_kwh, misc_sens_frac, misc_lat_frac,
-                                        misc_weekday_sch, misc_weekend_sch, misc_monthly_sch, tv_annual_kwh,
-                                        @cfa, @living_space)
-    return false if not success
-
-    return true
+    MiscLoads.apply_plug(model, misc_annual_kwh, misc_sens_frac, misc_lat_frac,
+                         misc_weekday_sch, misc_weekend_sch, misc_monthly_sch, tv_annual_kwh,
+                         @cfa, @living_space)
   end
 
   def self.add_lighting(runner, model, building, weather, spaces)
     lighting = building.elements["BuildingDetails/Lighting"]
-    return true if lighting.nil?
+    return if lighting.nil?
 
     lighting_values = HPXML.get_lighting_values(lighting: lighting)
 
@@ -3111,11 +2899,8 @@ class OSModel
                                                               lighting_values[:fraction_tier_ii_garage])
 
     garage_space = get_space_of_type(spaces, Constants.SpaceTypeGarage)
-    success, sch = Lighting.apply(model, runner, weather, int_kwh, grg_kwh, ext_kwh, @cfa, @gfa,
-                                  @living_space, garage_space)
-    return false if not success
-
-    return true
+    Lighting.apply(model, weather, int_kwh, grg_kwh, ext_kwh, @cfa, @gfa,
+                   @living_space, garage_space)
   end
 
   def self.add_airflow(runner, model, building, weather, spaces)
@@ -3390,12 +3175,9 @@ class OSModel
       window_area += window_values[:area]
     end
 
-    success = Airflow.apply(model, runner, weather, infil, mech_vent, nat_vent, duct_systems,
-                            @cfa, @infilvolume, @nbeds, @nbaths, @ncfl, @ncfl_ag, window_area,
-                            @min_neighbor_distance)
-    return false if not success
-
-    return true
+    Airflow.apply(model, runner, weather, infil, mech_vent, nat_vent, duct_systems,
+                  @cfa, @infilvolume, @nbeds, @nbaths, @ncfl, @ncfl_ag, window_area,
+                  @min_neighbor_distance)
   end
 
   def self.create_ducts(air_distribution, model, spaces, dist_id)
@@ -3485,10 +3267,7 @@ class OSModel
   end
 
   def self.add_hvac_sizing(runner, model, weather)
-    success = HVACSizing.apply(model, runner, weather, @cfa, @infilvolume, @nbeds, @min_neighbor_distance, false, @living_space)
-    return false if not success
-
-    return true
+    HVACSizing.apply(model, runner, weather, @cfa, @infilvolume, @nbeds, @min_neighbor_distance, false, @living_space)
   end
 
   def self.add_fuel_heating_eae(runner, model, building)
@@ -3507,11 +3286,8 @@ class OSModel
       load_frac = heating_system_values[:fraction_heat_load_served]
       sys_id = heating_system_values[:id]
 
-      success = HVAC.apply_eae_to_heating_fan(runner, @hvac_map[sys_id], fuel_eae, fuel, load_frac, htg_type)
-      return false if not success
+      HVAC.apply_eae_to_heating_fan(runner, @hvac_map[sys_id], fuel_eae, fuel, load_frac, htg_type)
     end
-
-    return true
   end
 
   def self.add_photovoltaics(runner, model, building)
@@ -3540,25 +3316,15 @@ class OSModel
       inv_eff = pv_system_values[:inverter_efficiency]
       system_losses = pv_system_values[:system_losses_fraction]
 
-      success = PV.apply(model, runner, pv_id, power_w, module_type,
-                         system_losses, inv_eff, tilt, az, array_type)
-      return false if not success
+      PV.apply(model, pv_id, power_w, module_type,
+               system_losses, inv_eff, tilt, az, array_type)
     end
-
-    return true
   end
 
   def self.add_outputs(runner, model, map_tsv_dir)
-    success = add_output_variables(runner, model, map_tsv_dir)
-    return false if not success
-
-    success = add_output_meters(runner, model)
-    return false if not success
-
-    success = add_component_loads_output(runner, model)
-    return false if not success
-
-    return true
+    add_output_variables(runner, model, map_tsv_dir)
+    add_output_meters(runner, model)
+    add_component_loads_output(runner, model)
   end
 
   def self.add_output_variables(runner, model, map_tsv_dir)
@@ -3636,8 +3402,6 @@ class OSModel
       write_mapping(@hvac_map, File.join(map_tsv_dir, "map_hvac.tsv"))
       write_mapping(@dhw_map, File.join(map_tsv_dir, "map_water_heating.tsv"))
     end
-
-    return true
   end
 
   def self.add_output_variable(model, vars, object)
@@ -4207,8 +3971,6 @@ class OSModel
     program_calling_manager.setName("component loads program calling manager")
     program_calling_manager.setCallingPoint("EndOfZoneTimestepAfterZoneReporting")
     program_calling_manager.addProgram(program)
-
-    return true
   end
 
   def self.calc_non_cavity_r(film_r, constr_set)
@@ -4254,13 +4016,11 @@ class OSModel
       ]
       match, constr_set, cavity_r = pick_wood_stud_construction_set(assembly_r, constr_sets, film_r, wall_id)
 
-      success = Constructions.apply_wood_stud_wall(runner, model, surfaces, "#{wall_id} construction",
-                                                   cavity_r, install_grade, constr_set.stud.thick_in,
-                                                   cavity_filled, constr_set.framing_factor,
-                                                   constr_set.drywall_thick_in, constr_set.osb_thick_in,
-                                                   constr_set.rigid_r, constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_wood_stud_wall(model, surfaces, "#{wall_id} construction",
+                                         cavity_r, install_grade, constr_set.stud.thick_in,
+                                         cavity_filled, constr_set.framing_factor,
+                                         constr_set.drywall_thick_in, constr_set.osb_thick_in,
+                                         constr_set.rigid_r, constr_set.exterior_material)
     elsif wall_type == "SteelFrame"
       install_grade = 1
       cavity_filled = true
@@ -4275,14 +4035,12 @@ class OSModel
       ]
       match, constr_set, cavity_r = pick_steel_stud_construction_set(assembly_r, constr_sets, film_r, "wall #{wall_id}")
 
-      success = Constructions.apply_steel_stud_wall(runner, model, surfaces, "#{wall_id} construction",
-                                                    cavity_r, install_grade, constr_set.cavity_thick_in,
-                                                    cavity_filled, constr_set.framing_factor,
-                                                    constr_set.corr_factor, constr_set.drywall_thick_in,
-                                                    constr_set.osb_thick_in, constr_set.rigid_r,
-                                                    constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_steel_stud_wall(model, surfaces, "#{wall_id} construction",
+                                          cavity_r, install_grade, constr_set.cavity_thick_in,
+                                          cavity_filled, constr_set.framing_factor,
+                                          constr_set.corr_factor, constr_set.drywall_thick_in,
+                                          constr_set.osb_thick_in, constr_set.rigid_r,
+                                          constr_set.exterior_material)
     elsif wall_type == "DoubleWoodStud"
       install_grade = 1
       is_staggered = false
@@ -4293,14 +4051,12 @@ class OSModel
       ]
       match, constr_set, cavity_r = pick_double_stud_construction_set(assembly_r, constr_sets, film_r, "wall #{wall_id}")
 
-      success = Constructions.apply_double_stud_wall(runner, model, surfaces, "#{wall_id} construction",
-                                                     cavity_r, install_grade, constr_set.stud.thick_in,
-                                                     constr_set.stud.thick_in, constr_set.framing_factor,
-                                                     constr_set.framing_spacing, is_staggered,
-                                                     constr_set.drywall_thick_in, constr_set.osb_thick_in,
-                                                     constr_set.rigid_r, constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_double_stud_wall(model, surfaces, "#{wall_id} construction",
+                                           cavity_r, install_grade, constr_set.stud.thick_in,
+                                           constr_set.stud.thick_in, constr_set.framing_factor,
+                                           constr_set.framing_spacing, is_staggered,
+                                           constr_set.drywall_thick_in, constr_set.osb_thick_in,
+                                           constr_set.rigid_r, constr_set.exterior_material)
     elsif wall_type == "ConcreteMasonryUnit"
       density = 119.0 # lb/ft^3
       furring_r = 0
@@ -4313,14 +4069,12 @@ class OSModel
       ]
       match, constr_set, rigid_r = pick_cmu_construction_set(assembly_r, constr_sets, film_r, "wall #{wall_id}")
 
-      success = Constructions.apply_cmu_wall(runner, model, surfaces, "#{wall_id} construction",
-                                             constr_set.thick_in, constr_set.cond_in, density,
-                                             constr_set.framing_factor, furring_r,
-                                             furring_cavity_depth_in, furring_spacing,
-                                             constr_set.drywall_thick_in, constr_set.osb_thick_in,
-                                             rigid_r, constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_cmu_wall(model, surfaces, "#{wall_id} construction",
+                                   constr_set.thick_in, constr_set.cond_in, density,
+                                   constr_set.framing_factor, furring_r,
+                                   furring_cavity_depth_in, furring_spacing,
+                                   constr_set.drywall_thick_in, constr_set.osb_thick_in,
+                                   rigid_r, constr_set.exterior_material)
     elsif wall_type == "StructurallyInsulatedPanel"
       sheathing_thick_in = 0.44
       sheathing_type = Constants.MaterialOSB
@@ -4332,13 +4086,11 @@ class OSModel
       ]
       match, constr_set, cavity_r = pick_sip_construction_set(assembly_r, constr_sets, film_r, "wall #{wall_id}")
 
-      success = Constructions.apply_sip_wall(runner, model, surfaces, "#{wall_id} construction",
-                                             cavity_r, constr_set.thick_in, constr_set.framing_factor,
-                                             sheathing_type, constr_set.sheath_thick_in,
-                                             constr_set.drywall_thick_in, constr_set.osb_thick_in,
-                                             constr_set.rigid_r, constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_sip_wall(model, surfaces, "#{wall_id} construction",
+                                   cavity_r, constr_set.thick_in, constr_set.framing_factor,
+                                   sheathing_type, constr_set.sheath_thick_in,
+                                   constr_set.drywall_thick_in, constr_set.osb_thick_in,
+                                   constr_set.rigid_r, constr_set.exterior_material)
     elsif wall_type == "InsulatedConcreteForms"
       constr_sets = [
         ICFConstructionSet.new(2.0, 4.0, 0.08, 0.0, 0.5, drywall_thick_in, mat_ext_finish), # ICF w/4" concrete and 2" rigid ins layers
@@ -4346,13 +4098,11 @@ class OSModel
       ]
       match, constr_set, icf_r = pick_icf_construction_set(assembly_r, constr_sets, film_r, "wall #{wall_id}")
 
-      success = Constructions.apply_icf_wall(runner, model, surfaces, "#{wall_id} construction",
-                                             icf_r, constr_set.ins_thick_in,
-                                             constr_set.concrete_thick_in, constr_set.framing_factor,
-                                             constr_set.drywall_thick_in, constr_set.osb_thick_in,
-                                             constr_set.rigid_r, constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_icf_wall(model, surfaces, "#{wall_id} construction",
+                                   icf_r, constr_set.ins_thick_in,
+                                   constr_set.concrete_thick_in, constr_set.framing_factor,
+                                   constr_set.drywall_thick_in, constr_set.osb_thick_in,
+                                   constr_set.rigid_r, constr_set.exterior_material)
     elsif ["SolidConcrete", "StructuralBrick", "StrawBale", "Stone", "LogWall"].include? wall_type
       constr_sets = [
         GenericConstructionSet.new(10.0, 0.5, drywall_thick_in, mat_ext_finish), # w/R-10 rigid
@@ -4386,16 +4136,12 @@ class OSModel
       denss = [base_mat.rho]
       specheats = [base_mat.cp]
 
-      success = Constructions.apply_generic_layered_wall(runner, model, surfaces, "#{wall_id} construction",
-                                                         thick_ins, conds, denss, specheats,
-                                                         constr_set.drywall_thick_in, constr_set.osb_thick_in,
-                                                         constr_set.rigid_r, constr_set.exterior_material)
-      return false if not success
-
+      Constructions.apply_generic_layered_wall(model, surfaces, "#{wall_id} construction",
+                                               thick_ins, conds, denss, specheats,
+                                               constr_set.drywall_thick_in, constr_set.osb_thick_in,
+                                               constr_set.rigid_r, constr_set.exterior_material)
     else
-
       fail "Unexpected wall type '#{wall_type}'."
-
     end
 
     check_surface_assembly_rvalue(runner, surfaces, film_r, assembly_r, match)

--- a/resources/airflow.rb
+++ b/resources/airflow.rb
@@ -10,6 +10,7 @@ class Airflow
   def self.apply(model, runner, weather, infil, mech_vent, nat_vent, duct_systems,
                  cfa, infilvolume, nbeds, nbaths, ncfl, ncfl_ag, window_area, min_neighbor_distance)
 
+    @runner = runner
     @infMethodConstantCFM = 'CONSTANT_CFM'
     @infMethodAIM2 = 'AIM2' # aka ASHRAE Enhanced
     @infMethodELA = 'ELA'
@@ -21,19 +22,19 @@ class Airflow
     building.height = Geometry.get_max_z_of_spaces(model_spaces)
     model.getThermalZones.each do |thermal_zone|
       if Geometry.is_living(thermal_zone)
-        building.living = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone, runner), Geometry.get_z_origin_for_zone(thermal_zone), nil, nil)
+        building.living = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, nil)
       elsif Geometry.is_garage(thermal_zone)
-        building.garage = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone, runner), Geometry.get_z_origin_for_zone(thermal_zone), nil, nil)
+        building.garage = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, nil)
       elsif Geometry.is_unconditioned_basement(thermal_zone)
-        building.unconditioned_basement = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone, runner), Geometry.get_z_origin_for_zone(thermal_zone), infil.unconditioned_basement_ach, nil)
+        building.unconditioned_basement = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), infil.unconditioned_basement_ach, nil)
       elsif Geometry.is_vented_crawl(thermal_zone)
-        building.vented_crawlspace = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone, runner), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.vented_crawl_sla)
+        building.vented_crawlspace = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.vented_crawl_sla)
       elsif Geometry.is_unvented_crawl(thermal_zone)
-        building.unvented_crawlspace = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone, runner), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.unvented_crawl_sla)
+        building.unvented_crawlspace = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.unvented_crawl_sla)
       elsif Geometry.is_vented_attic(thermal_zone)
-        building.vented_attic = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone, runner), Geometry.get_z_origin_for_zone(thermal_zone), infil.vented_attic_const_ach, infil.vented_attic_sla)
+        building.vented_attic = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), infil.vented_attic_const_ach, infil.vented_attic_sla)
       elsif Geometry.is_unvented_attic(thermal_zone)
-        building.unvented_attic = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone, runner), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.unvented_attic_sla)
+        building.unvented_attic = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, "m^2", "ft^2"), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.unvented_attic_sla)
       end
     end
     building.cfa = cfa
@@ -48,9 +49,7 @@ class Airflow
     building.window_area = window_area
 
     wind_speed = process_wind_speed_correction(infil.terrain, infil.shelter_coef, min_neighbor_distance, building.height)
-    if not process_infiltration(model, infil, wind_speed, building, weather)
-      return false
-    end
+    process_infiltration(model, infil, wind_speed, building, weather)
 
     # Global sensors
 
@@ -83,35 +82,24 @@ class Airflow
 
     # Update model
 
-    air_loop_objects = create_air_loop_objects(model, runner, model.getAirLoopHVACs, mech_vent, building)
-    return false if air_loop_objects.nil?
-
-    success = process_infiltration_for_conditioned_zones(model, runner, infil, wind_speed, building, weather)
-    return false if not success
-
-    success = process_mech_vent(model, runner, mech_vent, building, weather, infil)
-    return false if not success
+    air_loop_objects = create_air_loop_objects(model, model.getAirLoopHVACs, mech_vent, building)
+    process_infiltration_for_conditioned_zones(model, infil, wind_speed, building, weather)
+    process_mech_vent(model, mech_vent, building, weather, infil)
 
     if mech_vent.type == Constants.VentTypeCFIS
-      cfis_program = create_cfis_objects(model, runner, building, mech_vent)
-      return false if cfis_program.nil?
+      cfis_program = create_cfis_objects(model, building, mech_vent)
     end
 
-    nv_program = process_nat_vent(model, runner, nat_vent, tin_sensor, tout_sensor, pbar_sensor, vwind_sensor, wind_speed, infil, building, weather, wout_sensor)
-    return false if nv_program.nil?
+    nv_program = process_nat_vent(model, nat_vent, tin_sensor, tout_sensor, pbar_sensor, vwind_sensor, wind_speed, infil, building, weather, wout_sensor)
 
     duct_programs = {}
     duct_lks = {}
     duct_systems.each do |ducts, air_loop|
-      success = process_ducts(model, runner, ducts, building, air_loop)
-      return false if not success
-
-      success = create_ducts_objects(model, runner, building, ducts, mech_vent, tin_sensor, pbar_sensor, adiabatic_const, air_loop, duct_programs, duct_lks, air_loop_objects)
-      return false if not success
+      process_ducts(model, ducts, building, air_loop)
+      create_ducts_objects(model, building, ducts, mech_vent, tin_sensor, pbar_sensor, adiabatic_const, air_loop, duct_programs, duct_lks, air_loop_objects)
     end
 
-    infil_program = create_infil_mech_vent_objects(model, runner, building, infil, mech_vent, wind_speed, tin_sensor, tout_sensor, vwind_sensor, duct_lks, wout_sensor, pbar_sensor)
-    return false if infil_program.nil?
+    infil_program = create_infil_mech_vent_objects(model, building, infil, mech_vent, wind_speed, tin_sensor, tout_sensor, vwind_sensor, duct_lks, wout_sensor, pbar_sensor)
 
     create_ems_program_managers(model, infil_program, nv_program, cfis_program, duct_programs)
 
@@ -161,8 +149,6 @@ class Airflow
 
       obj.remove
     end
-
-    return true
   end
 
   def self.get_default_shelter_coefficient()
@@ -300,11 +286,9 @@ class Airflow
     end
 
     process_infiltration_for_spaces(model, spaces, wind_speed)
-
-    return true
   end
 
-  def self.create_air_loop_objects(model, runner, air_loops, mech_vent, building)
+  def self.create_air_loop_objects(model, air_loops, mech_vent, building)
     # Obtain data across all air loops (needed for ducts, CFIS w/ separate heating and cooling air loops)
     air_loop_objects = {}
     air_loops.each_with_index do |air_loop, air_loop_index|
@@ -356,7 +340,7 @@ class Airflow
     return air_loop_objects
   end
 
-  def self.process_infiltration_for_conditioned_zones(model, runner, infil, wind_speed, building, weather)
+  def self.process_infiltration_for_conditioned_zones(model, infil, wind_speed, building, weather)
     spaces = []
     spaces << building.living
 
@@ -411,9 +395,9 @@ class Airflow
         leakage_floor = 0.25
       end
       if leakkage_ceiling + leakage_walls + leakage_floor != 1
-        runner.registerError("Invalid air leakage distribution specified (#{leakkage_ceiling}, #{leakage_walls}, #{leakage_floor}); does not add up to 1.")
-        return false
+        fail "Invalid air leakage distribution specified (#{leakkage_ceiling}, #{leakage_walls}, #{leakage_floor}); does not add up to 1."
       end
+
       r_i = (leakkage_ceiling + leakage_floor)
       x_i = (leakkage_ceiling - leakage_floor)
       r_i = r_i * (1 - y_i)
@@ -499,8 +483,6 @@ class Airflow
     infil.wind_coef = wind_coef
     infil.y_i = y_i
     infil.s_wflue = s_wflue
-
-    return true
   end
 
   def self.process_infiltration_for_spaces(model, spaces, wind_speed)
@@ -546,11 +528,10 @@ class Airflow
     end
   end
 
-  def self.process_mech_vent(model, runner, mech_vent, building, weather, infil)
+  def self.process_mech_vent(model, mech_vent, building, weather, infil)
     if mech_vent.type == Constants.VentTypeCFIS
-      if not HVAC.has_ducted_equipment(model, runner, mech_vent.cfis_air_loop)
-        runner.registerError("A CFIS ventilation system has been specified but the building does not have central, forced air equipment.")
-        return false
+      if not HVAC.has_ducted_equipment(model, mech_vent.cfis_air_loop)
+        fail "A CFIS ventilation system has been specified but the building does not have central, forced air equipment."
       end
     end
 
@@ -562,16 +543,12 @@ class Airflow
     # Fraction of fan heat that goes to the space
     if mech_vent.type == Constants.VentTypeExhaust
       frac_fan_heat = 0.0 # Fan heat does not enter space
-      num_fans = 1
     elsif mech_vent.type == Constants.VentTypeSupply or mech_vent.type == Constants.VentTypeCFIS
       frac_fan_heat = 1.0 # Fan heat does enter space
-      num_fans = 1
     elsif mech_vent.type == Constants.VentTypeBalanced
       frac_fan_heat = 0.5 # Assumes supply fan heat enters space
-      num_fans = 2
     else
       frac_fan_heat = 0.0
-      num_fans = 0
     end
 
     # Get the clothes washer so we can use the day shift for the clothes dryer
@@ -596,7 +573,7 @@ class Airflow
     end
 
     if not has_dryer and mech_vent.dryer_exhaust > 0
-      runner.registerWarning("No clothes dryer object was found but the clothes dryer exhaust specified is non-zero. Overriding clothes dryer exhaust to be zero.")
+      @runner.registerWarning("No clothes dryer object was found but the clothes dryer exhaust specified is non-zero. Overriding clothes dryer exhaust to be zero.")
     end
 
     bathroom_hour_avg_exhaust = mech_vent.bathroom_exhaust * building.nbaths * bath_exhaust_sch_operation / 60.0 # cfm
@@ -610,11 +587,11 @@ class Airflow
 
     if mech_vent.type == Constants.VentTypeBalanced and (mech_vent.sensible_efficiency > 0 or mech_vent.sensible_efficiency_adjusted > 0) and mech_vent.whole_house_cfm > 0
       # Must assume an operating condition (HVI seems to use CSA 439)
-      t_sup_in = 0
+      t_sup_in = 0.0
       w_sup_in = 0.0028
-      t_exh_in = 22
+      t_exh_in = 22.0
       w_exh_in = 0.0065
-      cp_a = 1006
+      cp_a = 1006.0
       p_fan = mech_vent.fan_power_w # Watts
 
       m_fan = UnitConversions.convert(mech_vent.whole_house_cfm, "cfm", "m^3/s") * 16.02 * Psychrometrics.rhoD_fT_w_P(UnitConversions.convert(t_sup_in, "C", "F"), w_sup_in, 14.7) # kg/s
@@ -642,8 +619,7 @@ class Airflow
       sensible_effectiveness = (t_sup_out_gross - t_sup_in) / (t_exh_in - t_sup_in)
 
       if (sensible_effectiveness < 0.0) or (sensible_effectiveness > 1.0)
-        runner.registerError("The calculated ERV/HRV sensible effectiveness is #{sensible_effectiveness} but should be between 0 and 1. Please revise ERV/HRV efficiency values.")
-        return false
+        fail "The calculated ERV/HRV sensible effectiveness is #{sensible_effectiveness} but should be between 0 and 1. Please revise ERV/HRV efficiency values."
       end
 
       # Use summer test condition to determine the latent effectiveness since TRE is generally specified under the summer condition
@@ -675,8 +651,7 @@ class Airflow
         latent_effectiveness = [0.0, (w_sup_out - w_sup_in) / (w_exh_in - w_sup_in)].max
 
         if (latent_effectiveness < 0.0) or (latent_effectiveness > 1.0)
-          runner.registerError("The calculated ERV/HRV latent effectiveness is #{latent_effectiveness} but should be between 0 and 1. Please revise ERV/HRV efficiency values.")
-          return false
+          fail "The calculated ERV/HRV latent effectiveness is #{latent_effectiveness} but should be between 0 and 1. Please revise ERV/HRV efficiency values."
         end
 
       else
@@ -698,7 +673,6 @@ class Airflow
     model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentWholeHouseRate, mech_vent.whole_house_cfm.to_f)
 
     mech_vent.frac_fan_heat = frac_fan_heat
-    mech_vent.num_fans = num_fans
     mech_vent.bathroom_hour_avg_exhaust = bathroom_hour_avg_exhaust
     mech_vent.range_hood_hour_avg_exhaust = range_hood_hour_avg_exhaust
     mech_vent.spot_fan_w_per_cfm = spot_fan_w_per_cfm
@@ -706,41 +680,34 @@ class Airflow
     mech_vent.sensible_effectiveness = sensible_effectiveness
     mech_vent.dryer_exhaust_day_shift = dryer_exhaust_day_shift
     mech_vent.has_dryer = has_dryer
-
-    return true
   end
 
-  def self.process_ducts(model, runner, ducts, building, air_loop)
+  def self.process_ducts(model, ducts, building, air_loop)
     # Validate Inputs
     ducts.each do |duct|
       if duct.leakage_frac.nil? == duct.leakage_cfm25.nil?
-        runner.registerError("Ducts: Must provide either leakage fraction or cfm25, but not both.")
-        return false
+        fail "Ducts: Must provide either leakage fraction or cfm25, but not both."
       end
       if not duct.leakage_frac.nil? and (duct.leakage_frac < 0 or duct.leakage_frac > 1)
-        runner.registerError("Ducts: Leakage Fraction must be greater than or equal to 0 and less than or equal to 1.")
-        return false
+        fail "Ducts: Leakage Fraction must be greater than or equal to 0 and less than or equal to 1."
       end
       if not duct.leakage_cfm25.nil? and duct.leakage_cfm25 < 0
-        runner.registerError("Ducts: Leakage CFM25 must be greater than or equal to 0.")
-        return false
+        fail "Ducts: Leakage CFM25 must be greater than or equal to 0."
       end
       if duct.rvalue < 0
-        runner.registerError("Ducts: Insulation Nominal R-Value must be greater than or equal to 0.")
-        return false
+        fail "Ducts: Insulation Nominal R-Value must be greater than or equal to 0."
       end
       if duct.area < 0
-        runner.registerError("Ducts: Surface Area must be greater than or equal to 0.")
-        return false
+        fail "Ducts: Surface Area must be greater than or equal to 0."
       end
     end
 
-    has_ducted_hvac = HVAC.has_ducted_equipment(model, runner, air_loop)
+    has_ducted_hvac = HVAC.has_ducted_equipment(model, air_loop)
     if ducts.size > 0 and not has_ducted_hvac
-      runner.registerWarning("No ducted HVAC equipment was found but ducts were specified. Overriding duct specification.")
+      @runner.registerWarning("No ducted HVAC equipment was found but ducts were specified. Overriding duct specification.")
       ducts.clear
     elsif ducts.size == 0 and has_ducted_hvac
-      runner.registerWarning("Ducted HVAC equipment was found but no ducts were specified. Proceeding without ducts.")
+      @runner.registerWarning("Ducted HVAC equipment was found but no ducts were specified. Proceeding without ducts.")
     end
 
     ducts.each do |duct|
@@ -764,11 +731,9 @@ class Airflow
       air_loop.additionalProperties.setFeature(Constants.SizingInfoDuctAreas, ducts.map { |duct| duct.area.to_f }.join(","))
       air_loop.additionalProperties.setFeature(Constants.SizingInfoDuctRvalues, ducts.map { |duct| duct.rvalue.to_f }.join(","))
     end
-
-    return true
   end
 
-  def self.process_nat_vent(model, runner, nat_vent, tin_sensor, tout_sensor, pbar_sensor, vwind_sensor, wind_speed, infil, building, weather, wout_sensor)
+  def self.process_nat_vent(model, nat_vent, tin_sensor, tout_sensor, pbar_sensor, vwind_sensor, wind_speed, infil, building, weather, wout_sensor)
     thermostatsetpointdualsetpoint = building.living.zone.thermostatSetpointDualSetpoint
 
     # Get heating setpoints
@@ -779,27 +744,21 @@ class Airflow
     if thermostatsetpointdualsetpoint.is_initialized
       thermostatsetpointdualsetpoint = thermostatsetpointdualsetpoint.get
 
-      heatingSetpointWeekday = HVAC.get_setpoint_schedule(thermostatsetpointdualsetpoint.heatingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekday', runner)
-      heatingSetpointWeekend = HVAC.get_setpoint_schedule(thermostatsetpointdualsetpoint.heatingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekend', runner)
-      if heatingSetpointWeekday.nil? or heatingSetpointWeekend.nil?
-        return false
-      end
+      heatingSetpointWeekday = HVAC.get_setpoint_schedule(thermostatsetpointdualsetpoint.heatingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekday')
+      heatingSetpointWeekend = HVAC.get_setpoint_schedule(thermostatsetpointdualsetpoint.heatingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekend')
 
       heatingSetpointWeekday = heatingSetpointWeekday[0].map { |j| UnitConversions.convert(j, "C", "F") } # get january hourly setpoints
       heatingSetpointWeekend = heatingSetpointWeekend[0].map { |j| UnitConversions.convert(j, "C", "F") } # get january hourly setpoints
 
-      coolingSetpointWeekday = HVAC.get_setpoint_schedule(thermostatsetpointdualsetpoint.coolingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekday', runner)
-      coolingSetpointWeekend = HVAC.get_setpoint_schedule(thermostatsetpointdualsetpoint.coolingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekend', runner)
-      if coolingSetpointWeekday.nil? or coolingSetpointWeekend.nil?
-        return false
-      end
+      coolingSetpointWeekday = HVAC.get_setpoint_schedule(thermostatsetpointdualsetpoint.coolingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekday')
+      coolingSetpointWeekend = HVAC.get_setpoint_schedule(thermostatsetpointdualsetpoint.coolingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekend')
 
       coolingSetpointWeekday = coolingSetpointWeekday[6].map { |j| UnitConversions.convert(j, "C", "F") } # get july hourly setpoints
       coolingSetpointWeekend = coolingSetpointWeekend[6].map { |j| UnitConversions.convert(j, "C", "F") } # get july hourly setpoints
     end
 
     if heatingSetpointWeekday.empty?
-      runner.registerWarning("No heating setpoint schedule found. Assuming #{Constants.DefaultHeatingSetpoint} F for natural ventilation calculations.")
+      @runner.registerWarning("No heating setpoint schedule found. Assuming #{Constants.DefaultHeatingSetpoint} F for natural ventilation calculations.")
       ovlp_ssn_hourly_temp = Array.new(24, UnitConversions.convert(Constants.DefaultHeatingSetpoint + nat_vent.ovlp_offset, "F", "C"))
       heatingSetpointWeekday = Array.new(24, Constants.DefaultHeatingSetpoint)
       heatingSetpointWeekend = Array.new(24, Constants.DefaultHeatingSetpoint)
@@ -807,17 +766,14 @@ class Airflow
       ovlp_ssn_hourly_temp = Array.new(24, UnitConversions.convert([heatingSetpointWeekday.max, heatingSetpointWeekend.max].max + nat_vent.ovlp_offset, "F", "C"))
     end
     if coolingSetpointWeekday.empty?
-      runner.registerWarning("No cooling setpoint schedule found. Assuming #{Constants.DefaultCoolingSetpoint} F for natural ventilation calculations.")
+      @runner.registerWarning("No cooling setpoint schedule found. Assuming #{Constants.DefaultCoolingSetpoint} F for natural ventilation calculations.")
       coolingSetpointWeekday = Array.new(24, Constants.DefaultCoolingSetpoint)
       coolingSetpointWeekend = Array.new(24, Constants.DefaultCoolingSetpoint)
     end
     ovlp_ssn_hourly_weekend_temp = ovlp_ssn_hourly_temp
 
     # Get heating and cooling seasons
-    heating_season, cooling_season = HVAC.calc_heating_and_cooling_seasons(model, weather, runner)
-    if heating_season.nil? or cooling_season.nil?
-      return false
-    end
+    heating_season, cooling_season = HVAC.calc_heating_and_cooling_seasons(model, weather)
 
     # Specify an array of hourly lower-temperature-limits for natural ventilation
     htg_ssn_hourly_temp = Array.new
@@ -878,7 +834,7 @@ class Airflow
       temp_hourly_wked << ssn_schedule_wked
     end
 
-    temp_sch = HourlyByMonthSchedule.new(model, runner, Constants.ObjectNameNaturalVentilation + " temp schedule", temp_hourly_wkdy, temp_hourly_wked, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsTemperature)
+    temp_sch = HourlyByMonthSchedule.new(model, Constants.ObjectNameNaturalVentilation + " temp schedule", temp_hourly_wkdy, temp_hourly_wked, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsTemperature)
 
     avail_sch = OpenStudio::Model::ScheduleRuleset.new(model)
     avail_sch.setName(Constants.ObjectNameNaturalVentilation + " avail schedule")
@@ -1049,8 +1005,8 @@ class Airflow
     return actuator
   end
 
-  def self.create_ducts_objects(model, runner, building, ducts, mech_vent, tin_sensor, pbar_sensor, adiabatic_const, air_loop, duct_programs, duct_lks, air_loop_objects)
-    return true if ducts.size == 0 # No ducts
+  def self.create_ducts_objects(model, building, ducts, mech_vent, tin_sensor, pbar_sensor, adiabatic_const, air_loop, duct_programs, duct_lks, air_loop_objects)
+    return if ducts.size == 0 # No ducts
 
     duct_zones = ducts.map { |duct| duct.zone }.uniq
     living_space = building.living.zone.spaces[0]
@@ -1062,7 +1018,7 @@ class Airflow
 
       all_ducts_conditioned = false
     end
-    return true if all_ducts_conditioned
+    return if all_ducts_conditioned
 
     if building.living.zone.airLoopHVACs.include? air_loop # next if airloop doesn't serve this
 
@@ -1532,22 +1488,13 @@ class Airflow
         end
 
         duct_programs[air_loop_name_idx] = duct_program
-
-        if duct_zone.nil? # Outside
-          runner.registerInfo("Created outside ducts for #{air_loop.name}.")
-        else
-          runner.registerInfo("Created ducts for #{air_loop.name} and zone #{duct_zone.name.to_s}.")
-        end
       end
     end
-
-    return true
   end
 
-  def self.create_cfis_objects(model, runner, building, mech_vent)
+  def self.create_cfis_objects(model, building, mech_vent)
     if mech_vent.cfis_airflow_frac < 0 or mech_vent.cfis_airflow_frac > 1
-      runner.registerError("Mechanical Ventilation: CFIS blower airflow rate must be greater than or equal to 0 and less than or equal to 1.")
-      return nil
+      fail "Mechanical Ventilation: CFIS blower airflow rate must be greater than or equal to 0 and less than or equal to 1."
     end
 
     mech_vent.cfis_t_sum_open_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(" ", "_")}_cfis_t_sum_open") # Sums the time during an hour the CFIS damper has been open
@@ -1573,30 +1520,28 @@ class Airflow
     cfis_program.addLine("Set #{mech_vent.cfis_on_for_hour_var.name} = 0")
     cfis_program.addLine("Set #{mech_vent.cfis_f_damper_open_var.name} = 0")
 
-    runner.registerInfo("Created a CFIS system.")
-
     return cfis_program
   end
 
-  def self.create_infil_mech_vent_objects(model, runner, building, infil, mech_vent, wind_speed, tin_sensor, tout_sensor, vwind_sensor, duct_lks, wout_sensor, pbar_sensor)
+  def self.create_infil_mech_vent_objects(model, building, infil, mech_vent, wind_speed, tin_sensor, tout_sensor, vwind_sensor, duct_lks, wout_sensor, pbar_sensor)
     # Sensors
 
     range_array = [0.0] * 24
     range_array[mech_vent.range_exhaust_hour - 1] = 1.0
-    range_hood_sch = HourlyByMonthSchedule.new(model, runner, Constants.ObjectNameMechanicalVentilation + " range exhaust schedule", [range_array] * 12, [range_array] * 12, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsOnOff)
+    range_hood_sch = HourlyByMonthSchedule.new(model, Constants.ObjectNameMechanicalVentilation + " range exhaust schedule", [range_array] * 12, [range_array] * 12, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsOnOff)
     range_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, "Schedule Value")
     range_sch_sensor.setName("#{Constants.ObjectNameMechanicalVentilation} range sch s")
     range_sch_sensor.setKeyName(range_hood_sch.schedule.name.to_s)
 
     bathroom_array = [0.0] * 24
     bathroom_array[mech_vent.bathroom_exhaust_hour - 1] = 1.0
-    bath_exhaust_sch = HourlyByMonthSchedule.new(model, runner, Constants.ObjectNameMechanicalVentilation + " bath exhaust schedule", [bathroom_array] * 12, [bathroom_array] * 12, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsOnOff)
+    bath_exhaust_sch = HourlyByMonthSchedule.new(model, Constants.ObjectNameMechanicalVentilation + " bath exhaust schedule", [bathroom_array] * 12, [bathroom_array] * 12, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsOnOff)
     bath_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, "Schedule Value")
     bath_sch_sensor.setName("#{Constants.ObjectNameMechanicalVentilation} bath sch s")
     bath_sch_sensor.setKeyName(bath_exhaust_sch.schedule.name.to_s)
 
     if mech_vent.has_dryer and mech_vent.dryer_exhaust > 0
-      dryer_exhaust_sch = HotWaterSchedule.new(model, runner, Constants.ObjectNameMechanicalVentilation + " dryer exhaust schedule", building.nbeds, 0, true)
+      dryer_exhaust_sch = HotWaterSchedule.new(model, Constants.ObjectNameMechanicalVentilation + " dryer exhaust schedule", building.nbeds, 0, true)
       dryer_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, "Schedule Value")
       dryer_sch_sensor.setName("#{Constants.ObjectNameMechanicalVentilation} dryer sch s")
       dryer_sch_sensor.setKeyName(dryer_exhaust_sch.schedule.name.to_s)
@@ -2045,7 +1990,7 @@ class MechanicalVentilation
                 :dryer_exhaust, :range_exhaust, :range_exhaust_hour, :bathroom_exhaust, :bathroom_exhaust_hour,
                 :cfis_open_time, :cfis_airflow_frac, :cfis_air_loop, :cfis_t_sum_open_var, :cfis_on_for_hour_var,
                 :cfis_f_damper_open_var, :cfis_fan_mfr_max_var, :cfis_fan_rtf_sensor, :cfis_fan_pressure_rise, :cfis_fan_efficiency,
-                :frac_fan_heat, :num_fans, :bathroom_hour_avg_exhaust, :range_hood_hour_avg_exhaust,
+                :frac_fan_heat, :bathroom_hour_avg_exhaust, :range_hood_hour_avg_exhaust,
                 :spot_fan_w_per_cfm, :latent_effectiveness, :sensible_effectiveness, :dryer_exhaust_day_shift, :has_dryer)
 end
 

--- a/resources/constants.rb
+++ b/resources/constants.rb
@@ -5,16 +5,8 @@ class Constants
     return 73.5 # deg-F
   end
 
-  def self.DefaultCoolingSetpoint
-    return 76.0
-  end
-
   def self.DefaultFramingFactorInterior
     return 0.16
-  end
-
-  def self.DefaultHeatingSetpoint
-    return 71.0
   end
 
   def self.DefaultHumiditySetpoint

--- a/resources/constructions.rb
+++ b/resources/constructions.rb
@@ -937,17 +937,17 @@ class Constructions
   end
 
   def self.apply_window(model, subsurfaces, constr_name, weather,
-                        cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
+                        is_sch, ufactor, shgc, heat_shade_mult, cool_shade_mult)
 
     apply_window_skylight(model, "Window", subsurfaces, constr_name, weather,
-                          cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
+                          is_sch, ufactor, shgc, heat_shade_mult, cool_shade_mult)
   end
 
   def self.apply_skylight(model, subsurfaces, constr_name, weather,
-                          cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
+                          is_sch, ufactor, shgc, heat_shade_mult, cool_shade_mult)
 
     apply_window_skylight(model, "Skylight", subsurfaces, constr_name, weather,
-                          cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
+                          is_sch, ufactor, shgc, heat_shade_mult, cool_shade_mult)
   end
 
   def self.apply_partition_walls(model, constr_name, drywall_thick_in, frac_of_ffa,
@@ -1453,7 +1453,7 @@ class Constructions
   end
 
   def self.apply_window_skylight(model, type, subsurfaces, constr_name, weather,
-                                 cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
+                                 is_sch, ufactor, shgc, heat_shade_mult, cool_shade_mult)
 
     return if subsurfaces.empty?
 
@@ -1471,12 +1471,6 @@ class Constructions
       total_shade_trans = cool_shade_mult / heat_shade_mult * 0.999
       total_shade_abs = 0.00001
       total_shade_ref = 1 - total_shade_trans - total_shade_abs
-
-      day_startm = [0, 1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
-      day_endm = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365]
-
-      # Interior Shading Schedule
-      sch = MonthWeekdayWeekendSchedule.new(model, "#{type} shading schedule", Array.new(24, 1), Array.new(24, 1), cooling_season, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
 
       # CoolingShade
       sm = OpenStudio::Model::Shade.new(model)
@@ -1501,7 +1495,7 @@ class Constructions
       sc.setName("#{type}ShadingControl")
       sc.setShadingType("InteriorShade")
       sc.setShadingControlType("OnIfScheduleAllows")
-      sc.setSchedule(sch.schedule)
+      sc.setSchedule(is_sch.schedule)
 
       # Add shading controls
       subsurfaces.each do |subsurface|

--- a/resources/constructions.rb
+++ b/resources/constructions.rb
@@ -6,12 +6,12 @@ require_relative "geometry"
 class Constructions
   # Container class for walls, floors/ceilings, roofs, etc.
 
-  def self.apply_wood_stud_wall(runner, model, surfaces, constr_name,
+  def self.apply_wood_stud_wall(model, surfaces, constr_name,
                                 cavity_r, install_grade, cavity_depth_in, cavity_filled,
                                 framing_factor, drywall_thick_in, osb_thick_in,
                                 rigid_r, mat_ext_finish)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     if cavity_r > 0
@@ -63,9 +63,7 @@ class Constructions
     constr.add_layer(Material.AirFilmVertical)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     (surfaces).each do |surface|
@@ -73,17 +71,15 @@ class Constructions
       surface.additionalProperties.setFeature(Constants.SizingInfoStudWallCavityRvalue, Float(cavity_r))
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsRvalue, Float(rigid_r))
     end
-
-    return true
   end
 
-  def self.apply_double_stud_wall(runner, model, surfaces, constr_name,
+  def self.apply_double_stud_wall(model, surfaces, constr_name,
                                   cavity_r, install_grade, stud_depth_in, gap_depth_in,
                                   framing_factor, framing_spacing, is_staggered,
                                   drywall_thick_in, osb_thick_in, rigid_r,
                                   mat_ext_finish)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     cavity_depth_in = 2.0 * stud_depth_in + gap_depth_in
@@ -109,9 +105,9 @@ class Constructions
     stud_frac = 1.5 / framing_spacing
     misc_framing_factor = framing_factor - stud_frac
     if misc_framing_factor < 0
-      runner.registerError("Framing Factor (#{framing_factor.to_s}) is less than the framing solely provided by the studs (#{stud_frac.to_s}).")
-      return false
+      fail "Framing Factor (#{framing_factor.to_s}) is less than the framing solely provided by the studs (#{stud_frac.to_s})."
     end
+
     dsGapFactor = self.get_gap_factor(install_grade, framing_factor, cavity_r)
     path_fracs = [misc_framing_factor, stud_frac, stud_frac, dsGapFactor, (1.0 - (2 * stud_frac + misc_framing_factor + dsGapFactor))]
 
@@ -144,26 +140,22 @@ class Constructions
     constr.add_layer(Material.AirFilmVertical)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     (surfaces).each do |surface|
       surface.additionalProperties.setFeature(Constants.SizingInfoWallType, "DoubleWoodStud")
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsRvalue, Float(rigid_r))
     end
-
-    return true
   end
 
-  def self.apply_cmu_wall(runner, model, surfaces, constr_name,
+  def self.apply_cmu_wall(model, surfaces, constr_name,
                           thick_in, conductivity, density, framing_factor,
                           furring_r, furring_cavity_depth, furring_spacing,
                           drywall_thick_in, osb_thick_in, rigid_r,
                           mat_ext_finish)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     mat_cmu = Material.new(name = nil, thick_in = thick_in, mat_base = BaseMaterial.Concrete, k_in = conductivity, rho = density)
@@ -223,9 +215,7 @@ class Constructions
     constr.add_layer(Material.AirFilmVertical)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     (surfaces).each do |surface|
@@ -233,16 +223,14 @@ class Constructions
       surface.additionalProperties.setFeature(Constants.SizingInfoCMUWallFurringInsRvalue, Float(furring_r))
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsRvalue, Float(rigid_r))
     end
-
-    return true
   end
 
-  def self.apply_icf_wall(runner, model, surfaces, constr_name,
+  def self.apply_icf_wall(model, surfaces, constr_name,
                           icf_r, ins_thick_in, concrete_thick_in, framing_factor,
                           drywall_thick_in, osb_thick_in, rigid_r,
                           mat_ext_finish)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     mat_ins = Material.new(name = nil, thick_in = ins_thick_in, mat_base = BaseMaterial.InsulationRigid, k_in = ins_thick_in / icf_r)
@@ -285,26 +273,22 @@ class Constructions
     constr.add_layer(Material.AirFilmVertical)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     (surfaces).each do |surface|
       surface.additionalProperties.setFeature(Constants.SizingInfoWallType, "ICF")
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsRvalue, Float(rigid_r))
     end
-
-    return true
   end
 
-  def self.apply_sip_wall(runner, model, surfaces, constr_name,
+  def self.apply_sip_wall(model, surfaces, constr_name,
                           sip_r, sip_thick_in, framing_factor,
                           sheathing_type, sheathing_thick_in,
                           drywall_thick_in, osb_thick_in, rigid_r,
                           mat_ext_finish)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     spline_thick_in = 0.5
@@ -360,9 +344,7 @@ class Constructions
     constr.add_layer(Material.AirFilmVertical)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     (surfaces).each do |surface|
@@ -371,17 +353,15 @@ class Constructions
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsRvalue, Float(rigid_r))
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsThickness, Float(sheathing_thick_in))
     end
-
-    return true
   end
 
-  def self.apply_steel_stud_wall(runner, model, surfaces, constr_name,
+  def self.apply_steel_stud_wall(model, surfaces, constr_name,
                                  cavity_r, install_grade, cavity_depth,
                                  cavity_filled, framing_factor, correction_factor,
                                  drywall_thick_in, osb_thick_in, rigid_r,
                                  mat_ext_finish)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     eR = cavity_r * correction_factor # The effective R-value of the cavity insulation with steel stud framing
@@ -433,9 +413,7 @@ class Constructions
     constr.add_layer(Material.AirFilmVertical)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     (surfaces).each do |surface|
@@ -443,22 +421,19 @@ class Constructions
       surface.additionalProperties.setFeature(Constants.SizingInfoStudWallCavityRvalue, Float(cavity_r))
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsRvalue, Float(rigid_r))
     end
-
-    return true
   end
 
-  def self.apply_generic_layered_wall(runner, model, surfaces, constr_name,
+  def self.apply_generic_layered_wall(model, surfaces, constr_name,
                                       thick_ins, conds, denss, specheats,
                                       drywall_thick_in, osb_thick_in, rigid_r,
                                       mat_ext_finish)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Validate inputs
     for idx in 0..4
       if thick_ins[idx].nil? != conds[idx].nil? or thick_ins[idx].nil? != denss[idx].nil? or thick_ins[idx].nil? != specheats[idx].nil?
-        runner.registerError("Layer #{idx + 1} does not have all four properties (thickness, conductivity, density, specific heat) entered.")
-        return false
+        fail "Layer #{idx + 1} does not have all four properties (thickness, conductivity, density, specific heat) entered."
       end
     end
 
@@ -513,25 +488,21 @@ class Constructions
     constr.add_layer(Material.AirFilmVertical)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     (surfaces).each do |surface|
       surface.additionalProperties.setFeature(Constants.SizingInfoWallType, "Generic")
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsRvalue, Float(rigid_r))
     end
-
-    return true
   end
 
-  def self.apply_rim_joist(runner, model, surfaces, constr_name,
+  def self.apply_rim_joist(model, surfaces, constr_name,
                            cavity_r, install_grade, framing_factor,
                            drywall_thick_in, osb_thick_in,
                            rigid_r, mat_ext_finish)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     rim_joist_thick_in = 1.5
@@ -581,9 +552,7 @@ class Constructions
     constr.add_layer(Material.AirFilmVertical)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     (surfaces).each do |surface|
@@ -591,17 +560,15 @@ class Constructions
       surface.additionalProperties.setFeature(Constants.SizingInfoStudWallCavityRvalue, Float(cavity_r))
       surface.additionalProperties.setFeature(Constants.SizingInfoWallRigidInsRvalue, Float(rigid_r))
     end
-
-    return true
   end
 
-  def self.apply_open_cavity_roof(runner, model, surfaces, constr_name,
+  def self.apply_open_cavity_roof(model, surfaces, constr_name,
                                   cavity_r, install_grade, cavity_ins_thick_in,
                                   framing_factor, framing_thick_in,
                                   osb_thick_in, rigid_r,
                                   mat_roofing, has_radiant_barrier)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     roof_ins_thickness_in = [cavity_ins_thick_in, framing_thick_in].max
@@ -662,9 +629,7 @@ class Constructions
     end
 
     # Create and assign construction to roof surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     surfaces.each do |surface|
@@ -674,16 +639,14 @@ class Constructions
       surface.additionalProperties.setFeature(Constants.SizingInfoRoofHasRadiantBarrier, has_radiant_barrier)
       surface.additionalProperties.setFeature(Constants.SizingInfoRoofCavityRvalue, Float(cavity_r))
     end
-
-    return true
   end
 
-  def self.apply_closed_cavity_roof(runner, model, surfaces, constr_name,
+  def self.apply_closed_cavity_roof(model, surfaces, constr_name,
                                     cavity_r, install_grade, cavity_depth,
                                     filled_cavity, framing_factor, drywall_thick_in,
                                     osb_thick_in, rigid_r, mat_roofing, has_radiant_barrier)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     if cavity_r > 0
@@ -742,9 +705,7 @@ class Constructions
     end
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(surfaces, model)
 
     # Store info for HVAC Sizing measure
     surfaces.each do |surface|
@@ -754,18 +715,16 @@ class Constructions
       surface.additionalProperties.setFeature(Constants.SizingInfoRoofHasRadiantBarrier, has_radiant_barrier)
       surface.additionalProperties.setFeature(Constants.SizingInfoRoofCavityRvalue, Float(cavity_r))
     end
-
-    return true
   end
 
-  def self.apply_ceiling(runner, model, surfaces, constr_name,
+  def self.apply_ceiling(model, surfaces, constr_name,
                          cavity_r, install_grade, ins_thick_in,
                          framing_factor, joist_height_in,
                          drywall_thick_in)
 
     # Drywall below, open cavity above (e.g., attic floor)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     mat_addtl_ins = nil
@@ -806,14 +765,10 @@ class Constructions
     constr.add_layer(Material.AirFilmFloorAverage)
 
     # Create and assign construction to ceiling surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
-
-    return true
+    constr.create_and_assign_constructions(surfaces, model)
   end
 
-  def self.apply_floor(runner, model, surfaces, constr_name,
+  def self.apply_floor(model, surfaces, constr_name,
                        cavity_r, install_grade,
                        framing_factor, joist_height_in,
                        plywood_thick_in, rigid_r, mat_floor_covering,
@@ -821,7 +776,7 @@ class Constructions
 
     # Open cavity below, floor covering above (e.g., crawlspace ceiling)
 
-    return true if surfaces.empty?
+    return if surfaces.empty?
 
     # Define materials
     mat_2x = Material.Stud2x(joist_height_in)
@@ -861,27 +816,20 @@ class Constructions
     constr.add_layer(Material.AirFilmFloorReduced)
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(surfaces, runner, model)
-      return false
-    end
-
-    return true
+    constr.create_and_assign_constructions(surfaces, model)
   end
 
-  def self.apply_foundation_wall(runner, model, wall_surfaces, wall_constr_name,
+  def self.apply_foundation_wall(model, wall_surfaces, wall_constr_name,
                                  wall_rigid_ins_height, wall_cavity_r, wall_install_grade,
                                  wall_cavity_depth_in, wall_filled_cavity, wall_framing_factor,
                                  wall_rigid_r, wall_drywall_thick_in, wall_concrete_thick_in,
                                  wall_height, wall_height_above_grade)
 
     # Calculate interior wall R-value
-    int_wall_rvalue = calc_interior_wall_r_value(runner, wall_cavity_depth_in, wall_cavity_r,
+    int_wall_rvalue = calc_interior_wall_r_value(wall_cavity_depth_in, wall_cavity_r,
                                                  wall_filled_cavity, wall_framing_factor,
                                                  wall_install_grade, wall_rigid_r,
                                                  wall_drywall_thick_in)
-    if int_wall_rvalue.nil?
-      return false
-    end
 
     # Create Kiva foundation for crawlspace/basement
     foundation = apply_kiva_walled_foundation(model, int_wall_rvalue, wall_height,
@@ -899,25 +847,21 @@ class Constructions
     end
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions(wall_surfaces, runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions(wall_surfaces, model)
 
     # Assign surfaces to Kiva foundation
     wall_surfaces.each do |wall_surface|
       wall_surface.setAdjacentFoundation(foundation)
     end
-
-    return true
   end
 
-  def self.apply_foundation_slab(runner, model, surface, constr_name,
+  def self.apply_foundation_slab(model, surface, constr_name,
                                  under_r, under_width, gap_r,
                                  perimeter_r, perimeter_depth,
                                  whole_r, concrete_thick_in, exposed_perimeter,
                                  mat_carpet, foundation)
 
-    return true if surface.nil?
+    return if surface.nil?
 
     if foundation.nil?
       # Create Kiva foundation for slab
@@ -966,19 +910,15 @@ class Constructions
     end
 
     # Create and assign construction to surfaces
-    if not constr.create_and_assign_constructions([surface], runner, model)
-      return false
-    end
+    constr.create_and_assign_constructions([surface], model)
 
     # Assign surface to Kiva foundation
     surface.setAdjacentFoundation(foundation)
     surface.createSurfacePropertyExposedFoundationPerimeter("TotalExposedPerimeter", UnitConversions.convert(exposed_perimeter, "ft", "m"))
-
-    return true
   end
 
-  def self.apply_door(runner, model, subsurfaces, constr_name, ufactor)
-    return true if subsurfaces.empty?
+  def self.apply_door(model, subsurfaces, constr_name, ufactor)
+    return if subsurfaces.empty?
 
     # Define materials
     door_Rvalue = 1.0 / ufactor - Material.AirFilmOutside.rvalue - Material.AirFilmVertical.rvalue
@@ -993,34 +933,24 @@ class Constructions
     constr.add_layer(fin_door_mat)
 
     # Create and assign construction to subsurfaces
-    if not constr.create_and_assign_constructions(subsurfaces, runner, model)
-      return false
-    end
-
-    return true
+    constr.create_and_assign_constructions(subsurfaces, model)
   end
 
-  def self.apply_window(runner, model, subsurfaces, constr_name, weather,
+  def self.apply_window(model, subsurfaces, constr_name, weather,
                         cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
 
-    success = apply_window_skylight(runner, model, "Window", subsurfaces, constr_name, weather,
-                                    cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
-    return false if not success
-
-    return true
+    apply_window_skylight(model, "Window", subsurfaces, constr_name, weather,
+                          cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
   end
 
-  def self.apply_skylight(runner, model, subsurfaces, constr_name, weather,
+  def self.apply_skylight(model, subsurfaces, constr_name, weather,
                           cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
 
-    success = apply_window_skylight(runner, model, "Skylight", subsurfaces, constr_name, weather,
-                                    cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
-    return false if not success
-
-    return true
+    apply_window_skylight(model, "Skylight", subsurfaces, constr_name, weather,
+                          cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
   end
 
-  def self.apply_partition_walls(runner, model, constr_name, drywall_thick_in, frac_of_ffa,
+  def self.apply_partition_walls(model, constr_name, drywall_thick_in, frac_of_ffa,
                                  basement_frac_of_cfa, cond_base_surfaces, living_space)
 
     imdefs = []
@@ -1033,7 +963,7 @@ class Constructions
       # Add remaining partition walls within spaces (those without geometric representation)
       # as internal mass object.
       obj_name = "#{living_space.name.to_s} Living Partition"
-      imdef = create_os_int_mass_and_def(runner, model, obj_name, living_space, addtl_surface_area_lv)
+      imdef = create_os_int_mass_and_def(model, obj_name, living_space, addtl_surface_area_lv)
       imdefs << imdef
     end
 
@@ -1041,22 +971,18 @@ class Constructions
       # Add remaining partition walls within spaces (those without geometric representation)
       # as internal mass object.
       obj_name = "#{living_space.name.to_s} Basement Partition"
-      imdef = create_os_int_mass_and_def(runner, model, obj_name, living_space, addtl_surface_area_base)
+      imdef = create_os_int_mass_and_def(model, obj_name, living_space, addtl_surface_area_base)
       cond_base_surfaces << imdef
       imdefs << imdef
     end
 
-    if not Constructions.apply_wood_stud_wall(runner, model, imdefs, constr_name,
-                                              0, 1, 3.5, false,
-                                              Constants.DefaultFramingFactorInterior,
-                                              drywall_thick_in, 0, 0, nil)
-      return false
-    end
-
-    return true
+    Constructions.apply_wood_stud_wall(model, imdefs, constr_name,
+                                       0, 1, 3.5, false,
+                                       Constants.DefaultFramingFactorInterior,
+                                       drywall_thick_in, 0, 0, nil)
   end
 
-  def self.apply_furniture(runner, model, mass_lb_per_sqft, density_lb_per_cuft,
+  def self.apply_furniture(model, mass_lb_per_sqft, density_lb_per_cuft,
                            mat, basement_frac_of_cfa, cond_base_surfaces, living_space)
 
     # Add user-specified furniture mass
@@ -1102,31 +1028,27 @@ class Constructions
         # living furniture mass
         if living_surface_area > 0
           living_obj_name = mass_obj_name_space + " living"
-          imdef = create_os_int_mass_and_def(runner, model, living_obj_name, space, living_surface_area)
+          imdef = create_os_int_mass_and_def(model, living_obj_name, space, living_surface_area)
           imdefs << imdef
         end
         # basement furniture mass
         if base_surface_area > 0
           base_obj_name = mass_obj_name_space + " basement"
-          imdef = create_os_int_mass_and_def(runner, model, base_obj_name, space, base_surface_area)
+          imdef = create_os_int_mass_and_def(model, base_obj_name, space, base_surface_area)
           cond_base_surfaces << imdef
           imdefs << imdef
         end
       else
         surface_area = furnAreaFraction * space.floorArea
-        imdef = create_os_int_mass_and_def(runner, model, mass_obj_name_space, space, surface_area)
+        imdef = create_os_int_mass_and_def(model, mass_obj_name_space, space, surface_area)
         imdefs << imdef
       end
       # Create and assign construction to surfaces
-      if not constr.create_and_assign_constructions(imdefs, runner, model)
-        return false
-      end
+      constr.create_and_assign_constructions(imdefs, model)
     end
-
-    return true
   end
 
-  def self.create_os_int_mass_and_def(runner, model, object_name, space, area)
+  def self.create_os_int_mass_and_def(model, object_name, space, area)
     # create internal mass objects
     imdef = OpenStudio::Model::InternalMassDefinition.new(model)
     imdef.setName(object_name)
@@ -1136,7 +1058,6 @@ class Constructions
     im.setName(object_name)
     im.setSpace(space)
 
-    runner.registerInfo("Assigned internal mass object '#{object_name}' to space '#{space.name}'.")
     return imdef
   end
 
@@ -1367,7 +1288,7 @@ class Constructions
     return 0
   end
 
-  def self.calc_interior_wall_r_value(runner, cavity_depth_in, cavity_r, filled_cavity,
+  def self.calc_interior_wall_r_value(cavity_depth_in, cavity_r, filled_cavity,
                                       framing_factor, install_grade, rigid_r, drywall_thick_in)
 
     # Define materials
@@ -1419,7 +1340,7 @@ class Constructions
       constr.add_layer(mat_rigid)
     end
 
-    return constr.assembly_rvalue(runner) - rigid_r - drywall_r
+    return constr.assembly_rvalue() - rigid_r - drywall_r
   end
 
   def self.create_kiva_slab_foundation(model, int_horiz_r, int_horiz_width, int_vert_r,
@@ -1531,10 +1452,10 @@ class Constructions
     return mat
   end
 
-  def self.apply_window_skylight(runner, model, type, subsurfaces, constr_name, weather,
+  def self.apply_window_skylight(model, type, subsurfaces, constr_name, weather,
                                  cooling_season, ufactor, shgc, heat_shade_mult, cool_shade_mult)
 
-    return true if subsurfaces.empty?
+    return if subsurfaces.empty?
 
     # Define shade and schedule
     sc = nil
@@ -1555,10 +1476,7 @@ class Constructions
       day_endm = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365]
 
       # Interior Shading Schedule
-      sch = MonthWeekdayWeekendSchedule.new(model, runner, "#{type} shading schedule", Array.new(24, 1), Array.new(24, 1), cooling_season, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
-      if not sch.validated?
-        return false
-      end
+      sch = MonthWeekdayWeekendSchedule.new(model, "#{type} shading schedule", Array.new(24, 1), Array.new(24, 1), cooling_season, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
 
       # CoolingShade
       sm = OpenStudio::Model::Shade.new(model)
@@ -1597,22 +1515,7 @@ class Constructions
     constr.add_layer(glaz_mat)
 
     # Create and assign construction to subsurfaces
-    if not constr.create_and_assign_constructions(subsurfaces, runner, model)
-      return false
-    end
-
-    sc_msg = ""
-    if not sc.nil?
-      # Add shading controls
-      sc_msg = " and interior shades"
-      subsurfaces.each do |subsurface|
-        subsurface.setShadingControl(sc)
-      end
-    end
-
-    runner.registerInfo("Construction#{sc_msg} added to #{subsurfaces.size.to_s} #{constr_name.gsub("Construction", "").downcase}(s).")
-
-    return true
+    constr.create_and_assign_constructions(subsurfaces, model)
   end
 end
 
@@ -1656,11 +1559,9 @@ class Construction
     end
   end
 
-  def assembly_rvalue(runner)
+  def assembly_rvalue()
     # Calculate overall R-value for assembly
-    if not validated?(runner)
-      return nil
-    end
+    validate
 
     u_overall = 0
     @path_fracs.each_with_index do |path_frac, path_num|
@@ -1683,13 +1584,11 @@ class Construction
 
   # Creates constructions as needed and assigns to surfaces.
   # Leave name as nil if the materials (e.g., exterior finish) apply to multiple constructions.
-  def create_and_assign_constructions(surfaces, runner, model)
-    if not validated?(runner)
-      return false
-    end
+  def create_and_assign_constructions(surfaces, model)
+    validate
 
     # Create list of OpenStudio materials
-    materials = construct_materials(model, runner)
+    materials = construct_materials(model)
 
     # Create OpenStudio construction and assign to surface
     constr = OpenStudio::Model::Construction.new(model)
@@ -1697,17 +1596,9 @@ class Construction
     constr.setLayers(materials)
     revconstr = nil
 
-    printed_constr = false
-    printed_revconstr = false
-
     # Assign constructions to surfaces
     surfaces.each do |surface|
       surface.setConstruction(constr)
-      if not printed_constr
-        print_construction_creation(runner, surface)
-        printed_constr = true
-      end
-      print_construction_assignment(runner, surface)
 
       # Assign reverse construction to adjacent surface as needed
       next if surface.is_a? OpenStudio::Model::SubSurface or surface.is_a? OpenStudio::Model::InternalMassDefinition or not surface.adjacentSurface.is_initialized
@@ -1717,18 +1608,12 @@ class Construction
       end
       adjacent_surface = surface.adjacentSurface.get
       adjacent_surface.setConstruction(revconstr)
-      if not printed_revconstr
-        print_construction_creation(runner, adjacent_surface)
-        printed_revconstr = true
-      end
-      print_construction_assignment(runner, adjacent_surface)
     end
-    return true
   end
 
   private
 
-  def get_parallel_material(curr_layer_num, runner, name)
+  def get_parallel_material(curr_layer_num, name)
     # Returns a Material object with effective properties for the specified
     # parallel path layer of the construction.
 
@@ -1736,7 +1621,7 @@ class Construction
 
     curr_layer_materials = @layers_materials[curr_layer_num]
 
-    r_overall = assembly_rvalue(runner)
+    r_overall = assembly_rvalue()
 
     # Calculate individual R-values for each layer
     sum_r_all_layers = 0
@@ -1783,35 +1668,33 @@ class Construction
     return mat
   end
 
-  def construct_materials(model, runner)
+  def construct_materials(model)
     # Create materials
     materials = []
     @layers_materials.each_with_index do |layer_materials, layer_num|
       if layer_materials.size == 1
         next if layer_materials[0].name == Constants.AirFilm # Do not include air films in construction
 
-        mat = Construction.create_os_material(model, runner, layer_materials[0])
+        mat = Construction.create_os_material(model, layer_materials[0])
       else
-        parallel_path_mat = get_parallel_material(layer_num, runner, @layers_names[layer_num])
-        mat = Construction.create_os_material(model, runner, parallel_path_mat)
+        parallel_path_mat = get_parallel_material(layer_num, @layers_names[layer_num])
+        mat = Construction.create_os_material(model, parallel_path_mat)
       end
       materials << mat
     end
     return materials
   end
 
-  def validated?(runner)
+  def validate
     # Check that sum of path fracs equal 1
     if @sum_path_fracs <= 0.999 or @sum_path_fracs >= 1.001
-      runner.registerError("Invalid construction: Sum of path fractions (#{@sum_path_fracs.to_s}) is not 1.")
-      return false
+      fail "Invalid construction: Sum of path fractions (#{@sum_path_fracs.to_s}) is not 1."
     end
 
     # Check that all path fractions are not negative
     @path_fracs.each do |path_frac|
       if path_frac < 0
-        runner.registerError("Invalid construction: Path fraction (#{path_frac.to_s}) must be greater than or equal to 0.")
-        return false
+        fail "Invalid construction: Path fraction (#{path_frac.to_s}) must be greater than or equal to 0."
       end
     end
 
@@ -1828,19 +1711,17 @@ class Construction
       # Check that no parallel materials
       @layers_materials.each do |layer_materials|
         if layer_materials.size > 1
-          runner.registerError("Invalid construction: Cannot have multiple GlazingMaterials in a single layer.")
-          return false
+          fail "Invalid construction: Cannot have multiple GlazingMaterials in a single layer."
         end
       end
-      return true
+      return
     end
 
     # Check for valid object types
     @layers_materials.each do |layer_materials|
       layer_materials.each do |mat|
         if not mat.is_a? SimpleMaterial and not mat.is_a? Material
-          runner.registerError("Invalid construction: Materials must be instances of SimpleMaterial or Material classes.")
-          return false
+          fail "Invalid construction: Materials must be instances of SimpleMaterial or Material classes."
         end
       end
     end
@@ -1848,8 +1729,7 @@ class Construction
     # Check if invalid number of materials in a layer
     @layers_materials.each do |layer_materials|
       if layer_materials.size > 1 and layer_materials.size < @path_fracs.size
-        runner.registerError("Invalid construction: Layer must either have one material or same number of materials as paths.")
-        return false
+        fail "Invalid construction: Layer must either have one material or same number of materials as paths."
       end
     end
 
@@ -1861,8 +1741,7 @@ class Construction
           if thick_in.nil?
             thick_in = mat.thick_in
           elsif thick_in != mat.thick_in
-            runner.registerError("Invalid construction: Materials in a layer have different thicknesses.")
-            return false
+            fail "Invalid construction: Materials in a layer have different thicknesses."
           end
         end
       end
@@ -1876,19 +1755,15 @@ class Construction
         if not found_parallel
           found_parallel = true
         elsif not last_parallel
-          runner.registerError("Invalid construction: Non-contiguous parallel layers found.")
-          return false
+          fail "Invalid construction: Non-contiguous parallel layers found."
         end
       end
       last_parallel = (layer_materials.size > 1)
     end
-
-    # If we got this far, we're good
-    return true
   end
 
   # Creates (or returns an existing) OpenStudio Material from our own Material object
-  def self.create_os_material(model, runner, material)
+  def self.create_os_material(model, material)
     name = material.name
     tolerance = 0.0001
     if material.is_a? SimpleMaterial
@@ -1949,32 +1824,6 @@ class Construction
         mat.setVisibleAbsorptance(material.vAbs)
       end
     end
-    runner.registerInfo("Material '#{mat.name.to_s}' was created.")
     return mat
-  end
-
-  def print_construction_creation(runner, surface)
-    s = ""
-    num_layers = surface.construction.get.to_LayeredConstruction.get.layers.size
-    if num_layers > 1
-      s = "s"
-    end
-    mats_s = ""
-    surface.construction.get.to_LayeredConstruction.get.layers.each do |layer|
-      mats_s += layer.name.to_s + " | "
-    end
-    mats_s.chomp!(" | ")
-    runner.registerInfo("Construction '#{surface.construction.get.name.to_s}' was created with #{num_layers.to_s} material#{s.to_s} (#{mats_s.to_s}).")
-  end
-
-  def print_construction_assignment(runner, surface)
-    if surface.is_a? OpenStudio::Model::SubSurface
-      type_s = "SubSurface"
-    elsif surface.is_a? OpenStudio::Model::InternalMassDefinition
-      type_s = "InternalMassDefinition"
-    else
-      type_s = "Surface"
-    end
-    runner.registerInfo("#{type_s.to_s} '#{surface.name.to_s}' has been assigned construction '#{surface.construction.get.name.to_s}'.")
   end
 end

--- a/resources/constructions.rb
+++ b/resources/constructions.rb
@@ -1502,6 +1502,11 @@ class Constructions
       sc.setShadingType("InteriorShade")
       sc.setShadingControlType("OnIfScheduleAllows")
       sc.setSchedule(sch.schedule)
+
+      # Add shading controls
+      subsurfaces.each do |subsurface|
+        subsurface.setShadingControl(sc)
+      end
     end
 
     # Define materials

--- a/resources/geometry.rb
+++ b/resources/geometry.rb
@@ -3,7 +3,7 @@ require_relative "unit_conversions"
 require_relative "util"
 
 class Geometry
-  def self.get_zone_volume(zone, runner = nil)
+  def self.get_zone_volume(zone)
     if zone.isVolumeAutocalculated or not zone.volume.is_initialized
       # Calculate volume from spaces
       volume = 0
@@ -13,10 +13,10 @@ class Geometry
     else
       volume = UnitConversions.convert(zone.volume.get, "m^3", "ft^3")
     end
-    if volume <= 0 and not runner.nil?
-      runner.registerError("Could not find any volume.")
-      return nil
+    if volume <= 0
+      fail "Could not find any volume."
     end
+
     return volume
   end
 
@@ -434,21 +434,18 @@ class Geometry
     return below_grade_exterior_floors
   end
 
-  def self.process_occupants(model, runner, num_occ, occ_gain, sens_frac, lat_frac, weekday_sch, weekend_sch, monthly_sch,
+  def self.process_occupants(model, num_occ, occ_gain, sens_frac, lat_frac, weekday_sch, weekend_sch, monthly_sch,
                              cfa, nbeds, space)
 
     # Error checking
     if sens_frac < 0 or sens_frac > 1
-      runner.registerError("Sensible fraction must be greater than or equal to 0 and less than or equal to 1.")
-      return false
+      fail "Sensible fraction must be greater than or equal to 0 and less than or equal to 1."
     end
     if lat_frac < 0 or lat_frac > 1
-      runner.registerError("Latent fraction must be greater than or equal to 0 and less than or equal to 1.")
-      return false
+      fail "Latent fraction must be greater than or equal to 0 and less than or equal to 1."
     end
     if lat_frac + sens_frac > 1
-      runner.registerError("Sum of sensible and latent fractions must be less than or equal to 1.")
-      return false
+      fail "Sum of sensible and latent fractions must be less than or equal to 1."
     end
 
     activity_per_person = UnitConversions.convert(occ_gain, "Btu/hr", "W")
@@ -464,10 +461,7 @@ class Geometry
     space_num_occ = num_occ * UnitConversions.convert(space.floorArea, "m^2", "ft^2") / cfa
 
     # Create schedule
-    people_sch = MonthWeekdayWeekendSchedule.new(model, runner, Constants.ObjectNameOccupants + " schedule", weekday_sch, weekend_sch, monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
-    if not people_sch.validated?
-      return false
-    end
+    people_sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameOccupants + " schedule", weekday_sch, weekend_sch, monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
 
     # Create schedule
     activity_sch = OpenStudio::Model::ScheduleRuleset.new(model, activity_per_person)
@@ -487,9 +481,6 @@ class Geometry
     occ_def.setEnableASHRAE55ComfortWarnings(false)
     occ.setActivityLevelSchedule(activity_sch)
     occ.setNumberofPeopleSchedule(people_sch.schedule)
-
-    runner.registerInfo("Space '#{space.name}' been assigned #{space_num_occ.round(2)} occupant(s).")
-    return true
   end
 
   def self.get_occupancy_default_num(nbeds)

--- a/resources/hotwater_appliances.rb
+++ b/resources/hotwater_appliances.rb
@@ -1,10 +1,7 @@
-# This file, which has 301 calculations, will eventually replace appliances.rb,
-# which has Building America calculations.
-
 require_relative "constants"
 
 class HotWaterAndAppliances
-  def self.apply(model, runner, weather, living_space,
+  def self.apply(model, weather, living_space,
                  cfa, nbeds, ncfl, has_uncond_bsmnt, wh_setpoint,
                  cw_mef, cw_ler, cw_elec_rate, cw_gas_rate,
                  cw_agc, cw_cap, cw_space, cd_fuel, cd_ef, cd_control,
@@ -54,9 +51,7 @@ class HotWaterAndAppliances
             setpoint_scheds[dhw_loop] = dhw_object.compressorSetpointTemperatureSchedule
           end
         end
-        if setpoint_scheds[dhw_loop].nil?
-          return false
-        end
+        fail "Could not find setpoint schedule." if setpoint_scheds[dhw_loop].nil?
       end
 
       # Calculate mixed water fractions
@@ -77,7 +72,7 @@ class HotWaterAndAppliances
     if not dist_type.nil? and not cw_mef.nil?
       cw_annual_kwh, cw_frac_sens, cw_frac_lat, cw_gpd = self.calc_clothes_washer_energy_gpd(eri_version, nbeds, cw_ler, cw_elec_rate, cw_gas_rate, cw_agc, cw_cap)
       cw_name = Constants.ObjectNameClothesWasher
-      cw_schedule = HotWaterSchedule.new(model, runner, cw_name, nbeds)
+      cw_schedule = HotWaterSchedule.new(model, cw_name, nbeds)
       cw_peak_flow = cw_schedule.calcPeakFlowFromDailygpm(cw_gpd)
       cw_design_level_w = cw_schedule.calcDesignLevelFromDailykWh(cw_annual_kwh / 365.0)
       add_electric_equipment(model, cw_name, cw_space, cw_design_level_w, cw_frac_sens, cw_frac_lat, cw_schedule.schedule)
@@ -93,7 +88,7 @@ class HotWaterAndAppliances
       cd_name = Constants.ObjectNameClothesDryer
       cd_weekday_sch = "0.010, 0.006, 0.004, 0.002, 0.004, 0.006, 0.016, 0.032, 0.048, 0.068, 0.078, 0.081, 0.074, 0.067, 0.057, 0.061, 0.055, 0.054, 0.051, 0.051, 0.052, 0.054, 0.044, 0.024"
       cd_monthly_sch = "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0"
-      cd_schedule = MonthWeekdayWeekendSchedule.new(model, runner, cd_name, cd_weekday_sch, cd_weekday_sch, cd_monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
+      cd_schedule = MonthWeekdayWeekendSchedule.new(model, cd_name, cd_weekday_sch, cd_weekday_sch, cd_monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
       cd_design_level_e = cd_schedule.calcDesignLevelFromDailykWh(cd_annual_kwh / 365.0)
       cd_design_level_f = cd_schedule.calcDesignLevelFromDailyTherm(cd_annual_therm / 365.0)
       add_electric_equipment(model, cd_name, cd_space, cd_design_level_e, cd_frac_sens, cd_frac_lat, cd_schedule.schedule)
@@ -104,7 +99,7 @@ class HotWaterAndAppliances
     if not dist_type.nil? and not dw_ef.nil?
       dw_annual_kwh, dw_frac_sens, dw_frac_lat, dw_gpd = self.calc_dishwasher_energy_gpd(eri_version, nbeds, dw_ef, dw_cap)
       dw_name = Constants.ObjectNameDishwasher
-      dw_schedule = HotWaterSchedule.new(model, runner, dw_name, nbeds)
+      dw_schedule = HotWaterSchedule.new(model, dw_name, nbeds)
       dw_peak_flow = dw_schedule.calcPeakFlowFromDailygpm(dw_gpd)
       dw_design_level_w = dw_schedule.calcDesignLevelFromDailykWh(dw_annual_kwh / 365.0)
       add_electric_equipment(model, dw_name, living_space, dw_design_level_w, dw_frac_sens, dw_frac_lat, dw_schedule.schedule)
@@ -119,7 +114,7 @@ class HotWaterAndAppliances
       fridge_name = Constants.ObjectNameRefrigerator
       fridge_weekday_sch = "0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041"
       fridge_monthly_sch = "0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837"
-      fridge_schedule = MonthWeekdayWeekendSchedule.new(model, runner, fridge_name, fridge_weekday_sch, fridge_weekday_sch, fridge_monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
+      fridge_schedule = MonthWeekdayWeekendSchedule.new(model, fridge_name, fridge_weekday_sch, fridge_weekday_sch, fridge_monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
       fridge_design_level = fridge_schedule.calcDesignLevelFromDailykWh(fridge_annual_kwh / 365.0)
       add_electric_equipment(model, fridge_name, fridge_space, fridge_design_level, 1.0, 0.0, fridge_schedule.schedule)
     end
@@ -130,7 +125,7 @@ class HotWaterAndAppliances
       cook_name = Constants.ObjectNameCookingRange
       cook_weekday_sch = "0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011"
       cook_monthly_sch = "1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097"
-      cook_schedule = MonthWeekdayWeekendSchedule.new(model, runner, cook_name, cook_weekday_sch, cook_weekday_sch, cook_monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
+      cook_schedule = MonthWeekdayWeekendSchedule.new(model, cook_name, cook_weekday_sch, cook_weekday_sch, cook_monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
       cook_design_level_e = cook_schedule.calcDesignLevelFromDailykWh(cook_annual_kwh / 365.0)
       cook_design_level_f = cook_schedule.calcDesignLevelFromDailyTherm(cook_annual_therm / 365.0)
       add_electric_equipment(model, cook_name, living_space, cook_design_level_e, cook_frac_sens, cook_frac_lat, cook_schedule.schedule)
@@ -165,7 +160,7 @@ class HotWaterAndAppliances
 
       fx_schedules = {}
       fx_names.each do |fx_name|
-        fx_schedules[fx_name] = HotWaterSchedule.new(model, runner, fx_name, nbeds)
+        fx_schedules[fx_name] = HotWaterSchedule.new(model, fx_name, nbeds)
       end
 
       # Calculate sum_total_flow
@@ -203,7 +198,7 @@ class HotWaterAndAppliances
         dist_pump_name = Constants.ObjectNameHotWaterRecircPump
         dist_pump_weekday_sch = "0.010, 0.006, 0.004, 0.002, 0.004, 0.006, 0.016, 0.032, 0.048, 0.068, 0.078, 0.081, 0.074, 0.067, 0.057, 0.061, 0.055, 0.054, 0.051, 0.051, 0.052, 0.054, 0.044, 0.024"
         dist_pump_monthly_sch = "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0"
-        dist_pump_schedule = MonthWeekdayWeekendSchedule.new(model, runner, dist_pump_name, dist_pump_weekday_sch, dist_pump_weekday_sch, dist_pump_monthly_sch, 1.0, 1.0)
+        dist_pump_schedule = MonthWeekdayWeekendSchedule.new(model, dist_pump_name, dist_pump_weekday_sch, dist_pump_weekday_sch, dist_pump_monthly_sch, 1.0, 1.0)
         dist_pump_design_level = dist_pump_schedule.calcDesignLevelFromDailykWh(dist_pump_annual_kwh / 365.0)
         dhw_loop_fracs.each do |sys_id, dhw_load_frac|
           dhw_loop = dhw_loops[sys_id]
@@ -212,8 +207,6 @@ class HotWaterAndAppliances
         end
       end
     end
-
-    return true
   end
 
   def self.get_range_oven_reference_is_induction()
@@ -570,7 +563,7 @@ class HotWaterAndAppliances
     elsif dist_type == "standard"
       return 0.0
     end
-    return nil
+    fail "Unexpected hot water distribution system."
   end
 
   def self.get_fixtures_effectiveness(has_low_flow_fixtures)
@@ -688,6 +681,6 @@ class HotWaterAndAppliances
         return 28.8
       end
     end
-    return nil
+    fail "Unexpected hot water distribution system."
   end
 end

--- a/resources/hpxml.rb
+++ b/resources/hpxml.rb
@@ -351,8 +351,6 @@ class HPXML
       surf = surfs[surf_id]
       surf.elements["ExposedPerimeter"].text = Float(surf.elements["ExposedPerimeter"].text) + exposed_perimeter_adjustment
     end
-
-    return true
   end
 
   def self.add_air_infiltration_measurement(hpxml:,

--- a/resources/hvac.rb
+++ b/resources/hvac.rb
@@ -91,9 +91,6 @@ class HVAC
 
     air_loop_unitary.addToNode(air_supply_inlet_node)
 
-    runner.registerInfo("Added '#{fan.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{clg_coil.name}' to '#{air_loop_unitary.name}'")
-
     air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
     # _processSystemDemandSideAir
@@ -109,7 +106,6 @@ class HVAC
     air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
 
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, 0))
@@ -118,8 +114,6 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACRatedCFMperTonCooling, cfms_ton_rated.join(","))
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACFracCoolLoadServed, frac_cool_load_served)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameCentralAirConditioner)
-
-    return true
   end
 
   def self.apply_central_ac_2speed(model, runner, seer, shrs,
@@ -208,9 +202,6 @@ class HVAC
 
     air_loop_unitary.addToNode(air_supply_inlet_node)
 
-    runner.registerInfo("Added '#{fan.name}' to #{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{clg_coil.name}' to '#{air_loop_unitary.name}'")
-
     air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
     # _processSystemDemandSideAir
@@ -226,7 +217,6 @@ class HVAC
     air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
 
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, 0))
@@ -236,8 +226,6 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACRatedCFMperTonCooling, cfms_ton_rated.join(","))
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACFracCoolLoadServed, frac_cool_load_served)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameCentralAirConditioner)
-
-    return true
   end
 
   def self.apply_central_ac_4speed(model, runner, seer, shrs,
@@ -331,9 +319,6 @@ class HVAC
 
     air_loop_unitary.addToNode(air_supply_inlet_node)
 
-    runner.registerInfo("Added '#{fan.name}' to #{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{clg_coil.name}' to #{air_loop_unitary.name}'")
-
     air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
     # _processSystemDemandSideAir
@@ -349,7 +334,6 @@ class HVAC
     air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
 
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, 0))
@@ -359,8 +343,6 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACRatedCFMperTonCooling, cfms_ton_rated.join(","))
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACFracCoolLoadServed, frac_cool_load_served)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameCentralAirConditioner)
-
-    return true
   end
 
   def self.apply_evaporative_cooler(model, runner, frac_cool_load_served,
@@ -434,15 +416,12 @@ class HVAC
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_terminal_living.setConstantMinimumAirFlowFraction(0)
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, 0))
 
     # Store info for HVAC Sizing measure
     evap_cooler.additionalProperties.setFeature(Constants.SizingInfoHVACFracCoolLoadServed, frac_cool_load_served)
     evap_cooler.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameEvaporativeCooler)
-
-    return true
   end
 
   def self.apply_central_ashp_1speed(model, runner, seer, hspf, shrs,
@@ -563,11 +542,6 @@ class HVAC
 
     air_loop_unitary.addToNode(air_supply_inlet_node)
 
-    runner.registerInfo("Added '#{fan.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{clg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_supp_coil.name}' to '#{air_loop_unitary.name}'")
-
     air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
     # _processSystemDemandSideAir
@@ -583,7 +557,6 @@ class HVAC
     air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
 
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_heat_load_frac.round(5)))
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
@@ -595,8 +568,6 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACFracCoolLoadServed, frac_cool_load_served)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameAirSourceHeatPump)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameAirSourceHeatPump)
-
-    return true
   end
 
   def self.apply_central_ashp_2speed(model, runner, seer, hspf, shrs,
@@ -722,11 +693,6 @@ class HVAC
 
     air_loop_unitary.addToNode(air_supply_inlet_node)
 
-    runner.registerInfo("Added '#{fan.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{clg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_supp_coil.name}' to '#{air_loop_unitary.name}'")
-
     air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
     # _processSystemDemandSideAir
@@ -742,7 +708,6 @@ class HVAC
     air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
 
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_heat_load_frac.round(5)))
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
@@ -756,8 +721,6 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACFracCoolLoadServed, frac_cool_load_served)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameAirSourceHeatPump)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameAirSourceHeatPump)
-
-    return true
   end
 
   def self.apply_central_ashp_4speed(model, runner, seer, hspf, shrs,
@@ -887,11 +850,6 @@ class HVAC
 
     air_loop_unitary.addToNode(air_supply_inlet_node)
 
-    runner.registerInfo("Added '#{fan.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{clg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_supp_coil.name}' to '#{air_loop_unitary.name}'")
-
     air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
     # _processSystemDemandSideAir
@@ -907,7 +865,6 @@ class HVAC
     air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
 
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_heat_load_frac.round(5)))
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
@@ -921,8 +878,6 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACFracCoolLoadServed, frac_cool_load_served)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameAirSourceHeatPump)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameAirSourceHeatPump)
-
-    return true
   end
 
   def self.apply_mshp(model, runner, seer, hspf, shr,
@@ -1090,11 +1045,6 @@ class HVAC
 
     air_loop_unitary.addToNode(air_supply_inlet_node)
 
-    runner.registerInfo("Added '#{fan.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{clg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_supp_coil.name}' to '#{air_loop_unitary.name}'")
-
     air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
     # _processSystemDemandSideAir
@@ -1110,7 +1060,6 @@ class HVAC
     air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
 
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_heat_load_frac.round(5)))
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
@@ -1190,8 +1139,6 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACSHR, shrs_rated_4.join(","))
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameMiniSplitHeatPump)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameMiniSplitHeatPump)
-
-    return true
   end
 
   def self.apply_gshp(model, runner, weather, cop, eer, shr,
@@ -1273,7 +1220,6 @@ class HVAC
     plant_loop.setMinimumLoopTemperature(UnitConversions.convert(hw_design, "F", "C"))
     plant_loop.setMinimumLoopFlowRate(0)
     plant_loop.setLoadDistributionScheme('SequentialLoad')
-    runner.registerInfo("Added '#{plant_loop.name}' to model.")
     hvac_map[sys_id] << plant_loop
 
     sizing_plant = plant_loop.sizingPlant
@@ -1406,10 +1352,6 @@ class HVAC
 
     air_loop_unitary.addToNode(air_supply_inlet_node)
 
-    runner.registerInfo("Added '#{htg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{clg_coil.name}' to '#{air_loop_unitary.name}'")
-    runner.registerInfo("Added '#{htg_supp_coil.name}' to '#{air_loop_unitary.name}'")
-
     air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
     zone_splitter = air_loop.zoneSplitter
@@ -1421,7 +1363,6 @@ class HVAC
     air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
     air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
     air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-    runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
 
     control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_heat_load_frac.round(5)))
     control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
@@ -1439,8 +1380,6 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoGSHPUTubeSpacingType, u_tube_spacing_type)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameGroundSourceHeatPump)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameGroundSourceHeatPump)
-
-    return true
   end
 
   def self.apply_room_ac(model, runner, eer, shr,
@@ -1499,7 +1438,6 @@ class HVAC
     ptac.setName(obj_name + " #{control_zone.name}")
     ptac.setSupplyAirFanOperatingModeSchedule(model.alwaysOffDiscreteSchedule)
     ptac.addToThermalZone(control_zone)
-    runner.registerInfo("Added '#{ptac.name}' to '#{control_zone.name}'")
     hvac_map[sys_id] << ptac
 
     control_zone.setSequentialCoolingFractionSchedule(ptac, get_constant_schedule(model, sequential_cool_load_frac.round(5)))
@@ -1510,8 +1448,6 @@ class HVAC
     ptac.additionalProperties.setFeature(Constants.SizingInfoHVACRatedCFMperTonCooling, cfms_ton_rated.join(","))
     ptac.additionalProperties.setFeature(Constants.SizingInfoHVACFracCoolLoadServed, frac_cool_load_served)
     ptac.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameRoomAirConditioner)
-
-    return true
   end
 
   def self.apply_furnace(model, runner, fuel_type, afue,
@@ -1583,9 +1519,6 @@ class HVAC
 
       air_loop_unitary.addToNode(air_supply_inlet_node)
 
-      runner.registerInfo("Added '#{fan.name}' to '#{air_loop_unitary.name}'")
-      runner.registerInfo("Added '#{htg_coil.name}' to '#{air_loop_unitary.name}'")
-
       air_loop_unitary.setControllingZoneorThermostatLocation(control_zone)
 
       # _processSystemDemandSideAir
@@ -1601,8 +1534,6 @@ class HVAC
       air_terminal_living = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, model.alwaysOnDiscreteSchedule)
       air_terminal_living.setName(obj_name + " #{control_zone.name} terminal")
       air_loop.multiAddBranchForZone(control_zone, air_terminal_living)
-      runner.registerInfo("Added '#{air_loop.name}' to '#{control_zone.name}'")
-
       control_zone.setSequentialHeatingFractionSchedule(air_terminal_living, get_constant_schedule(model, sequential_heat_load_frac.round(5)))
       control_zone.setSequentialCoolingFractionSchedule(air_terminal_living, get_constant_schedule(model, 0))
 
@@ -1651,8 +1582,6 @@ class HVAC
       air_loop.setName(obj_name + " airloop")
       hvac_map[sys_id] << air_loop
 
-      runner.registerInfo("Added '#{htg_coil.name}' to '#{attached_clg_system.name}'")
-
       zone_splitter = air_loop.zoneSplitter
       zone_splitter.setName(obj_name + " zone splitter")
 
@@ -1669,8 +1598,6 @@ class HVAC
       attached_clg_system.additionalProperties.setFeature(Constants.SizingInfoHVACFracHeatLoadServed, frac_heat_load_served)
       attached_clg_system.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameFurnace)
     end
-
-    return true
   end
 
   def self.apply_boiler(model, runner, fuel_type, system_type, afue,
@@ -1682,8 +1609,7 @@ class HVAC
     # _processHydronicSystem
 
     if system_type == Constants.BoilerTypeSteam
-      runner.registerError("Cannot currently model steam boilers.")
-      return false
+      fail "Cannot currently model steam boilers."
     end
 
     if oat_reset_enabled
@@ -1708,7 +1634,6 @@ class HVAC
     plant_loop.setMinimumLoopTemperature(0)
     plant_loop.setMinimumLoopFlowRate(0)
     plant_loop.autocalculatePlantLoopVolume()
-    runner.registerInfo("Added '#{plant_loop.name}' to model.")
     hvac_map[sys_id] << plant_loop
 
     loop_sizing = plant_loop.sizingPlant
@@ -1805,7 +1730,6 @@ class HVAC
     baseboard_heater = OpenStudio::Model::ZoneHVACBaseboardConvectiveWater.new(model, model.alwaysOnDiscreteSchedule, baseboard_coil)
     baseboard_heater.setName(obj_name + " #{control_zone.name}")
     baseboard_heater.addToThermalZone(control_zone)
-    runner.registerInfo("Added '#{baseboard_heater.name}' to '#{control_zone.name}'")
     hvac_map[sys_id] << baseboard_heater
     hvac_map[sys_id] += self.disaggregate_fan_or_pump(model, pump, baseboard_heater, nil, nil)
 
@@ -1817,8 +1741,6 @@ class HVAC
     # Store info for HVAC Sizing measure
     baseboard_heater.additionalProperties.setFeature(Constants.SizingInfoHVACFracHeatLoadServed, frac_heat_load_served)
     baseboard_heater.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameBoiler)
-
-    return true
   end
 
   def self.apply_electric_baseboard(model, runner, efficiency, capacity,
@@ -1836,16 +1758,12 @@ class HVAC
     hvac_map[sys_id] << baseboard_heater
 
     baseboard_heater.addToThermalZone(control_zone)
-    runner.registerInfo("Added '#{baseboard_heater.name}' to '#{control_zone.name}'")
-
     control_zone.setSequentialHeatingFractionSchedule(baseboard_heater, get_constant_schedule(model, sequential_heat_load_frac.round(5)))
     control_zone.setSequentialCoolingFractionSchedule(baseboard_heater, get_constant_schedule(model, 0))
 
     # Store info for HVAC Sizing measure
     baseboard_heater.additionalProperties.setFeature(Constants.SizingInfoHVACFracHeatLoadServed, frac_heat_load_served)
     baseboard_heater.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameElectricBaseboard)
-
-    return true
   end
 
   def self.apply_unit_heater(model, runner, fuel_type,
@@ -1855,8 +1773,7 @@ class HVAC
                              hvac_map, sys_id)
 
     if fan_power > 0 and airflow_rate == 0
-      runner.registerError("If Fan Power > 0, then Airflow Rate cannot be zero.")
-      return false
+      fail "If Fan Power > 0, then Airflow Rate cannot be zero."
     end
 
     obj_name = Constants.ObjectNameUnitHeater
@@ -1909,9 +1826,6 @@ class HVAC
     unitary_system.setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(0)
     hvac_map[sys_id] << unitary_system
 
-    runner.registerInfo("Added '#{fan.name}' to '#{unitary_system.name}''")
-    runner.registerInfo("Added '#{htg_coil.name}' to '#{unitary_system.name}'")
-
     unitary_system.setControllingZoneorThermostatLocation(control_zone)
     unitary_system.addToThermalZone(control_zone)
 
@@ -1922,8 +1836,6 @@ class HVAC
     unitary_system.additionalProperties.setFeature(Constants.SizingInfoHVACRatedCFMperTonHeating, airflow_rate.to_s)
     unitary_system.additionalProperties.setFeature(Constants.SizingInfoHVACFracHeatLoadServed, frac_heat_load_served)
     unitary_system.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameUnitHeater)
-
-    return true
   end
 
   def self.apply_ideal_air_loads(model, runner, sequential_cool_load_frac, sequential_heat_load_frac,
@@ -1949,8 +1861,6 @@ class HVAC
     # Store info for HVAC Sizing measure
     ideal_air.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameIdealAirSystem)
     ideal_air.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameIdealAirSystem)
-
-    return true
   end
 
   def self.disaggregate_fan_or_pump(model, fan_or_pump, htg_object, clg_object, backup_htg_object)
@@ -2089,24 +1999,18 @@ class HVAC
 
     # Get heating season
     if use_auto_season
-      heating_season, _ = calc_heating_and_cooling_seasons(model, weather, runner)
+      heating_season, _ = calc_heating_and_cooling_seasons(model, weather)
     else
       if season_start_month <= season_end_month
         heating_season = Array.new(season_start_month - 1, 0) + Array.new(season_end_month - season_start_month + 1, 1) + Array.new(12 - season_end_month, 0)
-      elsif season_start_month > season_end_month
+      else
         heating_season = Array.new(season_end_month, 1) + Array.new(season_start_month - season_end_month - 1, 0) + Array.new(12 - season_start_month + 1, 1)
       end
-    end
-    if heating_season.nil?
-      return false
     end
 
     cooling_season = get_season(model, weather, runner, Constants.ObjectNameCoolingSeason)
 
-    heating_season_sch = MonthWeekdayWeekendSchedule.new(model, runner, Constants.ObjectNameHeatingSeason, Array.new(24, 1), Array.new(24, 1), heating_season, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsOnOff)
-    unless heating_season_sch.validated?
-      return false
-    end
+    heating_season_sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameHeatingSeason, Array.new(24, 1), Array.new(24, 1), heating_season, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsOnOff)
 
     htg_wkdy_monthly = htg_wkdy_monthly.map { |i| i.map { |j| UnitConversions.convert(j, "F", "C") } }
     htg_wked_monthly = htg_wked_monthly.map { |i| i.map { |j| UnitConversions.convert(j, "F", "C") } }
@@ -2118,17 +2022,12 @@ class HVAC
     if thermostat_setpoint.is_initialized
 
       thermostat_setpoint = thermostat_setpoint.get
-      runner.registerInfo("Found existing thermostat #{thermostat_setpoint.name} for #{living_zone.name}.")
 
-      clg_wkdy_monthly = get_setpoint_schedule(thermostat_setpoint.coolingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekday', runner)
-      clg_wked_monthly = get_setpoint_schedule(thermostat_setpoint.coolingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekend', runner)
-      if clg_wkdy_monthly.nil? or clg_wked_monthly.nil?
-        return false
-      end
+      clg_wkdy_monthly = get_setpoint_schedule(thermostat_setpoint.coolingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekday')
+      clg_wked_monthly = get_setpoint_schedule(thermostat_setpoint.coolingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekend')
 
       if not clg_wkdy_monthly.uniq.length == 1 or not clg_wked_monthly.uniq.length == 1
-        runner.registerError("Found monthly variation in cooling setpoint schedule.")
-        return false
+        fail "Found monthly variation in cooling setpoint schedule."
       end
 
       model.getScheduleRulesets.each do |sch|
@@ -2171,42 +2070,28 @@ class HVAC
       clg_wked_monthly[i] = clg_wked
     end
 
-    heating_setpoint = HourlyByMonthSchedule.new(model, runner, Constants.ObjectNameHeatingSetpoint, htg_wkdy_monthly, htg_wked_monthly, normalize_values = false)
-    cooling_setpoint = HourlyByMonthSchedule.new(model, runner, Constants.ObjectNameCoolingSetpoint, clg_wkdy_monthly, clg_wked_monthly, normalize_values = false)
-
-    unless heating_setpoint.validated? and cooling_setpoint.validated?
-      return false
-    end
+    heating_setpoint = HourlyByMonthSchedule.new(model, Constants.ObjectNameHeatingSetpoint, htg_wkdy_monthly, htg_wked_monthly, normalize_values = false)
+    cooling_setpoint = HourlyByMonthSchedule.new(model, Constants.ObjectNameCoolingSetpoint, clg_wkdy_monthly, clg_wked_monthly, normalize_values = false)
 
     # Set the setpoint schedules
     thermostat_setpoint = living_zone.thermostatSetpointDualSetpoint
     if thermostat_setpoint.is_initialized
-
       thermostat_setpoint = thermostat_setpoint.get
       thermostat_setpoint.setHeatingSetpointTemperatureSchedule(heating_setpoint.schedule)
       thermostat_setpoint.setCoolingSetpointTemperatureSchedule(cooling_setpoint.schedule)
-
     else
-
       thermostat_setpoint = OpenStudio::Model::ThermostatSetpointDualSetpoint.new(model)
       thermostat_setpoint.setName("#{living_zone.name} temperature setpoint")
-      runner.registerInfo("Created new thermostat #{thermostat_setpoint.name} for #{living_zone.name}.")
       thermostat_setpoint.setHeatingSetpointTemperatureSchedule(heating_setpoint.schedule)
       thermostat_setpoint.setCoolingSetpointTemperatureSchedule(cooling_setpoint.schedule)
       living_zone.setThermostatSetpointDualSetpoint(thermostat_setpoint)
-      runner.registerInfo("Set a dummy cooling setpoint schedule for #{thermostat_setpoint.name}.")
-
     end
-
-    runner.registerInfo("Set the heating setpoint schedule for #{thermostat_setpoint.name}.")
 
     model.getScheduleDays.each do |obj| # remove orphaned summer and winter design day schedules
       next if obj.directUseCount > 0
 
       obj.remove
     end
-
-    return true
   end
 
   def self.apply_cooling_setpoints(model, runner, weather, clg_wkdy_monthly, clg_wked_monthly,
@@ -2215,24 +2100,18 @@ class HVAC
 
     # Get cooling season
     if use_auto_season
-      _, cooling_season = calc_heating_and_cooling_seasons(model, weather, runner)
+      _, cooling_season = calc_heating_and_cooling_seasons(model, weather)
     else
       if season_start_month <= season_end_month
         cooling_season = Array.new(season_start_month - 1, 0) + Array.new(season_end_month - season_start_month + 1, 1) + Array.new(12 - season_end_month, 0)
-      elsif season_start_month > season_end_month
+      else
         cooling_season = Array.new(season_end_month, 1) + Array.new(season_start_month - season_end_month - 1, 0) + Array.new(12 - season_start_month + 1, 1)
       end
-    end
-    if cooling_season.nil?
-      return false
     end
 
     heating_season = get_season(model, weather, runner, Constants.ObjectNameHeatingSeason)
 
-    cooling_season_sch = MonthWeekdayWeekendSchedule.new(model, runner, Constants.ObjectNameCoolingSeason, Array.new(24, 1), Array.new(24, 1), cooling_season, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsOnOff)
-    unless cooling_season_sch.validated?
-      return false
-    end
+    cooling_season_sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameCoolingSeason, Array.new(24, 1), Array.new(24, 1), cooling_season, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = false, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsOnOff)
 
     clg_wkdy_monthly = clg_wkdy_monthly.map { |i| i.map { |j| UnitConversions.convert(j, "F", "C") } }
     clg_wked_monthly = clg_wked_monthly.map { |i| i.map { |j| UnitConversions.convert(j, "F", "C") } }
@@ -2244,17 +2123,12 @@ class HVAC
     if thermostat_setpoint.is_initialized
 
       thermostat_setpoint = thermostat_setpoint.get
-      runner.registerInfo("Found existing thermostat #{thermostat_setpoint.name} for #{living_zone.name}.")
 
-      htg_wkdy_monthly = get_setpoint_schedule(thermostat_setpoint.heatingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekday', runner)
-      htg_wked_monthly = get_setpoint_schedule(thermostat_setpoint.heatingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekend', runner)
-      if htg_wkdy_monthly.nil? or htg_wked_monthly.nil?
-        return false
-      end
+      htg_wkdy_monthly = get_setpoint_schedule(thermostat_setpoint.heatingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekday')
+      htg_wked_monthly = get_setpoint_schedule(thermostat_setpoint.heatingSetpointTemperatureSchedule.get.to_Schedule.get.to_ScheduleRuleset.get, 'weekend')
 
       if not htg_wkdy_monthly.uniq.length == 1 or not htg_wked_monthly.uniq.length == 1
-        runner.registerError("Found monthly variation in heating setpoint schedule.")
-        return false
+        fail "Found monthly variation in heating setpoint schedule."
       end
 
       model.getScheduleRulesets.each do |sch|
@@ -2297,45 +2171,31 @@ class HVAC
       clg_wked_monthly[i] = clg_wked
     end
 
-    heating_setpoint = HourlyByMonthSchedule.new(model, runner, Constants.ObjectNameHeatingSetpoint, htg_wkdy_monthly, htg_wked_monthly, normalize_values = false)
-    cooling_setpoint = HourlyByMonthSchedule.new(model, runner, Constants.ObjectNameCoolingSetpoint, clg_wkdy_monthly, clg_wked_monthly, normalize_values = false)
-
-    unless heating_setpoint.validated? and cooling_setpoint.validated?
-      return false
-    end
+    heating_setpoint = HourlyByMonthSchedule.new(model, Constants.ObjectNameHeatingSetpoint, htg_wkdy_monthly, htg_wked_monthly, normalize_values = false)
+    cooling_setpoint = HourlyByMonthSchedule.new(model, Constants.ObjectNameCoolingSetpoint, clg_wkdy_monthly, clg_wked_monthly, normalize_values = false)
 
     # Set the setpoint schedules
     thermostat_setpoint = living_zone.thermostatSetpointDualSetpoint
     if thermostat_setpoint.is_initialized
-
       thermostat_setpoint = thermostat_setpoint.get
       thermostat_setpoint.setHeatingSetpointTemperatureSchedule(heating_setpoint.schedule)
       thermostat_setpoint.setCoolingSetpointTemperatureSchedule(cooling_setpoint.schedule)
-
     else
-
       thermostat_setpoint = OpenStudio::Model::ThermostatSetpointDualSetpoint.new(model)
       thermostat_setpoint.setName("#{living_zone.name} temperature setpoint")
-      runner.registerInfo("Created new thermostat #{thermostat_setpoint.name} for #{living_zone.name}.")
       thermostat_setpoint.setHeatingSetpointTemperatureSchedule(heating_setpoint.schedule)
       thermostat_setpoint.setCoolingSetpointTemperatureSchedule(cooling_setpoint.schedule)
       living_zone.setThermostatSetpointDualSetpoint(thermostat_setpoint)
-      runner.registerInfo("Set a dummy heating setpoint schedule for #{thermostat_setpoint.name}.")
-
     end
-
-    runner.registerInfo("Set the cooling setpoint schedule for #{thermostat_setpoint.name}.")
 
     model.getScheduleDays.each do |obj| # remove orphaned summer and winter design day schedules
       next if obj.directUseCount > 0
 
       obj.remove
     end
-
-    return true
   end
 
-  def self.get_setpoint_schedule(schedule_ruleset, weekday_or_weekend, runner)
+  def self.get_setpoint_schedule(schedule_ruleset, weekday_or_weekend)
     setpoint_schedule = [[0] * 24] * 12
     schedule_ruleset.scheduleRules.each do |rule|
       month = rule.startDate.get.monthOfYear.value.to_i - 1
@@ -2348,9 +2208,9 @@ class HVAC
       setpoint_schedule[month] = backfill_schedule_values(setpoint_schedule[month])
     end
     if setpoint_schedule.any? { |m| m.any? { |h| h == 0 } }
-      runner.registerError("Failed to get the setpoint schedule.")
-      return nil
+      fail "Failed to get the setpoint schedule."
     end
+
     return setpoint_schedule
   end
 
@@ -2363,7 +2223,7 @@ class HVAC
       return 'weekend'
     end
 
-    return nil
+    fail "Unexpected schedule ruleset days."
   end
 
   def self.backfill_schedule_values(values)
@@ -2391,7 +2251,7 @@ class HVAC
       end
     end
     if season.empty?
-      heating_season, cooling_season = calc_heating_and_cooling_seasons(model, weather, runner)
+      heating_season, cooling_season = calc_heating_and_cooling_seasons(model, weather)
       if sch_name == Constants.ObjectNameHeatingSeason
         season = heating_season
       else
@@ -2436,20 +2296,16 @@ class HVAC
 
     # error checking
     if humidity_setpoint < 0 or humidity_setpoint > 1
-      runner.registerError("Invalid humidity setpoint value entered.")
-      return false
+      fail "Invalid humidity setpoint value entered."
     end
     if water_removal_rate != Constants.Auto and water_removal_rate.to_f <= 0
-      runner.registerError("Invalid water removal rate value entered.")
-      return false
+      fail "Invalid water removal rate value entered."
     end
     if energy_factor != Constants.Auto and energy_factor.to_f < 0
-      runner.registerError("Invalid energy factor value entered.")
-      return false
+      fail "Invalid energy factor value entered."
     end
     if air_flow_rate != Constants.Auto and air_flow_rate.to_f < 0
-      runner.registerError("Invalid air flow rate value entered.")
-      return false
+      fail "Invalid air flow rate value entered."
     end
 
     obj_name = Constants.ObjectNameDehumidifier
@@ -2494,20 +2350,14 @@ class HVAC
       zone_hvac.setMaximumDryBulbTemperatureforDehumidifierOperation(40)
 
       zone_hvac.addToThermalZone(control_zone)
-      runner.registerInfo("Added '#{zone_hvac.name}' to '#{control_zone.name}'")
     end
-
-    return true
   end
 
   def self.apply_ceiling_fans(model, runner, annual_kWh, weekday_sch, weekend_sch, monthly_sch,
                               cfa, living_space)
     obj_name = Constants.ObjectNameCeilingFan
 
-    ceiling_fan_sch = MonthWeekdayWeekendSchedule.new(model, runner, obj_name + " schedule", weekday_sch, weekend_sch, monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalized_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
-    if not ceiling_fan_sch.validated?
-      return false
-    end
+    ceiling_fan_sch = MonthWeekdayWeekendSchedule.new(model, obj_name + " schedule", weekday_sch, weekend_sch, monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalized_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
 
     space_design_level = ceiling_fan_sch.calcDesignLevelFromDailykWh(annual_kWh / 365.0)
 
@@ -2522,8 +2372,6 @@ class HVAC
     equip_def.setFractionLost(0)
     equip.setEndUseSubcategory(obj_name)
     equip.setSchedule(ceiling_fan_sch.schedule)
-
-    return true
   end
 
   def self.get_default_ceiling_fan_power()
@@ -2613,8 +2461,6 @@ class HVAC
       end
 
     end
-
-    return true
   end
 
   def self.get_default_eae(htg_type, fuel, load_frac, furnace_capacity_kbtuh)
@@ -2905,11 +2751,11 @@ class HVAC
   end
 
   def self.get_gshp_cooling_eir(eer, fanKW_Adjust, pumpKW_Adjust)
-    return UnitConversions.convert((1.0 - eer * (fanKW_Adjust + pumpKW_Adjust)) / (eer * (1 + UnitConversions.convert(fanKW_Adjust, "Wh", "Btu"))), "Wh", "Btu")
+    return UnitConversions.convert((1.0 - eer * (fanKW_Adjust + pumpKW_Adjust)) / (eer * (1.0 + UnitConversions.convert(fanKW_Adjust, "Wh", "Btu"))), "Wh", "Btu")
   end
 
   def self.get_gshp_heating_eir(cop, fanKW_Adjust, pumpKW_Adjust)
-    return (1.0 - cop * (fanKW_Adjust + pumpKW_Adjust)) / (cop * (1 - fanKW_Adjust))
+    return (1.0 - cop * (fanKW_Adjust + pumpKW_Adjust)) / (cop * (1.0 - fanKW_Adjust))
   end
 
   def self.get_gshp_FanKW_Adjust(cfm_btuh)
@@ -2921,17 +2767,17 @@ class HVAC
   end
 
   def self.calc_EIR_from_COP(cop, fan_power_rated)
-    return UnitConversions.convert((UnitConversions.convert(1, "Btu", "Wh") + fan_power_rated * 0.03333) / cop - fan_power_rated * 0.03333, "Wh", "Btu")
+    return UnitConversions.convert((UnitConversions.convert(1.0, "Btu", "Wh") + fan_power_rated * 0.03333) / cop - fan_power_rated * 0.03333, "Wh", "Btu")
   end
 
   def self.calc_EIR_from_EER(eer, fan_power_rated)
-    return UnitConversions.convert((1 - UnitConversions.convert(fan_power_rated * 0.03333, "Wh", "Btu")) / eer - fan_power_rated * 0.03333, "Wh", "Btu")
+    return UnitConversions.convert((1.0 - UnitConversions.convert(fan_power_rated * 0.03333, "Wh", "Btu")) / eer - fan_power_rated * 0.03333, "Wh", "Btu")
   end
 
   def self.calc_EER_from_EIR(eir, fan_power_rated)
     cfm_per_ton = 400.0
     cfm_per_btuh = cfm_per_ton / 12000.0
-    return ((1 - 3.412 * (fan_power_rated * cfm_per_btuh)) / (eir / 3.412 + (fan_power_rated * cfm_per_btuh)))
+    return ((1.0 - 3.412 * (fan_power_rated * cfm_per_btuh)) / (eir / 3.412 + (fan_power_rated * cfm_per_btuh)))
   end
 
   def self.calc_COP_from_EIR(eir, fan_power_rated)
@@ -3027,7 +2873,7 @@ class HVAC
     c_d = HVAC.get_c_d_cooling(1, seer)
 
     # 1. Calculate eer_b using SEER and c_d
-    eer_b = seer / (1 - 0.5 * c_d)
+    eer_b = seer / (1.0 - 0.5 * c_d)
 
     # 2. Calculate eir_b
     eir_b = calc_EIR_from_EER(eer_b, fan_power_rated)
@@ -3076,8 +2922,7 @@ class HVAC
     end
 
     if err > tol
-      eer_c = -99
-      runner.registerWarning('Two-speed cooling EERs iteration failed to converge.')
+      fail 'Two-speed cooling EERs iteration failed to converge.'
     end
 
     return calc_EERs_from_EIR_2spd(eer_c, fan_power_rated, is_heat_pump)
@@ -3120,8 +2965,7 @@ class HVAC
     end
 
     if err > tol
-      eer_c = -99
-      runner.registerWarning('Variable-speed cooling EERs iteration failed to converge.')
+      fail 'Variable-speed cooling EERs iteration failed to converge.'
     end
 
     return calc_EERs_from_EIR_4spd(eer_c, fan_power_rated, calc_type = 'model')
@@ -3329,8 +3173,7 @@ class HVAC
     end
 
     if err > tol
-      cop_c = -99
-      runner.registerWarning('Single-speed heating COP iteration failed to converge.')
+      fail 'Single-speed heating COP iteration failed to converge.'
     end
 
     return cop_c
@@ -3378,9 +3221,9 @@ class HVAC
         p_h = p_17 + (((p_47 - p_17) * (t_bins[i] - 17.0)) / (47.0 - 17.0))
       end
 
-      x_t = [bL / q_h, 1].min
+      x_t = [bL / q_h, 1.0].min
 
-      pLF = 1 - (c_d * (1 - x_t))
+      pLF = 1.0 - (c_d * (1.0 - x_t))
       if t_bins[i] <= t_off or q_h / (3.412 * p_h) < 1.0
         sigma_t = 0.0
       elsif t_off < t_bins[i] and t_bins[i] <= t_on and q_h / (p_h * 3.412) >= 1.0
@@ -3438,8 +3281,7 @@ class HVAC
     end
 
     if err > tol
-      cop_c = -99
-      runner.registerWarning('Two-speed heating COP iteration failed to converge.')
+      fail 'Two-speed heating COP iteration failed to converge.'
     end
 
     return calc_COPs_from_EIR_2spd(cop_c, fan_power_rated)
@@ -3482,8 +3324,7 @@ class HVAC
     end
 
     if err > tol
-      cop_c = -99
-      runner.registerWarning('Variable-speed heating COPs iteration failed to converge.')
+      fail 'Variable-speed heating COPs iteration failed to converge.'
     end
 
     return calc_COPs_from_EIR_4spd(cop_c, fan_power_rated, calc_type = 'model')
@@ -3550,7 +3391,7 @@ class HVAC
       if t_bins[i] >= 40.0
         q_l = q_L47_net + (((q_L62_net - q_L47_net) * (t_bins[i] - 47.0)) / (62.0 - 47.0))
         p_l = p_L47 + (((p_L62 - p_L47) * (t_bins[i] - 47.0)) / (62.0 - 47.0))
-      elsif 17 <= t_bins[i] and t_bins[i] < 40.0
+      elsif 17.0 <= t_bins[i] and t_bins[i] < 40.0
         q_l = q_L17_net + (((q_L35_net - q_L17_net) * (t_bins[i] - 17.0)) / (35.0 - 17.0))
         p_l = p_L17 + (((p_L35 - p_L17) * (t_bins[i] - 17.0)) / (35.0 - 17.0))
       else
@@ -3558,9 +3399,9 @@ class HVAC
         p_l = p_L17 + (((p_L47 - p_L17) * (t_bins[i] - 17.0)) / (47.0 - 17.0))
       end
 
-      x_t_h = [bL / q_h, 1].min
-      x_t_l = [bL / q_l, 1].min
-      pLF = 1 - (c_d * (1 - x_t_l))
+      x_t_h = [bL / q_h, 1.0].min
+      x_t_l = [bL / q_l, 1.0].min
+      pLF = 1.0 - (c_d * (1.0 - x_t_l))
       if t_bins[i] <= t_off or q_h / (p_h * 3.412) < 1.0
         sigma_t_h = 0.0
       elsif t_off < t_bins[i] and t_bins[i] <= t_on and q_h / (p_h * 3.412) >= 1.0
@@ -3646,7 +3487,7 @@ class HVAC
     q_H35_1 = q_H1_1_net + (q_H0_1_net - q_H1_1_net) / (62.0 - 47.0) * (35.0 - 47.0)
     p_H35_1 = p_H1_1 + (p_H0_1 - p_H1_1) / (62.0 - 47.0) * (35.0 - 47.0)
     n_Q = (q_H2_v_net - q_H35_1) / (q_H35_2 - q_H35_1)
-    m_Q = (q_H0_1_net - q_H1_1_net) / (62.0 - 47.0) * (1 - n_Q) + n_Q * (q_H35_2 - q_H3_2_net) / (35.0 - 17.0)
+    m_Q = (q_H0_1_net - q_H1_1_net) / (62.0 - 47.0) * (1.0 - n_Q) + n_Q * (q_H35_2 - q_H3_2_net) / (35.0 - 17.0)
     n_E = (p_H2_v - p_H35_1) / (p_H35_2 - p_H35_1)
     m_E = (p_H0_1 - p_H1_1) / (62.0 - 47.0) * (1.0 - n_E) + n_E * (p_H35_2 - p_H3_2) / (35.0 - 17.0)
 
@@ -4010,7 +3851,7 @@ class HVAC
     if c_d.nil?
       c_d = self.get_c_d_heating(num_speeds, heatingHSPF)
     end
-    return [(1 - c_d), c_d, 0] # Linear part load model
+    return [(1.0 - c_d), c_d, 0.0] # Linear part load model
   end
 
   def self.get_c_d_cooling(num_speeds, coolingSEER)
@@ -4077,13 +3918,13 @@ class HVAC
     return pump_eff * pump_power / UnitConversions.convert(1.0, "gal/min", "m^3/s") # Pa
   end
 
-  def self.existing_equipment(model, runner, thermal_zone)
+  def self.existing_equipment(model, thermal_zone, runner)
     # Returns a list of equipment objects
 
     equipment = []
     hvac_types = []
 
-    unitary_system_air_loops = self.get_unitary_system_air_loops(model, runner, thermal_zone)
+    unitary_system_air_loops = self.get_unitary_system_air_loops(model, thermal_zone)
     unitary_system_air_loops.each do |unitary_system_air_loop|
       system, clg_coil, htg_coil, air_loop = unitary_system_air_loop
       equipment << system
@@ -4095,31 +3936,31 @@ class HVAC
       hvac_types << hvac_type_heat.get if hvac_type_heat.is_initialized
     end
 
-    ptacs = self.get_ptacs(model, runner, thermal_zone)
+    ptacs = self.get_ptacs(model, thermal_zone)
     ptacs.each do |ptac|
       equipment << ptac
       hvac_types << ptac.additionalProperties.getFeatureAsString(Constants.SizingInfoHVACCoolType).get
     end
 
-    evap_coolers = self.get_evap_coolers(model, runner, thermal_zone)
+    evap_coolers = self.get_evap_coolers(model, thermal_zone)
     evap_coolers.each do |evap_cooler|
       equipment << evap_cooler
       hvac_types << evap_cooler.additionalProperties.getFeatureAsString(Constants.SizingInfoHVACCoolType).get
     end
 
-    baseboards = self.get_baseboard_waters(model, runner, thermal_zone)
+    baseboards = self.get_baseboard_waters(model, thermal_zone)
     baseboards.each do |baseboard|
       equipment << baseboard
       hvac_types << baseboard.additionalProperties.getFeatureAsString(Constants.SizingInfoHVACHeatType).get
     end
 
-    baseboards = self.get_baseboard_electrics(model, runner, thermal_zone)
+    baseboards = self.get_baseboard_electrics(model, thermal_zone)
     baseboards.each do |baseboard|
       equipment << baseboard
       hvac_types << baseboard.additionalProperties.getFeatureAsString(Constants.SizingInfoHVACHeatType).get
     end
 
-    unitary_system_hvac_map = self.get_unitary_system_hvac_map(model, runner, thermal_zone)
+    unitary_system_hvac_map = self.get_unitary_system_hvac_map(model, thermal_zone)
     unitary_system_hvac_map.each do |unitary_system_zone_hvac|
       system, clg_coil, htg_coil = unitary_system_zone_hvac
       next if htg_coil.nil?
@@ -4128,39 +3969,12 @@ class HVAC
       hvac_types << system.additionalProperties.getFeatureAsString(Constants.SizingInfoHVACHeatType).get
     end
 
-    ideal_air = self.get_ideal_air(model, runner, thermal_zone)
+    ideal_air = self.get_ideal_air(model, thermal_zone)
     if not ideal_air.nil?
       equipment << ideal_air
       hvac_types << ideal_air.additionalProperties.getFeatureAsString(Constants.SizingInfoHVACCoolType).get
       hvac_types << ideal_air.additionalProperties.getFeatureAsString(Constants.SizingInfoHVACHeatType).get
     end
-
-    hvac_types.uniq.each do |hvac_type|
-      if hvac_type == Constants.ObjectNameCentralAirConditioner
-        runner.registerInfo("Found central air conditioner in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameAirSourceHeatPump
-        runner.registerInfo("Found air source heat pump in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameGroundSourceHeatPump
-        runner.registerInfo("Found ground source heat pump in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameMiniSplitHeatPump
-        runner.registerInfo("Found mini split heat pump in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameRoomAirConditioner
-        runner.registerInfo("Found room air conditioner in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameIdealAirSystem
-        runner.registerInfo("Found ideal air system in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameFurnace
-        runner.registerInfo("Found furnace in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameElectricBaseboard
-        runner.registerInfo("Found electric baseboard in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameBoiler
-        runner.registerInfo("Found boiler serving #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameUnitHeater
-        runner.registerInfo("Found unit heater in #{thermal_zone.name}.")
-      elsif hvac_type == Constants.ObjectNameEvaporativeCooler
-        runner.registerInfo("Found evaporative cooler in #{thermal_zone.name}.")
-      end
-    end
-
     return equipment
   end
 
@@ -4241,7 +4055,7 @@ class HVAC
     return nil
   end
 
-  def self.get_unitary_system_air_loops(model, runner, thermal_zone)
+  def self.get_unitary_system_air_loops(model, thermal_zone)
     # Returns the unitary system(s), cooling coil(s), heating coil(s), and air loops(s) if available
     unitary_system_air_loops = []
     thermal_zone.airLoopHVACs.each do |air_loop|
@@ -4261,7 +4075,7 @@ class HVAC
     return unitary_system_air_loops
   end
 
-  def self.get_unitary_system_hvac_map(model, runner, thermal_zone)
+  def self.get_unitary_system_hvac_map(model, thermal_zone)
     # Returns the unitary system, cooling coil, and heating coil if available
     unitary_system_hvac_map = []
     thermal_zone.equipment.each do |equipment|
@@ -4281,7 +4095,7 @@ class HVAC
     return unitary_system_hvac_map
   end
 
-  def self.get_ptacs(model, runner, thermal_zone)
+  def self.get_ptacs(model, thermal_zone)
     # Returns the PTAC(s) if available
     ptacs = []
     model.getZoneHVACPackagedTerminalAirConditioners.each do |ptac|
@@ -4292,7 +4106,7 @@ class HVAC
     return ptacs
   end
 
-  def self.get_evap_coolers(model, runner, thermal_zone)
+  def self.get_evap_coolers(model, thermal_zone)
     # Returns the evaporative cooler if available
     evap_coolers = []
     thermal_zone.airLoopHVACs.each do |air_loop|
@@ -4304,7 +4118,7 @@ class HVAC
     return evap_coolers
   end
 
-  def self.get_baseboard_waters(model, runner, thermal_zone)
+  def self.get_baseboard_waters(model, thermal_zone)
     # Returns the water baseboard if available
     baseboards = []
     model.getZoneHVACBaseboardConvectiveWaters.each do |baseboard|
@@ -4315,7 +4129,7 @@ class HVAC
     return baseboards
   end
 
-  def self.get_baseboard_electrics(model, runner, thermal_zone)
+  def self.get_baseboard_electrics(model, thermal_zone)
     # Returns the electric baseboard if available
     baseboards = []
     model.getZoneHVACBaseboardConvectiveElectrics.each do |baseboard|
@@ -4337,7 +4151,7 @@ class HVAC
     return dehums
   end
 
-  def self.get_ideal_air(model, runner, thermal_zone)
+  def self.get_ideal_air(model, thermal_zone)
     # Returns the heating ideal air loads system if available
     model.getZoneHVACIdealLoadsAirSystems.each do |ideal_air|
       next unless thermal_zone.handle.to_s == ideal_air.thermalZone.get.handle.to_s
@@ -4347,7 +4161,7 @@ class HVAC
     return nil
   end
 
-  def self.has_ducted_equipment(model, runner, air_loop)
+  def self.has_ducted_equipment(model, air_loop)
     if air_loop.name.to_s.include? Constants.ObjectNameEvaporativeCooler
       system = air_loop
     else
@@ -4375,7 +4189,7 @@ class HVAC
     return false
   end
 
-  def self.calc_heating_and_cooling_seasons(model, weather, runner = nil)
+  def self.calc_heating_and_cooling_seasons(model, weather)
     # Calculates heating/cooling seasons from BAHSP definition
 
     monthly_temps = weather.data.MonthlyAvgDrybulbs
@@ -4495,7 +4309,7 @@ class HVAC
     end
 
     if not cvg or final_n > itmax
-      cop_maxSpeed = UnitConversions.convert(0.547 * coolingSEER - 0.104, "Btu/hr", "W") # Correlation developed from JonW's MatLab scripts. Only used is an EER cannot be found.
+      cop_maxSpeed = UnitConversions.convert(0.547 * coolingSEER - 0.104, "Btu/hr", "W") # Correlation developed from JonW's MatLab scripts. Only used if an EER cannot be found.
       runner.registerWarning('Mini-split heat pump COP iteration failed to converge. Setting to default value.')
     end
 

--- a/resources/hvac_sizing.rb
+++ b/resources/hvac_sizing.rb
@@ -7,6 +7,7 @@ require_relative "constructions"
 
 class HVACSizing
   def self.apply(model, runner, weather, cfa, infilvolume, nbeds, min_neighbor_distance, show_debug_info, living_space)
+    @runner = runner
     @model_spaces = model.getSpaces
     @cond_space = living_space
     @cond_zone = @cond_space.thermalZone.get
@@ -16,92 +17,69 @@ class HVACSizing
 
     @model_year = model.yearDescription.get.assumedYear
     @north_axis = model.getBuilding.northAxis
-    @min_cooling_capacity = 1 # Btu/hr
+    @min_cooling_capacity = 1.0 # Btu/hr
 
     # Based on EnergyPlus's model for calculating SHR at off-rated conditions. This curve fit
     # avoids the iterations in the actual model. It does not account for altitude or variations
     # in the SHRRated. It is a function of ODB (MJ design temp) and CFM/Ton (from MJ)
     @shr_biquadratic = [1.08464364, 0.002096954, 0, -0.005766327, 0, -0.000011147]
 
-    @conditioned_heat_design_temp = 70 # Indoor heating design temperature according to acca MANUAL J
-    @conditioned_cool_design_temp = 75 # Indoor heating design temperature according to acca MANUAL J
+    @conditioned_heat_design_temp = 70.0 # Indoor heating design temperature according to acca MANUAL J
+    @conditioned_cool_design_temp = 75.0 # Indoor heating design temperature according to acca MANUAL J
 
     assumed_inside_temp = 73.5 # F
     @inside_air_dens = UnitConversions.convert(weather.header.LocalPressure, "atm", "Btu/ft^3") / (Gas.Air.r * (assumed_inside_temp + 460.0))
 
-    if not process_site_calcs_and_design_temps(runner, weather)
-      return false
-    end
+    process_site_calcs_and_design_temps(weather)
 
     # Get shelter class
     @shelter_class = get_shelter_class(model, min_neighbor_distance)
 
     # Calculate loads for the conditioned thermal zone
-    zone_loads = process_zone_loads(runner, model, weather)
-    return false if zone_loads.nil?
+    zone_loads = process_zone_loads(model, weather)
 
     # Display debug info
     if show_debug_info
-      display_zone_loads(runner, zone_loads)
+      display_zone_loads(zone_loads)
     end
 
     # Aggregate zone loads into initial loads
     init_loads = aggregate_zone_loads(zone_loads)
-    return false if init_loads.nil?
 
     # Get HVAC system info
-    hvacs = get_hvacs(runner, model)
-    return false if hvacs.nil?
+    hvacs = get_hvacs(model)
 
     hvacs.each do |hvac|
       hvac = calculate_hvac_temperatures(init_loads, hvac)
-      return false if init_loads.nil?
 
       hvac_init_loads = apply_hvac_load_fractions(init_loads, hvac)
-      return false if hvac_init_loads.nil?
-
       hvac_init_loads = apply_hp_sizing_logic(hvac_init_loads, hvac)
-      return false if hvac_init_loads.nil?
 
       hvac_final_values = FinalValues.new
 
       # Calculate heating ducts load
-      hvac_final_values = process_duct_loads_heating(runner, hvac_final_values, weather, hvac, hvac_init_loads.Heat)
-      return false if hvac_final_values.nil?
+      hvac_final_values = process_duct_loads_heating(hvac_final_values, weather, hvac, hvac_init_loads.Heat)
 
       # Calculate cooling ducts load
-      hvac_final_values = process_duct_loads_cooling(runner, hvac_final_values, weather, hvac, hvac_init_loads.Cool_Sens, hvac_init_loads.Cool_Lat)
-      return false if hvac_final_values.nil?
-
-      hvac_final_values = process_equipment_adjustments(runner, hvac_final_values, weather, hvac)
-      return false if hvac_final_values.nil?
-
-      hvac_final_values = process_fixed_equipment(runner, hvac_final_values, hvac)
-      return false if hvac_final_values.nil?
-
-      hvac_final_values = process_ground_loop(runner, hvac_final_values, weather, hvac)
-      return false if hvac_final_values.nil?
-
-      hvac_final_values = process_finalize(runner, hvac_final_values, zone_loads, weather, hvac)
-      return false if hvac_final_values.nil?
+      hvac_final_values = process_duct_loads_cooling(hvac_final_values, weather, hvac, hvac_init_loads.Cool_Sens, hvac_init_loads.Cool_Lat)
+      hvac_final_values = process_equipment_adjustments(hvac_final_values, weather, hvac)
+      hvac_final_values = process_fixed_equipment(hvac_final_values, hvac)
+      hvac_final_values = process_ground_loop(hvac_final_values, weather, hvac)
+      hvac_final_values = process_finalize(hvac_final_values, zone_loads, weather, hvac)
 
       # Set OpenStudio object values
-      if not set_object_values(runner, model, hvac, hvac_final_values)
-        return false
-      end
+      set_object_values(model, hvac, hvac_final_values)
 
       # Display debug info
       if show_debug_info
-        display_hvac_final_values_results(runner, hvac_final_values, hvac)
+        display_hvac_final_values_results(hvac_final_values, hvac)
       end
     end
-
-    return true
   end
 
   private
 
-  def self.process_site_calcs_and_design_temps(runner, weather)
+  def self.process_site_calcs_and_design_temps(weather)
     '''
     Site Calculations and Design Temperatures
     '''
@@ -122,12 +100,12 @@ class HVACSizing
     # # Calculate the average Daily Temperature Range (DTR) to determine the class (low, medium, high)
     dtr = weather.design.DailyTemperatureRange
 
-    if dtr < 16
-      @daily_range_num = 0   # Low
-    elsif dtr > 25
-      @daily_range_num = 2   # High
+    if dtr < 16.0
+      @daily_range_num = 0.0   # Low
+    elsif dtr > 25.0
+      @daily_range_num = 2.0   # High
     else
-      @daily_range_num = 1   # Medium
+      @daily_range_num = 1.0   # Medium
     end
 
     # Altitude Correction Factors (ACF) taken from Table 10A (sea level - 12,000 ft)
@@ -135,7 +113,7 @@ class HVACSizing
 
     # Calculate the altitude correction factor (ACF) for the site
     alt_cnt = (weather.header.Altitude / 1000.0).to_i
-    @acf = MathTools.interp2(weather.header.Altitude, alt_cnt * 1000, (alt_cnt + 1) * 1000, acfs[alt_cnt], acfs[alt_cnt + 1])
+    @acf = MathTools.interp2(weather.header.Altitude, alt_cnt * 1000.0, (alt_cnt + 1.0) * 1000.0, acfs[alt_cnt], acfs[alt_cnt + 1])
 
     # Calculate the interior humidity in Grains and enthalpy in Btu/lb for cooling
     pwsat = UnitConversions.convert(0.430075, "psi", "kPa") # Calculated for 75degF indoor temperature
@@ -145,7 +123,7 @@ class HVACSizing
     @wetbulb_indoor_cooling = Psychrometrics.Twb_fT_R_P(@cool_setpoint, rh_indoor_cooling, UnitConversions.convert(weather.header.LocalPressure, "atm", "psi"))
 
     db_indoor_degC = UnitConversions.convert(@cool_setpoint, "F", "C")
-    @enthalpy_indoor_cooling = (1.006 * db_indoor_degC + hr_indoor_cooling * (2501 + 1.86 * db_indoor_degC)) * UnitConversions.convert(1.0, "kJ", "Btu") * UnitConversions.convert(1.0, "lbm", "kg")
+    @enthalpy_indoor_cooling = (1.006 * db_indoor_degC + hr_indoor_cooling * (2501.0 + 1.86 * db_indoor_degC)) * UnitConversions.convert(1.0, "kJ", "Btu") * UnitConversions.convert(1.0, "lbm", "kg")
 
     # Design Temperatures
 
@@ -159,34 +137,25 @@ class HVACSizing
 
     # Initialize Manual J buffer space temperatures using current design temperatures
     @model_spaces.each do |space|
-      @cool_design_temps[space] = process_design_temp_cooling(runner, weather, space)
-      return false if @cool_design_temps[space].nil?
-
-      @heat_design_temps[space] = process_design_temp_heating(runner, weather, space, weather.design.HeatingDrybulb)
-      return false if @heat_design_temps[space].nil?
+      @cool_design_temps[space] = process_design_temp_cooling(weather, space)
+      @heat_design_temps[space] = process_design_temp_heating(weather, space, weather.design.HeatingDrybulb)
     end
-
-    return true
   end
 
-  def self.process_design_temp_heating(runner, weather, space, design_db)
+  def self.process_design_temp_heating(weather, space, design_db)
     if Geometry.space_is_conditioned(space)
       # Living space, conditioned attic, conditioned basement
       heat_temp = @conditioned_heat_design_temp
 
     elsif Geometry.is_garage(space)
       # Garage
-      heat_temp = design_db + 13
+      heat_temp = design_db + 13.0
 
     elsif Geometry.is_vented_attic(space) or Geometry.is_unvented_attic(space)
 
       is_vented = Geometry.is_vented_attic(space)
-
-      attic_floor_r = self.get_space_r_value(runner, space, "floor")
-      return nil if attic_floor_r.nil?
-
-      attic_roof_r = self.get_space_r_value(runner, space, "roofceiling")
-      return nil if attic_roof_r.nil?
+      attic_floor_r = get_space_r_value(space, "floor")
+      attic_roof_r = get_space_r_value(space, "roofceiling")
 
       # Unconditioned attic
       if attic_floor_r < attic_roof_r
@@ -197,7 +166,7 @@ class HVACSizing
         if is_vented
           heat_temp = design_db
         else # not is_vented
-          heat_temp = calculate_space_design_temps(runner, space, weather, @conditioned_heat_design_temp, design_db, weather.data.GroundMonthlyTemps.min)
+          heat_temp = calculate_space_design_temps(space, weather, @conditioned_heat_design_temp, design_db, weather.data.GroundMonthlyTemps.min)
         end
 
       else
@@ -208,14 +177,16 @@ class HVACSizing
 
     else
       # Unconditioned basement, Crawlspace
-      heat_temp = calculate_space_design_temps(runner, space, weather, @conditioned_heat_design_temp, design_db, weather.data.GroundMonthlyTemps.min)
+      heat_temp = calculate_space_design_temps(space, weather, @conditioned_heat_design_temp, design_db, weather.data.GroundMonthlyTemps.min)
 
     end
+
+    fail "Design temp heating not calculated for #{space.name}." if heat_temp.nil?
 
     return heat_temp
   end
 
-  def self.process_design_temp_cooling(runner, weather, space)
+  def self.process_design_temp_cooling(weather, space)
     if Geometry.space_is_conditioned(space)
       # Living space, conditioned attic, conditioned basement
       cool_temp = @conditioned_cool_design_temp
@@ -241,29 +212,25 @@ class HVACSizing
 
       # Calculate the garage cooling design temperature based on Table 4C
       # Linearly interpolate between having living space over the garage and not having living space above the garage
-      if @daily_range_num == 0
+      if @daily_range_num == 0.0
         cool_temp = (weather.design.CoolingDrybulb +
-                     (11 * garage_frac_under_conditioned) +
-                     (22 * (1 - garage_frac_under_conditioned)))
-      elsif @daily_range_num == 1
+                     (11.0 * garage_frac_under_conditioned) +
+                     (22.0 * (1.0 - garage_frac_under_conditioned)))
+      elsif @daily_range_num == 1.0
         cool_temp = (weather.design.CoolingDrybulb +
-                     (6 * garage_frac_under_conditioned) +
-                     (17 * (1 - garage_frac_under_conditioned)))
-      elsif @daily_range_num == 2
+                     (6.0 * garage_frac_under_conditioned) +
+                     (17.0 * (1.0 - garage_frac_under_conditioned)))
+      elsif @daily_range_num == 2.0
         cool_temp = (weather.design.CoolingDrybulb +
-                     (1 * garage_frac_under_conditioned) +
-                     (12 * (1 - garage_frac_under_conditioned)))
+                     (1.0 * garage_frac_under_conditioned) +
+                     (12.0 * (1.0 - garage_frac_under_conditioned)))
       end
 
     elsif Geometry.is_vented_attic(space) or Geometry.is_unvented_attic(space)
 
       is_vented = Geometry.is_vented_attic(space)
-
-      attic_floor_r = self.get_space_r_value(runner, space, "floor")
-      return nil if attic_floor_r.nil?
-
-      attic_roof_r = self.get_space_r_value(runner, space, "roofceiling")
-      return nil if attic_roof_r.nil?
+      attic_floor_r = get_space_r_value(space, "floor")
+      attic_roof_r = get_space_r_value(space, "roofceiling")
 
       # Unconditioned attic
       if attic_floor_r < attic_roof_r
@@ -272,35 +239,32 @@ class HVACSizing
         # temperature of 95F, however alternative approaches are permissible
 
         if is_vented
-          cool_temp = weather.design.CoolingDrybulb + 40 # This is the number from a California study with dark shingle roof and similar ventilation.
+          cool_temp = weather.design.CoolingDrybulb + 40.0 # This is the number from a California study with dark shingle roof and similar ventilation.
         else # not is_vented
-          cool_temp = calculate_space_design_temps(runner, space, weather, @conditioned_cool_design_temp, weather.design.CoolingDrybulb, weather.data.GroundMonthlyTemps.max, true)
+          cool_temp = calculate_space_design_temps(space, weather, @conditioned_cool_design_temp, weather.design.CoolingDrybulb, weather.data.GroundMonthlyTemps.max, true)
         end
 
       else
 
         # Calculate the cooling design temperature for the unconditioned attic based on Figure A12-14
         # Use an area-weighted temperature in case roof surfaces are different
-        tot_roof_area = 0
-        cool_temp = 0
+        tot_roof_area = 0.0
+        cool_temp = 0.0
 
         space.surfaces.each do |surface|
           next if surface.surfaceType.downcase != "roofceiling"
 
           tot_roof_area += surface.netArea
 
-          roof_color = get_feature(runner, surface, Constants.SizingInfoRoofColor, 'string')
-          roof_material = get_feature(runner, surface, Constants.SizingInfoRoofMaterial, 'string')
-          return nil if roof_color.nil? or roof_material.nil?
-
-          has_radiant_barrier = get_feature(runner, surface, Constants.SizingInfoRoofHasRadiantBarrier, 'boolean')
-          return nil if has_radiant_barrier.nil?
+          roof_color = get_feature(surface, Constants.SizingInfoRoofColor, 'string')
+          roof_material = get_feature(surface, Constants.SizingInfoRoofMaterial, 'string')
+          has_radiant_barrier = get_feature(surface, Constants.SizingInfoRoofHasRadiantBarrier, 'boolean')
 
           if not is_vented
             if not has_radiant_barrier
-              cool_temp += (150 + (weather.design.CoolingDrybulb - 95) + @daily_range_temp_adjust[@daily_range_num]) * surface.netArea
+              cool_temp += (150.0 + (weather.design.CoolingDrybulb - 95.0) + @daily_range_temp_adjust[@daily_range_num]) * surface.netArea
             else
-              cool_temp += (130 + (weather.design.CoolingDrybulb - 95) + @daily_range_temp_adjust[@daily_range_num]) * surface.netArea
+              cool_temp += (130.0 + (weather.design.CoolingDrybulb - 95.0) + @daily_range_temp_adjust[@daily_range_num]) * surface.netArea
             end
 
           else # is_vented
@@ -308,69 +272,69 @@ class HVACSizing
             if not has_radiant_barrier
               if [Constants.RoofMaterialAsphaltShingles, Constants.RoofMaterialTarGravel].include?(roof_material)
                 if roof_color == Constants.ColorDark
-                  cool_temp += 130 * surface.netArea
+                  cool_temp += 130.0 * surface.netArea
                 else
-                  cool_temp += 120 * surface.netArea
+                  cool_temp += 120.0 * surface.netArea
                 end
 
               elsif [Constants.RoofMaterialWoodShakes].include?(roof_material)
-                cool_temp += 120 * surface.netArea
+                cool_temp += 120.0 * surface.netArea
 
               elsif [Constants.RoofMaterialMetal, Constants.RoofMaterialMembrane].include?(roof_material)
                 if roof_color == Constants.ColorDark
-                  cool_temp += 130 * surface.netArea
+                  cool_temp += 130.0 * surface.netArea
                 elsif roof_color == Constants.ColorWhite
-                  cool_temp += 95 * surface.netArea
+                  cool_temp += 95.0 * surface.netArea
                 else
-                  cool_temp += 120 * surface.netArea
+                  cool_temp += 120.0 * surface.netArea
                 end
 
               elsif [Constants.RoofMaterialTile].include?(roof_material)
                 if roof_color == Constants.ColorDark
-                  cool_temp += 110 * surface.netArea
+                  cool_temp += 110.0 * surface.netArea
                 elsif roof_color == Constants.ColorWhite
-                  cool_temp += 95 * surface.netArea
+                  cool_temp += 95.0 * surface.netArea
                 else
-                  cool_temp += 105 * surface.netArea
+                  cool_temp += 105.0 * surface.netArea
                 end
 
               else
-                runner.registerWarning("Specified roofing material (#{roof_material}) is not supported. Assuming dark asphalt shingles")
-                cool_temp += 130 * surface.netArea
+                @runner.registerWarning("Specified roofing material (#{roof_material}) is not supported. Assuming dark asphalt shingles")
+                cool_temp += 130.0 * surface.netArea
               end
 
             else # with a radiant barrier
               if [Constants.RoofMaterialAsphaltShingles, Constants.RoofMaterialTarGravel].include?(roof_material)
                 if roof_color == Constants.ColorDark
-                  cool_temp += 120 * surface.netArea
+                  cool_temp += 120.0 * surface.netArea
                 else
-                  cool_temp += 110 * surface.netArea
+                  cool_temp += 110.0 * surface.netArea
                 end
 
               elsif [Constants.RoofMaterialWoodShakes].include?(roof_material)
-                cool_temp += 110 * surface.netArea
+                cool_temp += 110.0 * surface.netArea
 
               elsif [Constants.RoofMaterialMetal, Constants.RoofMaterialMembrane].include?(roof_material)
                 if roof_color == Constants.ColorDark
-                  cool_temp += 120 * surface.netArea
+                  cool_temp += 120.0 * surface.netArea
                 elsif roof_color == Constants.ColorWhite
-                  cool_temp += 95 * surface.netArea
+                  cool_temp += 95.0 * surface.netArea
                 else
-                  cool_temp += 110 * surface.netArea
+                  cool_temp += 110.0 * surface.netArea
                 end
 
               elsif [Constants.RoofMaterialTile].include?(roof_material)
                 if roof_color == Constants.ColorDark
-                  cool_temp += 105 * surface.netArea
+                  cool_temp += 105.0 * surface.netArea
                 elsif roof_color == Constants.ColorWhite
-                  cool_temp += 95 * surface.netArea
+                  cool_temp += 95.0 * surface.netArea
                 else
-                  cool_temp += 105 * surface.netArea
+                  cool_temp += 105.0 * surface.netArea
                 end
 
               else
-                runner.registerWarning("Specified roofing material (#{roof_material}) is not supported. Assuming dark asphalt shingles")
-                cool_temp += 120 * surface.netArea
+                @runner.registerWarning("Specified roofing material (#{roof_material}) is not supported. Assuming dark asphalt shingles")
+                cool_temp += 120.0 * surface.netArea
 
               end
             end
@@ -380,40 +344,38 @@ class HVACSizing
         cool_temp = cool_temp / tot_roof_area
 
         # Adjust base CLTD for cooling design temperature and daily range
-        cool_temp += (weather.design.CoolingDrybulb - 95) + @daily_range_temp_adjust[@daily_range_num]
+        cool_temp += (weather.design.CoolingDrybulb - 95.0) + @daily_range_temp_adjust[@daily_range_num]
 
       end
 
     else
       # Unconditioned basement, Crawlspace
-      cool_temp = calculate_space_design_temps(runner, space, weather, @conditioned_cool_design_temp, weather.design.CoolingDrybulb, weather.data.GroundMonthlyTemps.max)
+      cool_temp = calculate_space_design_temps(space, weather, @conditioned_cool_design_temp, weather.design.CoolingDrybulb, weather.data.GroundMonthlyTemps.max)
 
     end
+
+    fail "Design temp cooling not calculated for #{space.name}." if cool_temp.nil?
 
     return cool_temp
   end
 
-  def self.process_zone_loads(runner, model, weather)
+  def self.process_zone_loads(model, weather)
     # Constant loads (no variation throughout day)
     zone_loads = ZoneLoads.new
-    zone_loads = process_load_windows_skylights(runner, @cond_zone, zone_loads, weather)
-    zone_loads = process_load_doors(runner, @cond_zone, zone_loads, weather)
-    zone_loads = process_load_walls(runner, @cond_zone, zone_loads, weather)
-    zone_loads = process_load_roofs(runner, @cond_zone, zone_loads, weather)
-    zone_loads = process_load_floors(runner, @cond_zone, zone_loads, weather)
-    zone_loads = process_infiltration_ventilation(runner, model, @cond_zone, zone_loads, weather)
-    zone_loads = process_internal_gains(runner, @cond_zone, zone_loads)
-    return nil if zone_loads.nil?
-
+    zone_loads = process_load_windows_skylights(@cond_zone, zone_loads, weather)
+    zone_loads = process_load_doors(@cond_zone, zone_loads, weather)
+    zone_loads = process_load_walls(@cond_zone, zone_loads, weather)
+    zone_loads = process_load_roofs(@cond_zone, zone_loads, weather)
+    zone_loads = process_load_floors(@cond_zone, zone_loads, weather)
+    zone_loads = process_infiltration_ventilation(model, @cond_zone, zone_loads, weather)
+    zone_loads = process_internal_gains(@cond_zone, zone_loads)
     return zone_loads
   end
 
-  def self.process_load_windows_skylights(runner, thermal_zone, zone_loads, weather)
+  def self.process_load_windows_skylights(thermal_zone, zone_loads, weather)
     '''
     Heating and Cooling Loads: Windows & Skylights
     '''
-
-    return nil if zone_loads.nil?
 
     # Average cooling load factors for windows/skylights WITHOUT internal shading for surface
     # azimuths of 0,22.5,45, ... ,337.5,360
@@ -479,7 +441,7 @@ class HVACSizing
     # The time of day (assuming 24 hr clock) to calculate the SLM for the ALP for azimuths
     # starting at 0 (South) in increments of 22.5 to 360
     # Nil denotes directions not used in the shading calculation (Note: south direction is symmetrical around noon)
-    slm_alp_hr = [15.5, 14.75, 14, 14.75, 15.5, nil, nil, nil, nil, nil, nil, nil, 8.5, 9.75, 10, 9.75, 8.5]
+    slm_alp_hr = [15.5, 14.75, 14.0, 14.75, 15.5, nil, nil, nil, nil, nil, nil, nil, 8.5, 9.75, 10.0, 9.75, 8.5]
 
     # Mid summer declination angle used for shading calculations
     declination_angle = 12.1 # Mid August
@@ -487,24 +449,24 @@ class HVACSizing
     # Peak solar factor (PSF) (aka solar heat gain factor) taken from ASHRAE HOF 1989 Ch.26 Table 34
     # (subset of data in MJ8 Table 3D-2)
     # Surface Azimuth = 0 (South), 22.5, 45.0, ... ,337.5,360 and Latitude = 20,24,28, ... ,60,64
-    psf = [[57,  72,  91,  111, 131, 149, 165, 180, 193, 203, 211, 217],
-           [88,  103, 120, 136, 151, 165, 177, 188, 197, 206, 213, 217],
-           [152, 162, 172, 181, 189, 196, 202, 208, 212, 215, 217, 217],
-           [200, 204, 207, 210, 212, 214, 215, 216, 216, 216, 214, 211],
-           [220, 220, 220, 219, 218, 216, 214, 211, 208, 203, 199, 193],
-           [206, 203, 199, 195, 190, 185, 180, 174, 169, 165, 161, 157],
-           [162, 156, 149, 141, 138, 135, 132, 128, 124, 119, 114, 109],
-           [91,  87,  83,  79,  75,  71,  66,  61,  56,  56,  57,  58],
-           [40,  38,  38,  37,  36,  35,  34,  33,  32,  30,  28,  27],
-           [91,  87,  83,  79,  75,  71,  66,  61,  56,  56,  57,  58],
-           [162, 156, 149, 141, 138, 135, 132, 128, 124, 119, 114, 109],
-           [206, 203, 199, 195, 190, 185, 180, 174, 169, 165, 161, 157],
-           [220, 220, 220, 219, 218, 216, 214, 211, 208, 203, 199, 193],
-           [200, 204, 207, 210, 212, 214, 215, 216, 216, 216, 214, 211],
-           [152, 162, 172, 181, 189, 196, 202, 208, 212, 215, 217, 217],
-           [88,  103, 120, 136, 151, 165, 177, 188, 197, 206, 213, 217],
-           [57,  72,  91,  111, 131, 149, 165, 180, 193, 203, 211, 217]]
-    psf_horiz = [280, 277, 272, 265, 257, 247, 236, 223, 208, 193, 176, 159]
+    psf = [[57.0,  72.0,  91.0,  111.0, 131.0, 149.0, 165.0, 180.0, 193.0, 203.0, 211.0, 217.0],
+           [88.0,  103.0, 120.0, 136.0, 151.0, 165.0, 177.0, 188.0, 197.0, 206.0, 213.0, 217.0],
+           [152.0, 162.0, 172.0, 181.0, 189.0, 196.0, 202.0, 208.0, 212.0, 215.0, 217.0, 217.0],
+           [200.0, 204.0, 207.0, 210.0, 212.0, 214.0, 215.0, 216.0, 216.0, 216.0, 214.0, 211.0],
+           [220.0, 220.0, 220.0, 219.0, 218.0, 216.0, 214.0, 211.0, 208.0, 203.0, 199.0, 193.0],
+           [206.0, 203.0, 199.0, 195.0, 190.0, 185.0, 180.0, 174.0, 169.0, 165.0, 161.0, 157.0],
+           [162.0, 156.0, 149.0, 141.0, 138.0, 135.0, 132.0, 128.0, 124.0, 119.0, 114.0, 109.0],
+           [91.0,  87.0,  83.0,  79.0,  75.0,  71.0,  66.0,  61.0,  56.0,  56.0,  57.0,  58.0],
+           [40.0,  38.0,  38.0,  37.0,  36.0,  35.0,  34.0,  33.0,  32.0,  30.0,  28.0,  27.0],
+           [91.0,  87.0,  83.0,  79.0,  75.0,  71.0,  66.0,  61.0,  56.0,  56.0,  57.0,  58.0],
+           [162.0, 156.0, 149.0, 141.0, 138.0, 135.0, 132.0, 128.0, 124.0, 119.0, 114.0, 109.0],
+           [206.0, 203.0, 199.0, 195.0, 190.0, 185.0, 180.0, 174.0, 169.0, 165.0, 161.0, 157.0],
+           [220.0, 220.0, 220.0, 219.0, 218.0, 216.0, 214.0, 211.0, 208.0, 203.0, 199.0, 193.0],
+           [200.0, 204.0, 207.0, 210.0, 212.0, 214.0, 215.0, 216.0, 216.0, 216.0, 214.0, 211.0],
+           [152.0, 162.0, 172.0, 181.0, 189.0, 196.0, 202.0, 208.0, 212.0, 215.0, 217.0, 217.0],
+           [88.0,  103.0, 120.0, 136.0, 151.0, 165.0, 177.0, 188.0, 197.0, 206.0, 213.0, 217.0],
+           [57.0,  72.0,  91.0,  111.0, 131.0, 149.0, 165.0, 180.0, 193.0, 203.0, 211.0, 217.0]]
+    psf_horiz = [280.0, 277.0, 272.0, 265.0, 257.0, 247.0, 236.0, 223.0, 208.0, 193.0, 176.0, 159.0]
 
     # Hourly Temperature Adjustment Values (HTA_DR) (MJ8 Table A11-3)
     # Low DR, Medium DR, High DR and Hour = 8,9, ... ,19,20
@@ -520,20 +482,20 @@ class HVACSizing
       if latitude < 20.0
         psf_lat << psf[cnt][0]
         if cnt == 0
-          runner.registerWarning('Latitude of 20 was assumed for Manual J solar load calculations.')
+          @runner.registerWarning('Latitude of 20 was assumed for Manual J solar load calculations.')
           psf_lat_horiz = psf_horiz[0]
         end
       elsif latitude > 64.0
         psf_lat << psf[cnt][11]
         if cnt == 0
-          runner.registerWarning('Latitude of 64 was assumed for Manual J solar load calculations.')
+          @runner.registerWarning('Latitude of 64 was assumed for Manual J solar load calculations.')
           psf_lat_horiz = psf_horiz[11]
         end
       else
         cnt_lat_s = ((latitude - 20.0) / 4.0).to_i
-        cnt_lat_n = cnt_lat_s + 1
-        lat_s = 20 + 4 * cnt_lat_s
-        lat_n = lat_s + 4
+        cnt_lat_n = cnt_lat_s + 1.0
+        lat_s = 20.0 + 4.0 * cnt_lat_s
+        lat_n = lat_s + 4.0
         psf_lat << MathTools.interp2(latitude, lat_s, lat_n, psf[cnt][cnt_lat_s], psf[cnt][cnt_lat_n])
         if cnt == 0
           psf_lat_horiz = MathTools.interp2(latitude, lat_s, lat_n, psf_horiz[cnt_lat_s], psf_horiz[cnt_lat_n])
@@ -542,9 +504,9 @@ class HVACSizing
     end
 
     # Windows
-    zone_loads.Heat_Windows = 0
-    alp_load = 0 # Average Load Procedure (ALP) Load
-    afl_hr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] # Initialize Hourly Aggregate Fenestration Load (AFL)
+    zone_loads.Heat_Windows = 0.0
+    alp_load = 0.0 # Average Load Procedure (ALP) Load
+    afl_hr = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] # Initialize Hourly Aggregate Fenestration Load (AFL)
 
     Geometry.get_spaces_above_grade_exterior_walls(thermal_zone.spaces).each do |wall|
       wall_true_azimuth = true_azimuth(wall)
@@ -554,14 +516,12 @@ class HVACSizing
         next if not window.subSurfaceType.downcase.include?("window")
 
         # U-factor
-        u_window = self.get_surface_ufactor(runner, window, window.subSurfaceType, true)
-        return nil if u_window.nil?
+        u_window = get_surface_ufactor(window, window.subSurfaceType)
 
         zone_loads.Heat_Windows += u_window * UnitConversions.convert(window.grossArea, "m^2", "ft^2") * @htd
 
         # SHGC & Internal Shading
-        shgc_with_interior_shade_cool, shgc_with_interior_shade_heat = get_fenestration_shgc(runner, window)
-        return nil if shgc_with_interior_shade_cool.nil? or shgc_with_interior_shade_heat.nil?
+        shgc_with_interior_shade_cool, shgc_with_interior_shade_heat = get_fenestration_shgc(window)
 
         windowHeight = Geometry.surface_height(window)
         windowHasIntShading = window.shadingControl.is_initialized
@@ -573,9 +533,8 @@ class HVACSizing
         window.shadingSurfaceGroups.each do |ssg|
           ssg.shadingSurfaces.each do |ss|
             windowHasOverhang = true
-            windowOverhangDepth = get_feature(runner, window, Constants.SizingInfoWindowOverhangDepth, 'double')
-            windowOverhangOffset = get_feature(runner, window, Constants.SizingInfoWindowOverhangOffset, 'double')
-            return nil if windowOverhangDepth.nil? or windowOverhangOffset.nil?
+            windowOverhangDepth = get_feature(window, Constants.SizingInfoWindowOverhangDepth, 'double')
+            windowOverhangOffset = get_feature(window, Constants.SizingInfoWindowOverhangOffset, 'double')
           end
         end
 
@@ -619,7 +578,7 @@ class HVACSizing
           if wall_true_azimuth < 180
             surf_azimuth = wall_true_azimuth
           else
-            surf_azimuth = wall_true_azimuth - 360
+            surf_azimuth = wall_true_azimuth - 360.0
           end
 
           # TODO: Account for eaves, porches, etc.
@@ -630,7 +589,7 @@ class HVACSizing
               else
                 actual_hr = hr + 8 # start at hour 8
               end
-              hour_angle = 0.25 * (actual_hr - 12) * 60 # ASHRAE HOF 1997 pg 29.19
+              hour_angle = 0.25 * (actual_hr - 12.0) * 60.0 # ASHRAE HOF 1997 pg 29.19
               altitude_angle = (Math::asin((Math::cos(weather.header.Latitude.deg2rad) *
                                             Math::cos(declination_angle.deg2rad) *
                                             Math::cos(hour_angle.deg2rad) +
@@ -660,7 +619,7 @@ class HVACSizing
                   htm = htm_d
                 elsif z_sl < (windowOverhangOffset + windowHeight)
                   percent_shaded = (z_sl - windowOverhangOffset) / windowHeight
-                  htm = percent_shaded * htm_n + (1 - percent_shaded) * htm_d
+                  htm = percent_shaded * htm_n + (1.0 - percent_shaded) * htm_d
                 else
                   # Window is entirely in the shade since the shade line is below the windowsill
                   htm = htm_n
@@ -693,15 +652,15 @@ class HVACSizing
     pfl = afl_hr.max
 
     # Excursion Adjustment Load (EAL)
-    eal = [0, pfl - ell].max
+    eal = [0.0, pfl - ell].max
 
     # Window Cooling Load
     zone_loads.Cool_Windows = alp_load + eal
 
     # Skylights
-    zone_loads.Heat_Skylights = 0
-    alp_load = 0 # Average Load Procedure (ALP) Load
-    afl_hr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] # Initialize Hourly Aggregate Fenestration Load (AFL)
+    zone_loads.Heat_Skylights = 0.0
+    alp_load = 0.0 # Average Load Procedure (ALP) Load
+    afl_hr = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] # Initialize Hourly Aggregate Fenestration Load (AFL)
 
     Geometry.get_spaces_above_grade_exterior_roofs(thermal_zone.spaces).each do |roof|
       roof_true_azimuth = true_azimuth(roof)
@@ -712,14 +671,12 @@ class HVACSizing
         next if not skylight.subSurfaceType.downcase.include?("skylight")
 
         # U-factor
-        u_skylight = self.get_surface_ufactor(runner, skylight, skylight.subSurfaceType, true)
-        return nil if u_skylight.nil?
+        u_skylight = get_surface_ufactor(skylight, skylight.subSurfaceType)
 
         zone_loads.Heat_Skylights += u_skylight * UnitConversions.convert(skylight.grossArea, "m^2", "ft^2") * @htd
 
         # SHGC & Internal Shading
-        shgc_with_interior_shade_cool, shgc_with_interior_shade_heat = get_fenestration_shgc(runner, skylight)
-        return nil if shgc_with_interior_shade_cool.nil? or shgc_with_interior_shade_heat.nil?
+        shgc_with_interior_shade_cool, shgc_with_interior_shade_heat = get_fenestration_shgc(skylight)
 
         skylightHasIntShading = skylight.shadingControl.is_initialized
 
@@ -761,7 +718,7 @@ class HVACSizing
           u_curb = 0.51 # default to wood (Table 2B-3)
           ar_curb = 0.35 # default to small (Table 2B-3)
           u_eff_skylight = u_skylight + u_curb * ar_curb
-          htm = (sol_h + sol_v) * (shgc_with_interior_shade_cool / 0.87) + u_eff_skylight * (ctd_adj + 15)
+          htm = (sol_h + sol_v) * (shgc_with_interior_shade_cool / 0.87) + u_eff_skylight * (ctd_adj + 15.0)
 
           if hr == -1
             alp_load += htm * UnitConversions.convert(skylight.grossArea, "m^2", "ft^2")
@@ -782,7 +739,7 @@ class HVACSizing
     pfl = afl_hr.max
 
     # Excursion Adjustment Load (EAL)
-    eal = [0, pfl - ell].max
+    eal = [0.0, pfl - ell].max
 
     # Skylight Cooling Load
     zone_loads.Cool_Skylights = alp_load + eal
@@ -790,30 +747,27 @@ class HVACSizing
     return zone_loads
   end
 
-  def self.process_load_doors(runner, thermal_zone, zone_loads, weather)
+  def self.process_load_doors(thermal_zone, zone_loads, weather)
     '''
     Heating and Cooling Loads: Doors
     '''
 
-    return nil if zone_loads.nil?
-
-    if @daily_range_num == 0
-      cltd = @ctd + 15
-    elsif @daily_range_num == 1
-      cltd = @ctd + 11
-    elsif @daily_range_num == 2
-      cltd = @ctd + 6
+    if @daily_range_num == 0.0
+      cltd = @ctd + 15.0
+    elsif @daily_range_num == 1.0
+      cltd = @ctd + 11.0
+    elsif @daily_range_num == 2.0
+      cltd = @ctd + 6.0
     end
 
-    zone_loads.Heat_Doors = 0
-    zone_loads.Cool_Doors = 0
+    zone_loads.Heat_Doors = 0.0
+    zone_loads.Cool_Doors = 0.0
 
     Geometry.get_spaces_above_grade_exterior_walls(thermal_zone.spaces).each do |wall|
       wall.subSurfaces.each do |door|
         next if not door.subSurfaceType.downcase.include?("door")
 
-        door_ufactor = self.get_surface_ufactor(runner, door, door.subSurfaceType, true)
-        return nil if door_ufactor.nil?
+        door_ufactor = get_surface_ufactor(door, door.subSurfaceType)
 
         zone_loads.Heat_Doors += door_ufactor * UnitConversions.convert(door.grossArea, "m^2", "ft^2") * @htd
         zone_loads.Cool_Doors += door_ufactor * UnitConversions.convert(door.grossArea, "m^2", "ft^2") * cltd
@@ -823,21 +777,18 @@ class HVACSizing
     return zone_loads
   end
 
-  def self.process_load_walls(runner, thermal_zone, zone_loads, weather)
+  def self.process_load_walls(thermal_zone, zone_loads, weather)
     '''
     Heating and Cooling Loads: Walls
     '''
 
-    return nil if zone_loads.nil?
-
-    zone_loads.Heat_Walls = 0
-    zone_loads.Cool_Walls = 0
+    zone_loads.Heat_Walls = 0.0
+    zone_loads.Cool_Walls = 0.0
     surfaces_processed = []
 
     # Above-Grade Exterior Walls
     Geometry.get_spaces_above_grade_exterior_walls(thermal_zone.spaces).each do |wall|
-      wallGroup = get_wallgroup(runner, wall)
-      return nil if wallGroup.nil?
+      wallGroup = get_wallgroup(wall)
 
       # Adjust base Cooling Load Temperature Difference (CLTD)
       # Assume absorptivity for light walls < 0.5, medium walls <= 0.75, dark walls > 0.75 (based on MJ8 Table 4B Notes)
@@ -857,8 +808,8 @@ class HVACSizing
       # Base Cooling Load Temperature Differences (CLTD's) for dark colored sunlit and shaded walls
       # with 95 degF outside temperature taken from MJ8 Figure A12-8 (intermediate wall groups were
       # determined using linear interpolation). Shaded walls apply to north facing and partition walls only.
-      cltd_base_sun = [38, 34.95, 31.9, 29.45, 27, 24.5, 22, 21.25, 20.5, 19.65, 18.8]
-      cltd_base_shade = [25, 22.5, 20, 18.45, 16.9, 15.45, 14, 13.55, 13.1, 12.85, 12.6]
+      cltd_base_sun = [38.0, 34.95, 31.9, 29.45, 27.0, 24.5, 22.0, 21.25, 20.5, 19.65, 18.8]
+      cltd_base_shade = [25.0, 22.5, 20.0, 18.45, 16.9, 15.45, 14.0, 13.55, 13.1, 12.85, 12.6]
 
       if wall_true_azimuth >= 157.5 and wall_true_azimuth <= 202.5
         cltd = cltd_base_shade[wallGroup - 1] * colorMultiplier
@@ -866,19 +817,18 @@ class HVACSizing
         cltd = cltd_base_sun[wallGroup - 1] * colorMultiplier
       end
 
-      if @ctd >= 10
+      if @ctd >= 10.0
         # Adjust the CLTD for different cooling design temperatures
-        cltd += (weather.design.CoolingDrybulb - 95)
+        cltd += (weather.design.CoolingDrybulb - 95.0)
         # Adjust the CLTD for daily temperature range
         cltd += @daily_range_temp_adjust[@daily_range_num]
       else
         # Handling cases ctd < 10 is based on A12-18 in MJ8
-        cltd_corr = @ctd - 20 - @daily_range_temp_adjust[@daily_range_num]
-        cltd = [cltd + cltd_corr, 0].max # Assume zero cooling load for negative CLTD's
+        cltd_corr = @ctd - 20.0 - @daily_range_temp_adjust[@daily_range_num]
+        cltd = [cltd + cltd_corr, 0.0].max # Assume zero cooling load for negative CLTD's
       end
 
-      wall_ufactor = self.get_surface_ufactor(runner, wall, wall.surfaceType, true)
-      return nil if wall_ufactor.nil?
+      wall_ufactor = get_surface_ufactor(wall, wall.surfaceType)
 
       zone_loads.Cool_Walls += wall_ufactor * UnitConversions.convert(wall.netArea, "m^2", "ft^2") * cltd
       zone_loads.Heat_Walls += wall_ufactor * UnitConversions.convert(wall.netArea, "m^2", "ft^2") * @htd
@@ -887,8 +837,7 @@ class HVACSizing
 
     # Interzonal Walls
     Geometry.get_spaces_interzonal_walls(thermal_zone.spaces).each do |wall|
-      wall_ufactor = self.get_surface_ufactor(runner, wall, wall.surfaceType, true)
-      return nil if wall_ufactor.nil?
+      wall_ufactor = get_surface_ufactor(wall, wall.surfaceType)
 
       adjacent_space = wall.adjacentSurface.get.space.get
       zone_loads.Cool_Walls += wall_ufactor * UnitConversions.convert(wall.netArea, "m^2", "ft^2") * (@cool_design_temps[adjacent_space] - @cool_setpoint)
@@ -898,11 +847,7 @@ class HVACSizing
 
     # Foundation walls
     Geometry.get_spaces_below_grade_exterior_walls(thermal_zone.spaces).each do |wall|
-      wall_ins_rvalue, wall_ins_height, wall_constr_rvalue = get_foundation_wall_insulation_props(runner, wall)
-      if wall_ins_rvalue.nil? or wall_ins_height.nil? or wall_constr_rvalue.nil?
-        return nil
-      end
-
+      wall_ins_rvalue, wall_ins_height, wall_constr_rvalue = get_foundation_wall_insulation_props(wall)
       k_soil = UnitConversions.convert(BaseMaterial.Soil.k_in, "in", "ft")
       ins_wall_ufactor = 1.0 / (wall_constr_rvalue + wall_ins_rvalue + Material.AirFilmVertical.rvalue)
       unins_wall_ufactor = 1.0 / (wall_constr_rvalue + Material.AirFilmVertical.rvalue)
@@ -929,55 +874,44 @@ class HVACSizing
     end
 
     if surfaces_processed.size != surfaces_processed.uniq.size
-      runner.registerError("Surface referenced twice in HVAC sizing\n#{surfaces_processed}.")
-      return nil
+      fail "Surface referenced twice in HVAC sizing\n#{surfaces_processed}."
     end
 
     return zone_loads
   end
 
-  def self.process_load_roofs(runner, thermal_zone, zone_loads, weather)
+  def self.process_load_roofs(thermal_zone, zone_loads, weather)
     '''
     Heating and Cooling Loads: Ceilings
     '''
 
-    return nil if zone_loads.nil?
+    cltd = 0.0
 
-    cltd = 0
-
-    zone_loads.Heat_Roofs = 0
-    zone_loads.Cool_Roofs = 0
+    zone_loads.Heat_Roofs = 0.0
+    zone_loads.Cool_Roofs = 0.0
     surfaces_processed = []
 
     # Roofs
     Geometry.get_spaces_above_grade_exterior_roofs(thermal_zone.spaces).each do |roof|
-      roof_color = get_feature(runner, roof, Constants.SizingInfoRoofColor, 'string')
-      return nil if roof_color.nil?
-
-      roof_material = get_feature(runner, roof, Constants.SizingInfoRoofMaterial, 'string')
-      return nil if roof_material.nil?
-
-      cavity_r = get_feature(runner, roof, Constants.SizingInfoRoofCavityRvalue, 'double')
-      return nil if cavity_r.nil?
-
-      rigid_r = get_feature(runner, roof, Constants.SizingInfoRoofRigidInsRvalue, 'double')
-      return nil if rigid_r.nil?
-
+      roof_color = get_feature(roof, Constants.SizingInfoRoofColor, 'string')
+      roof_material = get_feature(roof, Constants.SizingInfoRoofMaterial, 'string')
+      cavity_r = get_feature(roof, Constants.SizingInfoRoofCavityRvalue, 'double')
+      rigid_r = get_feature(roof, Constants.SizingInfoRoofRigidInsRvalue, 'double')
       total_r = cavity_r + rigid_r
 
       # Base CLTD for conditioned roofs (Roof-Joist-Ceiling Sandwiches) taken from MJ8 Figure A12-16
       if total_r <= 6
-        cltd = 50
+        cltd = 50.0
       elsif total_r <= 13
-        cltd = 45
+        cltd = 45.0
       elsif total_r <= 15
-        cltd = 38
+        cltd = 38.0
       elsif total_r <= 21
-        cltd = 31
+        cltd = 31.0
       elsif total_r <= 30
-        cltd = 30
+        cltd = 30.0
       else
-        cltd = 27
+        cltd = 27.0
       end
 
       # Base CLTD color adjustment based on notes in MJ8 Figure A12-16
@@ -1000,10 +934,9 @@ class HVACSizing
       end
 
       # Adjust base CLTD for different CTD or DR
-      cltd += (weather.design.CoolingDrybulb - 95) + @daily_range_temp_adjust[@daily_range_num]
+      cltd += (weather.design.CoolingDrybulb - 95.0) + @daily_range_temp_adjust[@daily_range_num]
 
-      roof_ufactor = self.get_surface_ufactor(runner, roof, roof.surfaceType, true)
-      return nil if roof_ufactor.nil?
+      roof_ufactor = get_surface_ufactor(roof, roof.surfaceType)
 
       zone_loads.Cool_Roofs += roof_ufactor * UnitConversions.convert(roof.netArea, "m^2", "ft^2") * cltd
       zone_loads.Heat_Roofs += roof_ufactor * UnitConversions.convert(roof.netArea, "m^2", "ft^2") * @htd
@@ -1011,38 +944,33 @@ class HVACSizing
     end
 
     if surfaces_processed.size != surfaces_processed.uniq.size
-      runner.registerError("Surface referenced twice in HVAC sizing\n#{surfaces_processed}.")
-      return nil
+      fail "Surface referenced twice in HVAC sizing\n#{surfaces_processed}."
     end
 
     return zone_loads
   end
 
-  def self.process_load_floors(runner, thermal_zone, zone_loads, weather)
+  def self.process_load_floors(thermal_zone, zone_loads, weather)
     '''
     Heating and Cooling Loads: Floors
     '''
 
-    return nil if zone_loads.nil?
-
-    zone_loads.Heat_Floors = 0
-    zone_loads.Cool_Floors = 0
+    zone_loads.Heat_Floors = 0.0
+    zone_loads.Cool_Floors = 0.0
     surfaces_processed = []
 
     # Exterior Floors
     Geometry.get_spaces_above_grade_exterior_floors(thermal_zone.spaces).each do |floor|
-      floor_ufactor = self.get_surface_ufactor(runner, floor, floor.surfaceType, true)
-      return nil if floor_ufactor.nil?
+      floor_ufactor = get_surface_ufactor(floor, floor.surfaceType)
 
-      zone_loads.Cool_Floors += floor_ufactor * UnitConversions.convert(floor.netArea, "m^2", "ft^2") * (@ctd - 5 + @daily_range_temp_adjust[@daily_range_num])
+      zone_loads.Cool_Floors += floor_ufactor * UnitConversions.convert(floor.netArea, "m^2", "ft^2") * (@ctd - 5.0 + @daily_range_temp_adjust[@daily_range_num])
       zone_loads.Heat_Floors += floor_ufactor * UnitConversions.convert(floor.netArea, "m^2", "ft^2") * @htd
       surfaces_processed << floor.name.to_s
     end
 
     # Interzonal Floors
     Geometry.get_spaces_interzonal_floors_and_ceilings(thermal_zone.spaces).each do |floor|
-      floor_ufactor = self.get_surface_ufactor(runner, floor, floor.surfaceType, true)
-      return nil if floor_ufactor.nil?
+      floor_ufactor = get_surface_ufactor(floor, floor.surfaceType)
 
       adjacent_space = floor.adjacentSurface.get.space.get
       zone_loads.Cool_Floors += floor_ufactor * UnitConversions.convert(floor.netArea, "m^2", "ft^2") * (@cool_design_temps[adjacent_space] - @cool_setpoint)
@@ -1055,7 +983,7 @@ class HVACSizing
       # Conditioned basement floor combinations based on MJ 8th Ed. A12-7 and ASHRAE HoF 2013 pg 18.31 Eq 40
       k_soil = UnitConversions.convert(BaseMaterial.Soil.k_in, "in", "ft")
       r_other = Material.Concrete(4.0).rvalue + Material.AirFilmFloorAverage.rvalue
-      z_f = -1 * (Geometry.getSurfaceZValues([floor]).min + UnitConversions.convert(floor.space.get.zOrigin, "m", "ft"))
+      z_f = -1.0 * (Geometry.getSurfaceZValues([floor]).min + UnitConversions.convert(floor.space.get.zOrigin, "m", "ft"))
       w_b = [Geometry.getSurfaceXValues([floor]).max - Geometry.getSurfaceXValues([floor]).min, Geometry.getSurfaceYValues([floor]).max - Geometry.getSurfaceYValues([floor]).min].min
       u_avg_bf = (2.0 * k_soil / (Math::PI * w_b)) * (Math::log(w_b / 2.0 + z_f / 2.0 + (k_soil * r_other) / Math::PI) - Math::log(z_f / 2.0 + (k_soil * r_other) / Math::PI))
       u_value_mj8 = 0.85 * u_avg_bf
@@ -1065,36 +993,25 @@ class HVACSizing
 
     # Ground Floors (Slab)
     Geometry.get_spaces_above_grade_ground_floors(thermal_zone.spaces).each do |floor|
-      # Get stored u-factor since the surface u-factor is fictional
-      # TODO: Revert this some day.
-      # floor_ufactor = get_surface_ufactor(runner, floor, floor.surfaceType, true)
-      # return nil if floor_ufactor.nil?
-      floor_rvalue = get_feature(runner, floor, Constants.SizingInfoSlabRvalue, 'double')
-      return nil if floor_rvalue.nil?
-
-      floor_ufactor = 1.0 / floor_rvalue
+      floor_ufactor = 1.0 / get_feature(floor, Constants.SizingInfoSlabRvalue, 'double')
       zone_loads.Heat_Floors += floor_ufactor * UnitConversions.convert(floor.netArea, "m^2", "ft^2") * (@heat_setpoint - weather.data.GroundMonthlyTemps[0])
       surfaces_processed << floor.name.to_s
     end
 
     if surfaces_processed.size != surfaces_processed.uniq.size
-      runner.registerError("Surface referenced twice in HVAC sizing\n#{surfaces_processed}.")
-      return nil
+      fail "Surface referenced twice in HVAC sizing\n#{surfaces_processed}."
     end
 
     return zone_loads
   end
 
-  def self.process_infiltration_ventilation(runner, model, thermal_zone, zone_loads, weather)
+  def self.process_infiltration_ventilation(model, thermal_zone, zone_loads, weather)
     '''
     Heating and Cooling Loads: Infiltration & Ventilation
     '''
 
-    return nil if zone_loads.nil?
-
     # Per ANSI/RESNET/ICC 301
-    ach_nat = get_feature(runner, thermal_zone, Constants.SizingInfoZoneInfiltrationACH, 'double')
-    return nil if ach_nat.nil?
+    ach_nat = get_feature(thermal_zone, Constants.SizingInfoZoneInfiltrationACH, 'double')
 
     ach_Cooling = 1.2 * ach_nat
     ach_Heating = 1.6 * ach_nat
@@ -1102,13 +1019,12 @@ class HVACSizing
     icfm_Cooling = ach_Cooling / UnitConversions.convert(1.0, "hr", "min") * @infilvolume
     icfm_Heating = ach_Heating / UnitConversions.convert(1.0, "hr", "min") * @infilvolume
 
-    q_unb, q_bal_Sens, q_bal_Lat = get_ventilation_rates(runner, model)
-    return nil if q_unb.nil? or q_bal_Sens.nil? or q_bal_Lat.nil?
+    q_unb, q_bal_Sens, q_bal_Lat = get_ventilation_rates(model)
 
-    cfm_Heating = q_bal_Sens + (icfm_Heating**2 + q_unb**2)**0.5
+    cfm_Heating = q_bal_Sens + (icfm_Heating**2.0 + q_unb**2.0)**0.5
 
-    cfm_Cool_Load_Sens = q_bal_Sens + (icfm_Cooling**2 + q_unb**2)**0.5
-    cfm_Cool_Load_Lat = q_bal_Lat + (icfm_Cooling**2 + q_unb**2)**0.5
+    cfm_Cool_Load_Sens = q_bal_Sens + (icfm_Cooling**2.0 + q_unb**2.0)**0.5
+    cfm_Cool_Load_Lat = q_bal_Lat + (icfm_Cooling**2.0 + q_unb**2.0)**0.5
 
     zone_loads.Heat_Infil = 1.1 * @acf * cfm_Heating * @htd
 
@@ -1118,15 +1034,13 @@ class HVACSizing
     return zone_loads
   end
 
-  def self.process_internal_gains(runner, thermal_zone, zone_loads)
+  def self.process_internal_gains(thermal_zone, zone_loads)
     '''
     Cooling Load: Internal Gains
     '''
 
-    return nil if zone_loads.nil?
-
-    zone_loads.Cool_IntGains_Sens = 0
-    zone_loads.Cool_IntGains_Lat = 0
+    zone_loads.Cool_IntGains_Sens = 0.0
+    zone_loads.Cool_IntGains_Lat = 0.0
 
     # Per ANSI/RESNET/ICC 301
     n_occupants = @nbeds + 1
@@ -1147,13 +1061,11 @@ class HVACSizing
     (total loads excluding ducts)
     '''
 
-    return nil if zone_loads.nil?
-
     init_loads = InitialLoads.new
     # Heating
     init_loads.Heat = [zone_loads.Heat_Windows + zone_loads.Heat_Skylights +
       zone_loads.Heat_Doors + zone_loads.Heat_Walls +
-      zone_loads.Heat_Floors + zone_loads.Heat_Roofs, 0].max +
+      zone_loads.Heat_Floors + zone_loads.Heat_Roofs, 0.0].max +
                       zone_loads.Heat_Infil
 
     # Cooling
@@ -1163,7 +1075,7 @@ class HVACSizing
                            zone_loads.Cool_Infil_Sens + zone_loads.Cool_IntGains_Sens
     init_loads.Cool_Lat = zone_loads.Cool_Infil_Lat + zone_loads.Cool_IntGains_Lat
 
-    init_loads.Cool_Lat = [init_loads.Cool_Lat, 0].max
+    init_loads.Cool_Lat = [init_loads.Cool_Lat, 0.0].max
     init_loads.Cool_Tot = init_loads.Cool_Sens + init_loads.Cool_Lat
 
     return init_loads
@@ -1173,8 +1085,6 @@ class HVACSizing
     '''
     HVAC Temperatures
     '''
-    return nil if init_loads.nil?
-
     # evap cooler temperature calculation based on Mannual S Figure 4-7
     if hvac.has_type(Constants.ObjectNameEvaporativeCooler)
       td_potential = @cool_design_temps[nil] - @wetbulb_outdoor_cooling
@@ -1185,21 +1095,21 @@ class HVACSizing
       shr = [init_loads.Cool_Sens / init_loads.Cool_Tot, 1.0].min
       # Determine the Leaving Air Temperature (LAT) based on Manual S Table 1-4
       if shr < 0.80
-        hvac.LeavingAirTemp = 54 # F
+        hvac.LeavingAirTemp = 54.0 # F
       elsif shr < 0.85
         # MJ8 says to use 56 degF in this SHR range. Linear interpolation provides a more
         # continuous supply air flow rate across building efficiency levels.
-        hvac.LeavingAirTemp = ((58 - 54) / (0.85 - 0.80)) * (shr - 0.8) + 54 # F
+        hvac.LeavingAirTemp = ((58.0 - 54.0) / (0.85 - 0.80)) * (shr - 0.8) + 54.0 # F
       else
-        hvac.LeavingAirTemp = 58 # F
+        hvac.LeavingAirTemp = 58.0 # F
       end
     end
 
     # Calculate Supply Air Temperature
     if hvac.has_type(Constants.ObjectNameFurnace)
-      hvac.SupplyAirTemp = 120 # F
+      hvac.SupplyAirTemp = 120.0 # F
     else
-      hvac.SupplyAirTemp = 105 # F
+      hvac.SupplyAirTemp = 105.0 # F
     end
 
     return hvac
@@ -1209,8 +1119,6 @@ class HVACSizing
     '''
     Intermediate Loads (HVAC-specific)
     '''
-    return nil if init_loads.nil?
-
     hvac_init_loads = init_loads.dup
     hvac_init_loads.Heat *= hvac.HeatingLoadFraction
     hvac_init_loads.Cool_Sens *= hvac.CoolingLoadFraction
@@ -1250,7 +1158,7 @@ class HVACSizing
     return hvac_init_loads
   end
 
-  def self.get_duct_regain_factor(runner, duct)
+  def self.get_duct_regain_factor(duct)
     # dse_Fregain values comes from MJ8 pg 204 and Walker (1998) "Technical background for default
     # values used for forced air systems in proposed ASHRAE Std. 152"
 
@@ -1261,8 +1169,7 @@ class HVACSizing
 
     elsif Geometry.is_unconditioned_basement(duct.LocationSpace)
 
-      walls_insulated, ceiling_insulated = get_foundation_walls_ceilings_insulated(runner, duct.LocationSpace)
-      return nil if walls_insulated.nil? or ceiling_insulated.nil?
+      walls_insulated, ceiling_insulated = get_foundation_walls_ceilings_insulated(duct.LocationSpace)
 
       if not ceiling_insulated
         if not walls_insulated
@@ -1276,9 +1183,7 @@ class HVACSizing
 
     elsif Geometry.is_vented_crawl(duct.LocationSpace) or Geometry.is_unvented_crawl(duct.LocationSpace)
 
-      walls_insulated, ceiling_insulated = get_foundation_walls_ceilings_insulated(runner, duct.LocationSpace)
-      return nil if walls_insulated.nil? or ceiling_insulated.nil?
-
+      walls_insulated, ceiling_insulated = get_foundation_walls_ceilings_insulated(duct.LocationSpace)
       is_vented = Geometry.is_vented_crawl(duct.LocationSpace)
 
       if is_vented
@@ -1313,21 +1218,18 @@ class HVACSizing
       dse_Fregain = 1.0
 
     else
-      runner.registerError("Unexpected duct location: #{duct.LocationSpace.name.to_s}")
-      return nil
+      fail "Unexpected duct location: #{duct.LocationSpace.name.to_s}"
     end
 
     return dse_Fregain
   end
 
-  def self.process_duct_loads_heating(runner, hvac_final_values, weather, hvac, init_heat_load)
+  def self.process_duct_loads_heating(hvac_final_values, weather, hvac, init_heat_load)
     '''
     Heating Duct Loads
     '''
-    return nil if hvac_final_values.nil?
-
-    if init_heat_load == 0 or hvac.Ducts.nil? or hvac.Ducts.size == 0
-      hvac_final_values.Heat_Load_Ducts = 0
+    if init_heat_load == 0 or hvac.Ducts.size == 0
+      hvac_final_values.Heat_Load_Ducts = 0.0
       hvac_final_values.Heat_Load = init_heat_load
     else
       # Distribution system efficiency (DSE) calculations based on ASHRAE Standard 152
@@ -1342,11 +1244,7 @@ class HVACSizing
       # in each space. Fregain shall be calculated separately for supply and return locations.
       dse_Fregains = {}
       hvac.Ducts.each do |duct|
-        dse_Fregains[duct.LocationSpace] = get_duct_regain_factor(runner, duct)
-        if dse_Fregains[duct.LocationSpace].nil?
-          runner.registerError("Unexpected duct location '#{duct.LocationSpace.name}'.")
-          return nil
-        end
+        dse_Fregains[duct.LocationSpace] = get_duct_regain_factor(duct)
       end
       fregain_values = { Constants.DuctSideSupply => dse_Fregains, Constants.DuctSideReturn => dse_Fregains }
       dse_Fregain_s, dse_Fregain_r = calc_ducts_area_weighted_average(hvac.Ducts, fregain_values)
@@ -1382,16 +1280,14 @@ class HVACSizing
     return hvac_final_values
   end
 
-  def self.process_duct_loads_cooling(runner, hvac_final_values, weather, hvac, init_cool_load_sens, init_cool_load_lat)
+  def self.process_duct_loads_cooling(hvac_final_values, weather, hvac, init_cool_load_sens, init_cool_load_lat)
     '''
     Cooling Duct Loads
     '''
 
-    return nil if hvac_final_values.nil?
-
-    if init_cool_load_sens == 0 or hvac.Ducts.nil? or hvac.Ducts.size == 0
-      hvac_final_values.Cool_Load_Ducts_Sens = 0
-      hvac_final_values.Cool_Load_Ducts_Tot = 0
+    if init_cool_load_sens == 0 or hvac.Ducts.size == 0
+      hvac_final_values.Cool_Load_Ducts_Sens = 0.0
+      hvac_final_values.Cool_Load_Ducts_Tot = 0.0
       hvac_final_values.Cool_Load_Sens = init_cool_load_sens
       hvac_final_values.Cool_Load_Lat = init_cool_load_lat
       hvac_final_values.Cool_Load_Tot = hvac_final_values.Cool_Load_Sens + hvac_final_values.Cool_Load_Lat
@@ -1408,14 +1304,13 @@ class HVACSizing
       # in each space. Fregain shall be calculated separately for supply and return locations.
       dse_Fregains = {}
       hvac.Ducts.each do |duct|
-        dse_Fregains[duct.LocationSpace] = get_duct_regain_factor(runner, duct)
-        return nil if dse_Fregains[duct.LocationSpace].nil?
+        dse_Fregains[duct.LocationSpace] = get_duct_regain_factor(duct)
       end
       fregain_values = { Constants.DuctSideSupply => dse_Fregains, Constants.DuctSideReturn => dse_Fregains }
       dse_Fregain_s, dse_Fregain_r = calc_ducts_area_weighted_average(hvac.Ducts, fregain_values)
 
       # Calculate the air enthalpy in the return duct location for DSE calculations
-      dse_h_r = (1.006 * UnitConversions.convert(dse_Tamb_cooling_r, "F", "C") + weather.design.CoolingHumidityRatio * (2501 + 1.86 * UnitConversions.convert(dse_Tamb_cooling_r, "F", "C"))) * UnitConversions.convert(1, "kJ", "Btu") * UnitConversions.convert(1, "lbm", "kg")
+      dse_h_r = (1.006 * UnitConversions.convert(dse_Tamb_cooling_r, "F", "C") + weather.design.CoolingHumidityRatio * (2501.0 + 1.86 * UnitConversions.convert(dse_Tamb_cooling_r, "F", "C"))) * UnitConversions.convert(1.0, "kJ", "Btu") * UnitConversions.convert(1.0, "lbm", "kg")
 
       # Initialize for the iteration
       delta = 1
@@ -1463,12 +1358,10 @@ class HVACSizing
     return hvac_final_values
   end
 
-  def self.process_equipment_adjustments(runner, hvac_final_values, weather, hvac)
+  def self.process_equipment_adjustments(hvac_final_values, weather, hvac)
     '''
     Equipment Adjustments
     '''
-
-    return nil if hvac_final_values.nil?
 
     underSizeLimit = 0.9
 
@@ -1506,7 +1399,7 @@ class HVACSizing
 
         sensibleCap_CurveValue = process_curve_fit(hvac_final_values.Cool_Airflow, hvac_final_values.Cool_Load_Tot, enteringTemp)
         sensCap_Design = sensCap_Rated * sensibleCap_CurveValue
-        latCap_Design = [hvac_final_values.Cool_Load_Tot - sensCap_Design, 1].max
+        latCap_Design = [hvac_final_values.Cool_Load_Tot - sensCap_Design, 1.0].max
 
         a_sens = @shr_biquadratic[0]
         b_sens = @shr_biquadratic[1]
@@ -1525,7 +1418,7 @@ class HVACSizing
           cool_Load_SensCap_Design = hvac_final_values.Cool_Load_Lat / ((totalCap_CurveValue / hvac.SHRRated[hvac.SizingSpeed] - \
                                     (UnitConversions.convert(b_sens, "ton", "Btu/hr") + UnitConversions.convert(d_sens, "ton", "Btu/hr") * enteringTemp) / \
                                     (1.1 * @acf * (@cool_setpoint - hvac.LeavingAirTemp))) / \
-                                    (a_sens + c_sens * enteringTemp) - 1)
+                                    (a_sens + c_sens * enteringTemp) - 1.0)
 
           cool_Capacity_Design = cool_Load_SensCap_Design + hvac_final_values.Cool_Load_Lat
 
@@ -1588,9 +1481,9 @@ class HVACSizing
         # Ensure the air flow rate is in between 200 and 500 cfm/ton.
         # Reset the air flow rate (with a safety margin), if required.
         if hvac_final_values.Cool_Airflow / UnitConversions.convert(hvac_final_values.Cool_Capacity, "Btu/hr", "ton") > 500
-          hvac_final_values.Cool_Airflow = 499 * UnitConversions.convert(hvac_final_values.Cool_Capacity, "Btu/hr", "ton")      # CFM
+          hvac_final_values.Cool_Airflow = 499.0 * UnitConversions.convert(hvac_final_values.Cool_Capacity, "Btu/hr", "ton")      # CFM
         elsif hvac_final_values.Cool_Airflow / UnitConversions.convert(hvac_final_values.Cool_Capacity, "Btu/hr", "ton") < 200
-          hvac_final_values.Cool_Airflow = 201 * UnitConversions.convert(hvac_final_values.Cool_Capacity, "Btu/hr", "ton")      # CFM
+          hvac_final_values.Cool_Airflow = 201.0 * UnitConversions.convert(hvac_final_values.Cool_Capacity, "Btu/hr", "ton")      # CFM
         end
 
       elsif hvac.has_type(Constants.ObjectNameMiniSplitHeatPump)
@@ -1625,8 +1518,8 @@ class HVACSizing
         hvac_final_values.Cool_Capacity_Sens = hvac_final_values.Cool_Capacity * hvac.SHRRated[hvac.SizingSpeed]
 
         cool_Load_SensCap_Design = (hvac_final_values.Cool_Capacity_Sens * sensibleCap_CurveValue /
-                                   (1 + (1 - hvac.CoilBF * bypassFactor_CurveValue) *
-                                   (80 - @cool_setpoint) / (@cool_setpoint - hvac.LeavingAirTemp)))
+                                   (1.0 + (1.0 - hvac.CoilBF * bypassFactor_CurveValue) *
+                                   (80.0 - @cool_setpoint) / (@cool_setpoint - hvac.LeavingAirTemp)))
         cool_Load_LatCap_Design = hvac_final_values.Cool_Load_Tot - cool_Load_SensCap_Design
 
         # Adjust Sizing so that coil sensible at design >= CoolingLoad_MJ8_Sens, and coil latent at design >= CoolingLoad_MJ8_Lat, and equipment SHRRated is maintained.
@@ -1641,14 +1534,12 @@ class HVACSizing
 
         # Recalculate the air flow rate in case the oversizing limit has been used
         cool_Load_SensCap_Design = (hvac_final_values.Cool_Capacity_Sens * sensibleCap_CurveValue /
-                                   (1 + (1 - hvac.CoilBF * bypassFactor_CurveValue) *
-                                   (80 - @cool_setpoint) / (@cool_setpoint - hvac.LeavingAirTemp)))
+                                   (1.0 + (1.0 - hvac.CoilBF * bypassFactor_CurveValue) *
+                                   (80.0 - @cool_setpoint) / (@cool_setpoint - hvac.LeavingAirTemp)))
         hvac_final_values.Cool_Airflow = calc_airflow_rate(cool_Load_SensCap_Design, (@cool_setpoint - hvac.LeavingAirTemp))
       else
 
-        runner.registerError("Unexpected cooling system.")
-        return nil
-
+        fail "Unexpected cooling system."
       end
 
     elsif hvac.has_type(Constants.ObjectNameEvaporativeCooler)
@@ -1657,19 +1548,18 @@ class HVACSizing
       if @cool_setpoint - hvac.LeavingAirTemp > 0
         hvac_final_values.Cool_Airflow = calc_airflow_rate(hvac_final_values.Cool_Load_Sens, (@cool_setpoint - hvac.LeavingAirTemp))
       else
-        hvac_final_values.Cool_Airflow = @cfa * 2 # Use industry rule of thumb sizing method adopted by HEScore
+        hvac_final_values.Cool_Airflow = @cfa * 2.0 # Use industry rule of thumb sizing method adopted by HEScore
       end
     else
-      hvac_final_values.Cool_Capacity = 0
-      hvac_final_values.Cool_Capacity_Sens = 0
-      hvac_final_values.Cool_Airflow = 0
+      hvac_final_values.Cool_Capacity = 0.0
+      hvac_final_values.Cool_Capacity_Sens = 0.0
+      hvac_final_values.Cool_Airflow = 0.0
 
     end
 
     # Heating
     if hvac.has_type(Constants.ObjectNameAirSourceHeatPump)
-      hvac_final_values = process_heat_pump_adjustment(runner, hvac_final_values, weather, hvac, totalCap_CurveValue)
-      return nil if hvac_final_values.nil?
+      hvac_final_values = process_heat_pump_adjustment(hvac_final_values, weather, hvac, totalCap_CurveValue)
 
       hvac_final_values.Heat_Capacity = hvac_final_values.Cool_Capacity
       hvac_final_values.Heat_Capacity_Supp = hvac_final_values.Heat_Load
@@ -1681,8 +1571,7 @@ class HVACSizing
       end
 
     elsif hvac.has_type(Constants.ObjectNameMiniSplitHeatPump)
-      hvac_final_values = process_heat_pump_adjustment(runner, hvac_final_values, weather, hvac, totalCap_CurveValue)
-      return nil if hvac_final_values.nil?
+      hvac_final_values = process_heat_pump_adjustment(hvac_final_values, weather, hvac, totalCap_CurveValue)
 
       hvac_final_values.Heat_Capacity = [hvac_final_values.Cool_Capacity + hvac.HeatingCapacityOffset, Constants.small].max
       hvac_final_values.Heat_Capacity_Supp = hvac_final_values.Heat_Load
@@ -1706,20 +1595,20 @@ class HVACSizing
 
       hvac_final_values.Cool_Capacity_Sens = hvac_final_values.Cool_Capacity * hvac.SHRRated[hvac.SizingSpeed]
       cool_Load_SensCap_Design = (hvac_final_values.Cool_Capacity_Sens * sensibleCap_CurveValue /
-                                 (1 + (1 - hvac.CoilBF * bypassFactor_CurveValue) *
-                                 (80 - @cool_setpoint) / (@cool_setpoint - hvac.LeavingAirTemp)))
+                                 (1.0 + (1.0 - hvac.CoilBF * bypassFactor_CurveValue) *
+                                 (80.0 - @cool_setpoint) / (@cool_setpoint - hvac.LeavingAirTemp)))
       hvac_final_values.Cool_Airflow = calc_airflow_rate(cool_Load_SensCap_Design, (@cool_setpoint - hvac.LeavingAirTemp))
       hvac_final_values.Heat_Airflow = calc_airflow_rate(hvac_final_values.Heat_Capacity, (hvac.SupplyAirTemp - @heat_setpoint))
 
     elsif hvac.has_type(Constants.ObjectNameFurnace)
       hvac_final_values.Heat_Capacity = hvac_final_values.Heat_Load
-      hvac_final_values.Heat_Capacity_Supp = 0
+      hvac_final_values.Heat_Capacity_Supp = 0.0
 
       hvac_final_values.Heat_Airflow = calc_airflow_rate(hvac_final_values.Heat_Capacity, (hvac.SupplyAirTemp - @heat_setpoint))
 
     elsif hvac.has_type(Constants.ObjectNameUnitHeater)
       hvac_final_values.Heat_Capacity = hvac_final_values.Heat_Load
-      hvac_final_values.Heat_Capacity_Supp = 0
+      hvac_final_values.Heat_Capacity_Supp = 0.0
 
       if hvac.RatedCFMperTonHeating[0] > 0
         # Fixed airflow rate
@@ -1732,26 +1621,23 @@ class HVACSizing
     elsif hvac.has_type([Constants.ObjectNameBoiler,
                          Constants.ObjectNameElectricBaseboard])
       hvac_final_values.Heat_Capacity = hvac_final_values.Heat_Load
-      hvac_final_values.Heat_Capacity_Supp = 0
-
-      hvac_final_values.Heat_Airflow = 0
+      hvac_final_values.Heat_Capacity_Supp = 0.0
+      hvac_final_values.Heat_Airflow = 0.0
 
     else
-      hvac_final_values.Heat_Capacity = 0
-      hvac_final_values.Heat_Capacity_Supp = 0
-      hvac_final_values.Heat_Airflow = 0
+      hvac_final_values.Heat_Capacity = 0.0
+      hvac_final_values.Heat_Capacity_Supp = 0.0
+      hvac_final_values.Heat_Airflow = 0.0
 
     end
 
     return hvac_final_values
   end
 
-  def self.process_fixed_equipment(runner, hvac_final_values, hvac)
+  def self.process_fixed_equipment(hvac_final_values, hvac)
     '''
     Fixed Sizing Equipment
     '''
-
-    return nil if hvac_final_values.nil?
 
     # Override Manual J sizes if Fixed sizes are being used
     if not hvac.FixedCoolingCapacity.nil?
@@ -1761,7 +1647,7 @@ class HVACSizing
       if prev_capacity > 0 # Preserve cfm/ton
         hvac_final_values.Cool_Airflow = hvac_final_values.Cool_Airflow * hvac_final_values.Cool_Capacity / prev_capacity
       else
-        hvac_final_values.Cool_Airflow = 0
+        hvac_final_values.Cool_Airflow = 0.0
       end
     end
     if not hvac.FixedHeatingCapacity.nil?
@@ -1770,7 +1656,7 @@ class HVACSizing
       if prev_capacity > 0 # Preserve cfm/ton
         hvac_final_values.Heat_Airflow = hvac_final_values.Heat_Airflow * hvac_final_values.Heat_Capacity / prev_capacity
       else
-        hvac_final_values.Heat_Airflow = 0
+        hvac_final_values.Heat_Airflow = 0.0
       end
     end
     if not hvac.FixedSuppHeatingCapacity.nil?
@@ -1780,12 +1666,10 @@ class HVACSizing
     return hvac_final_values
   end
 
-  def self.process_ground_loop(runner, hvac_final_values, weather, hvac)
+  def self.process_ground_loop(hvac_final_values, weather, hvac)
     '''
     GSHP Ground Loop Sizing Calculations
     '''
-    return nil if hvac_final_values.nil?
-
     if hvac.has_type(Constants.ObjectNameGroundSourceHeatPump)
       ground_conductivity = UnitConversions.convert(hvac.GSHP_HXVertical.groundThermalConductivity.get, "W/(m*K)", "Btu/(hr*ft*R)")
       grout_conductivity = UnitConversions.convert(hvac.GSHP_HXVertical.groutThermalConductivity.get, "W/(m*K)", "Btu/(hr*ft*R)")
@@ -1828,7 +1712,7 @@ class HVACSizing
         hvac.GSHP_BoreHoles = hvac.GSHP_BoreHoles.to_f
         hvac.GSHP_BoreDepth = (bore_length / hvac.GSHP_BoreHoles).floor + 5
       else
-        runner.registerWarning("User is hard sizing the bore field, improper sizing may lead to unbalanced / unsteady ground loop temperature and erroneous prediction of system energy related cost.")
+        @runner.registerWarning("User is hard sizing the bore field, improper sizing may lead to unbalanced / unsteady ground loop temperature and erroneous prediction of system energy related cost.")
         hvac.GSHP_BoreHoles = hvac.GSHP_BoreHoles.to_f
         hvac.GSHP_BoreDepth = hvac.GSHP_BoreDepth.to_f
       end
@@ -1865,7 +1749,7 @@ class HVACSizing
         # Any configuration with a max_valid_configs value can accept any number of bores up to the maximum
         if max_valid_configs.keys.include? hvac.GSHP_BoreConfig
           max_bore_holes = max_valid_configs[hvac.GSHP_BoreConfig]
-          runner.registerWarning("Maximum number of bore holes for '#{hvac.GSHP_BoreConfig}' bore configuration is #{max_bore_holes}. Overriding value of #{hvac.GSHP_BoreHoles} bore holes to #{max_bore_holes}.")
+          @runner.registerWarning("Maximum number of bore holes for '#{hvac.GSHP_BoreConfig}' bore configuration is #{max_bore_holes}. Overriding value of #{hvac.GSHP_BoreHoles} bore holes to #{max_bore_holes}.")
           hvac.GSHP_BoreHoles = max_bore_holes
         else
           # Search for first valid bore field
@@ -1879,11 +1763,10 @@ class HVACSizing
             end
           end
           if valid_field_found
-            runner.registerWarning("Bore field '#{hvac.GSHP_BoreConfig}' with #{hvac.GSHP_BoreHoles.to_i} bore holes is an invalid configuration. Changing layout to '#{new_bore_config}' configuration.")
+            @runner.registerWarning("Bore field '#{hvac.GSHP_BoreConfig}' with #{hvac.GSHP_BoreHoles.to_i} bore holes is an invalid configuration. Changing layout to '#{new_bore_config}' configuration.")
             hvac.GSHP_BoreConfig = new_bore_config
           else
-            runner.registerError("Could not construct a valid GSHP bore field configuration.")
-            return nil
+            fail "Could not construct a valid GSHP bore field configuration."
           end
         end
       end
@@ -1901,12 +1784,10 @@ class HVACSizing
     return hvac_final_values
   end
 
-  def self.process_finalize(runner, hvac_final_values, zone_loads, weather, hvac)
+  def self.process_finalize(hvac_final_values, zone_loads, weather, hvac)
     '''
     Finalize Sizing Calculations
     '''
-
-    return nil if hvac_final_values.nil?
 
     # Prevent errors of "has no air flow"
     min_air_flow = 3.0 # cfm; E+ minimum is 0.001 m^3/s"
@@ -1920,12 +1801,10 @@ class HVACSizing
     return hvac_final_values
   end
 
-  def self.process_heat_pump_adjustment(runner, hvac_final_values, weather, hvac, totalCap_CurveValue)
+  def self.process_heat_pump_adjustment(hvac_final_values, weather, hvac, totalCap_CurveValue)
     '''
     Adjust heat pump sizing
     '''
-    return nil if hvac_final_values.nil?
-
     if hvac.NumSpeedsHeating > 1
       coefficients = hvac.HEAT_CAP_FT_SPEC[hvac.NumSpeedsHeating - 1]
       capacity_ratio = hvac.CapacityRatioHeating[hvac.NumSpeedsHeating - 1]
@@ -2017,41 +1896,36 @@ class HVACSizing
     return wallGroup
   end
 
-  def self.get_ventilation_rates(runner, model)
-    mechVentType = get_feature(runner, model.getBuilding, Constants.SizingInfoMechVentType, 'string')
-    mechVentWholeHouseRate = get_feature(runner, model.getBuilding, Constants.SizingInfoMechVentWholeHouseRate, 'double')
-    return nil if mechVentType.nil? or mechVentWholeHouseRate.nil?
+  def self.get_ventilation_rates(model)
+    mechVentType = get_feature(model.getBuilding, Constants.SizingInfoMechVentType, 'string')
+    mechVentWholeHouseRate = get_feature(model.getBuilding, Constants.SizingInfoMechVentWholeHouseRate, 'double')
 
-    q_unb = 0
-    q_bal_Sens = 0
-    q_bal_Lat = 0
+    q_unb = 0.0
+    q_bal_Sens = 0.0
+    q_bal_Lat = 0.0
 
     if mechVentType == Constants.VentTypeExhaust
       q_unb = mechVentWholeHouseRate
     elsif mechVentType == Constants.VentTypeSupply or mechVentType == Constants.VentTypeCFIS
       q_unb = mechVentWholeHouseRate
     elsif mechVentType == Constants.VentTypeBalanced
-      totalEfficiency = get_feature(runner, model.getBuilding, Constants.SizingInfoMechVentTotalEfficiency, 'double')
-      apparentSensibleEffectiveness = get_feature(runner, model.getBuilding, Constants.SizingInfoMechVentApparentSensibleEffectiveness, 'double')
-      latentEffectiveness = get_feature(runner, model.getBuilding, Constants.SizingInfoMechVentLatentEffectiveness, 'double')
-      return nil if totalEfficiency.nil? or latentEffectiveness.nil? or apparentSensibleEffectiveness.nil?
+      totalEfficiency = get_feature(model.getBuilding, Constants.SizingInfoMechVentTotalEfficiency, 'double')
+      apparentSensibleEffectiveness = get_feature(model.getBuilding, Constants.SizingInfoMechVentApparentSensibleEffectiveness, 'double')
+      latentEffectiveness = get_feature(model.getBuilding, Constants.SizingInfoMechVentLatentEffectiveness, 'double')
 
-      q_bal_Sens = mechVentWholeHouseRate * (1 - apparentSensibleEffectiveness)
-      q_bal_Lat = mechVentWholeHouseRate * (1 - latentEffectiveness)
+      q_bal_Sens = mechVentWholeHouseRate * (1.0 - apparentSensibleEffectiveness)
+      q_bal_Lat = mechVentWholeHouseRate * (1.0 - latentEffectiveness)
     elsif mechVentType == Constants.VentTypeNone
       # nop
     else
-        runner.registerError("Unexpected mechanical ventilation type: #{mechVentType}.")
-        return nil
+      fail "Unexpected mechanical ventilation type: #{mechVentType}."
     end
 
     return [q_unb, q_bal_Sens, q_bal_Lat]
   end
 
-  def self.get_fenestration_shgc(runner, surface)
-    simple_glazing = self.get_window_simple_glazing(runner, surface, true)
-    return nil if simple_glazing.nil?
-
+  def self.get_fenestration_shgc(surface)
+    simple_glazing = get_window_simple_glazing(surface)
     shgc_with_interior_shade_heat = simple_glazing.solarHeatGainCoefficient
 
     int_shade_heat_to_cool_ratio = 1.0
@@ -2063,8 +1937,7 @@ class HVACSizing
           shade = shading_material.to_Shade.get
           int_shade_heat_to_cool_ratio = shade.solarTransmittance
         else
-          runner.registerError("Unhandled shading material: #{shading_material.name.to_s}.")
-          return nil
+          fail "Unhandled shading material: #{shading_material.name.to_s}."
         end
       end
     end
@@ -2094,7 +1967,7 @@ class HVACSizing
     Calculate the Delivery Effectiveness for cooling (using the method of ASHRAE Standard 152).
     '''
     dse_Bs, dse_Br, dse_a_s, dse_a_r, dse_dTe, dse_dT_s, dse_dT_r = _calc_dse_init(system_cfm, load_sens, dse_Tamb_s, dse_Tamb_r, dse_As, dse_Ar, t_setpoint, dse_Qs, dse_Qr, supply_r, return_r, air_dens, air_cp)
-    dse_dTe *= -1
+    dse_dTe *= -1.0
     dse_DE, coolingLoad_Ducts_Sens = _calc_dse_DE_cooling(dse_a_s, system_cfm, load_total, dse_a_r, dse_h_r, dse_Br, dse_dT_r, dse_Bs, leavingAirTemp, dse_Tamb_s, load_sens, air_dens, air_cp, h_in)
     dse_DEcorr = _calc_dse_DEcorr(dse_DE, dse_Fregain_s, dse_Fregain_r, dse_Br, dse_a_r, dse_dT_r, dse_dTe)
 
@@ -2103,13 +1976,13 @@ class HVACSizing
 
   def self._calc_dse_init(system_cfm, load_sens, dse_Tamb_s, dse_Tamb_r, dse_As, dse_Ar, t_setpoint, dse_Qs, dse_Qr, supply_r, return_r, air_dens, air_cp)
     # Supply and return conduction functions, Bs and Br
-    dse_Bs = Math.exp((-1.0 * dse_As) / (60 * system_cfm * air_dens * air_cp * supply_r))
-    dse_Br = Math.exp((-1.0 * dse_Ar) / (60 * system_cfm * air_dens * air_cp * return_r))
+    dse_Bs = Math.exp((-1.0 * dse_As) / (60.0 * system_cfm * air_dens * air_cp * supply_r))
+    dse_Br = Math.exp((-1.0 * dse_Ar) / (60.0 * system_cfm * air_dens * air_cp * return_r))
 
     dse_a_s = (system_cfm - dse_Qs) / system_cfm
     dse_a_r = (system_cfm - dse_Qr) / system_cfm
 
-    dse_dTe = load_sens / (60 * system_cfm * air_dens * air_cp)
+    dse_dTe = load_sens / (60.0 * system_cfm * air_dens * air_cp)
     dse_dT_s = t_setpoint - dse_Tamb_s
     dse_dT_r = t_setpoint - dse_Tamb_r
 
@@ -2118,14 +1991,14 @@ class HVACSizing
 
   def self._calc_dse_DE_cooling(dse_a_s, system_cfm, load_total, dse_a_r, dse_h_r, dse_Br, dse_dT_r, dse_Bs, leavingAirTemp, dse_Tamb_s, load_sens, air_dens, air_cp, h_in)
     # Calculate the delivery effectiveness (Equation 6-25)
-    dse_DE = ((dse_a_s * 60 * system_cfm * air_dens) / (-1 * load_total)) * \
-             (((-1 * load_total) / (60 * system_cfm * air_dens)) + \
-              (1 - dse_a_r) * (dse_h_r - h_in) + \
-              dse_a_r * air_cp * (dse_Br - 1) * dse_dT_r + \
-              air_cp * (dse_Bs - 1) * (leavingAirTemp - dse_Tamb_s))
+    dse_DE = ((dse_a_s * 60.0 * system_cfm * air_dens) / (-1.0 * load_total)) * \
+             (((-1.0 * load_total) / (60.0 * system_cfm * air_dens)) + \
+              (1.0 - dse_a_r) * (dse_h_r - h_in) + \
+              dse_a_r * air_cp * (dse_Br - 1.0) * dse_dT_r + \
+              air_cp * (dse_Bs - 1.0) * (leavingAirTemp - dse_Tamb_s))
 
     # Calculate the sensible heat transfer from surroundings
-    coolingLoad_Ducts_Sens = (1 - [dse_DE, 0].max) * load_sens
+    coolingLoad_Ducts_Sens = (1.0 - [dse_DE, 0.0].max) * load_sens
 
     return dse_DE, coolingLoad_Ducts_Sens
   end
@@ -2133,15 +2006,15 @@ class HVACSizing
   def self._calc_dse_DE_heating(dse_a_s, dse_Bs, dse_a_r, dse_Br, dse_dT_s, dse_dT_r, dse_dTe)
     # Calculate the delivery effectiveness (Equation 6-23)
     dse_DE = (dse_a_s * dse_Bs -
-              dse_a_s * dse_Bs * (1 - dse_a_r * dse_Br) * (dse_dT_r / dse_dTe) -
-              dse_a_s * (1 - dse_Bs) * (dse_dT_s / dse_dTe))
+              dse_a_s * dse_Bs * (1.0 - dse_a_r * dse_Br) * (dse_dT_r / dse_dTe) -
+              dse_a_s * (1.0 - dse_Bs) * (dse_dT_s / dse_dTe))
 
     return dse_DE
   end
 
   def self._calc_dse_DEcorr(dse_DE, dse_Fregain_s, dse_Fregain_r, dse_Br, dse_a_r, dse_dT_r, dse_dTe)
     # Calculate the delivery effectiveness corrector for regain (Equation 6-40)
-    dse_DEcorr = (dse_DE + dse_Fregain_s * (1 - dse_DE) - (dse_Fregain_s - dse_Fregain_r -
+    dse_DEcorr = (dse_DE + dse_Fregain_s * (1.0 - dse_DE) - (dse_Fregain_s - dse_Fregain_r -
                   dse_Br * (dse_a_r * dse_Fregain_s - dse_Fregain_r)) * dse_dT_r / dse_dTe)
 
     # Limit the DE to a reasonable value to prevent negative values and huge equipment
@@ -2153,7 +2026,7 @@ class HVACSizing
 
   def self.calculate_sensible_latent_split(return_leakage_cfm, cool_load_tot, coolingLoadLat)
     # Calculate the latent duct leakage load (Manual J accounts only for return duct leakage)
-    dse_Cool_Load_Latent = [0, 0.68 * @acf * return_leakage_cfm * (@cool_design_grains - @cool_indoor_grains)].max
+    dse_Cool_Load_Latent = [0.0, 0.68 * @acf * return_leakage_cfm * (@cool_design_grains - @cool_indoor_grains)].max
 
     # Calculate final latent and load
     cool_Load_Lat = coolingLoadLat + dse_Cool_Load_Latent
@@ -2162,17 +2035,16 @@ class HVACSizing
     return cool_Load_Lat, cool_Load_Sens
   end
 
-  def self.get_ducts_for_air_loop(runner, air_loop)
+  def self.get_ducts_for_air_loop(air_loop)
     ducts = []
 
     # Has ducts?
-    has_ducts = get_feature(runner, air_loop, Constants.SizingInfoDuctExist, 'boolean')
-    return ducts unless has_ducts
+    has_ducts = get_feature(air_loop, Constants.SizingInfoDuctExist, 'boolean')
 
     # Leakage values
-    leakage_fracs = get_feature(runner, air_loop, Constants.SizingInfoDuctLeakageFracs, 'string')
-    leakage_cfm25s = get_feature(runner, air_loop, Constants.SizingInfoDuctLeakageCFM25s, 'string')
-    return nil if leakage_fracs.nil? or leakage_cfm25s.nil?
+    leakage_fracs = get_feature(air_loop, Constants.SizingInfoDuctLeakageFracs, 'string', false)
+    leakage_cfm25s = get_feature(air_loop, Constants.SizingInfoDuctLeakageCFM25s, 'string', false)
+    return ducts if leakage_fracs.nil? or leakage_cfm25s.nil?
 
     leakage_fracs = leakage_fracs.split(",").map(&:to_f)
     leakage_cfm25s = leakage_cfm25s.split(",").map(&:to_f)
@@ -2183,21 +2055,15 @@ class HVACSizing
     end
 
     # Areas
-    areas = get_feature(runner, air_loop, Constants.SizingInfoDuctAreas, 'string')
-    return nil if areas.nil?
-
+    areas = get_feature(air_loop, Constants.SizingInfoDuctAreas, 'string')
     areas = areas.split(",").map(&:to_f)
 
     # R-values
-    rvalues = get_feature(runner, air_loop, Constants.SizingInfoDuctRvalues, 'string')
-    return nil if rvalues.nil?
-
+    rvalues = get_feature(air_loop, Constants.SizingInfoDuctRvalues, 'string')
     rvalues = rvalues.split(",").map(&:to_f)
 
     # Locations
-    locations = get_feature(runner, air_loop, Constants.SizingInfoDuctLocationZones, 'string')
-    return nil if locations.nil?
-
+    locations = get_feature(air_loop, Constants.SizingInfoDuctLocationZones, 'string')
     locations = locations.split(",")
     location_spaces = []
     thermal_zones = Geometry.get_thermal_zones_from_spaces(@model_spaces)
@@ -2215,16 +2081,14 @@ class HVACSizing
         break
       end
       if location_space.nil?
-        runner.registerError("Could not determine duct location.")
-        return nil
+        fail "Could not determine duct location."
       end
+
       location_spaces << location_space
     end
 
     # Sides
-    sides = get_feature(runner, air_loop, Constants.SizingInfoDuctSides, 'string')
-    return nil if sides.nil?
-
+    sides = get_feature(air_loop, Constants.SizingInfoDuctSides, 'string')
     sides = sides.split(",")
 
     location_spaces.each_with_index do |location_space, index|
@@ -2317,13 +2181,13 @@ class HVACSizing
     return 1.0 / supply_u, 1.0 / return_u
   end
 
-  def self.get_hvacs(runner, model)
+  def self.get_hvacs(model)
     hvacs = []
 
     # Get unique set of HVAC equipment
     equips = []
 
-    HVAC.existing_equipment(model, runner, @cond_zone).each do |equip|
+    HVAC.existing_equipment(model, @cond_zone, @runner).each do |equip|
       next if equips.include? equip
       next if equip.is_a? OpenStudio::Model::ZoneHVACIdealLoadsAirSystem
 
@@ -2340,8 +2204,8 @@ class HVACSizing
       clg_coil, htg_coil, supp_htg_coil = HVAC.get_coils_from_hvac_equip(model, equip)
 
       # Get type of heating/cooling system
-      hvac.CoolType = get_feature(runner, equip, Constants.SizingInfoHVACCoolType, 'string', false)
-      hvac.HeatType = get_feature(runner, equip, Constants.SizingInfoHVACHeatType, 'string', false)
+      hvac.CoolType = get_feature(equip, Constants.SizingInfoHVACCoolType, 'string', false)
+      hvac.HeatType = get_feature(equip, Constants.SizingInfoHVACHeatType, 'string', false)
 
       # Retrieve ducts if they exist
       if equip.is_a? OpenStudio::Model::AirLoopHVACUnitarySystem
@@ -2355,39 +2219,35 @@ class HVACSizing
           end
         end
         if not air_loop.nil?
-          hvac.Ducts = get_ducts_for_air_loop(runner, air_loop)
-          return nil if hvac.Ducts.nil?
+          hvac.Ducts = get_ducts_for_air_loop(air_loop)
         end
       end
 
       if equip.is_a? OpenStudio::Model::EvaporativeCoolerDirectResearchSpecial
-        hvac.CoolingLoadFraction = get_feature(runner, equip, Constants.SizingInfoHVACFracCoolLoadServed, 'double')
-        return nil if hvac.CoolingLoadFraction.nil?
+        hvac.CoolingLoadFraction = get_feature(equip, Constants.SizingInfoHVACFracCoolLoadServed, 'double')
 
         air_loop = equip.airLoopHVAC.get
         if air_loop.additionalProperties.getFeatureAsBoolean(Constants.OptionallyDuctedSystemIsDucted).get
-          hvac.Ducts = get_ducts_for_air_loop(runner, air_loop)
+          hvac.Ducts = get_ducts_for_air_loop(air_loop)
         end
 
         hvac.EvapCoolerEffectiveness = equip.coolerEffectiveness
       end
 
       if not clg_coil.nil?
-        ratedCFMperTonCooling = get_feature(runner, equip, Constants.SizingInfoHVACRatedCFMperTonCooling, 'string', false)
+        ratedCFMperTonCooling = get_feature(equip, Constants.SizingInfoHVACRatedCFMperTonCooling, 'string', false)
         if not ratedCFMperTonCooling.nil?
           hvac.RatedCFMperTonCooling = ratedCFMperTonCooling.split(",").map(&:to_f)
         end
 
-        hvac.CoolingLoadFraction = get_feature(runner, equip, Constants.SizingInfoHVACFracCoolLoadServed, 'double')
-        return nil if hvac.CoolingLoadFraction.nil?
+        hvac.CoolingLoadFraction = get_feature(equip, Constants.SizingInfoHVACFracCoolLoadServed, 'double')
       end
 
       if clg_coil.is_a? OpenStudio::Model::CoilCoolingDXSingleSpeed
         hvac.NumSpeedsCooling = 1
 
         if hvac.has_type(Constants.ObjectNameRoomAirConditioner)
-          coolingCFMs = get_feature(runner, equip, Constants.SizingInfoHVACCoolingCFMs, 'string')
-          return nil if coolingCFMs.nil?
+          coolingCFMs = get_feature(equip, Constants.SizingInfoHVACCoolingCFMs, 'string')
 
           hvac.CoolingCFMs = coolingCFMs.split(",").map(&:to_f)
         end
@@ -2395,9 +2255,9 @@ class HVACSizing
         curves = [clg_coil.totalCoolingCapacityFunctionOfTemperatureCurve]
         hvac.COOL_CAP_FT_SPEC = get_2d_vector_from_CAP_FT_SPEC_curves(curves, hvac.NumSpeedsCooling)
         if not clg_coil.ratedSensibleHeatRatio.is_initialized
-          runner.registerError("SHR not set for #{clg_coil.name}.")
-          return nil
+          fail "SHR not set for #{clg_coil.name}."
         end
+
         hvac.SHRRated = [clg_coil.ratedSensibleHeatRatio.get]
         if clg_coil.ratedTotalCoolingCapacity.is_initialized
           hvac.FixedCoolingCapacity = UnitConversions.convert(clg_coil.ratedTotalCoolingCapacity.get, "W", "ton")
@@ -2411,22 +2271,21 @@ class HVACSizing
           hvac.OverSizeLimit = 1.3
         end
 
-        capacityRatioCooling = get_feature(runner, equip, Constants.SizingInfoHVACCapacityRatioCooling, 'string')
-        return nil if capacityRatioCooling.nil?
+        capacityRatioCooling = get_feature(equip, Constants.SizingInfoHVACCapacityRatioCooling, 'string')
 
         hvac.CapacityRatioCooling = capacityRatioCooling.split(",").map(&:to_f)
 
         if not equip.designSpecificationMultispeedObject.is_initialized
-          runner.registerError("DesignSpecificationMultispeedObject not set for #{equip.name.to_s}.")
-          return nil
+          fail "DesignSpecificationMultispeedObject not set for #{equip.name.to_s}."
         end
+
         perf = equip.designSpecificationMultispeedObject.get
         hvac.FanspeedRatioCooling = []
         perf.supplyAirflowRatioFields.each do |airflowRatioField|
           if not airflowRatioField.coolingRatio.is_initialized
-            runner.registerError("Cooling airflow ratio not set for #{perf.name.to_s}")
-            return nil
+            fail "Cooling airflow ratio not set for #{perf.name.to_s}"
           end
+
           hvac.FanspeedRatioCooling << airflowRatioField.coolingRatio.get
         end
 
@@ -2435,9 +2294,9 @@ class HVACSizing
         clg_coil.stages.each_with_index do |stage, speed|
           curves << stage.totalCoolingCapacityFunctionofTemperatureCurve
           if not stage.grossRatedSensibleHeatRatio.is_initialized
-            runner.registerError("SHR not set for #{clg_coil.name}.")
-            return nil
+            fail "SHR not set for #{clg_coil.name}."
           end
+
           hvac.SHRRated << stage.grossRatedSensibleHeatRatio.get
           next if !stage.grossRatedTotalCoolingCapacity.is_initialized
 
@@ -2446,9 +2305,7 @@ class HVACSizing
         hvac.COOL_CAP_FT_SPEC = get_2d_vector_from_CAP_FT_SPEC_curves(curves, hvac.NumSpeedsCooling)
 
         if hvac.CoolType == Constants.ObjectNameMiniSplitHeatPump
-          coolingCFMs = get_feature(runner, equip, Constants.SizingInfoHVACCoolingCFMs, 'string')
-          return nil if coolingCFMs.nil?
-
+          coolingCFMs = get_feature(equip, Constants.SizingInfoHVACCoolingCFMs, 'string')
           hvac.CoolingCFMs = coolingCFMs.split(",").map(&:to_f)
         end
 
@@ -2469,18 +2326,13 @@ class HVACSizing
                            clg_coil.sensibleCoolingCapacityCoefficient6]
         hvac.COOL_SH_FT_SPEC = [HVAC.convert_curve_gshp(cOOL_SH_FT_SPEC, true)]
 
-        cOIL_BF_FT_SPEC = get_feature(runner, equip, Constants.SizingInfoGSHPCoil_BF_FT_SPEC, 'string')
-        return nil if cOIL_BF_FT_SPEC.nil?
-
+        cOIL_BF_FT_SPEC = get_feature(equip, Constants.SizingInfoGSHPCoil_BF_FT_SPEC, 'string')
         hvac.COIL_BF_FT_SPEC = [cOIL_BF_FT_SPEC.split(",").map(&:to_f)]
 
-        shr_rated = get_feature(runner, equip, Constants.SizingInfoHVACSHR, 'string')
-        return nil if shr_rated.nil?
-
+        shr_rated = get_feature(equip, Constants.SizingInfoHVACSHR, 'string')
         hvac.SHRRated = shr_rated.split(",").map(&:to_f)
 
-        hvac.CoilBF = get_feature(runner, equip, Constants.SizingInfoGSHPCoilBF, 'double')
-        return nil if hvac.CoilBF.nil?
+        hvac.CoilBF = get_feature(equip, Constants.SizingInfoGSHPCoilBF, 'double')
 
         if clg_coil.ratedTotalCoolingCapacity.is_initialized
           hvac.FixedCoolingCapacity = UnitConversions.convert(clg_coil.ratedTotalCoolingCapacity.get, "W", "ton")
@@ -2488,26 +2340,23 @@ class HVACSizing
 
         hvac.CoolingEIR = 1.0 / clg_coil.ratedCoolingCoefficientofPerformance
 
-        hvac.GSHP_BoreSpacing = get_feature(runner, equip, Constants.SizingInfoGSHPBoreSpacing, 'double')
-        hvac.GSHP_BoreHoles = get_feature(runner, equip, Constants.SizingInfoGSHPBoreHoles, 'string')
-        hvac.GSHP_BoreDepth = get_feature(runner, equip, Constants.SizingInfoGSHPBoreDepth, 'string')
-        hvac.GSHP_BoreConfig = get_feature(runner, equip, Constants.SizingInfoGSHPBoreConfig, 'string')
-        hvac.GSHP_SpacingType = get_feature(runner, equip, Constants.SizingInfoGSHPUTubeSpacingType, 'string')
-        return nil if hvac.GSHP_BoreSpacing.nil? or hvac.GSHP_BoreHoles.nil? or hvac.GSHP_BoreDepth.nil? or hvac.GSHP_BoreConfig.nil? or hvac.GSHP_SpacingType.nil?
-
+        hvac.GSHP_BoreSpacing = get_feature(equip, Constants.SizingInfoGSHPBoreSpacing, 'double')
+        hvac.GSHP_BoreHoles = get_feature(equip, Constants.SizingInfoGSHPBoreHoles, 'string')
+        hvac.GSHP_BoreDepth = get_feature(equip, Constants.SizingInfoGSHPBoreDepth, 'string')
+        hvac.GSHP_BoreConfig = get_feature(equip, Constants.SizingInfoGSHPBoreConfig, 'string')
+        hvac.GSHP_SpacingType = get_feature(equip, Constants.SizingInfoGSHPUTubeSpacingType, 'string')
       elsif not clg_coil.nil?
-        runner.registerError("Unexpected cooling coil: #{clg_coil.name}.")
-        return nil
+        fail "Unexpected cooling coil: #{clg_coil.name}."
       end
 
       if not htg_coil.nil?
-        ratedCFMperTonHeating = get_feature(runner, equip, Constants.SizingInfoHVACRatedCFMperTonHeating, 'string', false)
+        ratedCFMperTonHeating = get_feature(equip, Constants.SizingInfoHVACRatedCFMperTonHeating, 'string', false)
         if not ratedCFMperTonHeating.nil?
           hvac.RatedCFMperTonHeating = ratedCFMperTonHeating.split(",").map(&:to_f)
         end
       end
 
-      heatingLoadFraction = get_feature(runner, equip, Constants.SizingInfoHVACFracHeatLoadServed, 'double', false)
+      heatingLoadFraction = get_feature(equip, Constants.SizingInfoHVACFracHeatLoadServed, 'double', false)
       if not heatingLoadFraction.nil?
         hvac.HeatingLoadFraction = heatingLoadFraction
       end
@@ -2555,9 +2404,7 @@ class HVACSizing
       elsif htg_coil.is_a? OpenStudio::Model::CoilHeatingDXMultiSpeed
         hvac.NumSpeedsHeating = htg_coil.stages.size
 
-        capacityRatioHeating = get_feature(runner, equip, Constants.SizingInfoHVACCapacityRatioHeating, 'string')
-        return nil if capacityRatioHeating.nil?
-
+        capacityRatioHeating = get_feature(equip, Constants.SizingInfoHVACCapacityRatioHeating, 'string')
         hvac.CapacityRatioHeating = capacityRatioHeating.split(",").map(&:to_f)
 
         curves = []
@@ -2570,13 +2417,10 @@ class HVACSizing
         hvac.HEAT_CAP_FT_SPEC = get_2d_vector_from_CAP_FT_SPEC_curves(curves, hvac.NumSpeedsHeating)
 
         if hvac.HeatType == Constants.ObjectNameMiniSplitHeatPump
-          heatingCFMs = get_feature(runner, equip, Constants.SizingInfoHVACHeatingCFMs, 'string')
-          return nil if heatingCFMs.nil?
-
+          heatingCFMs = get_feature(equip, Constants.SizingInfoHVACHeatingCFMs, 'string')
           hvac.HeatingCFMs = heatingCFMs.split(",").map(&:to_f)
 
-          hvac.HeatingCapacityOffset = get_feature(runner, equip, Constants.SizingInfoHVACHeatingCapacityOffset, 'double')
-          return nil if hvac.HeatingCapacityOffset.nil?
+          hvac.HeatingCapacityOffset = get_feature(equip, Constants.SizingInfoHVACHeatingCapacityOffset, 'double')
         end
 
       elsif htg_coil.is_a? OpenStudio::Model::CoilHeatingWaterToAirHeatPumpEquationFit
@@ -2595,21 +2439,18 @@ class HVACSizing
           hvac.GSHP_HXVertical = plc.to_GroundHeatExchangerVertical.get
         end
         if hvac.GSHP_HXVertical.nil?
-          runner.registerError("Could not find GroundHeatExchangerVertical object on GSHP plant loop.")
-          return nil
+          fail "Could not find GroundHeatExchangerVertical object on GSHP plant loop."
         end
+
         hvac.GSHP_HXDTDesign = UnitConversions.convert(plant_loop.sizingPlant.loopDesignTemperatureDifference, "K", "R")
         hvac.GSHP_HXCHWDesign = UnitConversions.convert(plant_loop.sizingPlant.designLoopExitTemperature, "C", "F")
         hvac.GSHP_HXHWDesign = UnitConversions.convert(plant_loop.minimumLoopTemperature, "C", "F")
         if hvac.GSHP_HXDTDesign.nil? or hvac.GSHP_HXCHWDesign.nil? or hvac.GSHP_HXHWDesign.nil?
-          runner.registerError("Could not find GSHP plant loop.")
-          return nil
+          fail "Could not find GSHP plant loop."
         end
 
       elsif not htg_coil.nil?
-        runner.registerError("Unexpected heating coil: #{htg_coil.name}.")
-        return nil
-
+        fail "Unexpected heating coil: #{htg_coil.name}."
       end
 
       # Supplemental heating
@@ -2619,8 +2460,7 @@ class HVACSizing
         end
 
       elsif not supp_htg_coil.nil?
-        runner.registerError("Unexpected supplemental heating coil: #{supp_htg_coil.name}.")
-        return nil
+        fail "Unexpected supplemental heating coil: #{supp_htg_coil.name}."
       end
     end
 
@@ -2677,25 +2517,24 @@ class HVACSizing
     elsif facade == Constants.FacadeFront
       true_azimuth = @north_axis
     elsif facade == Constants.FacadeBack
-      true_azimuth = @north_axis + 180
+      true_azimuth = @north_axis + 180.0
     elsif facade == Constants.FacadeLeft
-      true_azimuth = @north_axis + 90
+      true_azimuth = @north_axis + 90.0
     elsif facade == Constants.FacadeRight
-      true_azimuth = @north_axis + 270
+      true_azimuth = @north_axis + 270.0
     end
     if true_azimuth >= 360
-      true_azimuth = true_azimuth - 360
+      true_azimuth = true_azimuth - 360.0
     end
     return true_azimuth
   end
 
-  def self.get_space_ua_values(runner, space, weather)
+  def self.get_space_ua_values(space, weather)
     if Geometry.space_is_conditioned(space)
-      runner.registerError("Method should not be called for a conditioned space: '#{space.name.to_s}'.")
-      return nil
+      fail "Method should not be called for a conditioned space: '#{space.name.to_s}'."
     end
 
-    space_UAs = { "foundation" => 0, "outdoors" => 0, "surface" => 0 }
+    space_UAs = { "foundation" => 0.0, "outdoors" => 0.0, "surface" => 0.0 }
 
     # Surface UAs
     space.surfaces.each do |surface|
@@ -2704,18 +2543,13 @@ class HVACSizing
       if obc == "foundation"
         # FIXME: Original approach used Winkelmann U-factors...
         if surface.surfaceType.downcase == "wall"
-          wall_ins_rvalue, wall_ins_height, wall_constr_rvalue = get_foundation_wall_insulation_props(runner, surface)
-          if wall_ins_rvalue.nil? or wall_ins_height.nil? or wall_constr_rvalue.nil?
-            return nil
-          end
-
+          wall_ins_rvalue, wall_ins_height, wall_constr_rvalue = get_foundation_wall_insulation_props(surface)
           ufactor = 1.0 / (wall_ins_rvalue + wall_constr_rvalue)
         elsif surface.surfaceType.downcase == "floor"
           next
         end
       else
-        ufactor = self.get_surface_ufactor(runner, surface, surface.surfaceType, true)
-        return nil if ufactor.nil?
+        ufactor = get_surface_ufactor(surface, surface.surfaceType)
       end
 
       # Exclude surfaces adjacent to unconditioned space
@@ -2725,7 +2559,7 @@ class HVACSizing
     end
 
     # Infiltration UA
-    infiltration_cfm = get_feature(runner, space.thermalZone.get, Constants.SizingInfoZoneInfiltrationCFM, 'double', false)
+    infiltration_cfm = get_feature(space.thermalZone.get, Constants.SizingInfoZoneInfiltrationCFM, 'double', false)
     infiltration_cfm = 0.0 if infiltration_cfm.nil?
     outside_air_density = UnitConversions.convert(weather.header.LocalPressure, "atm", "Btu/ft^3") / (Gas.Air.r * (weather.data.AnnualAvgDrybulb + 460.0))
     space_UAs["infil"] = infiltration_cfm * outside_air_density * Gas.Air.cp * UnitConversions.convert(1.0, "hr", "min")
@@ -2739,15 +2573,14 @@ class HVACSizing
     return space_UAs
   end
 
-  def self.calculate_space_design_temps(runner, space, weather, conditioned_design_temp, design_db, ground_db, is_cooling_for_unvented_attic_roof_insulation = false)
-    space_UAs = get_space_ua_values(runner, space, weather)
-    return nil if space_UAs.nil?
+  def self.calculate_space_design_temps(space, weather, conditioned_design_temp, design_db, ground_db, is_cooling_for_unvented_attic_roof_insulation = false)
+    space_UAs = get_space_ua_values(space, weather)
 
     # Calculate space design temp from space UAs
     design_temp = nil
     if not is_cooling_for_unvented_attic_roof_insulation
 
-      sum_uat = 0
+      sum_uat = 0.0
       space_UAs.each do |ua_type, ua|
         if ua_type == "foundation"
           sum_uat += ua * ground_db
@@ -2758,8 +2591,7 @@ class HVACSizing
         elsif ua_type == "total"
         # skip
         else
-          runner.registerError("Unexpected space ua type: '#{ua_type}'.")
-          return nil
+          fail "Unexpected space ua type: '#{ua_type}'."
         end
       end
       design_temp = sum_uat / space_UAs["total"]
@@ -2771,27 +2603,24 @@ class HVACSizing
       # This number comes from the number from the Vented Attic
       # assumption, but assuming an unvented attic will be hotter
       # during the summer when insulation is at the ceiling level
-      max_temp_rise = 50
+      max_temp_rise = 50.0
       # Estimate from running a few cases in E+ and DOE2 since the
       # attic will always be a little warmer than the living space
       # when the roof is insulated
-      min_temp_rise = 5
+      min_temp_rise = 5.0
 
       max_cooling_temp = @conditioned_cool_design_temp + max_temp_rise
       min_cooling_temp = @conditioned_cool_design_temp + min_temp_rise
 
-      ua_conditioned = 0
-      ua_outside = 0
+      ua_conditioned = 0.0
+      ua_outside = 0.0
       space_UAs.each do |ua_type, ua|
         if ua_type == "outdoors" or ua_type == "infil"
           ua_outside += ua
         elsif ua_type == "surface" # adjacent to conditioned
           ua_conditioned += ua
-        elsif ua_type == "total" or ua_type == "foundation"
-        # skip
-        else
-          runner.registerError("Unexpected space ua type: '#{ua_type}'.")
-          return nil
+        elsif not (ua_type == "total" or ua_type == "foundation")
+          fail "Unexpected space ua type: '#{ua_type}'."
         end
       end
       percent_ua_conditioned = ua_conditioned / (ua_conditioned + ua_outside)
@@ -2802,14 +2631,11 @@ class HVACSizing
     return design_temp
   end
 
-  def self.get_wallgroup(runner, wall)
+  def self.get_wallgroup(wall)
     exteriorFinishDensity = UnitConversions.convert(wall.construction.get.to_LayeredConstruction.get.getLayer(0).to_StandardOpaqueMaterial.get.density, "kg/m^3", "lbm/ft^3")
 
-    wall_type = get_feature(runner, wall, Constants.SizingInfoWallType, 'string')
-    return nil if wall_type.nil?
-
-    rigid_r = get_feature(runner, wall, Constants.SizingInfoWallRigidInsRvalue, 'double', false)
-    return nil if rigid_r.nil?
+    wall_type = get_feature(wall, Constants.SizingInfoWallType, 'string')
+    rigid_r = get_feature(wall, Constants.SizingInfoWallRigidInsRvalue, 'double', false)
 
     # Determine the wall Group Number (A - K = 1 - 11) for exterior walls (ie. all walls except basement walls)
     maxWallGroup = 11
@@ -2817,8 +2643,7 @@ class HVACSizing
     # The following correlations were estimated by analyzing MJ8 construction tables. This is likely a better
     # approach than including the Group Number.
     if ['WoodStud', 'SteelStud'].include?(wall_type)
-      cavity_r = get_feature(runner, wall, Constants.SizingInfoStudWallCavityRvalue, 'double')
-      return nil if cavity_r.nil?
+      cavity_r = get_feature(wall, Constants.SizingInfoStudWallCavityRvalue, 'double')
 
       wallGroup = get_wallgroup_wood_or_steel_stud(cavity_r)
 
@@ -2853,11 +2678,8 @@ class HVACSizing
       end
 
     elsif wall_type == 'SIP'
-      rigid_thick_in = get_feature(runner, wall, Constants.SizingInfoWallRigidInsThickness, 'double', false)
-      return nil if rigid_thick_in.nil?
-
-      sip_ins_thick_in = get_feature(runner, wall, Constants.SizingInfoSIPWallInsThickness, 'double')
-      return nil if sip_ins_thick_in.nil?
+      rigid_thick_in = get_feature(wall, Constants.SizingInfoWallRigidInsThickness, 'double', false)
+      sip_ins_thick_in = get_feature(wall, Constants.SizingInfoSIPWallInsThickness, 'double')
 
       # Manual J refers to SIPs as Structural Foam Panel (SFP)
       if sip_ins_thick_in + rigid_thick_in < 4.5
@@ -2872,8 +2694,7 @@ class HVACSizing
       end
 
     elsif wall_type == 'CMU'
-      cmu_furring_ins_r = get_feature(runner, wall, Constants.SizingInfoCMUWallFurringInsRvalue, 'double', false)
-      return nil if cmu_furring_ins_r.nil?
+      cmu_furring_ins_r = get_feature(wall, Constants.SizingInfoCMUWallFurringInsRvalue, 'double', false)
 
       # Manual J uses the same wall group for filled or hollow block
       if cmu_furring_ins_r < 2
@@ -2902,8 +2723,7 @@ class HVACSizing
       wallGroup = 11 # K
 
     else
-      runner.registerError("Unexpected wall type: '#{@wall_type}'.")
-      return nil
+      fail "Unexpected wall type: '#{@wall_type}'."
     end
 
     # Maximum wall group is K
@@ -3263,17 +3083,14 @@ class HVACSizing
     return gfnc_coeff
   end
 
-  def self.get_foundation_walls_ceilings_insulated(runner, space)
+  def self.get_foundation_walls_ceilings_insulated(space)
     # Check if walls insulated via Kiva:Foundation object
     walls_insulated = false
     space.surfaces.each do |surface|
       next if surface.surfaceType.downcase != "wall"
       next if not surface.adjacentFoundation.is_initialized
 
-      wall_ins_rvalue, wall_ins_height, wall_constr_rvalue = get_foundation_wall_insulation_props(runner, surface)
-      if wall_ins_rvalue.nil? or wall_ins_height.nil? or wall_constr_rvalue.nil?
-        return nil
-      end
+      wall_ins_rvalue, wall_ins_height, wall_constr_rvalue = get_foundation_wall_insulation_props(surface)
 
       wall_rvalue = wall_ins_rvalue + wall_constr_rvalue
       if wall_rvalue >= 3.0
@@ -3288,11 +3105,10 @@ class HVACSizing
     space.surfaces.each do |surface|
       next if surface.surfaceType.downcase != "roofceiling"
 
-      ceiling_ufactor = self.get_surface_ufactor(runner, surface, surface.surfaceType, true)
+      ceiling_ufactor = get_surface_ufactor(surface, surface.surfaceType)
     end
     if ceiling_ufactor.nil?
-      runner.registerError("Unable to identify the foundation ceiling.")
-      return nil
+      fail "Unable to identify the foundation ceiling."
     end
 
     ceiling_rvalue = 1.0 / UnitConversions.convert(ceiling_ufactor, 'm^2*k/w', 'hr*ft^2*f/btu')
@@ -3303,16 +3119,14 @@ class HVACSizing
     return walls_insulated, ceilings_insulated
   end
 
-  def self.get_foundation_wall_insulation_props(runner, surface)
-    if surface.surfaceType.downcase != "wall"
-      return nil
-    end
+  def self.get_foundation_wall_insulation_props(surface)
+    fail "Unexpected surface type." if surface.surfaceType.downcase != "wall"
 
     # Get wall insulation R-value/height from Kiva:Foundation object
     if not surface.adjacentFoundation.is_initialized
-      runner.registerError("Could not get foundation object for wall '#{surface.name.to_s}'.")
-      return nil
+      fail "Could not get foundation object for wall '#{surface.name.to_s}'."
     end
+
     foundation = surface.adjacentFoundation.get
 
     wall_ins_rvalue = 0.0
@@ -3332,12 +3146,12 @@ class HVACSizing
       wall_ins_height = UnitConversions.convert(foundation.exteriorVerticalInsulationDepth.get, "m", "ft").round
     end
 
-    wall_constr_rvalue = 1.0 / self.get_surface_ufactor(runner, surface, surface.surfaceType, true)
+    wall_constr_rvalue = 1.0 / get_surface_ufactor(surface, surface.surfaceType)
 
     return wall_ins_rvalue, wall_ins_height, wall_constr_rvalue
   end
 
-  def self.get_feature(runner, obj, feature, datatype, register_error = true)
+  def self.get_feature(obj, feature, datatype, fail_on_error = true)
     val = nil
     if datatype == 'string'
       val = obj.additionalProperties.getFeatureAsString(feature)
@@ -3347,15 +3161,16 @@ class HVACSizing
       val = obj.additionalProperties.getFeatureAsBoolean(feature)
     end
     if not val.is_initialized
-      if register_error
-        runner.registerError("Could not find additionalProperties value for '#{feature}' with datatype #{datatype} on object #{obj.name}.")
+      if fail_on_error
+        fail "Could not find additionalProperties value for '#{feature}' with datatype #{datatype} on object #{obj.name}."
       end
+
       return nil
     end
     return val.get
   end
 
-  def self.set_object_values(runner, model, hvac, hvac_final_values)
+  def self.set_object_values(model, hvac, hvac_final_values)
     # Updates object properties in the model
 
     hvac.Objects.each do |object|
@@ -3419,7 +3234,7 @@ class HVACSizing
         end
 
         # Coils
-        setCoilsObjectValues(runner, model, hvac, object, hvac_final_values)
+        setCoilsObjectValues(model, hvac, object, hvac_final_values)
 
         if hvac.has_type(Constants.ObjectNameGroundSourceHeatPump)
 
@@ -3477,7 +3292,7 @@ class HVACSizing
         fanonoff.setMaximumFlowRate(UnitConversions.convert(fan_airflow + 0.01, "cfm", "m^3/s"))
 
         # Coils
-        setCoilsObjectValues(runner, model, hvac, object, hvac_final_values)
+        setCoilsObjectValues(model, hvac, object, hvac_final_values)
 
       elsif object.is_a? OpenStudio::Model::EvaporativeCoolerDirectResearchSpecial
 
@@ -3565,7 +3380,7 @@ class HVACSizing
         fanonoff.setMaximumFlowRate(UnitConversions.convert(hvac_final_values.Cool_Airflow, "cfm", "m^3/s"))
 
         # Coils
-        setCoilsObjectValues(runner, model, hvac, object, hvac_final_values)
+        setCoilsObjectValues(model, hvac, object, hvac_final_values)
 
         # Heating Coil override
         ptac_htg_coil = object.heatingCoil.to_CoilHeatingElectric.get
@@ -3576,11 +3391,9 @@ class HVACSizing
 
       end # object type
     end # hvac Object
-
-    return true
   end
 
-  def self.setCoilsObjectValues(runner, model, hvac, equip, hvac_final_values)
+  def self.setCoilsObjectValues(model, hvac, equip, hvac_final_values)
     clg_coil, htg_coil, supp_htg_coil = HVAC.get_coils_from_hvac_equip(model, equip)
 
     # Cooling coil
@@ -3639,13 +3452,10 @@ class HVACSizing
     # Supplemental heating coil
     if supp_htg_coil.is_a? OpenStudio::Model::CoilHeatingElectric or supp_htg_coil.is_a? OpenStudio::Model::CoilHeatingGas
       supp_htg_coil.setNominalCapacity(UnitConversions.convert(hvac_final_values.Heat_Capacity_Supp, "Btu/hr", "W"))
-
     end
-
-    return true
   end
 
-  def self.get_space_r_value(runner, space, surface_type, register_error = false)
+  def self.get_space_r_value(space, surface_type)
     # Get area-weighted space r-value
     sum_surface_ua = 0.0
     total_area = 0.0
@@ -3653,40 +3463,33 @@ class HVACSizing
       next if surface.surfaceType.downcase != surface_type
 
       surf_area = UnitConversions.convert(surface.netArea, "m^2", "ft^2")
-      ufactor = self.get_surface_ufactor(runner, surface, surface_type, register_error)
-      next if ufactor.nil?
+      ufactor = get_surface_ufactor(surface, surface_type)
 
       sum_surface_ua += surf_area * ufactor
       total_area += surf_area
     end
-    return nil if sum_surface_ua == 0
+    fail "Calculated zero UA for #{space.name}" if sum_surface_ua == 0
 
     return total_area / sum_surface_ua
   end
 
-  def self.get_surface_ufactor(runner, surface, surface_type, register_error = false)
+  def self.get_surface_ufactor(surface, surface_type)
     if surface_type.downcase.include?("window")
-      simple_glazing = self.get_window_simple_glazing(runner, surface, register_error)
-      return nil if simple_glazing.nil?
-
+      simple_glazing = get_window_simple_glazing(surface)
       return UnitConversions.convert(simple_glazing.uFactor, "W/(m^2*K)", "Btu/(hr*ft^2*F)")
     else
       if not surface.construction.is_initialized
-        if register_error
-          runner.registerError("Construction not assigned to '#{surface.name.to_s}'.")
-        end
-        return nil
+        fail "Construction not assigned to '#{surface.name.to_s}'."
       end
+
       ufactor = UnitConversions.convert(surface.uFactor.get, "W/(m^2*K)", "Btu/(hr*ft^2*F)")
       if surface.class.method_defined?('adjacentSurface') and surface.adjacentSurface.is_initialized
         # Use average u-factor of adjacent surface, as OpenStudio returns
         # two different values for, e.g., floor vs adjacent roofceiling
         if not surface.adjacentSurface.get.construction.is_initialized
-          if register_error
-            runner.registerError("Construction not assigned to '#{surface.adjacentSurface.get.name.to_s}'.")
-          end
-          return nil
+          fail "Construction not assigned to '#{surface.adjacentSurface.get.name.to_s}'."
         end
+
         adjacent_ufactor = UnitConversions.convert(surface.adjacentSurface.get.uFactor.get, "W/(m^2*K)", "Btu/(hr*ft^2*F)")
         return (ufactor + adjacent_ufactor) / 2.0
       end
@@ -3694,28 +3497,26 @@ class HVACSizing
     end
   end
 
-  def self.get_window_simple_glazing(runner, surface, register_error = false)
+  def self.get_window_simple_glazing(surface)
     if not surface.construction.is_initialized
-      if register_error
-        runner.registerError("Construction not assigned to '#{surface.name.to_s}'.")
-      end
-      return nil
+      fail "Construction not assigned to '#{surface.name.to_s}'."
     end
+
     construction = surface.construction.get
     if not construction.to_LayeredConstruction.is_initialized
-      runner.registerError("Expected LayeredConstruction for '#{surface.name.to_s}'.")
-      return nil
+      fail "Expected LayeredConstruction for '#{surface.name.to_s}'."
     end
+
     window_layered_construction = construction.to_LayeredConstruction.get
     if not window_layered_construction.getLayer(0).to_SimpleGlazing.is_initialized
-      runner.registerError("Expected SimpleGlazing for '#{surface.name.to_s}'.")
-      return nil
+      fail "Expected SimpleGlazing for '#{surface.name.to_s}'."
     end
+
     simple_glazing = window_layered_construction.getLayer(0).to_SimpleGlazing.get
     return simple_glazing
   end
 
-  def self.display_zone_loads(runner, zone_loads)
+  def self.display_zone_loads(zone_loads)
     s = "Zone Loads for #{@cond_zone.name.to_s}:"
     properties = [
       :Heat_Windows, :Heat_Skylights,
@@ -3731,10 +3532,10 @@ class HVACSizing
     properties.each do |property|
       s += "\n#{property.to_s.gsub("_", " ")} = #{zone_loads.send(property).round(0).to_s} Btu/hr"
     end
-    runner.registerInfo("#{s}\n")
+    @runner.registerInfo("#{s}\n")
   end
 
-  def self.display_hvac_final_values_results(runner, hvac_final_values, hvac)
+  def self.display_hvac_final_values_results(hvac_final_values, hvac)
     s = "Final Results for #{hvac.Objects[0].name.to_s}:"
     loads = [
       :Heat_Load, :Heat_Load_Ducts,
@@ -3757,7 +3558,7 @@ class HVACSizing
     airflows.each do |airflow|
       s += "\n#{airflow.to_s.gsub("_", " ")} = #{hvac_final_values.send(airflow).round(0).to_s} cfm"
     end
-    runner.registerInfo("#{s}\n")
+    @runner.registerInfo("#{s}\n")
   end
 end
 
@@ -3802,6 +3603,7 @@ class HVACInfo
     self.OverSizeLimit = 1.15
     self.OverSizeDelta = 15000.0
     self.FanspeedRatioCooling = [1.0]
+    self.Ducts = []
   end
 
   def has_type(name_or_names)

--- a/resources/lighting.rb
+++ b/resources/lighting.rb
@@ -3,7 +3,7 @@ require_relative "geometry"
 require_relative "unit_conversions"
 
 class Lighting
-  def self.apply(model, runner, weather, interior_kwh, garage_kwh, exterior_kwh, cfa, gfa,
+  def self.apply(model, weather, interior_kwh, garage_kwh, exterior_kwh, cfa, gfa,
                  living_space, garage_space)
     lat = weather.header.Latitude
     long = weather.header.Longitude
@@ -118,10 +118,7 @@ class Lighting
     end
 
     # Create schedule
-    sch = HourlyByMonthSchedule.new(model, runner, "lighting schedule", lighting_sch, lighting_sch, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
-    if not sch.validated?
-      return false
-    end
+    sch = HourlyByMonthSchedule.new(model, "lighting schedule", lighting_sch, lighting_sch, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
 
     # Add lighting to each conditioned space
     if interior_kwh > 0
@@ -170,8 +167,6 @@ class Lighting
       ltg_def.setDesignLevel(space_design_level)
       ltg.setSchedule(sch.schedule)
     end
-
-    return true
   end
 
   def self.get_reference_fractions()

--- a/resources/location.rb
+++ b/resources/location.rb
@@ -4,28 +4,14 @@ require_relative "unit_conversions"
 
 class Location
   def self.apply(model, runner, weather_file_path, dst_start_date, dst_end_date)
-    success, weather, epw_file = apply_weather_file(model, runner, weather_file_path)
-    return false if not success
-
-    success = apply_year(model, runner, epw_file)
-    return false if not success
-
-    success = apply_site(model, runner, epw_file)
-    return false if not success
-
-    success = apply_climate_zones(model, runner, epw_file)
-    return false if not success
-
-    success = apply_mains_temp(model, runner, weather)
-    return false if not success
-
-    success = apply_dst(model, runner, dst_start_date, dst_end_date)
-    return false if not success
-
-    success = apply_ground_temp(model, runner, weather)
-    return false if not success
-
-    return true, weather
+    weather, epw_file = apply_weather_file(model, runner, weather_file_path)
+    apply_year(model, epw_file)
+    apply_site(model, epw_file)
+    apply_climate_zones(model, epw_file)
+    apply_mains_temp(model, weather)
+    apply_dst(model, dst_start_date, dst_end_date)
+    apply_ground_temp(model, weather)
+    return weather
   end
 
   private
@@ -34,12 +20,10 @@ class Location
     if File.exists?(weather_file_path) and weather_file_path.downcase.end_with? ".epw"
       epw_file = OpenStudio::EpwFile.new(weather_file_path)
     else
-      runner.registerError("'#{weather_file_path}' does not exist or is not an .epw file.")
-      return false
+      fail "'#{weather_file_path}' does not exist or is not an .epw file."
     end
 
     OpenStudio::Model::WeatherFile.setWeatherFile(model, epw_file).get
-    runner.registerInfo("Setting weather file.")
 
     # Obtain weather object
     # Load from cache file if exists, as this is faster and doesn't require
@@ -50,38 +34,29 @@ class Location
       weather.cache_weather(model)
     else
       weather = WeatherProcess.new(model, runner)
-      if weather.error?
-        return false
-      end
     end
 
-    return true, weather, epw_file
+    return weather, epw_file
   end
 
-  def self.apply_site(model, runner, epw_file)
+  def self.apply_site(model, epw_file)
     site = model.getSite
     site.setName("#{epw_file.city}_#{epw_file.stateProvinceRegion}_#{epw_file.country}")
     site.setLatitude(epw_file.latitude)
     site.setLongitude(epw_file.longitude)
     site.setTimeZone(epw_file.timeZone)
     site.setElevation(epw_file.elevation)
-    runner.registerInfo("Setting site data.")
-
-    return true
   end
 
-  def self.apply_climate_zones(model, runner, epw_file)
+  def self.apply_climate_zones(model, epw_file)
     ba_zone = get_climate_zone_ba(epw_file.wmoNumber)
-    return true if ba_zone.nil?
+    return if ba_zone.nil?
 
     climateZones = model.getClimateZones
     climateZones.setClimateZone(Constants.BuildingAmericaClimateZone, ba_zone)
-    runner.registerInfo("Setting #{Constants.BuildingAmericaClimateZone} climate zone to #{ba_zone}.")
-
-    return true
   end
 
-  def self.apply_mains_temp(model, runner, weather)
+  def self.apply_mains_temp(model, weather)
     avgOAT = UnitConversions.convert(weather.data.AnnualAvgDrybulb, "F", "C")
     monthlyOAT = weather.data.MonthlyAvgDrybulbs
 
@@ -95,24 +70,18 @@ class Location
     swmt.setCalculationMethod "Correlation"
     swmt.setAnnualAverageOutdoorAirTemperature avgOAT
     swmt.setMaximumDifferenceInMonthlyAverageOutdoorAirTemperatures maxDiffOAT
-
-    runner.registerInfo("Setting mains water temperature profile.")
-
-    return true
   end
 
-  def self.apply_year(model, runner, epw_file)
+  def self.apply_year(model, epw_file)
     year_description = model.getYearDescription
     if epw_file.startDateActualYear.is_initialized # AMY
       year_description.setCalendarYear(epw_file.startDateActualYear.get)
     else # TMY
       year_description.setDayofWeekforStartDay('Monday') # For consistency with SAM utility bill calculations
     end
-
-    return true
   end
 
-  def self.apply_dst(model, runner, dst_start_date, dst_end_date)
+  def self.apply_dst(model, dst_start_date, dst_end_date)
     if not (dst_start_date.downcase == 'na' and dst_end_date.downcase == 'na')
       begin
         dst_start_date_month = OpenStudio::monthOfYear(dst_start_date.split[0])
@@ -123,26 +92,18 @@ class Location
         dst = model.getRunPeriodControlDaylightSavingTime
         dst.setStartDate(dst_start_date_month, dst_start_date_day)
         dst.setEndDate(dst_end_date_month, dst_end_date_day)
-        runner.registerInfo("Set daylight saving time from #{dst.startDate.to_s} to #{dst.endDate.to_s}.")
       rescue
-        runner.registerError("Invalid daylight saving date specified.")
-        return false
+        fail "Invalid daylight saving date specified."
       end
-    else
-      runner.registerInfo("No daylight saving time set.")
     end
-
-    return true
   end
 
-  def self.apply_ground_temp(model, runner, weather)
+  def self.apply_ground_temp(model, weather)
     annual_temps = Array.new(12, weather.data.AnnualAvgDrybulb)
     annual_temps = annual_temps.map { |i| UnitConversions.convert(i, "F", "C") }
     s_gt_d = model.getSiteGroundTemperatureDeep
     s_gt_d.resetAllMonths
     s_gt_d.setAllMonthlyTemperatures(annual_temps)
-
-    return true
   end
 
   def self.get_climate_zone_ba(wmo)

--- a/resources/misc_loads.rb
+++ b/resources/misc_loads.rb
@@ -3,31 +3,25 @@ require_relative "unit_conversions"
 require_relative "schedules"
 
 class MiscLoads
-  def self.apply_plug(model, runner, misc_kwh, sens_frac, lat_frac,
+  def self.apply_plug(model, misc_kwh, sens_frac, lat_frac,
                       weekday_sch, weekend_sch, monthly_sch, tv_kwh, cfa,
                       living_space)
 
-    return true if misc_kwh + tv_kwh == 0
+    return if misc_kwh + tv_kwh == 0
 
     # check for valid inputs
     if sens_frac < 0 or sens_frac > 1
-      runner.registerError("Sensible fraction must be greater than or equal to 0 and less than or equal to 1.")
-      return false
+      fail "Sensible fraction must be greater than or equal to 0 and less than or equal to 1."
     end
     if lat_frac < 0 or lat_frac > 1
-      runner.registerError("Latent fraction must be greater than or equal to 0 and less than or equal to 1.")
-      return false
+      fail "Latent fraction must be greater than or equal to 0 and less than or equal to 1."
     end
     if lat_frac + sens_frac > 1
-      runner.registerError("Sum of sensible and latent fractions must be less than or equal to 1.")
-      return false
+      fail "Sum of sensible and latent fractions must be less than or equal to 1."
     end
 
     # Create schedule
-    sch = MonthWeekdayWeekendSchedule.new(model, runner, Constants.ObjectNameMiscPlugLoads + " schedule", weekday_sch, weekend_sch, monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
-    if not sch.validated?
-      return false
-    end
+    sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameMiscPlugLoads + " schedule", weekday_sch, weekend_sch, monthly_sch, mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
 
     # Misc plug loads
     if misc_kwh > 0
@@ -67,8 +61,6 @@ class MiscLoads
       mel_def.setFractionLost(1 - tv_sens_frac - tv_lat_frac)
       mel.setSchedule(sch.schedule)
     end
-
-    return true
   end
 
   def self.get_residual_mels_values(cfa)

--- a/resources/pv.rb
+++ b/resources/pv.rb
@@ -1,5 +1,5 @@
 class PV
-  def self.apply(model, runner, obj_name, size_w, module_type, system_losses,
+  def self.apply(model, obj_name, size_w, module_type, system_losses,
                  inverter_eff, tilt_abs, azimuth_abs, array_type)
 
     generator = OpenStudio::Model::GeneratorPVWatts.new(model, size_w)
@@ -19,8 +19,6 @@ class PV
 
     electric_load_center_dist.addGenerator(generator)
     electric_load_center_dist.setInverter(inverter)
-
-    return true
   end
 
   def self.calc_module_power_from_year(year_modules_manufactured)

--- a/resources/schedules.rb
+++ b/resources/schedules.rb
@@ -4,20 +4,15 @@ require_relative "unit_conversions"
 class HourlyByMonthSchedule
   # weekday_month_by_hour_values must be a 12-element array of 24-element arrays of numbers.
   # weekend_month_by_hour_values must be a 12-element array of 24-element arrays of numbers.
-  def initialize(model, runner, sch_name, weekday_month_by_hour_values, weekend_month_by_hour_values,
+  def initialize(model, sch_name, weekday_month_by_hour_values, weekend_month_by_hour_values,
                  normalize_values = true, create_sch_object = true,
                  schedule_type_limits_name = nil)
-    @validated = true
     @model = model
-    @runner = runner
     @sch_name = sch_name
     @schedule = nil
     @weekday_month_by_hour_values = validateValues(weekday_month_by_hour_values, 12, 24)
     @weekend_month_by_hour_values = validateValues(weekend_month_by_hour_values, 12, 24)
     @schedule_type_limits_name = schedule_type_limits_name
-    if not @validated
-      return
-    end
 
     if normalize_values
       @maxval = calcMaxval()
@@ -27,10 +22,6 @@ class HourlyByMonthSchedule
     if create_sch_object
       @schedule = createSchedule()
     end
-  end
-
-  def validated?
-    return @validated
   end
 
   def calcDesignLevel(val)
@@ -50,32 +41,24 @@ class HourlyByMonthSchedule
   def validateValues(vals, num_outter_values, num_inner_values)
     err_msg = "A #{num_outter_values.to_s}-element array with #{num_inner_values.to_s}-element arrays of numbers must be entered for the schedule."
     if not vals.is_a?(Array)
-      @runner.registerError(err_msg)
-      @validated = false
-      return nil
+      fail err_msg
     end
+
     begin
       if vals.length != num_outter_values
-        @runner.registerError(err_msg)
-        @validated = false
-        return nil
+        fail err_msg
       end
+
       vals.each do |val|
         if not val.is_a?(Array)
-          @runner.registerError(err_msg)
-          @validated = false
-          return nil
+          fail err_msg
         end
         if val.length != num_inner_values
-          @runner.registerError(err_msg)
-          @validated = false
-          return nil
+          fail err_msg
         end
       end
     rescue
-      @runner.registerError(err_msg)
-      @validated = false
-      return nil
+      fail err_msg
     end
     return vals
   end
@@ -184,12 +167,10 @@ class MonthWeekdayWeekendSchedule
   # weekday_hourly_values can either be a comma-separated string of 24 numbers or a 24-element array of numbers.
   # weekend_hourly_values can either be a comma-separated string of 24 numbers or a 24-element array of numbers.
   # monthly_values can either be a comma-separated string of 12 numbers or a 12-element array of numbers.
-  def initialize(model, runner, sch_name, weekday_hourly_values, weekend_hourly_values, monthly_values,
+  def initialize(model, sch_name, weekday_hourly_values, weekend_hourly_values, monthly_values,
                  mult_weekday = 1.0, mult_weekend = 1.0, normalize_values = true, create_sch_object = true,
                  schedule_type_limits_name = nil)
-    @validated = true
     @model = model
-    @runner = runner
     @sch_name = sch_name
     @schedule = nil
     @mult_weekday = mult_weekday
@@ -198,9 +179,6 @@ class MonthWeekdayWeekendSchedule
     @weekend_hourly_values = validateValues(weekend_hourly_values, 24, "weekend")
     @monthly_values = validateValues(monthly_values, 12, "monthly")
     @schedule_type_limits_name = schedule_type_limits_name
-    if not @validated
-      return
-    end
 
     if normalize_values
       @weekday_hourly_values = normalizeSumToOne(@weekday_hourly_values)
@@ -215,10 +193,6 @@ class MonthWeekdayWeekendSchedule
     if create_sch_object
       @schedule = createSchedule()
     end
-  end
-
-  def validated?
-    return @validated
   end
 
   def calcDesignLevelFromDailykWh(daily_kwh)
@@ -239,15 +213,12 @@ class MonthWeekdayWeekendSchedule
     err_msg = "A comma-separated string of #{num_values.to_s} numbers must be entered for the #{sch_name} schedule."
     if values.is_a?(Array)
       if values.length != num_values
-        @runner.registerError(err_msg)
-        @validated = false
-        return nil
+        fail err_msg
       end
+
       values.each do |val|
         if not valid_float?(val)
-          @runner.registerError(err_msg)
-          @validated = false
-          return nil
+          fail err_msg
         end
       end
       floats = values.map { |i| i.to_f }
@@ -256,26 +227,18 @@ class MonthWeekdayWeekendSchedule
         vals = values.split(",")
         vals.each do |val|
           if not valid_float?(val)
-            @runner.registerError(err_msg)
-            @validated = false
-            return nil
+            fail err_msg
           end
         end
         floats = vals.map { |i| i.to_f }
         if floats.length != num_values
-          @runner.registerError(err_msg)
-          @validated = false
-          return nil
+          fail err_msg
         end
       rescue
-        @runner.registerError(err_msg)
-        @validated = false
-        return nil
+        fail err_msg
       end
     else
-      @runner.registerError(err_msg)
-      @validated = false
-      return nil
+      fail err_msg
     end
     return floats
   end
@@ -423,10 +386,8 @@ class MonthWeekdayWeekendSchedule
 end
 
 class HotWaterSchedule
-  def initialize(model, runner, obj_name, nbeds, days_shift = 0, create_sch_object = true)
-    @validated = true
+  def initialize(model, obj_name, nbeds, days_shift = 0, create_sch_object = true)
     @model = model
-    @runner = runner
     @sch_name = "#{obj_name} schedule"
     @schedule = nil
     @days_shift = days_shift
@@ -451,17 +412,9 @@ class HotWaterSchedule
 
     data = loadMinuteDrawProfileFromFile(timestep_minutes, days_shift, weeks)
     @totflow, @maxflow, @ontime = loadDrawProfileStatsFromFile()
-    if data.nil? or @totflow.nil? or @maxflow.nil? or @ontime.nil?
-      @validated = false
-      return
-    end
     if create_sch_object
       @schedule = createSchedule(data, timestep_minutes, weeks)
     end
-  end
-
-  def validated?
-    return @validated
   end
 
   def calcDesignLevelFromDailykWh(daily_kWh)
@@ -499,8 +452,7 @@ class HotWaterSchedule
     # Get appropriate file
     minute_draw_profile = File.join(File.dirname(__FILE__), "HotWater#{@file_prefix}Schedule_#{@nbeds}bed.csv")
     if not File.file?(minute_draw_profile)
-      @runner.registerError("Unable to find file: #{minute_draw_profile}")
-      return nil
+      fail "Unable to find file: #{minute_draw_profile}"
     end
 
     minutes_in_year = 8760 * 60
@@ -587,9 +539,9 @@ class HotWaterSchedule
     end
 
     if not datafound
-      @runner.registerError("Unable to find data for bedrooms = #{@nbeds}.")
-      return nil, nil, nil
+      fail "Unable to find data for bedrooms = #{@nbeds}."
     end
+
     return totflow, maxflow, ontime
   end
 

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -42,7 +42,7 @@ class HPXMLTranslatorTest < MiniTest::Test
 
     xmls = []
     test_dirs.each do |test_dir|
-      Dir["#{test_dir}/base-dhw*.xml"].sort.each do |xml|
+      Dir["#{test_dir}/base*.xml"].sort.each do |xml|
         xmls << File.absolute_path(xml)
       end
     end


### PR DESCRIPTION
1. Replaces `runner.registerError` with `fail` and simplifies corresponding code (e.g., no longer need to return true/false, no longer need to pass around runner in most situations, etc).
2. Improves performance (of FT and writing IDF) for schedules by extending ScheduleRules for consecutive months with identical values
3. Prevents creating an interior shading schedule for each window/skylight.
4. Significantly streamlines the code that creates heating/cooling setpoint schedules.

No CI diffs are expected.