### PR TITLE
Gem speed improvement

### DIFF
--- a/resources/run_simulation.rb
+++ b/resources/run_simulation.rb
@@ -18,7 +18,7 @@ def rm_path(path)
   end
 end
 
-def create_idf(basedir, rundir, hpxml, debug, skip_validation)
+def create_idf(basedir, rundir, hpxml, debug)
   OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
 
   model = OpenStudio::Model::Model.new
@@ -36,7 +36,6 @@ def create_idf(basedir, rundir, hpxml, debug, skip_validation)
   if debug
     args['osm_output_path'] = File.join(rundir, "in.osm")
   end
-  args['skip_validation'] = skip_validation
   update_args_hash(measures, measure_subdir, args)
 
   # Apply measures
@@ -89,7 +88,7 @@ end
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "Usage: #{File.basename(__FILE__)} -x building.xml\n e.g., #{File.basename(__FILE__)} -s -x tests/base.xml\n"
+  opts.banner = "Usage: #{File.basename(__FILE__)} -x building.xml\n e.g., #{File.basename(__FILE__)} -x tests/base.xml\n"
 
   opts.on('-x', '--xml <FILE>', 'HPXML file') do |t|
     options[:hpxml] = t
@@ -97,11 +96,6 @@ OptionParser.new do |opts|
 
   opts.on('-o', '--output-dir <DIR>', 'Output directory') do |t|
     options[:output_dir] = t
-  end
-
-  options[:skip_validation] = false
-  opts.on('-s', '--skip-validation', 'Skips HPXML validation') do |t|
-    options[:skip_validation] = true
   end
 
   options[:debug] = false
@@ -143,7 +137,7 @@ Dir.mkdir(rundir)
 # Run design
 puts "HPXML: #{options[:hpxml]}"
 puts "Creating input..."
-create_idf(basedir, rundir, options[:hpxml], options[:debug], options[:skip_validation])
+create_idf(basedir, rundir, options[:hpxml], options[:debug])
 
 puts "Running simulation..."
 run_energyplus(rundir)

--- a/resources/xmlhelper.rb
+++ b/resources/xmlhelper.rb
@@ -116,12 +116,12 @@ class XMLHelper
   end
 
   def self.validate(doc, xsd_path, runner = nil)
-    begin
+    if Gem::Specification::find_all_by_name('nokogiri').any?
       require 'nokogiri'
       xsd = Nokogiri::XML::Schema(File.open(xsd_path))
       doc = Nokogiri::XML(doc)
       return xsd.validate(doc)
-    rescue LoadError
+    else
       if not runner.nil?
         runner.registerWarning("Could not load nokogiri, no HPXML validation performed.")
       end

--- a/tests/hpxml_translator_test.rb
+++ b/tests/hpxml_translator_test.rb
@@ -439,7 +439,6 @@ class HPXMLTranslatorTest < MiniTest::Test
     args['osm_output_path'] = File.absolute_path(File.join(rundir, "in.osm"))
     args['hpxml_path'] = xml
     args['map_tsv_dir'] = rundir
-    args['skip_validation'] = false
     args['weather_dir'] = "weather"
 
     # Add measure to workflow


### PR DESCRIPTION
Rather than simply trying to load nokogiri (which has a runtime impact), check if it's available first. Shaves around a quarter of a second on runtime. Also removes the (dangerous) skip_validation argument, no longer needed now that the primary runtime bottleneck has been addressed.

