### PR TITLE
Fix bugs in cifs hourly simulation

### DIFF
--- a/resources/airflow.rb
+++ b/resources/airflow.rb
@@ -1448,7 +1448,7 @@ class Airflow
 
           duct_program.addLine("If #{mech_vent.cfis_on_for_hour_var.name}")
           duct_program.addLine("  Set cfis_m3s = (#{mech_vent.cfis_fan_mfr_max_var} / 1.16097654) * #{mech_vent.cfis_airflow_frac}") # Density of 1.16097654 was back calculated using E+ results
-          duct_program.addLine("  Set #{fan_rtf_var.name} = (1.0-#{mech_vent.cfis_fan_rtf_sensor})*#{mech_vent.cfis_f_damper_open_var.name}")
+          duct_program.addLine("  Set #{fan_rtf_var.name} = #{mech_vent.cfis_f_damper_extra_open_var.name}") # Need to use global vars to sync duct_program and infiltration program of different calling points
           duct_program.addLine("  Set #{ah_vfr_var.name} = #{fan_rtf_var.name}*cfis_m3s")
           duct_program.addLine("  Set rho_in = (@RhoAirFnPbTdbW #{pbar_sensor.name} #{tin_sensor.name} #{win_sensor.name})")
           duct_program.addLine("  Set #{ah_mfr_var.name} = #{ah_vfr_var.name} * rho_in")
@@ -1490,6 +1490,7 @@ class Airflow
     mech_vent.cfis_t_sum_open_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(" ", "_")}_cfis_t_sum_open") # Sums the time during an hour the CFIS damper has been open
     mech_vent.cfis_on_for_hour_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(" ", "_")}_cfis_on_for_hour") # Flag to open the CFIS damper for the remainder of the hour
     mech_vent.cfis_f_damper_open_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(" ", "_")}_cfis_f_damper_open") # Fraction of timestep the CFIS damper is open. Used by infiltration and duct leakage programs
+    mech_vent.cfis_f_damper_extra_open_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(" ", "_")}_cfis_f_extra_damper_open") # Fraction of timestep the CFIS blower is running while hvac is not operating. Used by infiltration and duct leakage programs
 
     if mech_vent.fan_power_w.nil?
       supply_fan = HVAC.get_unitary_system_from_air_loop_hvac(mech_vent.cfis_air_loop).supplyFan.get.to_FanOnOff.get
@@ -1509,6 +1510,7 @@ class Airflow
     cfis_program.addLine("Set #{mech_vent.cfis_t_sum_open_var.name} = 0")
     cfis_program.addLine("Set #{mech_vent.cfis_on_for_hour_var.name} = 0")
     cfis_program.addLine("Set #{mech_vent.cfis_f_damper_open_var.name} = 0")
+    cfis_program.addLine("Set #{mech_vent.cfis_f_damper_extra_open_var.name} = 0")
 
     return cfis_program
   end
@@ -1686,7 +1688,7 @@ class Airflow
 
     if mech_vent.type == 'central fan integrated supply'
 
-      infil_program.addLine("Set fan_rtf = #{mech_vent.cfis_fan_rtf_sensor}")
+      infil_program.addLine("Set fan_rtf_hvac = #{mech_vent.cfis_fan_rtf_sensor}")
       if mech_vent.fan_power_w.nil?
         # Use supply fan W/cfm
         infil_program.addLine("Set CFIS_fan_power = #{mech_vent.cfis_fan_pressure_rise.name} / #{mech_vent.cfis_fan_efficiency.name} * #{UnitConversions.convert(1.0, 'cfm', 'm^3/s').round(6)}") # W/cfm
@@ -1708,36 +1710,34 @@ class Airflow
 
       infil_program.addLine("If #{mech_vent.cfis_t_sum_open_var.name} < CFIS_t_min_hr_open")
       infil_program.addLine("  Set CFIS_t_fan_on = 60 - (CFIS_t_min_hr_open - #{mech_vent.cfis_t_sum_open_var.name})") # minute at which the blower needs to turn on to meet the ventilation requirements
-      infil_program.addLine("  If ((Minute+0.00001) >= CFIS_t_fan_on) || #{mech_vent.cfis_on_for_hour_var.name}")
-
-      # Supply fan needs to run for remainder of hour to achieve target minutes per hour of operation
-      infil_program.addLine("    If #{mech_vent.cfis_on_for_hour_var.name}")
-      infil_program.addLine("      Set #{mech_vent.cfis_f_damper_open_var.name} = 1")
-      infil_program.addLine("    Else")
-      infil_program.addLine("      Set cfistemp1 = (@Mod (60.0-CFIS_t_fan_on) (60.0*ZoneTimeStep))")
-      infil_program.addLine("      Set #{mech_vent.cfis_f_damper_open_var.name} = cfistemp1/(60.0*ZoneTimeStep)") # calculates the portion of the current timestep the CFIS damper needs to be open
-      infil_program.addLine("      Set #{mech_vent.cfis_on_for_hour_var.name} = 1") # CFIS damper will need to open for all the remaining timesteps in this hour
-      infil_program.addLine("    EndIf")
+      # Evaluate condition of if supply fan have to run to achieve target minutes per hour of operation
+      infil_program.addLine("  If (Minute+0.00001) >= CFIS_t_fan_on")
+      infil_program.addLine("    Set #{mech_vent.cfis_on_for_hour_var.name} = 1") # on flag for duct program
+      # Consider fan rtf read in current calling point (results of previous time step) + CFIS_t_fan_on based on min/hr requirement and previous EMS results.
+      infil_program.addLine("    Set cfis_fan_runtime1 = @Max (@ABS(Minute - CFIS_t_fan_on)) (fan_rtf_hvac * ZoneTimeStep * 60)")
+      # If fan_rtf_hvac, make sure it's not exceeding ventilation requirements
+      infil_program.addLine("    Set cfis_fan_runtime = @Min cfis_fan_runtime1 (CFIS_t_min_hr_open - #{mech_vent.cfis_t_sum_open_var.name})")
+      infil_program.addLine("    Set #{mech_vent.cfis_f_damper_open_var.name} = cfis_fan_runtime/(60.0*ZoneTimeStep)") # calculates the portion of the current timestep the CFIS damper needs to be open
       infil_program.addLine("    Set QWHV = #{mech_vent.cfis_f_damper_open_var.name}*CFIS_Q_duct")
-      infil_program.addLine("    Set cfistemp2 = #{mech_vent.cfis_f_damper_open_var.name}*(ZoneTimeStep*60)")
-      infil_program.addLine("    Set #{mech_vent.cfis_t_sum_open_var.name} = #{mech_vent.cfis_t_sum_open_var.name}+cfistemp2")
+      infil_program.addLine("    Set #{mech_vent.cfis_t_sum_open_var.name} = #{mech_vent.cfis_t_sum_open_var.name}+cfis_fan_runtime")
       infil_program.addLine("    Set cfis_cfm = airloop_cfm*#{mech_vent.cfis_airflow_frac}")
-      infil_program.addLine("    Set cfis_frac = #{mech_vent.cfis_f_damper_open_var.name}*(1-fan_rtf)")
-      infil_program.addLine("    Set #{whole_house_fan_actuator.name} = CFIS_fan_power*cfis_cfm*cfis_frac")
+      infil_program.addLine("    Set #{mech_vent.cfis_f_damper_extra_open_var.name} = @Max (#{mech_vent.cfis_f_damper_open_var.name}-fan_rtf_hvac) 0.0") # additional runtime fraction to meet min/hr
+      infil_program.addLine("    Set #{whole_house_fan_actuator.name} = CFIS_fan_power*cfis_cfm*#{mech_vent.cfis_f_damper_extra_open_var.name}")
       infil_program.addLine("  Else")
-      infil_program.addLine("    Set cfistemp4 = fan_rtf*ZoneTimeStep*60")
-      infil_program.addLine("    If (#{mech_vent.cfis_t_sum_open_var.name}+cfistemp4) > CFIS_t_min_hr_open")
+      # No need to turn on blower for extra ventilation
+      infil_program.addLine("    Set cfis_fan_runtime2 = fan_rtf_hvac*ZoneTimeStep*60")
+      infil_program.addLine("    If (#{mech_vent.cfis_t_sum_open_var.name}+cfis_fan_runtime2) > CFIS_t_min_hr_open")
       # Damper is only open for a portion of this time step to achieve target minutes per hour
-      infil_program.addLine("      Set cfistemp5 = CFIS_t_min_hr_open-#{mech_vent.cfis_t_sum_open_var.name}")
-      infil_program.addLine("      Set #{mech_vent.cfis_f_damper_open_var.name} = cfistemp5/(ZoneTimeStep*60)")
+      infil_program.addLine("      Set cfis_fan_runtime = CFIS_t_min_hr_open-#{mech_vent.cfis_t_sum_open_var.name}")
+      infil_program.addLine("      Set #{mech_vent.cfis_f_damper_open_var.name} = cfis_fan_runtime/(ZoneTimeStep*60)")
       infil_program.addLine("      Set QWHV = #{mech_vent.cfis_f_damper_open_var.name}*CFIS_Q_duct")
       infil_program.addLine("      Set #{mech_vent.cfis_t_sum_open_var.name} = CFIS_t_min_hr_open")
       infil_program.addLine("    Else")
       # Damper is open and using call for heat/cool to supply fresh air
-      infil_program.addLine("      Set cfistemp6 = fan_rtf*ZoneTimeStep*60")
-      infil_program.addLine("      Set #{mech_vent.cfis_t_sum_open_var.name} = #{mech_vent.cfis_t_sum_open_var.name}+cfistemp6")
-      infil_program.addLine("      Set #{mech_vent.cfis_f_damper_open_var.name} = 1")
-      infil_program.addLine("      Set QWHV = fan_rtf*CFIS_Q_duct")
+      infil_program.addLine("      Set cfis_fan_runtime = fan_rtf_hvac*ZoneTimeStep*60")
+      infil_program.addLine("      Set #{mech_vent.cfis_f_damper_open_var.name} = fan_rtf_hvac")
+      infil_program.addLine("      Set QWHV = #{mech_vent.cfis_f_damper_open_var.name}*CFIS_Q_duct")
+      infil_program.addLine("      Set #{mech_vent.cfis_t_sum_open_var.name} = #{mech_vent.cfis_t_sum_open_var.name}+cfis_fan_runtime")
       infil_program.addLine("    EndIf")
       # Fan power is metered under fan cooling and heating meters
       infil_program.addLine("    Set #{whole_house_fan_actuator.name} = 0")
@@ -1985,7 +1985,7 @@ class MechanicalVentilation
   attr_accessor(:type, :total_efficiency, :total_efficiency_adjusted, :whole_house_cfm, :fan_power_w, :sensible_efficiency, :sensible_efficiency_adjusted,
                 :dryer_exhaust, :range_exhaust, :range_exhaust_hour, :bathroom_exhaust, :bathroom_exhaust_hour,
                 :cfis_open_time, :cfis_airflow_frac, :cfis_air_loop, :cfis_t_sum_open_var, :cfis_on_for_hour_var,
-                :cfis_f_damper_open_var, :cfis_fan_mfr_max_var, :cfis_fan_rtf_sensor, :cfis_fan_pressure_rise, :cfis_fan_efficiency,
+                :cfis_f_damper_open_var, :cfis_f_damper_extra_open_var, :cfis_fan_mfr_max_var, :cfis_fan_rtf_sensor, :cfis_fan_pressure_rise, :cfis_fan_efficiency,
                 :frac_fan_heat, :bathroom_hour_avg_exhaust, :range_hood_hour_avg_exhaust,
                 :spot_fan_w_per_cfm, :latent_effectiveness, :sensible_effectiveness, :dryer_exhaust_day_shift, :has_dryer)
 end


### PR DESCRIPTION
## Pull Request Description

The hourly simulation always stepped into conditions of opening cfis fan, where the fan runtime fraction most recently read is not applied correctly. This PR is aimed to fix this issue while keeping its approach capability of scaling into smaller time step simulations.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `rake update_measures` has been run
- [ ] No unexpected regression test changes on CI
