### PR TITLE
Duct program Cfis bugfix

### DIFF
--- a/HPXMLtoOpenStudio/resources/airflow.rb
+++ b/HPXMLtoOpenStudio/resources/airflow.rb
@@ -1437,6 +1437,12 @@ class Airflow
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_cond_to_dz"].name} = 0")
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_sens_lk_to_dz"].name} = 0")
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_dz"].name} = 0")
+          if not duct_actuators["dz_to_liv_flow_rate"].nil?
+            duct_program.addLine("  Set #{duct_actuators["cfis_dz_to_liv_flow_rate"].name} = 0")
+          end
+          if not duct_actuators["liv_to_dz_flow_rate"].nil?
+            duct_program.addLine("  Set #{duct_actuators["cfis_liv_to_dz_flow_rate"].name} = 0")
+          end
           duct_program.addLine("EndIf")
 
         end

--- a/HPXMLtoOpenStudio/resources/airflow.rb
+++ b/HPXMLtoOpenStudio/resources/airflow.rb
@@ -1419,7 +1419,7 @@ class Airflow
           duct_program.addLine("  Set #{duct_actuators["cfis_return_cond_to_dz"].name} = #{duct_vars["return_cond_to_dz"].name}")
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_cond_to_dz"].name} = #{duct_vars["supply_cond_to_dz"].name}")
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_sens_lk_to_dz"].name} = #{duct_vars["supply_sens_lk_to_dz"].name}")
-          duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_dz"].name} = #{duct_vars["supply_lat_lk_to_dz"].name}")          
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_dz"].name} = #{duct_vars["supply_lat_lk_to_dz"].name}")
           if not duct_actuators["dz_to_liv_flow_rate"].nil?
             duct_program.addLine("  Set #{duct_actuators["cfis_dz_to_liv_flow_rate"].name} = #{duct_vars["dz_to_liv_flow_rate"].name}")
           end
@@ -1436,7 +1436,7 @@ class Airflow
           duct_program.addLine("  Set #{duct_actuators["cfis_return_cond_to_dz"].name} = 0")
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_cond_to_dz"].name} = 0")
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_sens_lk_to_dz"].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_dz"].name} = 0")  
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_dz"].name} = 0")
           duct_program.addLine("EndIf")
 
         end

--- a/HPXMLtoOpenStudio/resources/airflow.rb
+++ b/HPXMLtoOpenStudio/resources/airflow.rb
@@ -1419,13 +1419,24 @@ class Airflow
           duct_program.addLine("  Set #{duct_actuators["cfis_return_cond_to_dz"].name} = #{duct_vars["return_cond_to_dz"].name}")
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_cond_to_dz"].name} = #{duct_vars["supply_cond_to_dz"].name}")
           duct_program.addLine("  Set #{duct_actuators["cfis_supply_sens_lk_to_dz"].name} = #{duct_vars["supply_sens_lk_to_dz"].name}")
-          duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_dz"].name} = #{duct_vars["supply_lat_lk_to_dz"].name}")
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_dz"].name} = #{duct_vars["supply_lat_lk_to_dz"].name}")          
           if not duct_actuators["dz_to_liv_flow_rate"].nil?
             duct_program.addLine("  Set #{duct_actuators["cfis_dz_to_liv_flow_rate"].name} = #{duct_vars["dz_to_liv_flow_rate"].name}")
           end
           if not duct_actuators["liv_to_dz_flow_rate"].nil?
             duct_program.addLine("  Set #{duct_actuators["cfis_liv_to_dz_flow_rate"].name} = #{duct_vars["liv_to_dz_flow_rate"].name}")
           end
+          duct_program.addLine("Else")
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_sens_lk_to_liv"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_liv"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_cond_to_liv"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_return_sens_lk_to_rp"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_return_lat_lk_to_rp"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_return_cond_to_rp"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_return_cond_to_dz"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_cond_to_dz"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_sens_lk_to_dz"].name} = 0")
+          duct_program.addLine("  Set #{duct_actuators["cfis_supply_lat_lk_to_dz"].name} = 0")  
           duct_program.addLine("EndIf")
 
         end

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -153,7 +153,7 @@ OptionParser.new do |opts|
   opts.on('-v', '--version', 'Reports the version') do |t|
     options[:version] = true
   end
-  
+
   options[:debug] = false
   opts.on('-d', '--debug') do |t|
     options[:debug] = true


### PR DESCRIPTION
## Pull Request Description

Fix a bug in duct program where power of cfis equipment objects is not reset to 0 when no extra mech vent required.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
