### PR TITLE
Refactors HPXML class

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -3116,7 +3116,7 @@ class OSModel
         cfis_sys_ids = []
         (@hpxml.heating_systems + @hpxml.cooling_systems + @hpxml.heat_pumps).each do |hvac_system|
           next if hvac_system[:distribution_system_idref].nil?
-          next unless hvac_distribution[:distribution_system_type] == hvac_system[:distribution_system_idref]
+          next unless hvac_distribution[:id] == hvac_system[:distribution_system_idref]
 
           cfis_sys_ids << hvac_system[:id]
         end

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -3103,7 +3103,6 @@ class OSModel
     cfis_airloop = nil
     if mech_vent_type == 'central fan integrated supply'
       # Get HVAC distribution system CFIS is attached to
-      cfis_hvac_dist = nil
       @hpxml.hvac_distributions.each do |hvac_distribution|
         next unless hvac_distribution.id == mech_vent_attached_dist_system
 

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -2133,7 +2133,7 @@ class OSModel
             boiler_afue = nil
             boiler_fuel_type = nil
             @hpxml.heating_systems.each do |heating_system|
-              next unless heating_system[:id] == idref
+              next unless heating_system[:id] == water_heating_system[:related_hvac]
 
               boiler_afue = heating_system[:heating_efficiency_afue]
               boiler_fuel_type = heating_system[:heating_system_fuel]
@@ -2208,9 +2208,9 @@ class OSModel
           fail "Attached water heating system '#{dhw_system_idref}' not found for solar thermal system '#{@hpxml.solar_thermal_system[:id]}'."
         end
 
-        Waterheater.apply_ @hpxml.solar_thermal_system(model, space, collector_area, frta, frul, storage_vol,
-                                                       azimuth, tilt, collector_type, loop_type, dhw_loop, @dhw_map,
-                                                       dhw_system_idref)
+        Waterheater.apply_solar_thermal(model, space, collector_area, frta, frul, storage_vol,
+                                        azimuth, tilt, collector_type, loop_type, dhw_loop, @dhw_map,
+                                        dhw_system_idref)
       end
     end
 
@@ -3049,36 +3049,36 @@ class OSModel
     @hpxml.ventilation_fans.each do |vent_fan_values|
       next unless vent_fan_values[:used_for_whole_building_ventilation]
 
-      mech_vent_id = mech_vent_fan_values[:id]
-      mech_vent_type = mech_vent_fan_values[:fan_type]
+      mech_vent_id = vent_fan_values[:id]
+      mech_vent_type = vent_fan_values[:fan_type]
       if mech_vent_type == 'energy recovery ventilator' or mech_vent_type == 'heat recovery ventilator'
-        if mech_vent_fan_values[:sensible_recovery_efficiency_adjusted].nil?
-          mech_vent_sens_eff = mech_vent_fan_values[:sensible_recovery_efficiency]
+        if vent_fan_values[:sensible_recovery_efficiency_adjusted].nil?
+          mech_vent_sens_eff = vent_fan_values[:sensible_recovery_efficiency]
         else
-          mech_vent_sens_eff_adj = mech_vent_fan_values[:sensible_recovery_efficiency_adjusted]
+          mech_vent_sens_eff_adj = vent_fan_values[:sensible_recovery_efficiency_adjusted]
         end
       end
       if mech_vent_type == 'energy recovery ventilator'
-        if mech_vent_fan_values[:total_recovery_efficiency_adjusted].nil?
-          mech_vent_total_eff = mech_vent_fan_values[:total_recovery_efficiency]
+        if vent_fan_values[:total_recovery_efficiency_adjusted].nil?
+          mech_vent_total_eff = vent_fan_values[:total_recovery_efficiency]
         else
-          mech_vent_total_eff_adj = mech_vent_fan_values[:total_recovery_efficiency_adjusted]
+          mech_vent_total_eff_adj = vent_fan_values[:total_recovery_efficiency_adjusted]
         end
       end
-      mech_vent_cfm = mech_vent_fan_values[:tested_flow_rate]
+      mech_vent_cfm = vent_fan_values[:tested_flow_rate]
       if mech_vent_cfm.nil?
-        mech_vent_cfm = mech_vent_fan_values[:rated_flow_rate]
+        mech_vent_cfm = vent_fan_values[:rated_flow_rate]
       end
-      mech_vent_fan_w = mech_vent_fan_values[:fan_power]
+      mech_vent_fan_w = vent_fan_values[:fan_power]
       if mech_vent_type == 'central fan integrated supply'
         # CFIS: Specify minimum open time in minutes
-        cfis_open_time = [mech_vent_fan_values[:hours_in_operation] / 24.0 * 60.0, 59.999].min
+        cfis_open_time = [vent_fan_values[:hours_in_operation] / 24.0 * 60.0, 59.999].min
       else
         # Other: Adjust constant CFM/power based on hours per day of operation
-        mech_vent_cfm *= (mech_vent_fan_values[:hours_in_operation] / 24.0)
-        mech_vent_fan_w *= (mech_vent_fan_values[:hours_in_operation] / 24.0)
+        mech_vent_cfm *= (vent_fan_values[:hours_in_operation] / 24.0)
+        mech_vent_fan_w *= (vent_fan_values[:hours_in_operation] / 24.0)
       end
-      mech_vent_attached_dist_system = mech_vent_fan_values[:distribution_system_idref]
+      mech_vent_attached_dist_system = vent_fan_values[:distribution_system_idref]
     end
     cfis_airflow_frac = 1.0
     clothes_dryer_exhaust = 0.0

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -1249,7 +1249,7 @@ class OSModel
         z_origin = @foundation_top
       end
 
-      if hpxml_frame_floor_is_ceiling(frame_floor.interior_adjacent_to, frame_floor.exterior_adjacent_to)
+      if frame_floor.is_ceiling
         surface = OpenStudio::Model::Surface.new(add_ceiling_polygon(length, width, z_origin), model)
         surface.additionalProperties.setFeature("SurfaceType", "Ceiling")
       else
@@ -2854,17 +2854,17 @@ class OSModel
         misc_lat_frac = MiscLoads.get_residual_mels_values(@cfa)[2]
       end
 
-      misc_weekday_sch = @hpxml.misc_load_schedule.weekday_fractions
+      misc_weekday_sch = @hpxml.misc_loads_schedule.weekday_fractions
       if misc_weekday_sch.nil?
         misc_weekday_sch = "0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05"
       end
 
-      misc_weekend_sch = @hpxml.misc_load_schedule.weekend_fractions
+      misc_weekend_sch = @hpxml.misc_loads_schedule.weekend_fractions
       if misc_weekend_sch.nil?
         misc_weekend_sch = "0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05"
       end
 
-      misc_monthly_sch = @hpxml.misc_load_schedule.monthly_multipliers
+      misc_monthly_sch = @hpxml.misc_loads_schedule.monthly_multipliers
       if misc_monthly_sch.nil?
         misc_monthly_sch = "1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248"
       end

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -109,14 +109,14 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
       unless (Pathname.new weather_dir).absolute?
         weather_dir = File.expand_path(File.join(File.dirname(__FILE__), "..", weather_dir))
       end
-      epw_path = hpxml.climate_and_risk_zones[:weather_station_epw_filename]
+      epw_path = hpxml.climate_and_risk_zones.weather_station_epw_filename
       if not epw_path.nil?
         epw_path = File.join(weather_dir, epw_path)
         if not File.exists?(epw_path)
           fail "'#{epw_path}' could not be found."
         end
       else
-        weather_wmo = hpxml.climate_and_risk_zones[:weather_station_wmo]
+        weather_wmo = hpxml.climate_and_risk_zones.weather_station_wmo
         CSV.foreach(File.join(weather_dir, "data.csv"), headers: true) do |row|
           next if row["wmo"] != weather_wmo
 
@@ -194,45 +194,43 @@ class OSModel
     @hpxml = hpxml
     @hpxml_path = hpxml_path
 
-    @eri_version = @hpxml.header[:eri_calculation_version] # Hidden feature
+    @eri_version = @hpxml.header.eri_calculation_version # Hidden feature
     @eri_version = 'latest' if @eri_version.nil?
     @eri_version = Constants.ERIVersions[-1] if @eri_version == 'latest'
 
-    @hpxml.collapse_enclosure()
-
     # Global variables
-    @timestep = @hpxml.header[:timestep]
+    @timestep = @hpxml.header.timestep
     @timestep = 60 if @timestep.nil?
-    @cfa = @hpxml.building_construction[:conditioned_floor_area]
+    @cfa = @hpxml.building_construction.conditioned_floor_area
     @cfa_ag = @cfa
     @hpxml.slabs.each do |slab|
-      next unless slab[:interior_adjacent_to] == 'basement - conditioned'
+      next unless slab.interior_adjacent_to == 'basement - conditioned'
 
-      @cfa_ag -= slab[:area]
+      @cfa_ag -= slab.area
     end
     @gfa = 0 # garage floor area
     @hpxml.slabs.each do |slab|
-      next unless slab[:interior_adjacent_to] == 'garage'
+      next unless slab.interior_adjacent_to == 'garage'
 
-      @gfa += slab[:area]
+      @gfa += slab.area
     end
-    @cvolume = @hpxml.building_construction[:conditioned_building_volume]
+    @cvolume = @hpxml.building_construction.conditioned_building_volume
     @infilvolume = get_infiltration_volume()
-    @ncfl = @hpxml.building_construction[:number_of_conditioned_floors]
-    @ncfl_ag = @hpxml.building_construction[:number_of_conditioned_floors_above_grade]
-    @nbeds = @hpxml.building_construction[:number_of_bedrooms]
-    @nbaths = @hpxml.building_construction[:number_of_bathrooms]
+    @ncfl = @hpxml.building_construction.number_of_conditioned_floors
+    @ncfl_ag = @hpxml.building_construction.number_of_conditioned_floors_above_grade
+    @nbeds = @hpxml.building_construction.number_of_bedrooms
+    @nbaths = @hpxml.building_construction.number_of_bathrooms
     if @nbaths.nil?
       @nbaths = Waterheater.get_default_num_bathrooms(@nbeds)
     end
-    @frac_window_area_operable = @hpxml.building_construction[:fraction_of_operable_window_area]
+    @frac_window_area_operable = @hpxml.building_construction.fraction_of_operable_window_area
     @has_uncond_bsmnt = false
     @has_vented_attic = false
     @has_vented_crawl = false
     (@hpxml.slabs + @hpxml.roofs).each do |surface|
-      @has_uncond_bsmnt = true if surface[:interior_adjacent_to] == 'basement - unconditioned'
-      @has_vented_attic = true if surface[:interior_adjacent_to] == 'attic - vented'
-      @has_vented_crawl = true if surface[:interior_adjacent_to] == 'crawlspace - vented'
+      @has_uncond_bsmnt = true if surface.interior_adjacent_to == 'basement - unconditioned'
+      @has_vented_attic = true if surface.interior_adjacent_to == 'attic - vented'
+      @has_vented_crawl = true if surface.interior_adjacent_to == 'crawlspace - vented'
     end
     @subsurface_areas_by_surface = calc_subsurface_areas_by_surface()
     @min_neighbor_distance = get_min_neighbor_distance()
@@ -243,8 +241,8 @@ class OSModel
     @dhw_map = {}  # mapping between HPXML Water Heating systems and model objects
 
     @use_only_ideal_air = false
-    if not @hpxml.building_construction[:use_only_ideal_air_system].nil?
-      @use_only_ideal_air = @hpxml.building_construction[:use_only_ideal_air_system]
+    if not @hpxml.building_construction.use_only_ideal_air_system.nil?
+      @use_only_ideal_air = @hpxml.building_construction.use_only_ideal_air_system
     end
 
     # Simulation parameters
@@ -917,8 +915,10 @@ class OSModel
   def self.add_num_occupants(model, hpxml, runner)
     # Occupants
     num_occ = Geometry.get_occupancy_default_num(@nbeds)
-    unless @hpxml.building_occupants[:number_of_residents].nil?
-      num_occ = @hpxml.building_occupants[:number_of_residents]
+    if not @hpxml.building_occupancy.nil?
+      if not @hpxml.building_occupancy.number_of_residents.nil?
+        num_occ = @hpxml.building_occupancy.number_of_residents
+      end
     end
     if num_occ > 0
       occ_gain, hrs_per_day, sens_frac, lat_frac = Geometry.get_occupancy_default_values()
@@ -942,23 +942,23 @@ class OSModel
 
     # Windows
     @hpxml.windows.each do |window|
-      wall_id = window[:wall_idref]
+      wall_id = window.wall_idref
       subsurface_areas[wall_id] = 0 if subsurface_areas[wall_id].nil?
-      subsurface_areas[wall_id] += window[:area]
+      subsurface_areas[wall_id] += window.area
     end
 
     # Skylights
     @hpxml.skylights.each do |skylight|
-      roof_id = skylight[:roof_idref]
+      roof_id = skylight.roof_idref
       subsurface_areas[roof_id] = 0 if subsurface_areas[roof_id].nil?
-      subsurface_areas[roof_id] += skylight[:area]
+      subsurface_areas[roof_id] += skylight.area
     end
 
     # Doors
     @hpxml.doors.each do |door|
-      wall_id = door[:wall_idref]
+      wall_id = door.wall_idref
       subsurface_areas[wall_id] = 0 if subsurface_areas[wall_id].nil?
-      subsurface_areas[wall_id] += door[:area]
+      subsurface_areas[wall_id] += door.area
     end
 
     return subsurface_areas
@@ -967,8 +967,8 @@ class OSModel
   def self.get_default_azimuths()
     azimuth_counts = {}
     (@hpxml.roofs + @hpxml.rim_joists + @hpxml.walls + @hpxml.foundation_walls +
-     @hpxml.frame_floors + @hpxml.slabs + @hpxml.windows + @hpxml.skylights + @hpxml.doors).each do |surface|
-      az = surface[:azimuth]
+     @hpxml.windows + @hpxml.skylights + @hpxml.doors).each do |surface|
+      az = surface.azimuth
       next if az.nil?
 
       azimuth_counts[az] = 0 if azimuth_counts[az].nil?
@@ -1005,25 +1005,25 @@ class OSModel
 
   def self.add_roofs(runner, model, spaces)
     @hpxml.roofs.each do |roof|
-      if roof[:azimuth].nil?
-        if roof[:pitch] > 0
+      if roof.azimuth.nil?
+        if roof.pitch > 0
           azimuths = @default_azimuths # Model as four directions for average exterior incident solar
         else
           azimuths = [90] # Arbitrary azimuth for flat roof
         end
       else
-        azimuths = [roof[:azimuth]]
+        azimuths = [roof.azimuth]
       end
 
       surfaces = []
 
       azimuths.each do |azimuth|
-        net_area = net_surface_area(roof[:area], roof[:id])
+        net_area = net_surface_area(roof.area, roof.id)
         next if net_area < 0.1
 
         width = Math::sqrt(net_area)
         length = (net_area / width) / azimuths.size
-        tilt = roof[:pitch] / 12.0
+        tilt = roof.pitch / 12.0
         z_origin = @walls_top + 0.5 * Math.sin(Math.atan(tilt)) * width
 
         surface = OpenStudio::Model::Surface.new(add_roof_polygon(length, width, z_origin, azimuth, tilt), model)
@@ -1034,13 +1034,13 @@ class OSModel
         surface.additionalProperties.setFeature("Tilt", tilt)
         surface.additionalProperties.setFeature("SurfaceType", "Roof")
         if azimuths.size > 1
-          surface.setName("#{roof[:id]}:#{azimuth}")
+          surface.setName("#{roof.id}:#{azimuth}")
         else
-          surface.setName(roof[:id])
+          surface.setName(roof.id)
         end
         surface.setSurfaceType("RoofCeiling")
         surface.setOutsideBoundaryCondition("Outdoors")
-        set_surface_interior(model, spaces, surface, roof[:id], roof[:interior_adjacent_to])
+        set_surface_interior(model, spaces, surface, roof.id, roof.interior_adjacent_to)
       end
 
       next if surfaces.empty?
@@ -1051,9 +1051,9 @@ class OSModel
       else
         drywall_thick_in = 0.0
       end
-      solar_abs = roof[:solar_absorptance]
-      emitt = roof[:emittance]
-      has_radiant_barrier = roof[:radiant_barrier]
+      solar_abs = roof.solar_absorptance
+      emitt = roof.emittance
+      has_radiant_barrier = roof.radiant_barrier
       if has_radiant_barrier
         film_r = Material.AirFilmOutside.rvalue + Material.AirFilmRoofRadiantBarrier(Geometry.get_roof_pitch([surfaces[0]])).rvalue
       else
@@ -1069,7 +1069,7 @@ class OSModel
         mat_roofing = Material.RoofingAsphaltShinglesWhiteCool(emitt, solar_abs)
       end
 
-      assembly_r = roof[:insulation_assembly_r_value]
+      assembly_r = roof.insulation_assembly_r_value
       constr_sets = [
         WoodStudConstructionSet.new(Material.Stud2x(8.0), 0.07, 10.0, 0.75, drywall_thick_in, mat_roofing), # 2x8, 24" o.c. + R10
         WoodStudConstructionSet.new(Material.Stud2x(8.0), 0.07, 5.0, 0.75, drywall_thick_in, mat_roofing),  # 2x8, 24" o.c. + R5
@@ -1078,11 +1078,11 @@ class OSModel
         WoodStudConstructionSet.new(Material.Stud2x4, 0.07, 0.0, 0.5, drywall_thick_in, mat_roofing),       # 2x4, 16" o.c.
         WoodStudConstructionSet.new(Material.Stud2x4, 0.01, 0.0, 0.0, 0.0, mat_roofing),                    # Fallback
       ]
-      match, constr_set, cavity_r = pick_wood_stud_construction_set(assembly_r, constr_sets, film_r, roof[:id])
+      match, constr_set, cavity_r = pick_wood_stud_construction_set(assembly_r, constr_sets, film_r, roof.id)
 
       install_grade = 1
 
-      Constructions.apply_closed_cavity_roof(model, surfaces, "#{roof[:id]} construction",
+      Constructions.apply_closed_cavity_roof(model, surfaces, "#{roof.id} construction",
                                              cavity_r, install_grade,
                                              constr_set.stud.thick_in,
                                              true, constr_set.framing_factor,
@@ -1095,20 +1095,20 @@ class OSModel
 
   def self.add_walls(runner, model, spaces)
     @hpxml.walls.each do |wall|
-      if wall[:azimuth].nil?
-        if wall[:exterior_adjacent_to] == "outside"
+      if wall.azimuth.nil?
+        if wall.exterior_adjacent_to == "outside"
           azimuths = @default_azimuths # Model as four directions for average exterior incident solar
         else
           azimuths = [@default_azimuths[0]] # Arbitrary direction, doesn't receive exterior incident solar
         end
       else
-        azimuths = [wall[:azimuth]]
+        azimuths = [wall.azimuth]
       end
 
       surfaces = []
 
       azimuths.each do |azimuth|
-        net_area = net_surface_area(wall[:area], wall[:id])
+        net_area = net_surface_area(wall.area, wall.id)
         next if net_area < 0.1
 
         height = 8.0 * @ncfl_ag
@@ -1122,14 +1122,14 @@ class OSModel
         surface.additionalProperties.setFeature("Tilt", 90.0)
         surface.additionalProperties.setFeature("SurfaceType", "Wall")
         if azimuths.size > 1
-          surface.setName("#{wall[:id]}:#{azimuth}")
+          surface.setName("#{wall.id}:#{azimuth}")
         else
-          surface.setName(wall[:id])
+          surface.setName(wall.id)
         end
         surface.setSurfaceType("Wall")
-        set_surface_interior(model, spaces, surface, wall[:id], wall[:interior_adjacent_to])
-        set_surface_exterior(model, spaces, surface, wall[:id], wall[:exterior_adjacent_to])
-        if wall[:exterior_adjacent_to] != "outside"
+        set_surface_interior(model, spaces, surface, wall.id, wall.interior_adjacent_to)
+        set_surface_exterior(model, spaces, surface, wall.id, wall.exterior_adjacent_to)
+        if wall.exterior_adjacent_to != "outside"
           surface.setSunExposure("NoSun")
           surface.setWindExposure("NoWind")
         end
@@ -1146,39 +1146,39 @@ class OSModel
       else
         drywall_thick_in = 0.0
       end
-      if wall[:exterior_adjacent_to] == "outside"
+      if wall.exterior_adjacent_to == "outside"
         film_r = Material.AirFilmVertical.rvalue + Material.AirFilmOutside.rvalue
         mat_ext_finish = Material.ExtFinishWoodLight
-        mat_ext_finish.tAbs = wall[:emittance]
-        mat_ext_finish.sAbs = wall[:solar_absorptance]
-        mat_ext_finish.vAbs = wall[:solar_absorptance]
+        mat_ext_finish.tAbs = wall.emittance
+        mat_ext_finish.sAbs = wall.solar_absorptance
+        mat_ext_finish.vAbs = wall.solar_absorptance
       else
         film_r = 2.0 * Material.AirFilmVertical.rvalue
         mat_ext_finish = nil
       end
 
-      apply_wall_construction(runner, model, surfaces, wall[:id], wall[:wall_type], wall[:insulation_assembly_r_value],
+      apply_wall_construction(runner, model, surfaces, wall.id, wall.wall_type, wall.insulation_assembly_r_value,
                               drywall_thick_in, film_r, mat_ext_finish)
     end
   end
 
   def self.add_rim_joists(runner, model, spaces)
     @hpxml.rim_joists.each do |rim_joist|
-      if rim_joist[:azimuth].nil?
-        if rim_joist[:exterior_adjacent_to] == "outside"
+      if rim_joist.azimuth.nil?
+        if rim_joist.exterior_adjacent_to == "outside"
           azimuths = @default_azimuths # Model as four directions for average exterior incident solar
         else
           azimuths = [@default_azimuths[0]] # Arbitrary direction, doesn't receive exterior incident solar
         end
       else
-        azimuths = [rim_joist[:azimuth]]
+        azimuths = [rim_joist.azimuth]
       end
 
       surfaces = []
 
       azimuths.each do |azimuth|
         height = 1.0
-        length = (rim_joist[:area] / height) / azimuths.size
+        length = (rim_joist.area / height) / azimuths.size
         z_origin = @foundation_top
 
         surface = OpenStudio::Model::Surface.new(add_wall_polygon(length, height, z_origin, azimuth), model)
@@ -1188,14 +1188,14 @@ class OSModel
         surface.additionalProperties.setFeature("Tilt", 90.0)
         surface.additionalProperties.setFeature("SurfaceType", "RimJoist")
         if azimuths.size > 1
-          surface.setName("#{rim_joist[:id]}:#{azimuth}")
+          surface.setName("#{rim_joist.id}:#{azimuth}")
         else
-          surface.setName(rim_joist[:id])
+          surface.setName(rim_joist.id)
         end
         surface.setSurfaceType("Wall")
-        set_surface_interior(model, spaces, surface, rim_joist[:id], rim_joist[:interior_adjacent_to])
-        set_surface_exterior(model, spaces, surface, rim_joist[:id], rim_joist[:exterior_adjacent_to])
-        if rim_joist[:exterior_adjacent_to] != "outside"
+        set_surface_interior(model, spaces, surface, rim_joist.id, rim_joist.interior_adjacent_to)
+        set_surface_exterior(model, spaces, surface, rim_joist.id, rim_joist.exterior_adjacent_to)
+        if rim_joist.exterior_adjacent_to != "outside"
           surface.setSunExposure("NoSun")
           surface.setWindExposure("NoWind")
         end
@@ -1208,18 +1208,18 @@ class OSModel
       else
         drywall_thick_in = 0.0
       end
-      if rim_joist[:exterior_adjacent_to] == "outside"
+      if rim_joist.exterior_adjacent_to == "outside"
         film_r = Material.AirFilmVertical.rvalue + Material.AirFilmOutside.rvalue
         mat_ext_finish = Material.ExtFinishWoodLight
-        mat_ext_finish.tAbs = rim_joist[:emittance]
-        mat_ext_finish.sAbs = rim_joist[:solar_absorptance]
-        mat_ext_finish.vAbs = rim_joist[:solar_absorptance]
+        mat_ext_finish.tAbs = rim_joist.emittance
+        mat_ext_finish.sAbs = rim_joist.solar_absorptance
+        mat_ext_finish.vAbs = rim_joist.solar_absorptance
       else
         film_r = 2.0 * Material.AirFilmVertical.rvalue
         mat_ext_finish = nil
       end
 
-      assembly_r = rim_joist[:insulation_assembly_r_value]
+      assembly_r = rim_joist.insulation_assembly_r_value
 
       constr_sets = [
         WoodStudConstructionSet.new(Material.Stud2x(2.0), 0.17, 10.0, 2.0, drywall_thick_in, mat_ext_finish),  # 2x4 + R10
@@ -1227,10 +1227,10 @@ class OSModel
         WoodStudConstructionSet.new(Material.Stud2x(2.0), 0.17, 0.0, 2.0, drywall_thick_in, mat_ext_finish),   # 2x4
         WoodStudConstructionSet.new(Material.Stud2x(2.0), 0.01, 0.0, 0.0, 0.0, mat_ext_finish),                # Fallback
       ]
-      match, constr_set, cavity_r = pick_wood_stud_construction_set(assembly_r, constr_sets, film_r, rim_joist[:id])
+      match, constr_set, cavity_r = pick_wood_stud_construction_set(assembly_r, constr_sets, film_r, rim_joist.id)
       install_grade = 1
 
-      Constructions.apply_rim_joist(model, surfaces, "#{rim_joist[:id]} construction",
+      Constructions.apply_rim_joist(model, surfaces, "#{rim_joist.id} construction",
                                     cavity_r, install_grade, constr_set.framing_factor,
                                     constr_set.drywall_thick_in, constr_set.osb_thick_in,
                                     constr_set.rigid_r, constr_set.exterior_material)
@@ -1240,32 +1240,32 @@ class OSModel
 
   def self.add_frame_floors(runner, model, spaces)
     @hpxml.frame_floors.each do |frame_floor|
-      area = frame_floor[:area]
+      area = frame_floor.area
       width = Math::sqrt(area)
       length = area / width
-      if frame_floor[:interior_adjacent_to].include? "attic" or frame_floor[:exterior_adjacent_to].include? "attic"
+      if frame_floor.interior_adjacent_to.include? "attic" or frame_floor.exterior_adjacent_to.include? "attic"
         z_origin = @walls_top
       else
         z_origin = @foundation_top
       end
 
-      if hpxml_frame_floor_is_ceiling(frame_floor[:interior_adjacent_to], frame_floor[:exterior_adjacent_to])
+      if hpxml_frame_floor_is_ceiling(frame_floor.interior_adjacent_to, frame_floor.exterior_adjacent_to)
         surface = OpenStudio::Model::Surface.new(add_ceiling_polygon(length, width, z_origin), model)
         surface.additionalProperties.setFeature("SurfaceType", "Ceiling")
       else
         surface = OpenStudio::Model::Surface.new(add_floor_polygon(length, width, z_origin), model)
         surface.additionalProperties.setFeature("SurfaceType", "Floor")
       end
-      set_surface_interior(model, spaces, surface, frame_floor[:id], frame_floor[:interior_adjacent_to])
-      set_surface_exterior(model, spaces, surface, frame_floor[:id], frame_floor[:exterior_adjacent_to])
-      surface.setName(frame_floor[:id])
+      set_surface_interior(model, spaces, surface, frame_floor.id, frame_floor.interior_adjacent_to)
+      set_surface_exterior(model, spaces, surface, frame_floor.id, frame_floor.exterior_adjacent_to)
+      surface.setName(frame_floor.id)
       surface.setSunExposure("NoSun")
       surface.setWindExposure("NoWind")
 
       # Apply construction
 
       film_r = 2.0 * Material.AirFilmFloorReduced.rvalue
-      assembly_r = frame_floor[:insulation_assembly_r_value]
+      assembly_r = frame_floor.insulation_assembly_r_value
 
       constr_sets = [
         WoodStudConstructionSet.new(Material.Stud2x6, 0.10, 10.0, 0.75, 0.0, Material.CoveringBare), # 2x6, 24" o.c. + R10
@@ -1273,13 +1273,13 @@ class OSModel
         WoodStudConstructionSet.new(Material.Stud2x4, 0.13, 0.0, 0.5, 0.0, Material.CoveringBare),   # 2x4, 16" o.c.
         WoodStudConstructionSet.new(Material.Stud2x4, 0.01, 0.0, 0.0, 0.0, nil),                     # Fallback
       ]
-      match, constr_set, cavity_r = pick_wood_stud_construction_set(assembly_r, constr_sets, film_r, frame_floor[:id])
+      match, constr_set, cavity_r = pick_wood_stud_construction_set(assembly_r, constr_sets, film_r, frame_floor.id)
 
       mat_floor_covering = nil
       install_grade = 1
 
       # Floor
-      Constructions.apply_floor(model, [surface], "#{frame_floor[:id]} construction",
+      Constructions.apply_floor(model, [surface], "#{frame_floor.id} construction",
                                 cavity_r, install_grade,
                                 constr_set.framing_factor, constr_set.stud.thick_in,
                                 constr_set.osb_thick_in, constr_set.rigid_r,
@@ -1293,32 +1293,32 @@ class OSModel
     @hpxml.foundation_walls.each do |foundation_wall|
       found_slab = false
       @hpxml.slabs.each do |slab|
-        found_slab = true if foundation_wall[:interior_adjacent_to] == slab[:interior_adjacent_to]
+        found_slab = true if foundation_wall.interior_adjacent_to == slab.interior_adjacent_to
       end
       next if found_slab
 
-      fail "Foundation wall '#{foundation_wall[:id]}' is adjacent to '#{foundation_wall[:interior_adjacent_to]}' but no corresponding slab was found adjacent to '#{foundation_wall[:interior_adjacent_to]}'."
+      fail "Foundation wall '#{foundation_wall.id}' is adjacent to '#{foundation_wall.interior_adjacent_to}' but no corresponding slab was found adjacent to '#{foundation_wall.interior_adjacent_to}'."
     end
 
     # Check for slabs without corresponding foundation walls
     @hpxml.slabs.each do |slab|
-      next if ['living space', 'garage'].include? slab[:interior_adjacent_to]
+      next if ['living space', 'garage'].include? slab.interior_adjacent_to
 
       found_foundation_wall = false
       @hpxml.foundation_walls.each do |foundation_wall|
-        found_foundation_wall = true if slab[:interior_adjacent_to] == foundation_wall[:interior_adjacent_to]
+        found_foundation_wall = true if slab.interior_adjacent_to == foundation_wall.interior_adjacent_to
       end
       next if found_foundation_wall
 
-      fail "Slab '#{slab[:id]}' is adjacent to '#{slab[:interior_adjacent_to]}' but no corresponding foundation walls were found adjacent to '#{slab[:interior_adjacent_to]}'.\n"
+      fail "Slab '#{slab.id}' is adjacent to '#{slab.interior_adjacent_to}' but no corresponding foundation walls were found adjacent to '#{slab.interior_adjacent_to}'.\n"
     end
 
     # Get foundation types
     foundation_types = []
     @hpxml.slabs.each do |slab|
-      next if foundation_types.include? slab[:interior_adjacent_to]
+      next if foundation_types.include? slab.interior_adjacent_to
 
-      foundation_types << slab[:interior_adjacent_to]
+      foundation_types << slab.interior_adjacent_to
     end
 
     foundation_types.each do |foundation_type|
@@ -1326,12 +1326,12 @@ class OSModel
       fnd_walls = []
       slabs = []
       @hpxml.foundation_walls.each do |foundation_wall|
-        next unless foundation_wall[:interior_adjacent_to] == foundation_type
+        next unless foundation_wall.interior_adjacent_to == foundation_type
 
         fnd_walls << foundation_wall
       end
       @hpxml.slabs.each do |slab|
-        next unless slab[:interior_adjacent_to] == foundation_type
+        next unless slab.interior_adjacent_to == foundation_type
 
         slabs << slab
       end
@@ -1342,17 +1342,17 @@ class OSModel
       # Obtain some wall/slab information
       fnd_wall_lengths = {}
       fnd_walls.each do |foundation_wall|
-        next unless foundation_wall[:exterior_adjacent_to] == "ground"
+        next unless foundation_wall.exterior_adjacent_to == "ground"
 
-        fnd_wall_lengths[foundation_wall] = foundation_wall[:area] / foundation_wall[:height]
+        fnd_wall_lengths[foundation_wall] = foundation_wall.area / foundation_wall.height
       end
       slab_exp_perims = {}
       slab_areas = {}
       slabs.each do |slab|
-        slab_exp_perims[slab] = slab[:exposed_perimeter]
-        slab_areas[slab] = slab[:area]
+        slab_exp_perims[slab] = slab.exposed_perimeter
+        slab_areas[slab] = slab.area
         if slab_exp_perims[slab] <= 0
-          fail "Exposed perimeter for Slab '#{slab[:id]}' must be greater than zero."
+          fail "Exposed perimeter for Slab '#{slab.id}' must be greater than zero."
         end
       end
       total_slab_exp_perim = slab_exp_perims.values.inject(0, :+)
@@ -1371,7 +1371,7 @@ class OSModel
         end
 
         kiva_foundation = nil
-        if not foundation_wall.empty?
+        if not foundation_wall.nil?
           # Add exterior foundation wall surface
           kiva_foundation = add_foundation_wall(runner, model, spaces, foundation_wall, slab_frac,
                                                 total_fnd_wall_length, total_slab_exp_perim)
@@ -1381,7 +1381,7 @@ class OSModel
         slab_exp_perim = slab_exp_perims[slab] * fnd_wall_frac
         slab_area = slab_areas[slab] * fnd_wall_frac
         no_wall_slab_exp_perim[slab] = 0.0 if no_wall_slab_exp_perim[slab].nil?
-        if not foundation_wall.empty? and slab_exp_perim > fnd_wall_lengths[foundation_wall] * slab_frac
+        if not foundation_wall.nil? and slab_exp_perim > fnd_wall_lengths[foundation_wall] * slab_frac
           # Keep track of no-wall slab exposed perimeter
           no_wall_slab_exp_perim[slab] += (slab_exp_perim - fnd_wall_lengths[foundation_wall] * slab_frac)
 
@@ -1393,10 +1393,10 @@ class OSModel
           slab_exp_perim *= exp_perim_frac
           slab_area *= exp_perim_frac
         end
-        if not foundation_wall.empty?
-          z_origin = -1 * foundation_wall[:depth_below_grade] # Position based on adjacent foundation walls
+        if not foundation_wall.nil?
+          z_origin = -1 * foundation_wall.depth_below_grade # Position based on adjacent foundation walls
         else
-          z_origin = -1 * slab[:depth_below_grade]
+          z_origin = -1 * slab.depth_below_grade
         end
         kiva_foundation = add_foundation_slab(runner, model, spaces, slab, slab_exp_perim,
                                               slab_area, z_origin, kiva_foundation)
@@ -1417,18 +1417,18 @@ class OSModel
       # The below-grade portion of these walls (in contact with ground) are not modeled, as Kiva does not
       # calculate heat flow between two zones through the ground.
       fnd_walls.each do |foundation_wall|
-        next unless foundation_wall[:exterior_adjacent_to] != "ground"
+        next unless foundation_wall.exterior_adjacent_to != "ground"
 
-        ag_height = foundation_wall[:height] - foundation_wall[:depth_below_grade]
-        ag_net_area = net_surface_area(foundation_wall[:area], foundation_wall[:id]) * ag_height / foundation_wall[:height]
+        ag_height = foundation_wall.height - foundation_wall.depth_below_grade
+        ag_net_area = net_surface_area(foundation_wall.area, foundation_wall.id) * ag_height / foundation_wall.height
         next if ag_net_area < 0.1
 
         length = ag_net_area / ag_height
         z_origin = -1 * ag_height
-        if foundation_wall[:azimuth].nil?
+        if foundation_wall.azimuth.nil?
           azimuth = @default_azimuths[0] # Arbitrary direction, doesn't receive exterior incident solar
         else
-          azimuth = foundation_wall[:azimuth]
+          azimuth = foundation_wall.azimuth
         end
 
         surface = OpenStudio::Model::Surface.new(add_wall_polygon(length, ag_height, z_origin, azimuth), model)
@@ -1436,10 +1436,10 @@ class OSModel
         surface.additionalProperties.setFeature("Azimuth", azimuth)
         surface.additionalProperties.setFeature("Tilt", 90.0)
         surface.additionalProperties.setFeature("SurfaceType", "FoundationWall")
-        surface.setName(foundation_wall[:id])
+        surface.setName(foundation_wall.id)
         surface.setSurfaceType("Wall")
-        set_surface_interior(model, spaces, surface, foundation_wall[:id], foundation_wall[:interior_adjacent_to])
-        set_surface_exterior(model, spaces, surface, foundation_wall[:id], foundation_wall[:exterior_adjacent_to])
+        set_surface_interior(model, spaces, surface, foundation_wall.id, foundation_wall.interior_adjacent_to)
+        set_surface_exterior(model, spaces, surface, foundation_wall.id, foundation_wall.exterior_adjacent_to)
         surface.setSunExposure("NoSun")
         surface.setWindExposure("NoWind")
 
@@ -1452,16 +1452,16 @@ class OSModel
           drywall_thick_in = 0.0
         end
         film_r = 2.0 * Material.AirFilmVertical.rvalue
-        assembly_r = foundation_wall[:insulation_assembly_r_value]
+        assembly_r = foundation_wall.insulation_assembly_r_value
         if assembly_r.nil?
-          concrete_thick_in = foundation_wall[:thickness]
-          int_r = foundation_wall[:insulation_interior_r_value]
-          ext_r = foundation_wall[:insulation_exterior_r_value]
+          concrete_thick_in = foundation_wall.thickness
+          int_r = foundation_wall.insulation_interior_r_value
+          ext_r = foundation_wall.insulation_exterior_r_value
           assembly_r = int_r + ext_r + Material.Concrete(concrete_thick_in).rvalue + Material.GypsumWall(drywall_thick_in).rvalue + film_r
         end
         mat_ext_finish = nil
 
-        apply_wall_construction(runner, model, [surface], foundation_wall[:id], wall_type, assembly_r,
+        apply_wall_construction(runner, model, [surface], foundation_wall.id, wall_type, assembly_r,
                                 drywall_thick_in, film_r, mat_ext_finish)
       end
     end
@@ -1470,16 +1470,16 @@ class OSModel
   def self.add_foundation_wall(runner, model, spaces, foundation_wall, slab_frac,
                                total_fnd_wall_length, total_slab_exp_perim)
 
-    net_area = net_surface_area(foundation_wall[:area], foundation_wall[:id]) * slab_frac
-    gross_area = foundation_wall[:area] * slab_frac
-    height = foundation_wall[:height]
-    height_ag = height - foundation_wall[:depth_below_grade]
-    z_origin = -1 * foundation_wall[:depth_below_grade]
+    net_area = net_surface_area(foundation_wall.area, foundation_wall.id) * slab_frac
+    gross_area = foundation_wall.area * slab_frac
+    height = foundation_wall.height
+    height_ag = height - foundation_wall.depth_below_grade
+    z_origin = -1 * foundation_wall.depth_below_grade
     length = gross_area / height
-    if foundation_wall[:azimuth].nil?
+    if foundation_wall.azimuth.nil?
       azimuth = @default_azimuths[0] # Arbitrary; solar incidence in Kiva is applied as an orientation average (to the above grade portion of the wall)
     else
-      azimuth = foundation_wall[:azimuth]
+      azimuth = foundation_wall.azimuth
     end
 
     if total_fnd_wall_length > total_slab_exp_perim
@@ -1500,18 +1500,18 @@ class OSModel
     surface.additionalProperties.setFeature("Azimuth", azimuth)
     surface.additionalProperties.setFeature("Tilt", 90.0)
     surface.additionalProperties.setFeature("SurfaceType", "FoundationWall")
-    surface.setName(foundation_wall[:id])
+    surface.setName(foundation_wall.id)
     surface.setSurfaceType("Wall")
-    set_surface_interior(model, spaces, surface, foundation_wall[:id], foundation_wall[:interior_adjacent_to])
-    set_surface_exterior(model, spaces, surface, foundation_wall[:id], foundation_wall[:exterior_adjacent_to])
+    set_surface_interior(model, spaces, surface, foundation_wall.id, foundation_wall.interior_adjacent_to)
+    set_surface_exterior(model, spaces, surface, foundation_wall.id, foundation_wall.exterior_adjacent_to)
 
     if is_thermal_boundary(foundation_wall)
       drywall_thick_in = 0.5
     else
       drywall_thick_in = 0.0
     end
-    concrete_thick_in = foundation_wall[:thickness]
-    assembly_r = foundation_wall[:insulation_assembly_r_value]
+    concrete_thick_in = foundation_wall.thickness
+    assembly_r = foundation_wall.insulation_assembly_r_value
     if not assembly_r.nil?
       ext_rigid_height = height
       ext_rigid_offset = 0.0
@@ -1532,15 +1532,15 @@ class OSModel
         match = true
       end
     else
-      ext_rigid_offset = foundation_wall[:insulation_exterior_distance_to_top]
-      ext_rigid_height = foundation_wall[:insulation_exterior_distance_to_bottom] - ext_rigid_offset
-      ext_rigid_r = foundation_wall[:insulation_exterior_r_value]
-      int_rigid_offset = foundation_wall[:insulation_interior_distance_to_top]
-      int_rigid_height = foundation_wall[:insulation_interior_distance_to_bottom] - int_rigid_offset
-      int_rigid_r = foundation_wall[:insulation_interior_r_value]
+      ext_rigid_offset = foundation_wall.insulation_exterior_distance_to_top
+      ext_rigid_height = foundation_wall.insulation_exterior_distance_to_bottom - ext_rigid_offset
+      ext_rigid_r = foundation_wall.insulation_exterior_r_value
+      int_rigid_offset = foundation_wall.insulation_interior_distance_to_top
+      int_rigid_height = foundation_wall.insulation_interior_distance_to_bottom - int_rigid_offset
+      int_rigid_r = foundation_wall.insulation_interior_r_value
     end
 
-    Constructions.apply_foundation_wall(model, [surface], "#{foundation_wall[:id]} construction",
+    Constructions.apply_foundation_wall(model, [surface], "#{foundation_wall.id} construction",
                                         ext_rigid_offset, int_rigid_offset, ext_rigid_height, int_rigid_height,
                                         ext_rigid_r, int_rigid_r, drywall_thick_in, concrete_thick_in, height_ag)
 
@@ -1565,28 +1565,28 @@ class OSModel
     slab_width = slab_tot_perim / 4.0 - Math.sqrt(sqrt_term) / 4.0
 
     surface = OpenStudio::Model::Surface.new(add_floor_polygon(slab_length, slab_width, z_origin), model)
-    surface.setName(slab[:id])
+    surface.setName(slab.id)
     surface.setSurfaceType("Floor")
     surface.setOutsideBoundaryCondition("Foundation")
     surface.additionalProperties.setFeature("SurfaceType", "Slab")
-    set_surface_interior(model, spaces, surface, slab[:id], slab[:interior_adjacent_to])
+    set_surface_interior(model, spaces, surface, slab.id, slab.interior_adjacent_to)
     surface.setSunExposure("NoSun")
     surface.setWindExposure("NoWind")
 
-    slab_perim_r = slab[:perimeter_insulation_r_value]
-    slab_perim_depth = slab[:perimeter_insulation_depth]
+    slab_perim_r = slab.perimeter_insulation_r_value
+    slab_perim_depth = slab.perimeter_insulation_depth
     if slab_perim_r == 0 or slab_perim_depth == 0
       slab_perim_r = 0
       slab_perim_depth = 0
     end
 
-    if slab[:under_slab_insulation_spans_entire_slab]
-      slab_whole_r = slab[:under_slab_insulation_r_value]
+    if slab.under_slab_insulation_spans_entire_slab
+      slab_whole_r = slab.under_slab_insulation_r_value
       slab_under_r = 0
       slab_under_width = 0
     else
-      slab_under_r = slab[:under_slab_insulation_r_value]
-      slab_under_width = slab[:under_slab_insulation_width]
+      slab_under_r = slab.under_slab_insulation_r_value
+      slab_under_width = slab.under_slab_insulation_width
       if slab_under_r == 0 or slab_under_width == 0
         slab_under_r = 0
         slab_under_width = 0
@@ -1596,14 +1596,14 @@ class OSModel
     slab_gap_r = slab_under_r
 
     mat_carpet = nil
-    if slab[:carpet_fraction] > 0 and slab[:carpet_r_value] > 0
-      mat_carpet = Material.CoveringBare(slab[:carpet_fraction],
-                                         slab[:carpet_r_value])
+    if slab.carpet_fraction > 0 and slab.carpet_r_value > 0
+      mat_carpet = Material.CoveringBare(slab.carpet_fraction,
+                                         slab.carpet_r_value)
     end
 
-    Constructions.apply_foundation_slab(model, surface, "#{slab[:id]} construction",
+    Constructions.apply_foundation_slab(model, surface, "#{slab.id} construction",
                                         slab_under_r, slab_under_width, slab_gap_r, slab_perim_r,
-                                        slab_perim_depth, slab_whole_r, slab[:thickness],
+                                        slab_perim_depth, slab_whole_r, slab.thickness,
                                         slab_exp_perim, mat_carpet, kiva_foundation)
     # FIXME: Temporary code for sizing
     surface.additionalProperties.setFeature(Constants.SizingInfoSlabRvalue, 10.0)
@@ -1700,9 +1700,9 @@ class OSModel
 
     shading_surfaces = []
     @hpxml.neighbor_buildings.each do |neighbor_building|
-      azimuth = neighbor_building[:azimuth]
-      distance = neighbor_building[:distance]
-      height = neighbor_building[:height].nil? ? default_height : neighbor_building[:height]
+      azimuth = neighbor_building.azimuth
+      distance = neighbor_building.distance
+      height = neighbor_building.height.nil? ? default_height : neighbor_building.height
 
       shading_surface = OpenStudio::Model::ShadingSurface.new(add_wall_polygon(length, height, z_origin, azimuth), model)
       shading_surface.additionalProperties.setFeature("Azimuth", azimuth)
@@ -1733,24 +1733,24 @@ class OSModel
   def self.add_windows(runner, model, spaces, weather)
     surfaces = []
     @hpxml.windows.each do |window|
-      window_id = window[:id]
+      window_id = window.id
 
       window_height = 4.0 # ft, default
       overhang_depth = nil
-      if not window[:overhangs_depth].nil?
-        overhang_depth = window[:overhangs_depth]
-        overhang_distance_to_top = window[:overhangs_distance_to_top_of_window]
-        overhang_distance_to_bottom = window[:overhangs_distance_to_bottom_of_window]
+      if not window.overhangs_depth.nil?
+        overhang_depth = window.overhangs_depth
+        overhang_distance_to_top = window.overhangs_distance_to_top_of_window
+        overhang_distance_to_bottom = window.overhangs_distance_to_bottom_of_window
         if overhang_distance_to_bottom <= overhang_distance_to_top
           fail "For Window '#{window_id}', overhangs distance to bottom (#{overhang_distance_to_bottom}) must be greater than distance to top (#{overhang_distance_to_top})."
         end
         window_height = overhang_distance_to_bottom - overhang_distance_to_top
       end
 
-      window_area = window[:area]
+      window_area = window.area
       window_width = window_area / window_height
       z_origin = @foundation_top
-      window_azimuth = window[:azimuth]
+      window_azimuth = window.azimuth
 
       # Create parent surface slightly bigger than window
       surface = OpenStudio::Model::Surface.new(add_wall_polygon(window_width, window_height, z_origin,
@@ -1762,7 +1762,7 @@ class OSModel
       surface.additionalProperties.setFeature("SurfaceType", "Window")
       surface.setName("surface #{window_id}")
       surface.setSurfaceType("Wall")
-      assign_space_to_subsurface(surface, window_id, window[:wall_idref], spaces, model, "window")
+      assign_space_to_subsurface(surface, window_id, window.wall_idref, spaces, model, "window")
       surface.setOutsideBoundaryCondition("Outdoors") # cannot be adiabatic because subsurfaces won't be created
       surfaces << surface
 
@@ -1781,19 +1781,19 @@ class OSModel
       end
 
       # Apply construction
-      ufactor = window[:ufactor]
-      shgc = window[:shgc]
+      ufactor = window.ufactor
+      shgc = window.shgc
       default_shade_summer, default_shade_winter = Constructions.get_default_interior_shading_factors()
       cool_shade_mult = default_shade_summer
-      if not window[:interior_shading_factor_summer].nil?
-        cool_shade_mult = window[:interior_shading_factor_summer]
+      if not window.interior_shading_factor_summer.nil?
+        cool_shade_mult = window.interior_shading_factor_summer
       end
       heat_shade_mult = default_shade_winter
-      if not window[:interior_shading_factor_winter].nil?
-        heat_shade_mult = window[:interior_shading_factor_winter]
+      if not window.interior_shading_factor_winter.nil?
+        heat_shade_mult = window.interior_shading_factor_winter
       end
       if cool_shade_mult > heat_shade_mult
-        fail "SummerShadingCoefficient (#{cool_shade_mult}) must be less than or equal to WinterShadingCoefficient (#{heat_shade_mult}) for window '#{window[:id]}'."
+        fail "SummerShadingCoefficient (#{cool_shade_mult}) must be less than or equal to WinterShadingCoefficient (#{heat_shade_mult}) for window '#{window.id}'."
       end
 
       Constructions.apply_window(model, [sub_surface],
@@ -1807,25 +1807,25 @@ class OSModel
 
   def self.add_skylights(runner, model, spaces, weather)
     surfaces = []
-    @hpxml.skylights.each do |skylight_values|
-      skylight_id = skylight_values[:id]
+    @hpxml.skylights.each do |skylight|
+      skylight_id = skylight.id
 
       # Obtain skylight tilt from attached roof
       skylight_tilt = nil
       @hpxml.roofs.each do |roof|
-        next unless roof[:id] == skylight_values[:roof_idref]
+        next unless roof.id == skylight.roof_idref
 
-        skylight_tilt = roof[:pitch] / 12.0
+        skylight_tilt = roof.pitch / 12.0
       end
       if skylight_tilt.nil?
-        fail "Attached roof '#{skylight_values[:roof_idref]}' not found for skylight '#{skylight_id}'."
+        fail "Attached roof '#{skylight.roof_idref}' not found for skylight '#{skylight_id}'."
       end
 
-      skylight_area = skylight_values[:area]
+      skylight_area = skylight.area
       skylight_height = Math::sqrt(skylight_area)
       skylight_width = skylight_area / skylight_height
       z_origin = @walls_top + 0.5 * Math.sin(Math.atan(skylight_tilt)) * skylight_height
-      skylight_azimuth = skylight_values[:azimuth]
+      skylight_azimuth = skylight.azimuth
 
       # Create parent surface slightly bigger than skylight
       surface = OpenStudio::Model::Surface.new(add_roof_polygon(skylight_width + 0.0001, skylight_height + 0.0001, z_origin,
@@ -1849,8 +1849,8 @@ class OSModel
       sub_surface.setSubSurfaceType("Skylight")
 
       # Apply construction
-      ufactor = skylight_values[:ufactor]
-      shgc = skylight_values[:shgc]
+      ufactor = skylight.ufactor
+      shgc = skylight.shgc
       cool_shade_mult = 1.0
       heat_shade_mult = 1.0
       Constructions.apply_skylight(model, [sub_surface],
@@ -1864,11 +1864,11 @@ class OSModel
 
   def self.add_doors(runner, model, spaces)
     surfaces = []
-    @hpxml.doors.each do |door_values|
-      door_id = door_values[:id]
+    @hpxml.doors.each do |door|
+      door_id = door.id
 
-      door_area = door_values[:area]
-      door_azimuth = door_values[:azimuth]
+      door_area = door.area
+      door_azimuth = door.azimuth
 
       door_height = 6.67 # ft
       door_width = door_area / door_height
@@ -1884,7 +1884,7 @@ class OSModel
       surface.additionalProperties.setFeature("SurfaceType", "Door")
       surface.setName("surface #{door_id}")
       surface.setSurfaceType("Wall")
-      assign_space_to_subsurface(surface, door_id, door_values[:wall_idref], spaces, model, "door")
+      assign_space_to_subsurface(surface, door_id, door.wall_idref, spaces, model, "door")
       surface.setOutsideBoundaryCondition("Outdoors") # cannot be adiabatic because subsurfaces won't be created
       surfaces << surface
 
@@ -1895,7 +1895,7 @@ class OSModel
       sub_surface.setSubSurfaceType("Door")
 
       # Apply construction
-      ufactor = 1.0 / door_values[:r_value]
+      ufactor = 1.0 / door.r_value
 
       Constructions.apply_door(model, [sub_surface], "Door", ufactor)
     end
@@ -1924,75 +1924,74 @@ class OSModel
   end
 
   def self.add_hot_water_and_appliances(runner, model, weather, spaces)
-    related_hvac_list = [] # list of hvac systems refered in water heating system "RelatedHvac" element
     # Clothes Washer
-    if not @hpxml.clothes_washer.empty?
-      cw_space = get_space_from_location(@hpxml.clothes_washer[:location], "ClothesWasher", model, spaces)
-      cw_ler = @hpxml.clothes_washer[:rated_annual_kwh]
-      cw_elec_rate = @hpxml.clothes_washer[:label_electric_rate]
-      cw_gas_rate = @hpxml.clothes_washer[:label_gas_rate]
-      cw_agc = @hpxml.clothes_washer[:label_annual_gas_cost]
-      cw_cap = @hpxml.clothes_washer[:capacity]
-      cw_mef = @hpxml.clothes_washer[:modified_energy_factor]
+    if not @hpxml.clothes_washer.nil?
+      cw_space = get_space_from_location(@hpxml.clothes_washer.location, "ClothesWasher", model, spaces)
+      cw_ler = @hpxml.clothes_washer.rated_annual_kwh
+      cw_elec_rate = @hpxml.clothes_washer.label_electric_rate
+      cw_gas_rate = @hpxml.clothes_washer.label_gas_rate
+      cw_agc = @hpxml.clothes_washer.label_annual_gas_cost
+      cw_cap = @hpxml.clothes_washer.capacity
+      cw_mef = @hpxml.clothes_washer.modified_energy_factor
       if cw_mef.nil?
-        cw_mef = HotWaterAndAppliances.calc_clothes_washer_mef_from_imef(@hpxml.clothes_washer[:integrated_modified_energy_factor])
+        cw_mef = HotWaterAndAppliances.calc_clothes_washer_mef_from_imef(@hpxml.clothes_washer.integrated_modified_energy_factor)
       end
     else
       cw_mef = cw_ler = cw_elec_rate = cw_gas_rate = cw_agc = cw_cap = cw_space = nil
     end
 
     # Clothes Dryer
-    if not @hpxml.clothes_dryer.empty?
-      cd_space = get_space_from_location(@hpxml.clothes_dryer[:location], "ClothesDryer", model, spaces)
-      cd_fuel = @hpxml.clothes_dryer[:fuel_type]
-      cd_control = @hpxml.clothes_dryer[:control_type]
-      cd_ef = @hpxml.clothes_dryer[:energy_factor]
+    if not @hpxml.clothes_dryer.nil?
+      cd_space = get_space_from_location(@hpxml.clothes_dryer.location, "ClothesDryer", model, spaces)
+      cd_fuel = @hpxml.clothes_dryer.fuel_type
+      cd_control = @hpxml.clothes_dryer.control_type
+      cd_ef = @hpxml.clothes_dryer.energy_factor
       if cd_ef.nil?
-        cd_ef = HotWaterAndAppliances.calc_clothes_dryer_ef_from_cef(@hpxml.clothes_dryer[:combined_energy_factor])
+        cd_ef = HotWaterAndAppliances.calc_clothes_dryer_ef_from_cef(@hpxml.clothes_dryer.combined_energy_factor)
       end
     else
       cd_ef = cd_control = cd_fuel = cd_space = nil
     end
 
     # Dishwasher
-    if not @hpxml.dishwasher.empty?
-      dw_cap = @hpxml.dishwasher[:place_setting_capacity]
-      dw_ef = @hpxml.dishwasher[:energy_factor]
+    if not @hpxml.dishwasher.nil?
+      dw_cap = @hpxml.dishwasher.place_setting_capacity
+      dw_ef = @hpxml.dishwasher.energy_factor
       if dw_ef.nil?
-        dw_ef = HotWaterAndAppliances.calc_dishwasher_ef_from_annual_kwh(@hpxml.dishwasher[:rated_annual_kwh])
+        dw_ef = HotWaterAndAppliances.calc_dishwasher_ef_from_annual_kwh(@hpxml.dishwasher.rated_annual_kwh)
       end
     else
       dw_ef = dw_cap = nil
     end
 
     # Refrigerator
-    if not @hpxml.refrigerator.empty?
-      fridge_space = get_space_from_location(@hpxml.refrigerator[:location], "Refrigerator", model, spaces)
-      fridge_annual_kwh = @hpxml.refrigerator[:adjusted_annual_kwh]
+    if not @hpxml.refrigerator.nil?
+      fridge_space = get_space_from_location(@hpxml.refrigerator.location, "Refrigerator", model, spaces)
+      fridge_annual_kwh = @hpxml.refrigerator.adjusted_annual_kwh
       if fridge_annual_kwh.nil?
-        fridge_annual_kwh = @hpxml.refrigerator[:rated_annual_kwh]
+        fridge_annual_kwh = @hpxml.refrigerator.rated_annual_kwh
       end
     else
       fridge_annual_kwh = fridge_space = nil
     end
 
     # Cooking Range/Oven
-    if not @hpxml.cooking_range.empty? and not @hpxml.oven.empty?
-      cook_fuel_type = @hpxml.cooking_range[:fuel_type]
-      cook_is_induction = @hpxml.cooking_range[:is_induction]
-      oven_is_convection = @hpxml.oven[:is_convection]
+    if not @hpxml.cooking_range.nil? and not @hpxml.oven.nil?
+      cook_fuel_type = @hpxml.cooking_range.fuel_type
+      cook_is_induction = @hpxml.cooking_range.is_induction
+      oven_is_convection = @hpxml.oven.is_convection
     else
       cook_fuel_type = cook_is_induction = oven_is_convection = nil
     end
 
     # Fixtures
     has_low_flow_fixtures = false
-    if not @hpxml.water_heating_systems.empty?
+    if @hpxml.water_heating_systems.size > 0
       low_flow_fixtures_list = []
-      @hpxml.water_fixtures.each do |water_fixture_values|
-        next unless ['shower head', 'faucet'].include? water_fixture_values[:water_fixture_type]
+      @hpxml.water_fixtures.each do |water_fixture|
+        next unless ['shower head', 'faucet'].include? water_fixture.water_fixture_type
 
-        low_flow_fixtures_list << water_fixture_values[:low_flow]
+        low_flow_fixtures_list << water_fixture.low_flow
       end
       low_flow_fixtures_list.uniq!
       if low_flow_fixtures_list.size == 1 and low_flow_fixtures_list[0]
@@ -2001,22 +2000,22 @@ class OSModel
     end
 
     # Distribution
-    if not @hpxml.water_heating_systems.empty?
-      dist_type = @hpxml.hot_water_distribution[:system_type].downcase
+    if @hpxml.water_heating_systems.size > 0
+      dist_type = @hpxml.hot_water_distribution.system_type.downcase
       if dist_type == "standard"
-        std_pipe_length = @hpxml.hot_water_distribution[:standard_piping_length]
+        std_pipe_length = @hpxml.hot_water_distribution.standard_piping_length
         recirc_loop_length = nil
         recirc_branch_length = nil
         recirc_control_type = nil
         recirc_pump_power = nil
       elsif dist_type == "recirculation"
-        recirc_loop_length = @hpxml.hot_water_distribution[:recirculation_piping_length]
-        recirc_branch_length = @hpxml.hot_water_distribution[:recirculation_branch_piping_length]
-        recirc_control_type = @hpxml.hot_water_distribution[:recirculation_control_type]
-        recirc_pump_power = @hpxml.hot_water_distribution[:recirculation_pump_power]
+        recirc_loop_length = @hpxml.hot_water_distribution.recirculation_piping_length
+        recirc_branch_length = @hpxml.hot_water_distribution.recirculation_branch_piping_length
+        recirc_control_type = @hpxml.hot_water_distribution.recirculation_control_type
+        recirc_pump_power = @hpxml.hot_water_distribution.recirculation_pump_power
         std_pipe_length = nil
       end
-      pipe_r = @hpxml.hot_water_distribution[:pipe_r_value]
+      pipe_r = @hpxml.hot_water_distribution.pipe_r_value
     end
 
     # Drain Water Heat Recovery
@@ -2024,12 +2023,12 @@ class OSModel
     dwhr_facilities_connected = nil
     dwhr_is_equal_flow = nil
     dwhr_efficiency = nil
-    if not @hpxml.water_heating_systems.empty?
-      if not @hpxml.hot_water_distribution[:dwhr_efficiency].nil?
+    if @hpxml.water_heating_systems.size > 0
+      if not @hpxml.hot_water_distribution.dwhr_efficiency.nil?
         dwhr_present = true
-        dwhr_facilities_connected = @hpxml.hot_water_distribution[:dwhr_facilities_connected]
-        dwhr_is_equal_flow = @hpxml.hot_water_distribution[:dwhr_equal_flow]
-        dwhr_efficiency = @hpxml.hot_water_distribution[:dwhr_efficiency]
+        dwhr_facilities_connected = @hpxml.hot_water_distribution.dwhr_facilities_connected
+        dwhr_is_equal_flow = @hpxml.hot_water_distribution.dwhr_equal_flow
+        dwhr_efficiency = @hpxml.hot_water_distribution.dwhr_efficiency
       end
     end
 
@@ -2039,24 +2038,24 @@ class OSModel
     water_heater_spaces = {}
     combi_sys_id_list = []
     avg_setpoint_temp = 0.0 # Weighted average by fraction DHW load served
-    if not @hpxml.water_heating_systems.empty?
+    if @hpxml.water_heating_systems.size > 0
       @hpxml.water_heating_systems.each do |water_heating_system|
-        sys_id = water_heating_system[:id]
+        sys_id = water_heating_system.id
         @dhw_map[sys_id] = []
 
-        space = get_space_from_location(water_heating_system[:location], "WaterHeatingSystem", model, spaces)
+        space = get_space_from_location(water_heating_system.location, "WaterHeatingSystem", model, spaces)
         water_heater_spaces[sys_id] = space
-        setpoint_temp = water_heating_system[:temperature]
+        setpoint_temp = water_heating_system.temperature
         if setpoint_temp.nil?
           setpoint_temp = Waterheater.get_default_hot_water_temperature(@eri_version)
         end
-        avg_setpoint_temp += setpoint_temp * water_heating_system[:fraction_dhw_load_served]
-        wh_type = water_heating_system[:water_heater_type]
-        fuel = water_heating_system[:fuel_type]
-        jacket_r = water_heating_system[:jacket_r_value]
+        avg_setpoint_temp += setpoint_temp * water_heating_system.fraction_dhw_load_served
+        wh_type = water_heating_system.water_heater_type
+        fuel = water_heating_system.fuel_type
+        jacket_r = water_heating_system.jacket_r_value
 
-        uses_desuperheater = water_heating_system[:uses_desuperheater]
-        relatedhvac = water_heating_system[:related_hvac]
+        uses_desuperheater = water_heating_system.uses_desuperheater
+        relatedhvac = water_heating_system.related_hvac
 
         if uses_desuperheater
           if not related_hvac_list.include? relatedhvac
@@ -2067,9 +2066,9 @@ class OSModel
           end
         end
 
-        ef = water_heating_system[:energy_factor]
+        ef = water_heating_system.energy_factor
         if ef.nil?
-          uef = water_heating_system[:uniform_energy_factor]
+          uef = water_heating_system.uniform_energy_factor
           # allow systems not requiring EF and not specifying fuel type, e.g., indirect water heater
           if not uef.nil?
             ef = Waterheater.calc_ef_from_uef(uef, wh_type, fuel)
@@ -2080,8 +2079,8 @@ class OSModel
         # Solar fraction is used to adjust water heater's tank losses and hot water use, because it is
         # the portion of the total conventional hot water heating load (delivered energy + tank losses).
         solar_fraction = nil
-        if not @hpxml.solar_thermal_system.empty? and @hpxml.solar_thermal_system[:water_heating_system_idref] == sys_id
-          solar_fraction = @hpxml.solar_thermal_system[:solar_fraction]
+        if not @hpxml.solar_thermal_system.nil? and @hpxml.solar_thermal_system.water_heating_system_idref == sys_id
+          solar_fraction = @hpxml.solar_thermal_system.solar_fraction
         end
         solar_fraction = 0.0 if solar_fraction.nil?
 
@@ -2091,15 +2090,15 @@ class OSModel
 
         runner.registerInfo("EC_adj=#{ec_adj}") # Pass value to tests
 
-        dhw_load_frac = water_heating_system[:fraction_dhw_load_served] * (1.0 - solar_fraction)
+        dhw_load_frac = water_heating_system.fraction_dhw_load_served * (1.0 - solar_fraction)
 
         @dhw_map[sys_id] = []
 
         if wh_type == "storage water heater"
 
-          tank_vol = water_heating_system[:tank_volume]
-          re = water_heating_system[:recovery_efficiency]
-          capacity_kbtuh = water_heating_system[:heating_capacity] / 1000.0
+          tank_vol = water_heating_system.tank_volume
+          re = water_heating_system.recovery_efficiency
+          capacity_kbtuh = water_heating_system.heating_capacity / 1000.0
 
           Waterheater.apply_tank(model, space, fuel, capacity_kbtuh, tank_vol,
                                  ef, re, setpoint_temp, ec_adj, @nbeds, @dhw_map,
@@ -2107,7 +2106,7 @@ class OSModel
 
         elsif wh_type == "instantaneous water heater"
 
-          cycling_derate = water_heating_system[:performance_adjustment]
+          cycling_derate = water_heating_system.performance_adjustment
 
           Waterheater.apply_tankless(model, space, fuel, ef, cycling_derate,
                                      setpoint_temp, ec_adj, @nbeds, @dhw_map,
@@ -2115,7 +2114,7 @@ class OSModel
 
         elsif wh_type == "heat pump water heater"
 
-          tank_vol = water_heating_system[:tank_volume]
+          tank_vol = water_heating_system.tank_volume
 
           Waterheater.apply_heatpump(model, runner, space, weather, setpoint_temp, tank_vol, ef, ec_adj,
                                      @nbeds, @dhw_map, sys_id, jacket_r, solar_fraction)
@@ -2123,9 +2122,9 @@ class OSModel
         elsif wh_type == "space-heating boiler with storage tank" or wh_type == "space-heating boiler with tankless coil"
 
           combi_sys_id_list << sys_id
-          heating_source_id = water_heating_system[:related_hvac]
-          standby_loss = water_heating_system[:standby_loss]
-          vol = water_heating_system[:tank_volume]
+          heating_source_id = water_heating_system.related_hvac
+          standby_loss = water_heating_system.standby_loss
+          vol = water_heating_system.tank_volume
           if not related_hvac_list.include? heating_source_id
             related_hvac_list << heating_source_id
             boiler_sys = get_boiler_and_plant_loop(@hvac_map, heating_source_id, sys_id)
@@ -2133,10 +2132,10 @@ class OSModel
             boiler_afue = nil
             boiler_fuel_type = nil
             @hpxml.heating_systems.each do |heating_system|
-              next unless heating_system[:id] == water_heating_system[:related_hvac]
+              next unless heating_system.id == water_heating_system.related_hvac
 
-              boiler_afue = heating_system[:heating_efficiency_afue]
-              boiler_fuel_type = heating_system[:heating_system_fuel]
+              boiler_afue = heating_system.heating_efficiency_afue
+              boiler_fuel_type = heating_system.heating_system_fuel
             end
           else
             fail "RelatedHVACSystem '#{heating_source_id}' for water heating system '#{sys_id}' is already attached to another water heating system."
@@ -2171,30 +2170,30 @@ class OSModel
                                 dwhr_efficiency, dhw_loop_fracs, @eri_version,
                                 @dhw_map, @hpxml_path)
 
-    if not @hpxml.solar_thermal_system.empty?
-      collector_area = @hpxml.solar_thermal_system[:collector_area]
-      dhw_system_idref = @hpxml.solar_thermal_system[:water_heating_system_idref]
+    if not @hpxml.solar_thermal_system.nil?
+      collector_area = @hpxml.solar_thermal_system.collector_area
+      dhw_system_idref = @hpxml.solar_thermal_system.water_heating_system_idref
 
       @hpxml.water_heating_systems.each do |water_heating_system|
-        next unless water_heating_system[:id] == dhw_system_idref
+        next unless water_heating_system.id == dhw_system_idref
 
-        if ['space-heating boiler with storage tank', 'space-heating boiler with tankless coil'].include? water_heating_system[:water_heater_type]
-          fail "Water heating system '#{dhw_system_idref}' connected to solar thermal system '#{@hpxml.solar_thermal_system[:id]}' cannot be a space-heating boiler."
+        if ['space-heating boiler with storage tank', 'space-heating boiler with tankless coil'].include? water_heating_system.water_heater_type
+          fail "Water heating system '#{dhw_system_idref}' connected to solar thermal system '#{@hpxml.solar_thermal_system.id}' cannot be a space-heating boiler."
         end
 
-        if water_heating_system[:uses_desuperheater]
-          fail "Water heating system '#{dhw_system_idref}' connected to solar thermal system '#{@hpxml.solar_thermal_system[:id]}' cannot be attached to a desuperheater."
+        if water_heating_system.uses_desuperheater
+          fail "Water heating system '#{dhw_system_idref}' connected to solar thermal system '#{@hpxml.solar_thermal_system.id}' cannot be attached to a desuperheater."
         end
       end
 
       if not collector_area.nil? # Detailed solar water heater
-        frta = @hpxml.solar_thermal_system[:collector_frta]
-        frul = @hpxml.solar_thermal_system[:collector_frul]
-        storage_vol = @hpxml.solar_thermal_system[:storage_volume]
-        loop_type = @hpxml.solar_thermal_system[:collector_loop_type]
-        azimuth = Float(@hpxml.solar_thermal_system[:collector_azimuth])
-        tilt = @hpxml.solar_thermal_system[:collector_tilt]
-        collector_type = @hpxml.solar_thermal_system[:collector_type]
+        frta = @hpxml.solar_thermal_system.collector_frta
+        frul = @hpxml.solar_thermal_system.collector_frul
+        storage_vol = @hpxml.solar_thermal_system.storage_volume
+        loop_type = @hpxml.solar_thermal_system.collector_loop_type
+        azimuth = Float(@hpxml.solar_thermal_system.collector_azimuth)
+        tilt = @hpxml.solar_thermal_system.collector_tilt
+        collector_type = @hpxml.solar_thermal_system.collector_type
         space = water_heater_spaces[dhw_system_idref]
 
         dhw_loop = nil
@@ -2205,7 +2204,7 @@ class OSModel
             dhw_loop = dhw_object
           end
         else
-          fail "Attached water heating system '#{dhw_system_idref}' not found for solar thermal system '#{@hpxml.solar_thermal_system[:id]}'."
+          fail "Attached water heating system '#{dhw_system_idref}' not found for solar thermal system '#{@hpxml.solar_thermal_system.id}'."
         end
 
         Waterheater.apply_solar_thermal(model, space, collector_area, frta, frul, storage_vol,
@@ -2262,28 +2261,28 @@ class OSModel
     return if @use_only_ideal_air
 
     @hpxml.cooling_systems.each do |cooling_system|
-      clg_type = cooling_system[:cooling_system_type]
+      clg_type = cooling_system.cooling_system_type
 
-      cool_capacity_btuh = cooling_system[:cooling_capacity]
+      cool_capacity_btuh = cooling_system.cooling_capacity
       if not cool_capacity_btuh.nil?
         if cool_capacity_btuh < 0
           cool_capacity_btuh = Constants.SizingAuto
         end
       end
 
-      load_frac = cooling_system[:fraction_cool_load_served]
+      load_frac = cooling_system.fraction_cool_load_served
       sequential_load_frac, @total_frac_remaining_cool_load_served, load_frac = calc_sequential_load_fraction(load_frac, @total_frac_remaining_cool_load_served)
 
-      sys_id = cooling_system[:id]
+      sys_id = cooling_system.id
 
-      check_distribution_system(cooling_system[:distribution_system_idref], sys_id, clg_type)
+      check_distribution_system(cooling_system.distribution_system_idref, sys_id, clg_type)
 
       @hvac_map[sys_id] = []
 
       if clg_type == "central air conditioner"
 
-        seer = cooling_system[:cooling_efficiency_seer]
-        compressor_type = cooling_system[:compressor_type]
+        seer = cooling_system.cooling_efficiency_seer
+        compressor_type = cooling_system.compressor_type
         if compressor_type.nil?
           compressor_type = HVAC.get_default_compressor_type(seer)
         end
@@ -2292,12 +2291,12 @@ class OSModel
 
         if compressor_type == "single stage"
 
-          if cooling_system[:cooling_shr].nil?
+          if cooling_system.cooling_shr.nil?
             shrs = [0.73]
           else
-            shrs = [cooling_system[:cooling_shr]]
+            shrs = [cooling_system.cooling_shr]
           end
-          airflow_rate = cooling_system[:cooling_cfm] # Hidden feature; used only for HERS DSE test
+          airflow_rate = cooling_system.cooling_cfm # Hidden feature; used only for HERS DSE test
           HVAC.apply_central_ac_1speed(model, runner, seer, shrs,
                                        crankcase_kw, crankcase_temp,
                                        cool_capacity_btuh, airflow_rate, load_frac,
@@ -2305,11 +2304,11 @@ class OSModel
                                        @hvac_map, sys_id)
         elsif compressor_type == "two stage"
 
-          if cooling_system[:cooling_shr].nil?
+          if cooling_system.cooling_shr.nil?
             shrs = [0.71, 0.73]
           else
             # TODO: is the following assumption correct (revisit Dylan's data?)? OR should value from HPXML be used for both stages
-            shrs = [cooling_system[:cooling_shr] - 0.02, cooling_system[:cooling_shr]]
+            shrs = [cooling_system.cooling_shr - 0.02, cooling_system.cooling_shr]
           end
           HVAC.apply_central_ac_2speed(model, runner, seer, shrs,
                                        crankcase_kw, crankcase_temp,
@@ -2318,11 +2317,11 @@ class OSModel
                                        @hvac_map, sys_id)
         elsif compressor_type == "variable speed"
 
-          if cooling_system[:cooling_shr].nil?
+          if cooling_system.cooling_shr.nil?
             shrs = [0.87, 0.80, 0.79, 0.78]
           else
             var_sp_shr_mult = [1.115, 1.026, 1.013, 1.0]
-            shrs = var_sp_shr_mult.map { |m| cooling_system[:cooling_shr] * m }
+            shrs = var_sp_shr_mult.map { |m| cooling_system.cooling_shr * m }
           end
           HVAC.apply_central_ac_4speed(model, runner, seer, shrs,
                                        crankcase_kw, crankcase_temp,
@@ -2333,12 +2332,12 @@ class OSModel
 
       elsif clg_type == "room air conditioner"
 
-        eer = cooling_system[:cooling_efficiency_eer]
+        eer = cooling_system.cooling_efficiency_eer
 
-        if cooling_system[:cooling_shr].nil?
+        if cooling_system.cooling_shr.nil?
           shr = 0.65
         else
-          shr = cooling_system[:cooling_shr]
+          shr = cooling_system.cooling_shr
         end
 
         airflow_rate = 350.0
@@ -2348,7 +2347,7 @@ class OSModel
                            @hvac_map, sys_id)
       elsif clg_type == "evaporative cooler"
 
-        is_ducted = !cooling_system[:distribution_system_idref].nil?
+        is_ducted = !cooling_system.distribution_system_idref.nil?
         HVAC.apply_evaporative_cooler(model, runner, load_frac,
                                       sequential_load_frac, @living_zone,
                                       @hvac_map, sys_id, is_ducted)
@@ -2364,10 +2363,10 @@ class OSModel
 
     [true, false].each do |only_furnaces_attached_to_cooling|
       @hpxml.heating_systems.each do |heating_system|
-        htg_type = heating_system[:heating_system_type]
-        sys_id = heating_system[:id]
+        htg_type = heating_system.heating_system_type
+        sys_id = heating_system.id
 
-        check_distribution_system(heating_system[:distribution_system_idref], sys_id, htg_type)
+        check_distribution_system(heating_system.distribution_system_idref, sys_id, htg_type)
 
         attached_clg_system = get_attached_clg_system(heating_system)
 
@@ -2377,23 +2376,23 @@ class OSModel
           next if htg_type == "Furnace" and not attached_clg_system.nil?
         end
 
-        fuel = heating_system[:heating_system_fuel]
+        fuel = heating_system.heating_system_fuel
 
-        heat_capacity_btuh = heating_system[:heating_capacity]
+        heat_capacity_btuh = heating_system.heating_capacity
         if heat_capacity_btuh < 0
           heat_capacity_btuh = Constants.SizingAuto
         end
 
-        load_frac = heating_system[:fraction_heat_load_served]
+        load_frac = heating_system.fraction_heat_load_served
         sequential_load_frac, @total_frac_remaining_heat_load_served, load_frac = calc_sequential_load_fraction(load_frac, @total_frac_remaining_heat_load_served)
 
         @hvac_map[sys_id] = []
 
         if htg_type == "Furnace"
 
-          afue = heating_system[:heating_efficiency_afue]
+          afue = heating_system.heating_efficiency_afue
           fan_power = 0.5 # For fuel furnaces, will be overridden by EAE later
-          airflow_rate = heating_system[:heating_cfm] # Hidden feature; used only for HERS DSE test
+          airflow_rate = heating_system.heating_cfm # Hidden feature; used only for HERS DSE test
           HVAC.apply_furnace(model, runner, fuel, afue,
                              heat_capacity_btuh, airflow_rate, fan_power,
                              load_frac, sequential_load_frac,
@@ -2401,7 +2400,7 @@ class OSModel
                              @hvac_map, sys_id)
         elsif htg_type == "WallFurnace"
 
-          afue = heating_system[:heating_efficiency_afue]
+          afue = heating_system.heating_efficiency_afue
           fan_power = 0.0
           airflow_rate = 0.0
           HVAC.apply_unit_heater(model, runner, fuel,
@@ -2412,7 +2411,7 @@ class OSModel
         elsif htg_type == "Boiler"
 
           system_type = Constants.BoilerTypeForcedDraft
-          afue = heating_system[:heating_efficiency_afue]
+          afue = heating_system.heating_efficiency_afue
           oat_reset_enabled = false
           oat_high = nil
           oat_low = nil
@@ -2426,14 +2425,14 @@ class OSModel
                             @hvac_map, sys_id)
         elsif htg_type == "ElectricResistance"
 
-          efficiency = heating_system[:heating_efficiency_percent]
+          efficiency = heating_system.heating_efficiency_percent
           HVAC.apply_electric_baseboard(model, runner, efficiency,
                                         heat_capacity_btuh, load_frac,
                                         sequential_load_frac, @living_zone,
                                         @hvac_map, sys_id)
         elsif htg_type == "Stove" or htg_type == "PortableHeater"
 
-          efficiency = heating_system[:heating_efficiency_percent]
+          efficiency = heating_system.heating_efficiency_percent
           airflow_rate = 125.0 # cfm/ton; doesn't affect energy consumption
           fan_power = 0.5 # For fuel equipment, will be overridden by EAE later
           HVAC.apply_unit_heater(model, runner, fuel,
@@ -2450,17 +2449,17 @@ class OSModel
     return if @use_only_ideal_air
 
     @hpxml.heat_pumps.each do |heat_pump|
-      hp_type = heat_pump[:heat_pump_type]
-      sys_id = heat_pump[:id]
+      hp_type = heat_pump.heat_pump_type
+      sys_id = heat_pump.id
 
-      check_distribution_system(heat_pump[:distribution_system_idref], sys_id, hp_type)
+      check_distribution_system(heat_pump.distribution_system_idref, sys_id, hp_type)
 
-      cool_capacity_btuh = heat_pump[:cooling_capacity]
+      cool_capacity_btuh = heat_pump.cooling_capacity
       if cool_capacity_btuh < 0
         cool_capacity_btuh = Constants.SizingAuto
       end
 
-      heat_capacity_btuh = heat_pump[:heating_capacity]
+      heat_capacity_btuh = heat_pump.heating_capacity
       if heat_capacity_btuh < 0
         heat_capacity_btuh = Constants.SizingAuto
       end
@@ -2470,21 +2469,21 @@ class OSModel
         fail "HeatPump '#{sys_id}' CoolingCapacity and HeatingCapacity must either both be auto-sized or fixed-sized."
       end
 
-      heat_capacity_btuh_17F = heat_pump[:heating_capacity_17F]
+      heat_capacity_btuh_17F = heat_pump.heating_capacity_17F
       if heat_capacity_btuh == Constants.SizingAuto and not heat_capacity_btuh_17F.nil?
         fail "HeatPump '#{sys_id}' has HeatingCapacity17F provided but heating capacity is auto-sized."
       end
 
-      load_frac_heat = heat_pump[:fraction_heat_load_served]
+      load_frac_heat = heat_pump.fraction_heat_load_served
       sequential_load_frac_heat, @total_frac_remaining_heat_load_served, load_frac_heat = calc_sequential_load_fraction(load_frac_heat, @total_frac_remaining_heat_load_served)
 
-      load_frac_cool = heat_pump[:fraction_cool_load_served]
+      load_frac_cool = heat_pump.fraction_cool_load_served
       sequential_load_frac_cool, @total_frac_remaining_cool_load_served, load_frac_cool = calc_sequential_load_fraction(load_frac_cool, @total_frac_remaining_cool_load_served)
 
-      backup_heat_fuel = heat_pump[:backup_heating_fuel]
+      backup_heat_fuel = heat_pump.backup_heating_fuel
       if not backup_heat_fuel.nil?
 
-        backup_heat_capacity_btuh = heat_pump[:backup_heating_capacity]
+        backup_heat_capacity_btuh = heat_pump.backup_heating_capacity
         if backup_heat_capacity_btuh < 0
           backup_heat_capacity_btuh = Constants.SizingAuto
         end
@@ -2494,13 +2493,13 @@ class OSModel
           fail "HeatPump '#{sys_id}' BackupHeatingCapacity and HeatingCapacity must either both be auto-sized or fixed-sized."
         end
 
-        if not heat_pump[:backup_heating_efficiency_percent].nil?
-          backup_heat_efficiency = heat_pump[:backup_heating_efficiency_percent]
+        if not heat_pump.backup_heating_efficiency_percent.nil?
+          backup_heat_efficiency = heat_pump.backup_heating_efficiency_percent
         else
-          backup_heat_efficiency = heat_pump[:backup_heating_efficiency_afue]
+          backup_heat_efficiency = heat_pump.backup_heating_efficiency_afue
         end
 
-        backup_switchover_temp = heat_pump[:backup_heating_switchover_temp]
+        backup_switchover_temp = heat_pump.backup_heating_switchover_temp
 
       else
         backup_heat_fuel = 'electricity'
@@ -2526,10 +2525,10 @@ class OSModel
 
       if hp_type == "air-to-air"
 
-        seer = heat_pump[:cooling_efficiency_seer]
-        hspf = heat_pump[:heating_efficiency_hspf]
+        seer = heat_pump.cooling_efficiency_seer
+        hspf = heat_pump.heating_efficiency_hspf
 
-        compressor_type = heat_pump[:compressor_type]
+        compressor_type = heat_pump.compressor_type
         if compressor_type.nil?
           compressor_type = HVAC.get_default_compressor_type(seer)
         end
@@ -2539,10 +2538,10 @@ class OSModel
 
         if compressor_type == "single stage"
 
-          if heat_pump[:cooling_shr].nil?
+          if heat_pump.cooling_shr.nil?
             shrs = [0.73]
           else
-            shrs = [heat_pump[:cooling_shr]]
+            shrs = [heat_pump.cooling_shr]
           end
 
           HVAC.apply_central_ashp_1speed(model, runner, seer, hspf, shrs,
@@ -2554,11 +2553,11 @@ class OSModel
                                          @living_zone, @hvac_map, sys_id)
         elsif compressor_type == "two stage"
 
-          if heat_pump[:cooling_shr].nil?
+          if heat_pump.cooling_shr.nil?
             shrs = [0.71, 0.724]
           else
             # TODO: is the following assumption correct (revisit Dylan's data?)? OR should value from HPXML be used for both stages?
-            shrs = [heat_pump[:cooling_shr] - 0.014, heat_pump[:cooling_shr]]
+            shrs = [heat_pump.cooling_shr - 0.014, heat_pump.cooling_shr]
           end
           HVAC.apply_central_ashp_2speed(model, runner, seer, hspf, shrs,
                                          hp_compressor_min_temp, crankcase_kw, crankcase_temp,
@@ -2569,11 +2568,11 @@ class OSModel
                                          @living_zone, @hvac_map, sys_id)
         elsif compressor_type == "variable speed"
 
-          if heat_pump[:cooling_shr].nil?
+          if heat_pump.cooling_shr.nil?
             shrs = [0.87, 0.80, 0.79, 0.78]
           else
             var_sp_shr_mult = [1.115, 1.026, 1.013, 1.0]
-            shrs = var_sp_shr_mult.map { |m| heat_pump[:cooling_shr] * m }
+            shrs = var_sp_shr_mult.map { |m| heat_pump.cooling_shr * m }
           end
           HVAC.apply_central_ashp_4speed(model, runner, seer, hspf, shrs,
                                          hp_compressor_min_temp, crankcase_kw, crankcase_temp,
@@ -2586,13 +2585,13 @@ class OSModel
 
       elsif hp_type == "mini-split"
 
-        seer = heat_pump[:cooling_efficiency_seer]
-        hspf = heat_pump[:heating_efficiency_hspf]
+        seer = heat_pump.cooling_efficiency_seer
+        hspf = heat_pump.heating_efficiency_hspf
 
-        if heat_pump[:cooling_shr].nil?
+        if heat_pump.cooling_shr.nil?
           shr = 0.73
         else
-          shr = heat_pump[:cooling_shr]
+          shr = heat_pump.cooling_shr
         end
 
         min_cooling_capacity = 0.4
@@ -2619,7 +2618,7 @@ class OSModel
 
         pan_heater_power = 0.0
         fan_power = 0.07
-        is_ducted = !heat_pump[:distribution_system_idref].nil?
+        is_ducted = !heat_pump.distribution_system_idref.nil?
         HVAC.apply_mshp(model, runner, seer, hspf, shr,
                         min_cooling_capacity, max_cooling_capacity,
                         min_cooling_airflow_rate, max_cooling_airflow_rate,
@@ -2635,12 +2634,12 @@ class OSModel
 
       elsif hp_type == "ground-to-air"
 
-        eer = heat_pump[:cooling_efficiency_eer]
-        cop = heat_pump[:heating_efficiency_cop]
-        if heat_pump[:cooling_shr].nil?
+        eer = heat_pump.cooling_efficiency_eer
+        cop = heat_pump.heating_efficiency_cop
+        if heat_pump.cooling_shr.nil?
           shr = 0.732
         else
-          shr = heat_pump[:cooling_shr]
+          shr = heat_pump.cooling_shr
         end
         ground_conductivity = 0.6
         grout_conductivity = 0.4
@@ -2705,17 +2704,17 @@ class OSModel
   end
 
   def self.add_setpoints(runner, model, weather)
-    return if @hpxml.hvac_control.empty?
+    return if @hpxml.hvac_control.nil?
 
     # Base heating setpoint
-    htg_setpoint = @hpxml.hvac_control[:heating_setpoint_temp]
+    htg_setpoint = @hpxml.hvac_control.heating_setpoint_temp
     @htg_weekday_setpoints = [[htg_setpoint] * 24] * 12
 
     # Apply heating setback?
-    htg_setback = @hpxml.hvac_control[:heating_setback_temp]
+    htg_setback = @hpxml.hvac_control.heating_setback_temp
     if not htg_setback.nil?
-      htg_setback_hrs_per_week = @hpxml.hvac_control[:heating_setback_hours_per_week]
-      htg_setback_start_hr = @hpxml.hvac_control[:heating_setback_start_hour]
+      htg_setback_hrs_per_week = @hpxml.hvac_control.heating_setback_hours_per_week
+      htg_setback_start_hr = @hpxml.hvac_control.heating_setback_start_hour
       for m in 1..12
         for hr in htg_setback_start_hr..htg_setback_start_hr + Integer(htg_setback_hrs_per_week / 7.0) - 1
           @htg_weekday_setpoints[m - 1][hr % 24] = htg_setback
@@ -2725,14 +2724,14 @@ class OSModel
     @htg_weekend_setpoints = @htg_weekday_setpoints
 
     # Base cooling setpoint
-    clg_setpoint = @hpxml.hvac_control[:cooling_setpoint_temp]
+    clg_setpoint = @hpxml.hvac_control.cooling_setpoint_temp
     @clg_weekday_setpoints = [[clg_setpoint] * 24] * 12
 
     # Apply cooling setup?
-    clg_setup = @hpxml.hvac_control[:cooling_setup_temp]
+    clg_setup = @hpxml.hvac_control.cooling_setup_temp
     if not clg_setup.nil?
-      clg_setup_hrs_per_week = @hpxml.hvac_control[:cooling_setup_hours_per_week]
-      clg_setup_start_hr = @hpxml.hvac_control[:cooling_setup_start_hour]
+      clg_setup_hrs_per_week = @hpxml.hvac_control.cooling_setup_hours_per_week
+      clg_setup_start_hr = @hpxml.hvac_control.cooling_setup_start_hour
       for m in 1..12
         for hr in clg_setup_start_hr..clg_setup_start_hr + Integer(clg_setup_hrs_per_week / 7.0) - 1
           @clg_weekday_setpoints[m - 1][hr % 24] = clg_setup
@@ -2741,7 +2740,7 @@ class OSModel
     end
 
     # Apply cooling setpoint offset due to ceiling fan?
-    clg_ceiling_fan_offset = @hpxml.hvac_control[:ceiling_fan_cooling_setpoint_temp_offset]
+    clg_ceiling_fan_offset = @hpxml.hvac_control.ceiling_fan_cooling_setpoint_temp_offset
     if not clg_ceiling_fan_offset.nil?
       HVAC.get_ceiling_fan_operation_months(weather).each_with_index do |operation, m|
         next unless operation == 1
@@ -2757,7 +2756,7 @@ class OSModel
   end
 
   def self.add_ceiling_fans(runner, model, weather)
-    return if @hpxml.ceiling_fans.empty?
+    return if @hpxml.ceiling_fans.size == 0
     ceiling_fan = @hpxml.ceiling_fans[0]
 
     monthly_sch = HVAC.get_ceiling_fan_operation_months(weather)
@@ -2766,12 +2765,12 @@ class OSModel
     weekend_sch = weekday_sch
     hrs_per_day = weekday_sch.inject(0, :+)
 
-    cfm_per_w = ceiling_fan[:efficiency]
+    cfm_per_w = ceiling_fan.efficiency
     if cfm_per_w.nil?
       fan_power_w = HVAC.get_default_ceiling_fan_power()
       cfm_per_w = medium_cfm / fan_power_w
     end
-    quantity = ceiling_fan[:quantity]
+    quantity = ceiling_fan.quantity
     if quantity.nil?
       quantity = HVAC.get_default_ceiling_fan_quantity(@nbeds)
     end
@@ -2797,10 +2796,10 @@ class OSModel
     found_attached_dist = false
     type_match = true
     @hpxml.hvac_distributions.each do |hvac_distribution|
-      next if dist_id != hvac_distribution[:id]
+      next if dist_id != hvac_distribution.id
 
       found_attached_dist = true
-      type_match = hvac_distribution_type_map[system_type].include? hvac_distribution[:distribution_system_type]
+      type_match = hvac_distribution_type_map[system_type].include? hvac_distribution.distribution_system_type
     end
 
     if not found_attached_dist
@@ -2838,34 +2837,34 @@ class OSModel
     misc_weekend_sch = nil
     misc_monthly_sch = nil
     @hpxml.plug_loads.each do |plug_load|
-      next unless plug_load[:plug_load_type] == "other"
+      next unless plug_load.plug_load_type == "other"
 
-      misc_annual_kwh = plug_load[:kWh_per_year]
+      misc_annual_kwh = plug_load.kWh_per_year
       if misc_annual_kwh.nil?
         misc_annual_kwh = MiscLoads.get_residual_mels_values(@cfa)[0]
       end
 
-      misc_sens_frac = plug_load[:frac_sensible]
+      misc_sens_frac = plug_load.frac_sensible
       if misc_sens_frac.nil?
         misc_sens_frac = MiscLoads.get_residual_mels_values(@cfa)[1]
       end
 
-      misc_lat_frac = plug_load[:frac_latent]
+      misc_lat_frac = plug_load.frac_latent
       if misc_lat_frac.nil?
         misc_lat_frac = MiscLoads.get_residual_mels_values(@cfa)[2]
       end
 
-      misc_weekday_sch = @hpxml.misc_load_schedule[:weekday_fractions]
+      misc_weekday_sch = @hpxml.misc_load_schedule.weekday_fractions
       if misc_weekday_sch.nil?
         misc_weekday_sch = "0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05"
       end
 
-      misc_weekend_sch = @hpxml.misc_load_schedule[:weekend_fractions]
+      misc_weekend_sch = @hpxml.misc_load_schedule.weekend_fractions
       if misc_weekend_sch.nil?
         misc_weekend_sch = "0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05"
       end
 
-      misc_monthly_sch = @hpxml.misc_load_schedule[:monthly_multipliers]
+      misc_monthly_sch = @hpxml.misc_load_schedule.monthly_multipliers
       if misc_monthly_sch.nil?
         misc_monthly_sch = "1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248"
       end
@@ -2874,9 +2873,9 @@ class OSModel
     # Television
     tv_annual_kwh = 0
     @hpxml.plug_loads.each do |plug_load|
-      next unless plug_load[:plug_load_type] == "TV other"
+      next unless plug_load.plug_load_type == "TV other"
 
-      tv_annual_kwh = plug_load[:kWh_per_year]
+      tv_annual_kwh = plug_load.kWh_per_year
       if tv_annual_kwh.nil?
         tv_annual_kwh, tv_sens_frac, tv_lat_frac = MiscLoads.get_televisions_values(@cfa, @nbeds)
       end
@@ -2888,25 +2887,25 @@ class OSModel
   end
 
   def self.add_lighting(runner, model, weather, spaces)
-    return if @hpxml.lighting.empty? # Either all or none of the values are nil
+    return if @hpxml.lighting.nil? # Either all or none of the values are nil
 
-    if @hpxml.lighting[:fraction_tier_i_interior] + @hpxml.lighting[:fraction_tier_ii_interior] > 1
-      fail "Fraction of qualifying interior lighting fixtures #{@hpxml.lighting[:fraction_tier_i_interior] + @hpxml.lighting[:fraction_tier_ii_interior]} is greater than 1."
+    if @hpxml.lighting.fraction_tier_i_interior + @hpxml.lighting.fraction_tier_ii_interior > 1
+      fail "Fraction of qualifying interior lighting fixtures #{@hpxml.lighting.fraction_tier_i_interior + @hpxml.lighting.fraction_tier_ii_interior} is greater than 1."
     end
-    if @hpxml.lighting[:fraction_tier_i_exterior] + @hpxml.lighting[:fraction_tier_ii_exterior] > 1
-      fail "Fraction of qualifying exterior lighting fixtures #{@hpxml.lighting[:fraction_tier_i_exterior] + @hpxml.lighting[:fraction_tier_ii_exterior]} is greater than 1."
+    if @hpxml.lighting.fraction_tier_i_exterior + @hpxml.lighting.fraction_tier_ii_exterior > 1
+      fail "Fraction of qualifying exterior lighting fixtures #{@hpxml.lighting.fraction_tier_i_exterior + @hpxml.lighting.fraction_tier_ii_exterior} is greater than 1."
     end
-    if @hpxml.lighting[:fraction_tier_i_garage] + @hpxml.lighting[:fraction_tier_ii_garage] > 1
-      fail "Fraction of qualifying garage lighting fixtures #{@hpxml.lighting[:fraction_tier_i_garage] + @hpxml.lighting[:fraction_tier_ii_garage]} is greater than 1."
+    if @hpxml.lighting.fraction_tier_i_garage + @hpxml.lighting.fraction_tier_ii_garage > 1
+      fail "Fraction of qualifying garage lighting fixtures #{@hpxml.lighting.fraction_tier_i_garage + @hpxml.lighting.fraction_tier_ii_garage} is greater than 1."
     end
 
     int_kwh, ext_kwh, grg_kwh = Lighting.calc_lighting_energy(@eri_version, @cfa, @gfa,
-                                                              @hpxml.lighting[:fraction_tier_i_interior],
-                                                              @hpxml.lighting[:fraction_tier_i_exterior],
-                                                              @hpxml.lighting[:fraction_tier_i_garage],
-                                                              @hpxml.lighting[:fraction_tier_ii_interior],
-                                                              @hpxml.lighting[:fraction_tier_ii_exterior],
-                                                              @hpxml.lighting[:fraction_tier_ii_garage])
+                                                              @hpxml.lighting.fraction_tier_i_interior,
+                                                              @hpxml.lighting.fraction_tier_i_exterior,
+                                                              @hpxml.lighting.fraction_tier_i_garage,
+                                                              @hpxml.lighting.fraction_tier_ii_interior,
+                                                              @hpxml.lighting.fraction_tier_ii_exterior,
+                                                              @hpxml.lighting.fraction_tier_ii_garage)
 
     garage_space = get_space_of_type(spaces, 'garage')
     Lighting.apply(model, weather, int_kwh, grg_kwh, ext_kwh, @cfa, @gfa,
@@ -2914,30 +2913,30 @@ class OSModel
   end
 
   def self.add_airflow(runner, model, weather, spaces)
-    shelter_coef = @hpxml.site[:shelter_coefficient]
+    shelter_coef = @hpxml.site.shelter_coefficient
 
     # Infiltration
     infil_ach50 = nil
     infil_const_ach = nil
-    @hpxml.air_infiltration_measurements.each do |air_infiltration_measurement_values|
-      if air_infiltration_measurement_values[:house_pressure] == 50 and air_infiltration_measurement_values[:unit_of_measure] == "ACH"
-        infil_ach50 = air_infiltration_measurement_values[:air_leakage]
-      elsif air_infiltration_measurement_values[:house_pressure] == 50 and air_infiltration_measurement_values[:unit_of_measure] == "CFM"
-        infil_ach50 = air_infiltration_measurement_values[:air_leakage] * 60.0 / @infilvolume # Convert CFM50 to ACH50
+    @hpxml.air_infiltration_measurements.each do |measurement|
+      if measurement.house_pressure == 50 and measurement.unit_of_measure == "ACH"
+        infil_ach50 = measurement.air_leakage
+      elsif measurement.house_pressure == 50 and measurement.unit_of_measure == "CFM"
+        infil_ach50 = measurement.air_leakage * 60.0 / @infilvolume # Convert CFM50 to ACH50
       else
-        infil_const_ach = air_infiltration_measurement_values[:constant_ach_natural]
+        infil_const_ach = measurement.constant_ach_natural
       end
     end
 
     vented_attic_sla = nil
     vented_attic_const_ach = nil
     if @has_vented_attic
-      @hpxml.attics.each do |attic_values|
-        next unless attic_values[:attic_type] == "VentedAttic"
-        next if attic_values[:vented_attic_sla].nil? and attic_values[:vented_attic_constant_ach].nil? # skip additional attic elements
+      @hpxml.attics.each do |attic|
+        next unless attic.attic_type == "VentedAttic"
+        next if attic.vented_attic_sla.nil? and attic.vented_attic_constant_ach.nil? # skip additional attic elements
 
-        vented_attic_sla = attic_values[:vented_attic_sla]
-        vented_attic_const_ach = attic_values[:vented_attic_constant_ach]
+        vented_attic_sla = attic.vented_attic_sla
+        vented_attic_const_ach = attic.vented_attic_constant_ach
       end
       if vented_attic_sla.nil? and vented_attic_const_ach.nil?
         vented_attic_sla = Airflow.get_default_vented_attic_sla()
@@ -2948,9 +2947,9 @@ class OSModel
 
     vented_crawl_sla = nil
     if @has_vented_crawl
-      @hpxml.foundations.each do |foundation_values|
-        next unless foundation_values[:foundation_type] == "VentedCrawlspace"
-        vented_crawl_sla = foundation_values[:vented_crawlspace_sla]
+      @hpxml.foundations.each do |foundation|
+        next unless foundation.foundation_type == "VentedCrawlspace"
+        vented_crawl_sla = foundation.vented_crawlspace_sla
       end
       if vented_crawl_sla.nil?
         vented_crawl_sla = Airflow.get_default_vented_crawl_sla()
@@ -2991,7 +2990,7 @@ class OSModel
     duct_systems = {}
     @hpxml.hvac_distributions.each do |hvac_distribution|
       # Check for errors
-      dist_id = hvac_distribution[:id]
+      dist_id = hvac_distribution.id
       num_attached = 0
       num_heating_attached = 0
       num_cooling_attached = 0
@@ -2999,11 +2998,11 @@ class OSModel
         'CoolingSystem' => @hpxml.cooling_systems,
         'HeatPump' => @hpxml.heat_pumps }.each do |sys_type, hvac_systems|
         hvac_systems.each do |hvac_system|
-          next if hvac_system[:distribution_system_idref].nil? or dist_id != hvac_system[:distribution_system_idref]
+          next if hvac_system.distribution_system_idref.nil? or dist_id != hvac_system.distribution_system_idref
 
           num_attached += 1
-          num_heating_attached += 1 if ['HeatingSystem', 'HeatPump'].include? sys_type and hvac_system[:fraction_heat_load_served] > 0
-          num_cooling_attached += 1 if ['CoolingSystem', 'HeatPump'].include? sys_type and hvac_system[:fraction_cool_load_served] > 0
+          num_heating_attached += 1 if ['HeatingSystem', 'HeatPump'].include? sys_type and hvac_system.fraction_heat_load_served > 0
+          num_cooling_attached += 1 if ['CoolingSystem', 'HeatPump'].include? sys_type and hvac_system.fraction_cool_load_served > 0
         end
       end
 
@@ -3011,15 +3010,15 @@ class OSModel
       fail "Multiple heating systems found attached to distribution system '#{dist_id}'." if num_heating_attached > 1
       fail "Distribution system '#{dist_id}' found but no HVAC system attached to it." if num_attached == 0
 
-      next unless hvac_distribution[:distribution_system_type] == "AirDistribution"
+      next unless hvac_distribution.distribution_system_type == "AirDistribution"
 
       air_ducts = self.create_ducts(hvac_distribution, model, spaces, dist_id)
 
       # Connect AirLoopHVACs to ducts
       (@hpxml.heating_systems + @hpxml.cooling_systems + @hpxml.heat_pumps).each do |hvac_system|
-        next if hvac_system[:distribution_system_idref].nil? or dist_id != hvac_system[:distribution_system_idref]
+        next if hvac_system.distribution_system_idref.nil? or dist_id != hvac_system.distribution_system_idref
 
-        sys_id = hvac_system[:id]
+        sys_id = hvac_system.id
         @hvac_map[sys_id].each do |loop|
           next unless loop.is_a? OpenStudio::Model::AirLoopHVAC
 
@@ -3046,39 +3045,39 @@ class OSModel
     mech_vent_cfm = 0.0
     mech_vent_attached_dist_system = nil
     cfis_open_time = 0.0
-    @hpxml.ventilation_fans.each do |vent_fan_values|
-      next unless vent_fan_values[:used_for_whole_building_ventilation]
+    @hpxml.ventilation_fans.each do |ventilation_fan|
+      next unless ventilation_fan.used_for_whole_building_ventilation
 
-      mech_vent_id = vent_fan_values[:id]
-      mech_vent_type = vent_fan_values[:fan_type]
+      mech_vent_id = ventilation_fan.id
+      mech_vent_type = ventilation_fan.fan_type
       if mech_vent_type == 'energy recovery ventilator' or mech_vent_type == 'heat recovery ventilator'
-        if vent_fan_values[:sensible_recovery_efficiency_adjusted].nil?
-          mech_vent_sens_eff = vent_fan_values[:sensible_recovery_efficiency]
+        if ventilation_fan.sensible_recovery_efficiency_adjusted.nil?
+          mech_vent_sens_eff = ventilation_fan.sensible_recovery_efficiency
         else
-          mech_vent_sens_eff_adj = vent_fan_values[:sensible_recovery_efficiency_adjusted]
+          mech_vent_sens_eff_adj = ventilation_fan.sensible_recovery_efficiency_adjusted
         end
       end
       if mech_vent_type == 'energy recovery ventilator'
-        if vent_fan_values[:total_recovery_efficiency_adjusted].nil?
-          mech_vent_total_eff = vent_fan_values[:total_recovery_efficiency]
+        if ventilation_fan.total_recovery_efficiency_adjusted.nil?
+          mech_vent_total_eff = ventilation_fan.total_recovery_efficiency
         else
-          mech_vent_total_eff_adj = vent_fan_values[:total_recovery_efficiency_adjusted]
+          mech_vent_total_eff_adj = ventilation_fan.total_recovery_efficiency_adjusted
         end
       end
-      mech_vent_cfm = vent_fan_values[:tested_flow_rate]
+      mech_vent_cfm = ventilation_fan.tested_flow_rate
       if mech_vent_cfm.nil?
-        mech_vent_cfm = vent_fan_values[:rated_flow_rate]
+        mech_vent_cfm = ventilation_fan.rated_flow_rate
       end
-      mech_vent_fan_w = vent_fan_values[:fan_power]
+      mech_vent_fan_w = ventilation_fan.fan_power
       if mech_vent_type == 'central fan integrated supply'
         # CFIS: Specify minimum open time in minutes
-        cfis_open_time = [vent_fan_values[:hours_in_operation] / 24.0 * 60.0, 59.999].min
+        cfis_open_time = [ventilation_fan.hours_in_operation / 24.0 * 60.0, 59.999].min
       else
         # Other: Adjust constant CFM/power based on hours per day of operation
-        mech_vent_cfm *= (vent_fan_values[:hours_in_operation] / 24.0)
-        mech_vent_fan_w *= (vent_fan_values[:hours_in_operation] / 24.0)
+        mech_vent_cfm *= (ventilation_fan.hours_in_operation / 24.0)
+        mech_vent_fan_w *= (ventilation_fan.hours_in_operation / 24.0)
       end
-      mech_vent_attached_dist_system = vent_fan_values[:distribution_system_idref]
+      mech_vent_attached_dist_system = ventilation_fan.distribution_system_idref
     end
     cfis_airflow_frac = 1.0
     clothes_dryer_exhaust = 0.0
@@ -3091,11 +3090,11 @@ class OSModel
     whole_house_fan_w = 0.0
     whole_house_fan_cfm = 0.0
     whf_num_days_per_week = 0
-    @hpxml.ventilation_fans.each do |vent_fan_values|
-      next unless vent_fan_values[:used_for_seasonal_cooling_load_reduction]
+    @hpxml.ventilation_fans.each do |ventilation_fan|
+      next unless ventilation_fan.used_for_seasonal_cooling_load_reduction
 
-      whole_house_fan_w = vent_fan_values[:fan_power]
-      whole_house_fan_cfm = vent_fan_values[:rated_flow_rate]
+      whole_house_fan_w = ventilation_fan.fan_power
+      whole_house_fan_cfm = ventilation_fan.rated_flow_rate
       whf_num_days_per_week = 7
     end
     whf = WholeHouseFan.new(whole_house_fan_cfm, whole_house_fan_w, whf_num_days_per_week)
@@ -3106,19 +3105,19 @@ class OSModel
       # Get HVAC distribution system CFIS is attached to
       cfis_hvac_dist = nil
       @hpxml.hvac_distributions.each do |hvac_distribution|
-        next unless hvac_distribution[:id] == mech_vent_attached_dist_system
+        next unless hvac_distribution.id == mech_vent_attached_dist_system
 
-        if hvac_distribution[:distribution_system_type] == 'HydronicDistribution'
+        if hvac_distribution.distribution_system_type == 'HydronicDistribution'
           fail "Attached HVAC distribution system '#{mech_vent_attached_dist_system}' cannot be hydronic for mechanical ventilation '#{mech_vent_id}'."
         end
 
         # Get HVAC systems attached to this distribution system
         cfis_sys_ids = []
         (@hpxml.heating_systems + @hpxml.cooling_systems + @hpxml.heat_pumps).each do |hvac_system|
-          next if hvac_system[:distribution_system_idref].nil?
-          next unless hvac_distribution[:id] == hvac_system[:distribution_system_idref]
+          next if hvac_system.distribution_system_idref.nil?
+          next unless hvac_distribution.id == hvac_system.distribution_system_idref
 
-          cfis_sys_ids << hvac_system[:id]
+          cfis_sys_ids << hvac_system.id
         end
 
         # Get AirLoopHVACs associated with these HVAC systems
@@ -3148,7 +3147,7 @@ class OSModel
 
     window_area = 0.0
     @hpxml.windows.each do |window|
-      window_area += window[:area]
+      window_area += window.area
     end
 
     Airflow.apply(model, runner, weather, infil, mech_vent, nat_vent, whf, duct_systems,
@@ -3165,37 +3164,37 @@ class OSModel
     # Duct leakage (supply/return => [value, units])
     leakage_to_outside = { Constants.DuctSideSupply => [0.0, nil],
                            Constants.DuctSideReturn => [0.0, nil] }
-    hvac_distribution[:duct_leakage_measurements].each do |duct_leakage_measurement|
-      next unless ['CFM25', 'Percent'].include? duct_leakage_measurement[:duct_leakage_units] and duct_leakage_measurement[:duct_leakage_total_or_to_outside] == "to outside"
+    hvac_distribution.duct_leakage_measurements.each do |duct_leakage_measurement|
+      next unless ['CFM25', 'Percent'].include? duct_leakage_measurement.duct_leakage_units and duct_leakage_measurement.duct_leakage_total_or_to_outside == "to outside"
 
-      duct_side = side_map[duct_leakage_measurement[:duct_type]]
+      duct_side = side_map[duct_leakage_measurement.duct_type]
       next if duct_side.nil?
 
-      leakage_to_outside[duct_side] = [duct_leakage_measurement[:duct_leakage_value], duct_leakage_measurement[:duct_leakage_units]]
+      leakage_to_outside[duct_side] = [duct_leakage_measurement.duct_leakage_value, duct_leakage_measurement.duct_leakage_units]
     end
 
     # Duct location, R-value, Area
     total_unconditioned_duct_area = { Constants.DuctSideSupply => 0.0,
                                       Constants.DuctSideReturn => 0.0 }
-    hvac_distribution[:ducts].each do |ducts|
-      next if ['living space', 'basement - conditioned'].include? ducts[:duct_location]
+    hvac_distribution.ducts.each do |ducts|
+      next if ['living space', 'basement - conditioned'].include? ducts.duct_location
 
       # Calculate total duct area in unconditioned spaces
-      duct_side = side_map[ducts[:duct_type]]
+      duct_side = side_map[ducts.duct_type]
       next if duct_side.nil?
 
-      total_unconditioned_duct_area[duct_side] += ducts[:duct_surface_area]
+      total_unconditioned_duct_area[duct_side] += ducts.duct_surface_area
     end
 
     # Create duct objects
-    hvac_distribution[:ducts].each do |ducts|
-      next if ['living space', 'basement - conditioned'].include? ducts[:duct_location]
+    hvac_distribution.ducts.each do |ducts|
+      next if ['living space', 'basement - conditioned'].include? ducts.duct_location
 
-      duct_side = side_map[ducts[:duct_type]]
+      duct_side = side_map[ducts.duct_type]
       next if duct_side.nil?
 
-      duct_area = ducts[:duct_surface_area]
-      duct_space = get_space_from_location(ducts[:duct_location], "Duct", model, spaces)
+      duct_area = ducts.duct_surface_area
+      duct_space = get_space_from_location(ducts.duct_location, "Duct", model, spaces)
       # Apportion leakage to individual ducts by surface area
       duct_leakage_value = leakage_to_outside[duct_side][0] * duct_area / total_unconditioned_duct_area[duct_side]
       duct_leakage_units = leakage_to_outside[duct_side][1]
@@ -3210,7 +3209,7 @@ class OSModel
         fail "#{duct_side.capitalize} ducts exist but leakage was not specified for distribution system '#{dist_id}'."
       end
 
-      air_ducts << Duct.new(duct_side, duct_space, duct_leakage_frac, duct_leakage_cfm, duct_area, ducts[:duct_insulation_r_value])
+      air_ducts << Duct.new(duct_side, duct_space, duct_leakage_frac, duct_leakage_cfm, duct_area, ducts.duct_insulation_r_value)
     end
 
     # If all ducts are in conditioned space, model leakage as going to outside
@@ -3248,17 +3247,17 @@ class OSModel
     # FUTURE: Could remove this method and simplify everything if we could autosize via the HPXML file
 
     @hpxml.heating_systems.each do |heating_system|
-      next unless heating_system[:fraction_heat_load_served] > 0
+      next unless heating_system.fraction_heat_load_served > 0
 
-      htg_type = heating_system[:heating_system_type]
+      htg_type = heating_system.heating_system_type
       next unless ["Furnace", "WallFurnace", "Stove", "Boiler"].include? htg_type
 
-      fuel = heating_system[:heating_system_fuel]
+      fuel = heating_system.heating_system_fuel
       next if fuel == 'electricity'
 
-      fuel_eae = heating_system[:electric_auxiliary_energy]
-      load_frac = heating_system[:fraction_heat_load_served]
-      sys_id = heating_system[:id]
+      fuel_eae = heating_system.electric_auxiliary_energy
+      load_frac = heating_system.fraction_heat_load_served
+      sys_id = heating_system.id
 
       HVAC.apply_eae_to_heating_fan(runner, @hvac_map[sys_id], fuel_eae, fuel, load_frac, htg_type)
     end
@@ -3269,25 +3268,25 @@ class OSModel
                     "premium" => 'Premium',
                     "thin film" => 'ThinFilm' }
 
-    @hpxml.pv_systems.each do |pv_system_values|
-      pv_id = pv_system_values[:id]
-      module_type = modules_map[pv_system_values[:module_type]]
-      if pv_system_values[:tracking] == 'fixed' and pv_system_values[:location] == 'roof'
+    @hpxml.pv_systems.each do |pv_system|
+      pv_id = pv_system.id
+      module_type = modules_map[pv_system.module_type]
+      if pv_system.tracking == 'fixed' and pv_system.location == 'roof'
         array_type = 'FixedRoofMounted'
-      elsif pv_system_values[:tracking] == 'fixed' and pv_system_values[:location] == 'ground'
+      elsif pv_system.tracking == 'fixed' and pv_system.location == 'ground'
         array_type = 'FixedOpenRack'
-      elsif pv_system_values[:tracking] == '1-axis'
+      elsif pv_system.tracking == '1-axis'
         array_type = 'OneAxis'
-      elsif pv_system_values[:tracking] == '1-axis backtracked'
+      elsif pv_system.tracking == '1-axis backtracked'
         array_type = 'OneAxisBacktracking'
-      elsif pv_system_values[:tracking] == '2-axis'
+      elsif pv_system.tracking == '2-axis'
         array_type = 'TwoAxis'
       end
-      az = pv_system_values[:array_azimuth]
-      tilt = pv_system_values[:array_tilt]
-      power_w = pv_system_values[:max_power_output]
-      inv_eff = pv_system_values[:inverter_efficiency]
-      system_losses = pv_system_values[:system_losses_fraction]
+      az = pv_system.array_azimuth
+      tilt = pv_system.array_tilt
+      power_w = pv_system.max_power_output
+      inv_eff = pv_system.inverter_efficiency
+      system_losses = pv_system.system_losses_fraction
 
       PV.apply(model, pv_id, power_w, module_type,
                system_losses, inv_eff, tilt, az, array_type)
@@ -4142,16 +4141,16 @@ class OSModel
     end
   end
 
-  def self.get_attached_clg_system(system_values)
-    return nil if system_values[:distribution_system_idref].nil?
+  def self.get_attached_clg_system(system)
+    return nil if system.distribution_system_idref.nil?
 
     # Finds the OpenStudio object of the cooling system attached (i.e., on the same
     # distribution system) to the current heating system.
     hvac_objects = []
-    @hpxml.cooling_systems.each do |attached_system_values|
-      next unless system_values[:distribution_system_idref] == attached_system_values[:distribution_system_idref]
+    @hpxml.cooling_systems.each do |attached_system|
+      next unless system.distribution_system_idref == attached_system.distribution_system_idref
 
-      @hvac_map[attached_system_values[:id]].each do |hvac_object|
+      @hvac_map[attached_system.id].each do |hvac_object|
         next unless hvac_object.is_a? OpenStudio::Model::AirLoopHVACUnitarySystem
 
         hvac_objects << hvac_object
@@ -4232,17 +4231,17 @@ class OSModel
   def self.assign_space_to_subsurface(surface, subsurface_id, wall_idref, spaces, model, subsurface_type)
     # Check walls
     @hpxml.walls.each do |wall|
-      next unless wall[:id] == wall_idref
+      next unless wall.id == wall_idref
 
-      set_surface_interior(model, spaces, surface, subsurface_id, wall[:interior_adjacent_to])
+      set_surface_interior(model, spaces, surface, subsurface_id, wall.interior_adjacent_to)
       return
     end
 
     # Check foundation walls
     @hpxml.foundation_walls.each do |foundation_wall|
-      next unless foundation_wall[:id] == wall_idref
+      next unless foundation_wall.id == wall_idref
 
-      set_surface_interior(model, spaces, surface, subsurface_id, foundation_wall[:interior_adjacent_to])
+      set_surface_interior(model, spaces, surface, subsurface_id, foundation_wall.interior_adjacent_to)
       return
     end
 
@@ -4253,13 +4252,13 @@ class OSModel
 
   def self.get_infiltration_volume()
     infilvolume = nil
-    @hpxml.air_infiltration_measurements.each do |air_infiltration_measurement_values|
-      is_ach50 = (air_infiltration_measurement_values[:house_pressure] == 50 and air_infiltration_measurement_values[:unit_of_measure] == "ACH")
-      is_cfm50 = (air_infiltration_measurement_values[:house_pressure] == 50 and air_infiltration_measurement_values[:unit_of_measure] == "CFM")
-      is_constant_nach = !air_infiltration_measurement_values[:constant_ach_natural].nil?
+    @hpxml.air_infiltration_measurements.each do |measurement|
+      is_ach50 = (measurement.house_pressure == 50 and measurement.unit_of_measure == "ACH")
+      is_cfm50 = (measurement.house_pressure == 50 and measurement.unit_of_measure == "CFM")
+      is_constant_nach = !measurement.constant_ach_natural.nil?
       next unless (is_ach50 or is_cfm50 or is_constant_nach)
 
-      infilvolume = air_infiltration_measurement_values[:infiltration_volume]
+      infilvolume = measurement.infiltration_volume
       if infilvolume.nil?
         infilvolume = @cvolume
       end
@@ -4273,8 +4272,8 @@ class OSModel
       if min_neighbor_distance.nil?
         min_neighbor_distance = 9e99
       end
-      if neighbor_building[:distance] < min_neighbor_distance
-        min_neighbor_distance = neighbor_building[:distance]
+      if neighbor_building.distance < min_neighbor_distance
+        min_neighbor_distance = neighbor_building.distance
       end
     end
     return min_neighbor_distance
@@ -4284,12 +4283,12 @@ class OSModel
     # Identify unique Kiva foundations that are required.
     kiva_fnd_walls = []
     fnd_walls.each do |foundation_wall|
-      next unless foundation_wall[:exterior_adjacent_to] == "ground"
+      next unless foundation_wall.exterior_adjacent_to == "ground"
 
       kiva_fnd_walls << foundation_wall
     end
     if kiva_fnd_walls.empty? # Handle slab foundation type
-      kiva_fnd_walls << {}
+      kiva_fnd_walls << nil
     end
 
     kiva_slabs = slabs
@@ -4300,7 +4299,7 @@ class OSModel
   def self.get_foundation_and_walls_top()
     foundation_top = 0
     @hpxml.foundation_walls.each do |foundation_wall|
-      top = -1 * foundation_wall[:depth_below_grade] + foundation_wall[:height]
+      top = -1 * foundation_wall.depth_below_grade + foundation_wall.height
       foundation_top = top if top > foundation_top
     end
     walls_top = foundation_top + 8.0 * @ncfl_ag

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>0df5bff4-6cf4-420d-bc1a-8ca9157e95fd</version_id>
-  <version_modified>20200305T203055Z</version_modified>
+  <version_id>bd84ad04-f694-4ebf-bb62-bd84c4af9d14</version_id>
+  <version_modified>20200305T220932Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -451,12 +451,6 @@
       <checksum>2CC66833</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E7EA7CFC</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -465,7 +459,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>6BE463EC</checksum>
+      <checksum>3884B113</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>84CDB478</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b73683c3-4b7d-47a5-a860-e254a9ec2aa1</version_id>
-  <version_modified>20200304T193609Z</version_modified>
+  <version_id>a0c1626c-7254-4d49-bd97-e84c7c97cdd2</version_id>
+  <version_modified>20200305T150824Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -459,13 +459,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>47BCF56F</checksum>
+      <checksum>24A4D3D0</checksum>
     </file>
     <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>600A52E3</checksum>
+      <checksum>9C65F9E2</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6bf9daaa-aaa6-420e-84a0-a2b9c29fb957</version_id>
-  <version_modified>20200309T033015Z</version_modified>
+  <version_id>88017cad-d8cb-4356-acc7-9603073399b8</version_id>
+  <version_modified>20200309T034256Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -451,12 +451,6 @@
       <checksum>E054F7CB</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>9CDC9BBE</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -466,6 +460,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>319C4CD0</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>D05DF052</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>a4b18071-089f-44bd-bba8-129b2572c2ef</version_id>
-  <version_modified>20200309T032908Z</version_modified>
+  <version_id>6bf9daaa-aaa6-420e-84a0-a2b9c29fb957</version_id>
+  <version_modified>20200309T033015Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -445,17 +445,6 @@
       <checksum>8BE07D75</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>BB488B2E</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -466,6 +455,17 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>9CDC9BBE</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>319C4CD0</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>bd84ad04-f694-4ebf-bb62-bd84c4af9d14</version_id>
-  <version_modified>20200305T220932Z</version_modified>
+  <version_id>334f464f-a3eb-4939-865b-c005a2a7638b</version_id>
+  <version_modified>20200307T002715Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -337,12 +337,6 @@
       <checksum>EC0A4557</checksum>
     </file>
     <file>
-      <filename>xmlhelper.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D793CB7E</checksum>
-    </file>
-    <file>
       <filename>weather.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -459,13 +453,19 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3884B113</checksum>
+      <checksum>6262FD80</checksum>
     </file>
     <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>84CDB478</checksum>
+      <checksum>735E4819</checksum>
+    </file>
+    <file>
+      <filename>xmlhelper.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>8BE07D75</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>e5dbc789-40ef-4daa-b67b-f4092888042c</version_id>
-  <version_modified>20200305T164016Z</version_modified>
+  <version_id>0df5bff4-6cf4-420d-bc1a-8ca9157e95fd</version_id>
+  <version_modified>20200305T203055Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -451,6 +451,12 @@
       <checksum>2CC66833</checksum>
     </file>
     <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>E7EA7CFC</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -459,13 +465,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>24A4D3D0</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E7EA7CFC</checksum>
+      <checksum>6BE463EC</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>a0c1626c-7254-4d49-bd97-e84c7c97cdd2</version_id>
-  <version_modified>20200305T150824Z</version_modified>
+  <version_id>e5dbc789-40ef-4daa-b67b-f4092888042c</version_id>
+  <version_modified>20200305T164016Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -465,7 +465,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>9C65F9E2</checksum>
+      <checksum>E7EA7CFC</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7a99702c-2f3c-49e4-8a6f-e2855e340adc</version_id>
-  <version_modified>20200308T174018Z</version_modified>
+  <version_id>b0ed14dd-1aed-45c3-9373-8b743e2fd8ce</version_id>
+  <version_modified>20200308T204543Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -409,12 +409,6 @@
       <checksum>ED54D750</checksum>
     </file>
     <file>
-      <filename>hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C69243AA</checksum>
-    </file>
-    <file>
       <filename>BaseElements.xsd</filename>
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
@@ -462,10 +456,16 @@
       <checksum>BB488B2E</checksum>
     </file>
     <file>
+      <filename>hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>E054F7CB</checksum>
+    </file>
+    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>16586F10</checksum>
+      <checksum>AC9D400A</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>334f464f-a3eb-4939-865b-c005a2a7638b</version_id>
-  <version_modified>20200307T002715Z</version_modified>
+  <version_id>9c8c5e78-8e3f-40ad-98d3-0a27e8577309</version_id>
+  <version_modified>20200307T175209Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -445,6 +445,12 @@
       <checksum>2CC66833</checksum>
     </file>
     <file>
+      <filename>xmlhelper.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>8BE07D75</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -453,19 +459,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>6262FD80</checksum>
+      <checksum>CC5D00E8</checksum>
     </file>
     <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>735E4819</checksum>
-    </file>
-    <file>
-      <filename>xmlhelper.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>8BE07D75</checksum>
+      <checksum>40FE3452</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b0ed14dd-1aed-45c3-9373-8b743e2fd8ce</version_id>
-  <version_modified>20200308T204543Z</version_modified>
+  <version_id>a4b18071-089f-44bd-bba8-129b2572c2ef</version_id>
+  <version_modified>20200309T032908Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -465,7 +465,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>AC9D400A</checksum>
+      <checksum>9CDC9BBE</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>57806f8f-2b78-41b1-ad88-deac780f72ea</version_id>
-  <version_modified>20200303T202240Z</version_modified>
+  <version_id>b73683c3-4b7d-47a5-a860-e254a9ec2aa1</version_id>
+  <version_modified>20200304T193609Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -433,12 +433,6 @@
       <checksum>913AC5AE</checksum>
     </file>
     <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>AC0D4F57</checksum>
-    </file>
-    <file>
       <filename>airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -451,10 +445,10 @@
       <checksum>79776380</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
+      <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D7C8F371</checksum>
+      <checksum>2CC66833</checksum>
     </file>
     <file>
       <version>
@@ -465,7 +459,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>09A7A0DE</checksum>
+      <checksum>47BCF56F</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>600A52E3</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>4e00e1bd-00ff-415c-b365-7b9a59c9ac02</version_id>
-  <version_modified>20200307T200601Z</version_modified>
+  <version_id>7a99702c-2f3c-49e4-8a6f-e2855e340adc</version_id>
+  <version_modified>20200308T174018Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -465,7 +465,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>409C2CB6</checksum>
+      <checksum>16586F10</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>9c8c5e78-8e3f-40ad-98d3-0a27e8577309</version_id>
-  <version_modified>20200307T175209Z</version_modified>
+  <version_id>4e00e1bd-00ff-415c-b365-7b9a59c9ac02</version_id>
+  <version_modified>20200307T200601Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -459,13 +459,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>CC5D00E8</checksum>
+      <checksum>BB488B2E</checksum>
     </file>
     <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>40FE3452</checksum>
+      <checksum>409C2CB6</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1,5 +1,13 @@
 require_relative 'xmlhelper'
 
+# TODO: Move various calculations/code blocks into these classes
+# Some examples:
+# - wall.windows or indirect_water_heater.related_hvac (idrefs)
+# - wall.is_thermal_boundary and wall.is_exterior_thermal_boundary
+# - wall.above_grade_boundary_area
+# - hpxml.predominant_heating_fuel
+# - hpxml.has_space_type
+
 class HPXML < Object
   def initialize(hpxml_path: nil, collapse_enclosure: true)
     @doc = nil
@@ -124,52 +132,52 @@ class HPXML < Object
       @doc = XMLHelper.parse_file(hpxml_path)
       hpxml = @doc.elements['/HPXML']
     end
-    @header = Header.new(hpxml: hpxml)
-    @site = Site.new(hpxml: hpxml)
-    @neighbor_buildings = NeighborBuildings.new(hpxml: hpxml)
-    @building_occupancy = BuildingOccupancy.new(hpxml: hpxml)
-    @building_construction = BuildingConstruction.new(hpxml: hpxml)
-    @climate_and_risk_zones = ClimateandRiskZones.new(hpxml: hpxml)
-    @air_infiltration_measurements = AirInfiltrationMeasurements.new(hpxml: hpxml)
-    @attics = Attics.new(hpxml: hpxml)
-    @foundations = Foundations.new(hpxml: hpxml)
-    @roofs = Roofs.new(hpxml: hpxml)
-    @rim_joists = RimJoists.new(hpxml: hpxml)
-    @walls = Walls.new(hpxml: hpxml)
-    @foundation_walls = FoundationWalls.new(hpxml: hpxml)
-    @frame_floors = FrameFloors.new(hpxml: hpxml)
-    @slabs = Slabs.new(hpxml: hpxml)
-    @windows = Windows.new(hpxml: hpxml)
-    @skylights = Skylights.new(hpxml: hpxml)
-    @doors = Doors.new(hpxml: hpxml)
-    @heating_systems = HeatingSystems.new(hpxml: hpxml)
-    @cooling_systems = CoolingSystems.new(hpxml: hpxml)
-    @heat_pumps = HeatPumps.new(hpxml: hpxml)
-    @hvac_control = HVACControl.new(hpxml: hpxml)
-    @hvac_distributions = HVACDistributions.new(hpxml: hpxml)
-    @ventilation_fans = VentilationFans.new(hpxml: hpxml)
-    @water_heating_systems = WaterHeatingSystems.new(hpxml: hpxml)
-    @hot_water_distribution = HotWaterDistribution.new(hpxml: hpxml)
-    @water_fixtures = WaterFixtures.new(hpxml: hpxml)
-    @solar_thermal_system = SolarThermalSystem.new(hpxml: hpxml)
-    @pv_systems = PVSystems.new(hpxml: hpxml)
-    @clothes_washer = ClothesWasher.new(hpxml: hpxml)
-    @clothes_dryer = ClothesDryer.new(hpxml: hpxml)
-    @dishwasher = Dishwasher.new(hpxml: hpxml)
-    @refrigerator = Refrigerator.new(hpxml: hpxml)
-    @cooking_range = CookingRange.new(hpxml: hpxml)
-    @oven = Oven.new(hpxml: hpxml)
-    @lighting = Lighting.new(hpxml: hpxml)
-    @ceiling_fans = CeilingFans.new(hpxml: hpxml)
-    @plug_loads = PlugLoads.new(hpxml: hpxml)
-    @misc_loads_schedule = MiscLoadsSchedule.new(hpxml: hpxml)
+    @header = Header.new(hpxml)
+    @site = Site.new(hpxml)
+    @neighbor_buildings = NeighborBuildings.new(hpxml)
+    @building_occupancy = BuildingOccupancy.new(hpxml)
+    @building_construction = BuildingConstruction.new(hpxml)
+    @climate_and_risk_zones = ClimateandRiskZones.new(hpxml)
+    @air_infiltration_measurements = AirInfiltrationMeasurements.new(hpxml)
+    @attics = Attics.new(hpxml)
+    @foundations = Foundations.new(hpxml)
+    @roofs = Roofs.new(hpxml)
+    @rim_joists = RimJoists.new(hpxml)
+    @walls = Walls.new(hpxml)
+    @foundation_walls = FoundationWalls.new(hpxml)
+    @frame_floors = FrameFloors.new(hpxml)
+    @slabs = Slabs.new(hpxml)
+    @windows = Windows.new(hpxml)
+    @skylights = Skylights.new(hpxml)
+    @doors = Doors.new(hpxml)
+    @heating_systems = HeatingSystems.new(hpxml)
+    @cooling_systems = CoolingSystems.new(hpxml)
+    @heat_pumps = HeatPumps.new(hpxml)
+    @hvac_control = HVACControl.new(hpxml)
+    @hvac_distributions = HVACDistributions.new(hpxml)
+    @ventilation_fans = VentilationFans.new(hpxml)
+    @water_heating_systems = WaterHeatingSystems.new(hpxml)
+    @hot_water_distribution = HotWaterDistribution.new(hpxml)
+    @water_fixtures = WaterFixtures.new(hpxml)
+    @solar_thermal_system = SolarThermalSystem.new(hpxml)
+    @pv_systems = PVSystems.new(hpxml)
+    @clothes_washer = ClothesWasher.new(hpxml)
+    @clothes_dryer = ClothesDryer.new(hpxml)
+    @dishwasher = Dishwasher.new(hpxml)
+    @refrigerator = Refrigerator.new(hpxml)
+    @cooking_range = CookingRange.new(hpxml)
+    @oven = Oven.new(hpxml)
+    @lighting = Lighting.new(hpxml)
+    @ceiling_fans = CeilingFans.new(hpxml)
+    @plug_loads = PlugLoads.new(hpxml)
+    @misc_loads_schedule = MiscLoadsSchedule.new(hpxml)
   end
 
   class BaseElement
-    def initialize(hpxml: nil, **kwargs)
-      if not hpxml.nil?
+    def initialize(hpxml_obj = nil, **kwargs)
+      if not hpxml_obj.nil?
         # Set values from HPXML object
-        from_hpxml(hpxml)
+        from_hpxml(hpxml_obj)
       else
         # Set values from **kwargs
         kwargs.each do |k, v|
@@ -200,10 +208,10 @@ class HPXML < Object
   end
 
   class BaseArrayElement < Array
-    def initialize(hpxml: nil)
-      if not hpxml.nil?
+    def initialize(hpxml_obj = nil)
+      if not hpxml_obj.nil?
         # Set values from HPXML object
-        from_hpxml(hpxml)
+        from_hpxml(hpxml_obj)
       end
     end
 
@@ -306,7 +314,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/BuildingSummary/Site/extension/Neighbors/NeighborBuilding") do |neighbor_building|
-        self << NeighborBuilding.new(hpxml: neighbor_building)
+        self << NeighborBuilding.new(neighbor_building)
       end
     end
   end
@@ -451,7 +459,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement") do |air_infiltration_measurement|
-        self << AirInfiltrationMeasurement.new(hpxml: air_infiltration_measurement)
+        self << AirInfiltrationMeasurement.new(air_infiltration_measurement)
       end
     end
   end
@@ -502,7 +510,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Attics/Attic") do |attic|
-        self << Attic.new(hpxml: attic)
+        self << Attic.new(attic)
       end
     end
   end
@@ -570,7 +578,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Foundations/Foundation") do |foundation|
-        self << Foundation.new(hpxml: foundation)
+        self << Foundation.new(foundation)
       end
     end
   end
@@ -644,7 +652,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Roofs/Roof") do |roof|
-        self << Roof.new(hpxml: roof)
+        self << Roof.new(roof)
       end
     end
   end
@@ -715,7 +723,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/RimJoists/RimJoist") do |rim_joist|
-        self << RimJoist.new(hpxml: rim_joist)
+        self << RimJoist.new(rim_joist)
       end
     end
   end
@@ -774,7 +782,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Walls/Wall") do |wall|
-        self << Wall.new(hpxml: wall)
+        self << Wall.new(wall)
       end
     end
   end
@@ -844,7 +852,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/FoundationWalls/FoundationWall") do |foundation_wall|
-        self << FoundationWall.new(hpxml: foundation_wall)
+        self << FoundationWall.new(foundation_wall)
       end
     end
   end
@@ -931,7 +939,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor") do |frame_floor|
-        self << FrameFloor.new(hpxml: frame_floor)
+        self << FrameFloor.new(frame_floor)
       end
     end
   end
@@ -1000,7 +1008,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Slabs/Slab") do |slab|
-        self << Slab.new(hpxml: slab)
+        self << Slab.new(slab)
       end
     end
   end
@@ -1092,7 +1100,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Windows/Window") do |window|
-        self << Window.new(hpxml: window)
+        self << Window.new(window)
       end
     end
   end
@@ -1167,7 +1175,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Skylights/Skylight") do |skylight|
-        self << Skylight.new(hpxml: skylight)
+        self << Skylight.new(skylight)
       end
     end
   end
@@ -1221,7 +1229,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Doors/Door") do |door|
-        self << Door.new(hpxml: door)
+        self << Door.new(door)
       end
     end
   end
@@ -1265,7 +1273,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem") do |heating_system|
-        self << HeatingSystem.new(hpxml: heating_system)
+        self << HeatingSystem.new(heating_system)
       end
     end
   end
@@ -1343,7 +1351,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem") do |cooling_system|
-        self << CoolingSystem.new(hpxml: cooling_system)
+        self << CoolingSystem.new(cooling_system)
       end
     end
   end
@@ -1420,7 +1428,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |heat_pump|
-        self << HeatPump.new(hpxml: heat_pump)
+        self << HeatPump.new(heat_pump)
       end
     end
   end
@@ -1580,7 +1588,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACDistribution") do |hvac_distribution|
-        self << HVACDistribution.new(hpxml: hvac_distribution)
+        self << HVACDistribution.new(hvac_distribution)
       end
     end
   end
@@ -1646,7 +1654,7 @@ class HPXML < Object
       return if hvac_distribution.nil?
 
       hvac_distribution.elements.each("DistributionSystemType/AirDistribution/DuctLeakageMeasurement") do |duct_leakage_measurement|
-        self << DuctLeakageMeasurement.new(hpxml: duct_leakage_measurement)
+        self << DuctLeakageMeasurement.new(duct_leakage_measurement)
       end
     end
   end
@@ -1687,7 +1695,7 @@ class HPXML < Object
       return if hvac_distribution.nil?
 
       hvac_distribution.elements.each("DistributionSystemType/AirDistribution/Ducts") do |duct|
-        self << Duct.new(hpxml: duct)
+        self << Duct.new(duct)
       end
     end
   end
@@ -1726,7 +1734,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan") do |ventilation_fan|
-        self << VentilationFan.new(hpxml: ventilation_fan)
+        self << VentilationFan.new(ventilation_fan)
       end
     end
   end
@@ -1790,7 +1798,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem") do |water_heating_system|
-        self << WaterHeatingSystem.new(hpxml: water_heating_system)
+        self << WaterHeatingSystem.new(water_heating_system)
       end
     end
   end
@@ -1925,7 +1933,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/WaterHeating/WaterFixture") do |water_fixture|
-        self << WaterFixture.new(hpxml: water_fixture)
+        self << WaterFixture.new(water_fixture)
       end
     end
   end
@@ -2011,7 +2019,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/Photovoltaics/PVSystem") do |pv_system|
-        self << PVSystem.new(hpxml: pv_system)
+        self << PVSystem.new(pv_system)
       end
     end
   end
@@ -2327,7 +2335,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Lighting/CeilingFan") do |ceiling_fan|
-        self << CeilingFan.new(hpxml: ceiling_fan)
+        self << CeilingFan.new(ceiling_fan)
       end
     end
   end
@@ -2366,7 +2374,7 @@ class HPXML < Object
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/MiscLoads/PlugLoad") do |plug_load|
-        self << PlugLoad.new(hpxml: plug_load)
+        self << PlugLoad.new(plug_load)
       end
     end
   end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -168,10 +168,6 @@ class HPXML < Object
   class BaseElement
     def initialize(hash = nil, hpxml = nil)
       if not hash.nil?
-        # Reset all attributes to nil
-        self.class::ATTRS.each do |attribute|
-          self.send(attribute.to_s + "=", nil)
-        end
         # Set values from hash
         hash.each do |k, v|
           self.send(k.to_s + "=", v)

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1279,6 +1279,7 @@ class HPXML
       child_vals[:electric_auxiliary_energy] = _to_float_or_nil(XMLHelper.get_value(heating_system, "ElectricAuxiliaryEnergy"))
       child_vals[:heating_cfm] = _to_float_or_nil(XMLHelper.get_value(heating_system, "extension/HeatingFlowRate"))
       child_vals[:energy_star] = XMLHelper.get_values(heating_system, "ThirdPartyCertification").include?("Energy Star")
+      child_vals[:seed_id] = XMLHelper.get_value(heating_system, "extension/SeedId")
       vals << child_vals
     end
     return vals
@@ -1350,6 +1351,7 @@ class HPXML
       child_vals[:cooling_shr] = _to_float_or_nil(XMLHelper.get_value(cooling_system, "SensibleHeatFraction"))
       child_vals[:cooling_cfm] = _to_float_or_nil(XMLHelper.get_value(cooling_system, "extension/CoolingFlowRate"))
       child_vals[:energy_star] = XMLHelper.get_values(cooling_system, "ThirdPartyCertification").include?("Energy Star")
+      child_vals[:seed_id] = XMLHelper.get_value(cooling_system, "extension/SeedId")
       vals << child_vals
     end
     return vals
@@ -1464,6 +1466,7 @@ class HPXML
       child_vals[:heating_efficiency_hspf] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='air-to-air' or HeatPumpType='mini-split']AnnualHeatingEfficiency[Units='HSPF']/Value"))
       child_vals[:heating_efficiency_cop] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='ground-to-air']AnnualHeatingEfficiency[Units='COP']/Value"))
       child_vals[:energy_star] = XMLHelper.get_values(heat_pump, "ThirdPartyCertification").include?("Energy Star")
+      child_vals[:seed_id] = XMLHelper.get_value(heat_pump, "extension/SeedId")
       vals << child_vals
     end
     return vals

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -683,7 +683,6 @@ class HPXML < Object
       return if roof.nil?
 
       @id = _get_id(roof)
-      @exterior_adjacent_to = "outside"
       @interior_adjacent_to = XMLHelper.get_value(roof, "InteriorAdjacentTo")
       @area = _to_float_or_nil(XMLHelper.get_value(roof, "Area"))
       @azimuth = _to_integer_or_nil(XMLHelper.get_value(roof, "Azimuth"))
@@ -700,6 +699,10 @@ class HPXML < Object
         @insulation_cavity_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
         @insulation_continuous_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
       end
+    end
+
+    def exterior_adjacent_to
+      return "outside"
     end
   end
 
@@ -1054,7 +1057,6 @@ class HPXML < Object
 
       @id = _get_id(slab)
       @interior_adjacent_to = XMLHelper.get_value(slab, "InteriorAdjacentTo")
-      @exterior_adjacent_to = "outside"
       @area = _to_float_or_nil(XMLHelper.get_value(slab, "Area"))
       @thickness = _to_float_or_nil(XMLHelper.get_value(slab, "Thickness"))
       @exposed_perimeter = _to_float_or_nil(XMLHelper.get_value(slab, "ExposedPerimeter"))
@@ -1074,6 +1076,10 @@ class HPXML < Object
         under_slab_insulation_id = _get_id(under_slab_insulation)
         @under_slab_insulation_r_value = _to_float_or_nil(XMLHelper.get_value(under_slab_insulation, "Layer[InstallationType='continuous']/NominalRValue"))
       end
+    end
+
+    def exterior_adjacent_to
+      return "outside" # FIXME: Switch to ground?
     end
   end
 
@@ -1918,7 +1924,7 @@ class HPXML < Object
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
-      hpxml.elements.each("BuildingDetails/Systems/WaterHeating/WaterFixture") do |water_fixture|
+      hpxml.elements.each("Building/BuildingDetails/Systems/WaterHeating/WaterFixture") do |water_fixture|
         self << WaterFixture.new(hpxml: water_fixture)
       end
     end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -225,9 +225,9 @@ class HPXML
   end
 
   def _get_object_header_values(hpxml:)
-    return {} if hpxml.nil?
-
     vals = {}
+    return vals if hpxml.nil?
+
     vals[:schema_version] = hpxml.attributes["schemaVersion"]
     vals[:xml_type] = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/XMLType")
     vals[:xml_generated_by] = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/XMLGeneratedBy")

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1,7 +1,11 @@
 require_relative 'xmlhelper'
 
+# TODO: Replace hashes with structures
+# TODO: Replace .empty? with .nil?
+
 class HPXML
   @data = nil
+  @doc = nil
 
   def initialize(hpxml_path: nil, hpxml_data: nil)
     if not hpxml_path.nil?
@@ -14,7 +18,6 @@ class HPXML
   end
 
   def method_missing(method_name, *args, &block)
-    # TODO: Allow "add_foo" methods
     if @data.keys.include? method_name
       return @data[method_name.to_sym]
     else
@@ -31,6 +34,8 @@ class HPXML
     return _convert_data_to_object()
   end
 
+  attr_accessor(:doc)
+
   private
 
   def _convert_file_to_data(hpxml_path)
@@ -38,7 +43,8 @@ class HPXML
 
     hpxml = nil
     if not hpxml_path.nil?
-      hpxml = XMLHelper.parse_file(hpxml_path).elements['/HPXML']
+      @doc = XMLHelper.parse_file(hpxml_path)
+      hpxml = @doc.elements['/HPXML']
     end
 
     data[:header] = _get_object_header_values(hpxml: hpxml)

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -26,7 +26,11 @@ Creating from scratch
 hpxml = HPXML.new()
 
 # Singleton elements
-hpxml.set_building_construction(:number_of_bedrooms => 3)
+hpxml.set_clothes_washer(:id => "MyClothesWasher",
+                         :modified_energy_factor => 0.83)
+if not hpxml.clothes_washer.nil?
+  puts hpxml.clothes_washer.to_s
+end
 
 # Array elements
 hpxml.walls.add(:id => "WallNorth", :area => 500)

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -10,68 +10,68 @@ class HPXML < Object
     end
   end
 
-  def set_header(hash)
-    @header = Header.new(hash)
+  def set_header(**kwargs)
+    @header = Header.new(**kwargs)
   end
 
-  def set_site(hash)
-    @site = Site.new(hash)
+  def set_site(**kwargs)
+    @site = Site.new(**kwargs)
   end
 
-  def set_building_occupancy(hash)
-    @building_occupancy = BuildingOccupancy.new(hash)
+  def set_building_occupancy(**kwargs)
+    @building_occupancy = BuildingOccupancy.new(**kwargs)
   end
 
-  def set_building_construction(hash)
-    @building_construction = BuildingConstruction.new(hash)
+  def set_building_construction(**kwargs)
+    @building_construction = BuildingConstruction.new(**kwargs)
   end
 
-  def set_climate_and_risk_zones(hash)
-    @climate_and_risk_zones = ClimateandRiskZones.new(hash)
+  def set_climate_and_risk_zones(**kwargs)
+    @climate_and_risk_zones = ClimateandRiskZones.new(**kwargs)
   end
 
-  def set_hvac_control(hash)
-    @hvac_control = HVACControl.new(hash)
+  def set_hvac_control(**kwargs)
+    @hvac_control = HVACControl.new(**kwargs)
   end
 
-  def set_hot_water_distribution(hash)
-    @hot_water_distribution = HotWaterDistribution.new(hash)
+  def set_hot_water_distribution(**kwargs)
+    @hot_water_distribution = HotWaterDistribution.new(**kwargs)
   end
 
-  def set_solar_thermal_system(hash)
-    @solar_thermal_system = SolarThermalSystem.new(hash)
+  def set_solar_thermal_system(**kwargs)
+    @solar_thermal_system = SolarThermalSystem.new(**kwargs)
   end
 
-  def set_clothes_washer(hash)
-    @clothes_washer = ClothesWasher.new(hash)
+  def set_clothes_washer(**kwargs)
+    @clothes_washer = ClothesWasher.new(**kwargs)
   end
 
-  def set_clothes_dryer(hash)
-    @clothes_dryer = ClothesDryer.new(hash)
+  def set_clothes_dryer(**kwargs)
+    @clothes_dryer = ClothesDryer.new(**kwargs)
   end
 
-  def set_dishwasher(hash)
-    @dishwasher = Dishwasher.new(hash)
+  def set_dishwasher(**kwargs)
+    @dishwasher = Dishwasher.new(**kwargs)
   end
 
-  def set_refrigerator(hash)
-    @refrigerator = Refrigerator.new(hash)
+  def set_refrigerator(**kwargs)
+    @refrigerator = Refrigerator.new(**kwargs)
   end
 
-  def set_cooking_range(hash)
-    @cooking_range = CookingRange.new(hash)
+  def set_cooking_range(**kwargs)
+    @cooking_range = CookingRange.new(**kwargs)
   end
 
-  def set_oven(hash)
-    @oven = Oven.new(hash)
+  def set_oven(**kwargs)
+    @oven = Oven.new(**kwargs)
   end
 
-  def set_lighting(hash)
-    @lighting = Lighting.new(hash)
+  def set_lighting(**kwargs)
+    @lighting = Lighting.new(**kwargs)
   end
 
-  def set_misc_loads_schedule(hash)
-    @misc_loads_schedule = MiscLoadsSchedule.new(hash)
+  def set_misc_loads_schedule(**kwargs)
+    @misc_loads_schedule = MiscLoadsSchedule.new(**kwargs)
   end
 
   def to_rexml()
@@ -124,57 +124,57 @@ class HPXML < Object
       @doc = XMLHelper.parse_file(hpxml_path)
       hpxml = @doc.elements['/HPXML']
     end
-    @header = Header.new(nil, hpxml)
-    @site = Site.new(nil, hpxml)
-    @neighbor_buildings = NeighborBuildings.new(nil, hpxml)
-    @building_occupancy = BuildingOccupancy.new(nil, hpxml)
-    @building_construction = BuildingConstruction.new(nil, hpxml)
-    @climate_and_risk_zones = ClimateandRiskZones.new(nil, hpxml)
-    @air_infiltration_measurements = AirInfiltrationMeasurements.new(nil, hpxml)
-    @attics = Attics.new(nil, hpxml)
-    @foundations = Foundations.new(nil, hpxml)
-    @roofs = Roofs.new(nil, hpxml)
-    @rim_joists = RimJoists.new(nil, hpxml)
-    @walls = Walls.new(nil, hpxml)
-    @foundation_walls = FoundationWalls.new(nil, hpxml)
-    @frame_floors = FrameFloors.new(nil, hpxml)
-    @slabs = Slabs.new(nil, hpxml)
-    @windows = Windows.new(nil, hpxml)
-    @skylights = Skylights.new(nil, hpxml)
-    @doors = Doors.new(nil, hpxml)
-    @heating_systems = HeatingSystems.new(nil, hpxml)
-    @cooling_systems = CoolingSystems.new(nil, hpxml)
-    @heat_pumps = HeatPumps.new(nil, hpxml)
-    @hvac_control = HVACControl.new(nil, hpxml)
-    @hvac_distributions = HVACDistributions.new(nil, hpxml)
-    @ventilation_fans = VentilationFans.new(nil, hpxml)
-    @water_heating_systems = WaterHeatingSystems.new(nil, hpxml)
-    @hot_water_distribution = HotWaterDistribution.new(nil, hpxml)
-    @water_fixtures = WaterFixtures.new(nil, hpxml)
-    @solar_thermal_system = SolarThermalSystem.new(nil, hpxml)
-    @pv_systems = PVSystems.new(nil, hpxml)
-    @clothes_washer = ClothesWasher.new(nil, hpxml)
-    @clothes_dryer = ClothesDryer.new(nil, hpxml)
-    @dishwasher = Dishwasher.new(nil, hpxml)
-    @refrigerator = Refrigerator.new(nil, hpxml)
-    @cooking_range = CookingRange.new(nil, hpxml)
-    @oven = Oven.new(nil, hpxml)
-    @lighting = Lighting.new(nil, hpxml)
-    @ceiling_fans = CeilingFans.new(nil, hpxml)
-    @plug_loads = PlugLoads.new(nil, hpxml)
-    @misc_loads_schedule = MiscLoadsSchedule.new(nil, hpxml)
+    @header = Header.new(hpxml: hpxml)
+    @site = Site.new(hpxml: hpxml)
+    @neighbor_buildings = NeighborBuildings.new(hpxml: hpxml)
+    @building_occupancy = BuildingOccupancy.new(hpxml: hpxml)
+    @building_construction = BuildingConstruction.new(hpxml: hpxml)
+    @climate_and_risk_zones = ClimateandRiskZones.new(hpxml: hpxml)
+    @air_infiltration_measurements = AirInfiltrationMeasurements.new(hpxml: hpxml)
+    @attics = Attics.new(hpxml: hpxml)
+    @foundations = Foundations.new(hpxml: hpxml)
+    @roofs = Roofs.new(hpxml: hpxml)
+    @rim_joists = RimJoists.new(hpxml: hpxml)
+    @walls = Walls.new(hpxml: hpxml)
+    @foundation_walls = FoundationWalls.new(hpxml: hpxml)
+    @frame_floors = FrameFloors.new(hpxml: hpxml)
+    @slabs = Slabs.new(hpxml: hpxml)
+    @windows = Windows.new(hpxml: hpxml)
+    @skylights = Skylights.new(hpxml: hpxml)
+    @doors = Doors.new(hpxml: hpxml)
+    @heating_systems = HeatingSystems.new(hpxml: hpxml)
+    @cooling_systems = CoolingSystems.new(hpxml: hpxml)
+    @heat_pumps = HeatPumps.new(hpxml: hpxml)
+    @hvac_control = HVACControl.new(hpxml: hpxml)
+    @hvac_distributions = HVACDistributions.new(hpxml: hpxml)
+    @ventilation_fans = VentilationFans.new(hpxml: hpxml)
+    @water_heating_systems = WaterHeatingSystems.new(hpxml: hpxml)
+    @hot_water_distribution = HotWaterDistribution.new(hpxml: hpxml)
+    @water_fixtures = WaterFixtures.new(hpxml: hpxml)
+    @solar_thermal_system = SolarThermalSystem.new(hpxml: hpxml)
+    @pv_systems = PVSystems.new(hpxml: hpxml)
+    @clothes_washer = ClothesWasher.new(hpxml: hpxml)
+    @clothes_dryer = ClothesDryer.new(hpxml: hpxml)
+    @dishwasher = Dishwasher.new(hpxml: hpxml)
+    @refrigerator = Refrigerator.new(hpxml: hpxml)
+    @cooking_range = CookingRange.new(hpxml: hpxml)
+    @oven = Oven.new(hpxml: hpxml)
+    @lighting = Lighting.new(hpxml: hpxml)
+    @ceiling_fans = CeilingFans.new(hpxml: hpxml)
+    @plug_loads = PlugLoads.new(hpxml: hpxml)
+    @misc_loads_schedule = MiscLoadsSchedule.new(hpxml: hpxml)
   end
 
   class BaseElement
-    def initialize(hash = nil, hpxml = nil)
-      if not hash.nil?
-        # Set values from hash
-        hash.each do |k, v|
-          self.send(k.to_s + "=", v)
-        end
-      elsif not hpxml.nil?
+    def initialize(hpxml: nil, **kwargs)
+      if not hpxml.nil?
         # Set values from HPXML object
         from_hpxml(hpxml)
+      else
+        # Set values from **kwargs
+        kwargs.each do |k, v|
+          self.send(k.to_s + "=", v)
+        end
       end
     end
 
@@ -200,7 +200,7 @@ class HPXML < Object
   end
 
   class BaseArrayElement < Array
-    def initialize(hash = nil, hpxml = nil)
+    def initialize(hpxml: nil)
       if not hpxml.nil?
         # Set values from HPXML object
         from_hpxml(hpxml)
@@ -298,15 +298,15 @@ class HPXML < Object
   end
 
   class NeighborBuildings < BaseArrayElement
-    def add(hash)
-      self << NeighborBuilding.new(hash)
+    def add(**kwargs)
+      self << NeighborBuilding.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/BuildingSummary/Site/extension/Neighbors/NeighborBuilding") do |neighbor_building|
-        self << NeighborBuilding.new(nil, neighbor_building)
+        self << NeighborBuilding.new(hpxml: neighbor_building)
       end
     end
   end
@@ -443,15 +443,15 @@ class HPXML < Object
   end
 
   class AirInfiltrationMeasurements < BaseArrayElement
-    def add(hash)
-      self << AirInfiltrationMeasurement.new(hash)
+    def add(**kwargs)
+      self << AirInfiltrationMeasurement.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement") do |air_infiltration_measurement|
-        self << AirInfiltrationMeasurement.new(nil, air_infiltration_measurement)
+        self << AirInfiltrationMeasurement.new(hpxml: air_infiltration_measurement)
       end
     end
   end
@@ -494,15 +494,15 @@ class HPXML < Object
   end
 
   class Attics < BaseArrayElement
-    def add(hash)
-      self << Attic.new(hash)
+    def add(**kwargs)
+      self << Attic.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Attics/Attic") do |attic|
-        self << Attic.new(nil, attic)
+        self << Attic.new(hpxml: attic)
       end
     end
   end
@@ -562,15 +562,15 @@ class HPXML < Object
   end
 
   class Foundations < BaseArrayElement
-    def add(hash)
-      self << Foundation.new(hash)
+    def add(**kwargs)
+      self << Foundation.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Foundations/Foundation") do |foundation|
-        self << Foundation.new(nil, foundation)
+        self << Foundation.new(hpxml: foundation)
       end
     end
   end
@@ -636,15 +636,15 @@ class HPXML < Object
   end
 
   class Roofs < BaseArrayElement
-    def add(hash)
-      self << Roof.new(hash)
+    def add(**kwargs)
+      self << Roof.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Roofs/Roof") do |roof|
-        self << Roof.new(nil, roof)
+        self << Roof.new(hpxml: roof)
       end
     end
   end
@@ -704,15 +704,15 @@ class HPXML < Object
   end
 
   class RimJoists < BaseArrayElement
-    def add(hash)
-      self << RimJoist.new(hash)
+    def add(**kwargs)
+      self << RimJoist.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/RimJoists/RimJoist") do |rim_joist|
-        self << RimJoist.new(nil, rim_joist)
+        self << RimJoist.new(hpxml: rim_joist)
       end
     end
   end
@@ -763,15 +763,15 @@ class HPXML < Object
   end
 
   class Walls < BaseArrayElement
-    def add(hash)
-      self << Wall.new(hash)
+    def add(**kwargs)
+      self << Wall.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Walls/Wall") do |wall|
-        self << Wall.new(nil, wall)
+        self << Wall.new(hpxml: wall)
       end
     end
   end
@@ -833,15 +833,15 @@ class HPXML < Object
   end
 
   class FoundationWalls < BaseArrayElement
-    def add(hash)
-      self << FoundationWall.new(hash)
+    def add(**kwargs)
+      self << FoundationWall.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/FoundationWalls/FoundationWall") do |foundation_wall|
-        self << FoundationWall.new(nil, foundation_wall)
+        self << FoundationWall.new(hpxml: foundation_wall)
       end
     end
   end
@@ -920,15 +920,15 @@ class HPXML < Object
   end
 
   class FrameFloors < BaseArrayElement
-    def add(hash)
-      self << FrameFloor.new(hash)
+    def add(**kwargs)
+      self << FrameFloor.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor") do |frame_floor|
-        self << FrameFloor.new(nil, frame_floor)
+        self << FrameFloor.new(hpxml: frame_floor)
       end
     end
   end
@@ -972,7 +972,7 @@ class HPXML < Object
         @insulation_continuous_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
       end
     end
-    
+
     def is_ceiling
       if ["attic - vented", "attic - unvented"].include? @interior_adjacent_to
         return true
@@ -982,22 +982,22 @@ class HPXML < Object
 
       return false
     end
-    
+
     def is_floor
       !is_ceiling
     end
   end
 
   class Slabs < BaseArrayElement
-    def add(hash)
-      self << Slab.new(hash)
+    def add(**kwargs)
+      self << Slab.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Slabs/Slab") do |slab|
-        self << Slab.new(nil, slab)
+        self << Slab.new(hpxml: slab)
       end
     end
   end
@@ -1078,15 +1078,15 @@ class HPXML < Object
   end
 
   class Windows < BaseArrayElement
-    def add(hash)
-      self << Window.new(hash)
+    def add(**kwargs)
+      self << Window.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Windows/Window") do |window|
-        self << Window.new(nil, window)
+        self << Window.new(hpxml: window)
       end
     end
   end
@@ -1153,15 +1153,15 @@ class HPXML < Object
   end
 
   class Skylights < BaseArrayElement
-    def add(hash)
-      self << Skylight.new(hash)
+    def add(**kwargs)
+      self << Skylight.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Skylights/Skylight") do |skylight|
-        self << Skylight.new(nil, skylight)
+        self << Skylight.new(hpxml: skylight)
       end
     end
   end
@@ -1207,15 +1207,15 @@ class HPXML < Object
   end
 
   class Doors < BaseArrayElement
-    def add(hash)
-      self << Door.new(hash)
+    def add(**kwargs)
+      self << Door.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Enclosure/Doors/Door") do |door|
-        self << Door.new(nil, door)
+        self << Door.new(hpxml: door)
       end
     end
   end
@@ -1251,15 +1251,15 @@ class HPXML < Object
   end
 
   class HeatingSystems < BaseArrayElement
-    def add(hash)
-      self << HeatingSystem.new(hash)
+    def add(**kwargs)
+      self << HeatingSystem.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem") do |heating_system|
-        self << HeatingSystem.new(nil, heating_system)
+        self << HeatingSystem.new(hpxml: heating_system)
       end
     end
   end
@@ -1329,15 +1329,15 @@ class HPXML < Object
   end
 
   class CoolingSystems < BaseArrayElement
-    def add(hash)
-      self << CoolingSystem.new(hash)
+    def add(**kwargs)
+      self << CoolingSystem.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem") do |cooling_system|
-        self << CoolingSystem.new(nil, cooling_system)
+        self << CoolingSystem.new(hpxml: cooling_system)
       end
     end
   end
@@ -1406,15 +1406,15 @@ class HPXML < Object
   end
 
   class HeatPumps < BaseArrayElement
-    def add(hash)
-      self << HeatPump.new(hash)
+    def add(**kwargs)
+      self << HeatPump.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |heat_pump|
-        self << HeatPump.new(nil, heat_pump)
+        self << HeatPump.new(hpxml: heat_pump)
       end
     end
   end
@@ -1566,15 +1566,15 @@ class HPXML < Object
   end
 
   class HVACDistributions < BaseArrayElement
-    def add(hash)
-      self << HVACDistribution.new(hash)
+    def add(**kwargs)
+      self << HVACDistribution.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACDistribution") do |hvac_distribution|
-        self << HVACDistribution.new(nil, hvac_distribution)
+        self << HVACDistribution.new(hpxml: hvac_distribution)
       end
     end
   end
@@ -1632,15 +1632,15 @@ class HPXML < Object
   end
 
   class DuctLeakageMeasurements < BaseArrayElement
-    def add(hash)
-      self << DuctLeakageMeasurement.new(hash)
+    def add(**kwargs)
+      self << DuctLeakageMeasurement.new(**kwargs)
     end
 
     def from_hpxml(hvac_distribution)
       return if hvac_distribution.nil?
 
       hvac_distribution.elements.each("DistributionSystemType/AirDistribution/DuctLeakageMeasurement") do |duct_leakage_measurement|
-        self << DuctLeakageMeasurement.new(nil, duct_leakage_measurement)
+        self << DuctLeakageMeasurement.new(hpxml: duct_leakage_measurement)
       end
     end
   end
@@ -1673,15 +1673,15 @@ class HPXML < Object
   end
 
   class Ducts < BaseArrayElement
-    def add(hash)
-      self << Duct.new(hash)
+    def add(**kwargs)
+      self << Duct.new(**kwargs)
     end
 
     def from_hpxml(hvac_distribution)
       return if hvac_distribution.nil?
 
       hvac_distribution.elements.each("DistributionSystemType/AirDistribution/Ducts") do |duct|
-        self << Duct.new(nil, duct)
+        self << Duct.new(hpxml: duct)
       end
     end
   end
@@ -1712,15 +1712,15 @@ class HPXML < Object
   end
 
   class VentilationFans < BaseArrayElement
-    def add(hash)
-      self << VentilationFan.new(hash)
+    def add(**kwargs)
+      self << VentilationFan.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan") do |ventilation_fan|
-        self << VentilationFan.new(nil, ventilation_fan)
+        self << VentilationFan.new(hpxml: ventilation_fan)
       end
     end
   end
@@ -1776,15 +1776,15 @@ class HPXML < Object
   end
 
   class WaterHeatingSystems < BaseArrayElement
-    def add(hash)
-      self << WaterHeatingSystem.new(hash)
+    def add(**kwargs)
+      self << WaterHeatingSystem.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem") do |water_heating_system|
-        self << WaterHeatingSystem.new(nil, water_heating_system)
+        self << WaterHeatingSystem.new(hpxml: water_heating_system)
       end
     end
   end
@@ -1911,15 +1911,15 @@ class HPXML < Object
   end
 
   class WaterFixtures < BaseArrayElement
-    def add(hash)
-      self << WaterFixture.new(hash)
+    def add(**kwargs)
+      self << WaterFixture.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("BuildingDetails/Systems/WaterHeating/WaterFixture") do |water_fixture|
-        self << WaterFixture.new(nil, water_fixture)
+        self << WaterFixture.new(hpxml: water_fixture)
       end
     end
   end
@@ -1997,15 +1997,15 @@ class HPXML < Object
   end
 
   class PVSystems < BaseArrayElement
-    def add(hash)
-      self << PVSystem.new(hash)
+    def add(**kwargs)
+      self << PVSystem.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Systems/Photovoltaics/PVSystem") do |pv_system|
-        self << PVSystem.new(nil, pv_system)
+        self << PVSystem.new(hpxml: pv_system)
       end
     end
   end
@@ -2313,15 +2313,15 @@ class HPXML < Object
   end
 
   class CeilingFans < BaseArrayElement
-    def add(hash)
-      self << CeilingFan.new(hash)
+    def add(**kwargs)
+      self << CeilingFan.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/Lighting/CeilingFan") do |ceiling_fan|
-        self << CeilingFan.new(nil, ceiling_fan)
+        self << CeilingFan.new(hpxml: ceiling_fan)
       end
     end
   end
@@ -2352,15 +2352,15 @@ class HPXML < Object
   end
 
   class PlugLoads < BaseArrayElement
-    def add(hash)
-      self << PlugLoad.new(hash)
+    def add(**kwargs)
+      self << PlugLoad.new(**kwargs)
     end
 
     def from_hpxml(hpxml)
       return if hpxml.nil?
 
       hpxml.elements.each("Building/BuildingDetails/MiscLoads/PlugLoad") do |plug_load|
-        self << PlugLoad.new(nil, plug_load)
+        self << PlugLoad.new(hpxml: plug_load)
       end
     end
   end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1370,7 +1370,8 @@ class HPXML < Object
       XMLHelper.add_element(heating_system, "FractionHeatLoadServed", Float(@fraction_heat_load_served)) unless @fraction_heat_load_served.nil?
       XMLHelper.add_element(heating_system, "ElectricAuxiliaryEnergy", Float(@electric_auxiliary_energy)) unless @electric_auxiliary_energy.nil?
       _add_extension(parent: heating_system,
-                     extensions: { "HeatingFlowRate" => _to_float_or_nil(@heating_cfm) })
+                     extensions: { "HeatingFlowRate" => _to_float_or_nil(@heating_cfm),
+                                   "SeedId" => @seed_id })
     end
 
     def from_hpxml(heating_system)
@@ -1446,7 +1447,8 @@ class HPXML < Object
 
       XMLHelper.add_element(cooling_system, "SensibleHeatFraction", Float(@cooling_shr)) unless @cooling_shr.nil?
       _add_extension(parent: cooling_system,
-                     extensions: { "CoolingFlowRate" => _to_float_or_nil(@cooling_cfm) })
+                     extensions: { "CoolingFlowRate" => _to_float_or_nil(@cooling_cfm),
+                                   "SeedId" => @seed_id })
     end
 
     def from_hpxml(cooling_system)
@@ -1552,6 +1554,9 @@ class HPXML < Object
         XMLHelper.add_element(annual_efficiency, "Units", htg_efficiency_units)
         XMLHelper.add_element(annual_efficiency, "Value", Float(htg_efficiency_value))
       end
+
+      _add_extension(parent: heat_pump,
+                     extensions: { "SeedId" => @seed_id })
     end
 
     def from_hpxml(heat_pump)

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1,15 +1,6 @@
 require_relative 'xmlhelper'
 
 class HPXML < Object
-  attr_accessor(:header, :site, :neighbor_buildings, :building_occupancy, :building_construction,
-                :climate_and_risk_zones, :air_infiltration_measurements, :attics, :foundations,
-                :roofs, :rim_joists, :walls, :foundation_walls, :frame_floors, :slabs, :windows,
-                :skylights, :doors, :heating_systems, :cooling_systems, :heat_pumps, :hvac_control,
-                :hvac_distributions, :ventilation_fans, :water_heating_systems, :hot_water_distribution,
-                :water_fixtures, :solar_thermal_system, :pv_systems, :clothes_washer, :clothes_dryer,
-                :dishwasher, :refrigerator, :cooking_range, :oven, :lighting, :ceiling_fans,
-                :plug_loads, :misc_load_schedule, :doc)
-
   def initialize(hpxml_path: nil, collapse_enclosure: true)
     @doc = nil
     @hpxml_path = hpxml_path
@@ -19,50 +10,111 @@ class HPXML < Object
     end
   end
 
-  # TODO: Create classes for Array elements (e.g., Walls, HeatingSystems, etc.) to simplify code.
+  def set_header(hash)
+    @header = Header.new(hash)
+  end
+
+  def set_site(hash)
+    @site = Site.new(hash)
+  end
+
+  def set_building_occupancy(hash)
+    @building_occupancy = BuildingOccupancy.new(hash)
+  end
+
+  def set_building_construction(hash)
+    @building_construction = BuildingConstruction.new(hash)
+  end
+
+  def set_climate_and_risk_zones(hash)
+    @climate_and_risk_zones = ClimateandRiskZones.new(hash)
+  end
+
+  def set_hvac_control(hash)
+    @hvac_control = HVACControl.new(hash)
+  end
+
+  def set_hot_water_distribution(hash)
+    @hot_water_distribution = HotWaterDistribution.new(hash)
+  end
+
+  def set_solar_thermal_system(hash)
+    @solar_thermal_system = SolarThermalSystem.new(hash)
+  end
+
+  def set_clothes_washer(hash)
+    @clothes_washer = ClothesWasher.new(hash)
+  end
+
+  def set_clothes_dryer(hash)
+    @clothes_dryer = ClothesDryer.new(hash)
+  end
+
+  def set_dishwasher(hash)
+    @dishwasher = Dishwasher.new(hash)
+  end
+
+  def set_refrigerator(hash)
+    @refrigerator = Refrigerator.new(hash)
+  end
+
+  def set_cooking_range(hash)
+    @cooking_range = CookingRange.new(hash)
+  end
+
+  def set_oven(hash)
+    @oven = Oven.new(hash)
+  end
+
+  def set_lighting(hash)
+    @lighting = Lighting.new(hash)
+  end
+
+  def set_misc_loads_schedule(hash)
+    @misc_loads_schedule = MiscLoadsSchedule.new(hash)
+  end
 
   def to_rexml()
-    # Note: In HPXML, order of elements matters.
     @doc = _create_rexml_document()
-    @header.to_rexml(doc) unless @header.nil?
-    @site.to_rexml(@doc) unless @site.nil?
-    @neighbor_buildings.each { |o| o.to_rexml(@doc) }
-    @building_occupancy.to_rexml(@doc) unless @building_occupancy.nil?
-    @building_construction.to_rexml(@doc) unless @building_construction.nil?
-    @climate_and_risk_zones.to_rexml(@doc) unless @climate_and_risk_zones.nil?
-    @air_infiltration_measurements.each { |o| o.to_rexml(@doc) }
-    @attics.each { |o| o.to_rexml(@doc) }
-    @foundations.each { |o| o.to_rexml(@doc) }
-    @roofs.each { |o| o.to_rexml(@doc) }
-    @rim_joists.each { |o| o.to_rexml(@doc) }
-    @walls.each { |o| o.to_rexml(@doc) }
-    @foundation_walls.each { |o| o.to_rexml(@doc) }
-    @frame_floors.each { |o| o.to_rexml(@doc) }
-    @slabs.each { |o| o.to_rexml(@doc) }
-    @windows.each { |o| o.to_rexml(@doc) }
-    @skylights.each { |o| o.to_rexml(@doc) }
-    @doors.each { |o| o.to_rexml(@doc) }
-    @heating_systems.each { |o| o.to_rexml(@doc) }
-    @cooling_systems.each { |o| o.to_rexml(@doc) }
-    @heat_pumps.each { |o| o.to_rexml(@doc) }
-    @hvac_control.to_rexml(@doc) unless @hvac_control.nil?
-    @hvac_distributions.each { |o| o.to_rexml(@doc) }
-    @ventilation_fans.each { |o| o.to_rexml(@doc) }
-    @water_heating_systems.each { |o| o.to_rexml(@doc) }
-    @hot_water_distribution.to_rexml(@doc) unless @hot_water_distribution.nil?
-    @water_fixtures.each { |o| o.to_rexml(@doc) }
-    @solar_thermal_system.to_rexml(@doc) unless @solar_thermal_system.nil?
-    @pv_systems.each { |o| o.to_rexml(@doc) }
-    @clothes_washer.to_rexml(@doc) unless @clothes_washer.nil?
-    @clothes_dryer.to_rexml(@doc) unless @clothes_dryer.nil?
-    @dishwasher.to_rexml(@doc) unless @dishwasher.nil?
-    @refrigerator.to_rexml(@doc) unless @refrigerator.nil?
-    @cooking_range.to_rexml(@doc) unless @cooking_range.nil?
-    @oven.to_rexml(@doc) unless @oven.nil?
-    @lighting.to_rexml(@doc) unless @lighting.nil?
-    @ceiling_fans.each { |o| o.to_rexml(@doc) }
-    @plug_loads.each { |o| o.to_rexml(@doc) }
-    @misc_load_schedule.to_rexml(@doc) unless @misc_load_schedule.nil?
+    @header.to_rexml(@doc)
+    @site.to_rexml(@doc)
+    @neighbor_buildings.to_rexml(@doc)
+    @building_occupancy.to_rexml(@doc)
+    @building_construction.to_rexml(@doc)
+    @climate_and_risk_zones.to_rexml(@doc)
+    @air_infiltration_measurements.to_rexml(@doc)
+    @attics.to_rexml(@doc)
+    @foundations.to_rexml(@doc)
+    @roofs.to_rexml(@doc)
+    @rim_joists.to_rexml(@doc)
+    @walls.to_rexml(@doc)
+    @foundation_walls.to_rexml(@doc)
+    @frame_floors.to_rexml(@doc)
+    @slabs.to_rexml(@doc)
+    @windows.to_rexml(@doc)
+    @skylights.to_rexml(@doc)
+    @doors.to_rexml(@doc)
+    @heating_systems.to_rexml(@doc)
+    @cooling_systems.to_rexml(@doc)
+    @heat_pumps.to_rexml(@doc)
+    @hvac_control.to_rexml(@doc)
+    @hvac_distributions.to_rexml(@doc)
+    @ventilation_fans.to_rexml(@doc)
+    @water_heating_systems.to_rexml(@doc)
+    @hot_water_distribution.to_rexml(@doc)
+    @water_fixtures.to_rexml(@doc)
+    @solar_thermal_system.to_rexml(@doc)
+    @pv_systems.to_rexml(@doc)
+    @clothes_washer.to_rexml(@doc)
+    @clothes_dryer.to_rexml(@doc)
+    @dishwasher.to_rexml(@doc)
+    @refrigerator.to_rexml(@doc)
+    @cooking_range.to_rexml(@doc)
+    @oven.to_rexml(@doc)
+    @lighting.to_rexml(@doc)
+    @ceiling_fans.to_rexml(@doc)
+    @plug_loads.to_rexml(@doc)
+    @misc_loads_schedule.to_rexml(@doc)
     return @doc
   end
 
@@ -72,16 +124,35 @@ class HPXML < Object
       @doc = XMLHelper.parse_file(hpxml_path)
       hpxml = @doc.elements['/HPXML']
     end
-
-    # Single elements
     @header = Header.new(nil, hpxml)
     @site = Site.new(nil, hpxml)
+    @neighbor_buildings = NeighborBuildings.new(nil, hpxml)
     @building_occupancy = BuildingOccupancy.new(nil, hpxml)
     @building_construction = BuildingConstruction.new(nil, hpxml)
     @climate_and_risk_zones = ClimateandRiskZones.new(nil, hpxml)
+    @air_infiltration_measurements = AirInfiltrationMeasurements.new(nil, hpxml)
+    @attics = Attics.new(nil, hpxml)
+    @foundations = Foundations.new(nil, hpxml)
+    @roofs = Roofs.new(nil, hpxml)
+    @rim_joists = RimJoists.new(nil, hpxml)
+    @walls = Walls.new(nil, hpxml)
+    @foundation_walls = FoundationWalls.new(nil, hpxml)
+    @frame_floors = FrameFloors.new(nil, hpxml)
+    @slabs = Slabs.new(nil, hpxml)
+    @windows = Windows.new(nil, hpxml)
+    @skylights = Skylights.new(nil, hpxml)
+    @doors = Doors.new(nil, hpxml)
+    @heating_systems = HeatingSystems.new(nil, hpxml)
+    @cooling_systems = CoolingSystems.new(nil, hpxml)
+    @heat_pumps = HeatPumps.new(nil, hpxml)
     @hvac_control = HVACControl.new(nil, hpxml)
+    @hvac_distributions = HVACDistributions.new(nil, hpxml)
+    @ventilation_fans = VentilationFans.new(nil, hpxml)
+    @water_heating_systems = WaterHeatingSystems.new(nil, hpxml)
     @hot_water_distribution = HotWaterDistribution.new(nil, hpxml)
+    @water_fixtures = WaterFixtures.new(nil, hpxml)
     @solar_thermal_system = SolarThermalSystem.new(nil, hpxml)
+    @pv_systems = PVSystems.new(nil, hpxml)
     @clothes_washer = ClothesWasher.new(nil, hpxml)
     @clothes_dryer = ClothesDryer.new(nil, hpxml)
     @dishwasher = Dishwasher.new(nil, hpxml)
@@ -89,103 +160,9 @@ class HPXML < Object
     @cooking_range = CookingRange.new(nil, hpxml)
     @oven = Oven.new(nil, hpxml)
     @lighting = Lighting.new(nil, hpxml)
-    @misc_load_schedule = MiscLoads.new(nil, hpxml)
-
-    # Arrays
-    @neighbor_buildings = []
-    @air_infiltration_measurements = []
-    @attics = []
-    @foundations = []
-    @roofs = []
-    @rim_joists = []
-    @walls = []
-    @foundation_walls = []
-    @frame_floors = []
-    @slabs = []
-    @windows = []
-    @skylights = []
-    @doors = []
-    @heating_systems = []
-    @cooling_systems = []
-    @heat_pumps = []
-    @hvac_distributions = []
-    @ventilation_fans = []
-    @water_heating_systems = []
-    @water_fixtures = []
-    @pv_systems = []
-    @ceiling_fans = []
-    @plug_loads = []
-    if not hpxml.nil?
-      hpxml.elements.each("Building/BuildingDetails/BuildingSummary/Site/extension/Neighbors/NeighborBuilding") do |neighbor_building|
-        @neighbor_buildings << NeighborBuilding.new(nil, neighbor_building)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement") do |air_infiltration_measurement|
-        @air_infiltration_measurements << AirInfiltrationMeasurement.new(nil, air_infiltration_measurement)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/Attics/Attic") do |attic|
-        @attics << Attic.new(nil, attic)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/Foundations/Foundation") do |foundation|
-        @foundations << Foundation.new(nil, foundation)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/Roofs/Roof") do |roof|
-        @roofs << Roof.new(nil, roof)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/RimJoists/RimJoist") do |rim_joist|
-        @rim_joists << RimJoist.new(nil, rim_joist)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/Walls/Wall") do |wall|
-        @walls << Wall.new(nil, wall)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/FoundationWalls/FoundationWall") do |foundation_wall|
-        @foundation_walls << FoundationWall.new(nil, foundation_wall)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor") do |frame_floor|
-        @frame_floors << FrameFloor.new(nil, frame_floor)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/Slabs/Slab") do |slab|
-        @slabs << Slab.new(nil, slab)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/Windows/Window") do |window|
-        @windows << Window.new(nil, window)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/Skylights/Skylight") do |skylight|
-        @skylights << Skylight.new(nil, skylight)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Enclosure/Doors/Door") do |door|
-        @doors << Door.new(nil, door)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem") do |heating_system|
-        @heating_systems << HeatingSystem.new(nil, heating_system)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem") do |cooling_system|
-        @cooling_systems << CoolingSystem.new(nil, cooling_system)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |heat_pump|
-        @heat_pumps << HeatPump.new(nil, heat_pump)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACDistribution") do |hvac_distribution|
-        @hvac_distributions << HVACDistribution.new(nil, hvac_distribution)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan") do |ventilation_fan|
-        @ventilation_fans << VentilationFan.new(nil, ventilation_fan)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem") do |water_heating_system|
-        @water_heating_systems << WaterHeatingSystem.new(nil, water_heating_system)
-      end
-      hpxml.elements.each("BuildingDetails/Systems/WaterHeating/WaterFixture") do |water_fixture|
-        @water_fixtures << WaterFixture.new(nil, water_fixture)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Systems/Photovoltaics/PVSystem") do |pv_system|
-        @pv_systems << PVSystem.new(nil, pv_system)
-      end
-      hpxml.elements.each("Building/BuildingDetails/Lighting/CeilingFan") do |ceiling_fan|
-        @ceiling_fans << CeilingFan.new(nil, ceiling_fan)
-      end
-      hpxml.elements.each("Building/BuildingDetails/MiscLoads/PlugLoad") do |plug_load|
-        @plug_loads << PlugLoad.new(nil, plug_load)
-      end
-    end
+    @ceiling_fans = CeilingFans.new(nil, hpxml)
+    @plug_loads = PlugLoads.new(nil, hpxml)
+    @misc_loads_schedule = MiscLoadsSchedule.new(nil, hpxml)
   end
 
   class BaseElement
@@ -214,7 +191,7 @@ class HPXML < Object
     end
 
     def to_s
-      puts to_h.to_s
+      return to_h.to_s
     end
 
     def nil?
@@ -226,6 +203,21 @@ class HPXML < Object
     end
   end
 
+  class BaseArrayElement < Array
+    def initialize(hash = nil, hpxml = nil)
+      if not hpxml.nil?
+        # Set values from HPXML object
+        from_hpxml(hpxml)
+      end
+    end
+
+    def to_rexml(doc)
+      self.each do |child|
+        child.to_rexml(doc)
+      end
+    end
+  end
+
   class Header < BaseElement
     ATTRS = [:xml_type, :xml_generated_by, :created_date_and_time, :transaction,
              :software_program_used, :software_program_version, :eri_calculation_version,
@@ -233,6 +225,8 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
+
       hpxml = doc.elements["/HPXML"]
       header = XMLHelper.add_element(hpxml, "XMLTransactionHeaderInformation")
       XMLHelper.add_element(header, "XMLType", @xml_type)
@@ -281,6 +275,8 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
+
       site = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "Site"])
       if not @fuels.empty?
         fuel_types_available = XMLHelper.add_element(site, "FuelTypesAvailable")
@@ -305,11 +301,26 @@ class HPXML < Object
     end
   end
 
+  class NeighborBuildings < BaseArrayElement
+    def add(hash)
+      self << NeighborBuilding.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/BuildingSummary/Site/extension/Neighbors/NeighborBuilding") do |neighbor_building|
+        self << NeighborBuilding.new(nil, neighbor_building)
+      end
+    end
+  end
+
   class NeighborBuilding < BaseElement
     ATTRS = [:azimuth, :distance, :height]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       neighbors = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "Site", "extension", "Neighbors"])
       neighbor_building = XMLHelper.add_element(neighbors, "NeighborBuilding")
       XMLHelper.add_element(neighbor_building, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
@@ -331,6 +342,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       building_occupancy = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "BuildingOccupancy"])
       XMLHelper.add_element(building_occupancy, "NumberofResidents", Float(@number_of_residents)) unless @number_of_residents.nil?
     end
@@ -353,6 +365,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       building_construction = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "BuildingConstruction"])
       XMLHelper.add_element(building_construction, "NumberofConditionedFloors", Integer(@number_of_conditioned_floors)) unless @number_of_conditioned_floors.nil?
       XMLHelper.add_element(building_construction, "NumberofConditionedFloorsAboveGrade", Integer(@number_of_conditioned_floors_above_grade)) unless @number_of_conditioned_floors_above_grade.nil?
@@ -391,6 +404,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       climate_and_risk_zones = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "ClimateandRiskZones"])
 
       climate_zones = { 2006 => @iecc2006,
@@ -432,12 +446,27 @@ class HPXML < Object
     end
   end
 
+  class AirInfiltrationMeasurements < BaseArrayElement
+    def add(hash)
+      self << AirInfiltrationMeasurement.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement") do |air_infiltration_measurement|
+        self << AirInfiltrationMeasurement.new(nil, air_infiltration_measurement)
+      end
+    end
+  end
+
   class AirInfiltrationMeasurement < BaseElement
     ATTRS = [:id, :house_pressure, :unit_of_measure, :air_leakage, :effective_leakage_area,
              :infiltration_volume, :constant_ach_natural, :leakiness_description]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       air_infiltration = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "AirInfiltration"])
       air_infiltration_measurement = XMLHelper.add_element(air_infiltration, "AirInfiltrationMeasurement")
       sys_id = XMLHelper.add_element(air_infiltration_measurement, "SystemIdentifier")
@@ -468,11 +497,26 @@ class HPXML < Object
     end
   end
 
+  class Attics < BaseArrayElement
+    def add(hash)
+      self << Attic.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Attics/Attic") do |attic|
+        self << Attic.new(nil, attic)
+      end
+    end
+  end
+
   class Attic < BaseElement
     ATTRS = [:id, :attic_type, :vented_attic_sla, :vented_attic_constant_ach]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       attics = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Attics"])
       attic = XMLHelper.add_element(attics, "Attic")
       sys_id = XMLHelper.add_element(attic, "SystemIdentifier")
@@ -521,11 +565,26 @@ class HPXML < Object
     end
   end
 
+  class Foundations < BaseArrayElement
+    def add(hash)
+      self << Foundation.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Foundations/Foundation") do |foundation|
+        self << Foundation.new(nil, foundation)
+      end
+    end
+  end
+
   class Foundation < BaseElement
     ATTRS = [:id, :foundation_type, :vented_crawlspace_sla, :unconditioned_basement_thermal_boundary]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       foundations = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Foundations"])
       foundation = XMLHelper.add_element(foundations, "Foundation")
       sys_id = XMLHelper.add_element(foundation, "SystemIdentifier")
@@ -580,6 +639,20 @@ class HPXML < Object
     end
   end
 
+  class Roofs < BaseArrayElement
+    def add(hash)
+      self << Roof.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Roofs/Roof") do |roof|
+        self << Roof.new(nil, roof)
+      end
+    end
+  end
+
   class Roof < BaseElement
     ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :area, :azimuth, :roof_type,
              :roof_color, :solar_absorptance, :emittance, :pitch, :radiant_barrier,
@@ -588,6 +661,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       roofs = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Roofs"])
       roof = XMLHelper.add_element(roofs, "Roof")
       sys_id = XMLHelper.add_element(roof, "SystemIdentifier")
@@ -633,12 +707,27 @@ class HPXML < Object
     end
   end
 
+  class RimJoists < BaseArrayElement
+    def add(hash)
+      self << RimJoist.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/RimJoists/RimJoist") do |rim_joist|
+        self << RimJoist.new(nil, rim_joist)
+      end
+    end
+  end
+
   class RimJoist < BaseElement
     ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :area, :azimuth, :solar_absorptance,
              :emittance, :insulation_id, :insulation_assembly_r_value]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       rim_joists = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "RimJoists"])
       rim_joist = XMLHelper.add_element(rim_joists, "RimJoist")
       sys_id = XMLHelper.add_element(rim_joist, "SystemIdentifier")
@@ -677,6 +766,20 @@ class HPXML < Object
     end
   end
 
+  class Walls < BaseArrayElement
+    def add(hash)
+      self << Wall.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Walls/Wall") do |wall|
+        self << Wall.new(nil, wall)
+      end
+    end
+  end
+
   class Wall < BaseElement
     ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :wall_type, :optimum_value_engineering,
              :area, :orientation, :azimuth, :siding, :solar_absorptance, :emittance, :insulation_id,
@@ -684,6 +787,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       walls = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Walls"])
       wall = XMLHelper.add_element(walls, "Wall")
       sys_id = XMLHelper.add_element(wall, "SystemIdentifier")
@@ -732,6 +836,20 @@ class HPXML < Object
     end
   end
 
+  class FoundationWalls < BaseArrayElement
+    def add(hash)
+      self << FoundationWall.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/FoundationWalls/FoundationWall") do |foundation_wall|
+        self << FoundationWall.new(nil, foundation_wall)
+      end
+    end
+  end
+
   class FoundationWall < BaseElement
     ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :height, :area, :azimuth, :thickness,
              :depth_below_grade, :insulation_id, :insulation_r_value, :insulation_interior_r_value,
@@ -741,6 +859,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       foundation_walls = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "FoundationWalls"])
       foundation_wall = XMLHelper.add_element(foundation_walls, "FoundationWall")
       sys_id = XMLHelper.add_element(foundation_wall, "SystemIdentifier")
@@ -804,12 +923,27 @@ class HPXML < Object
     end
   end
 
+  class FrameFloors < BaseArrayElement
+    def add(hash)
+      self << FrameFloor.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor") do |frame_floor|
+        self << FrameFloor.new(nil, frame_floor)
+      end
+    end
+  end
+
   class FrameFloor < BaseElement
     ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :area, :insulation_id,
              :insulation_assembly_r_value, :insulation_cavity_r_value, :insulation_continuous_r_value]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       frame_floors = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "FrameFloors"])
       frame_floor = XMLHelper.add_element(frame_floors, "FrameFloor")
       sys_id = XMLHelper.add_element(frame_floor, "SystemIdentifier")
@@ -842,6 +976,34 @@ class HPXML < Object
         @insulation_continuous_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
       end
     end
+    
+    def is_ceiling
+      if ["attic - vented", "attic - unvented"].include? @interior_adjacent_to
+        return true
+      elsif ["attic - vented", "attic - unvented", "other housing unit above"].include? @exterior_adjacent_to
+        return true
+      end
+
+      return false
+    end
+    
+    def is_floor
+      !is_ceiling
+    end
+  end
+
+  class Slabs < BaseArrayElement
+    def add(hash)
+      self << Slab.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Slabs/Slab") do |slab|
+        self << Slab.new(nil, slab)
+      end
+    end
   end
 
   class Slab < BaseElement
@@ -853,6 +1015,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       slabs = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Slabs"])
       slab = XMLHelper.add_element(slabs, "Slab")
       sys_id = XMLHelper.add_element(slab, "SystemIdentifier")
@@ -918,6 +1081,20 @@ class HPXML < Object
     end
   end
 
+  class Windows < BaseArrayElement
+    def add(hash)
+      self << Window.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Windows/Window") do |window|
+        self << Window.new(nil, window)
+      end
+    end
+  end
+
   class Window < BaseElement
     ATTRS = [:id, :area, :azimuth, :orientation, :frame_type, :aluminum_thermal_break, :glass_layers,
              :glass_type, :gas_fill, :ufactor, :shgc, :interior_shading_factor_summer,
@@ -927,6 +1104,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       windows = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Windows"])
       window = XMLHelper.add_element(windows, "Window")
       sys_id = XMLHelper.add_element(window, "SystemIdentifier")
@@ -978,12 +1156,27 @@ class HPXML < Object
     end
   end
 
+  class Skylights < BaseArrayElement
+    def add(hash)
+      self << Skylight.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Skylights/Skylight") do |skylight|
+        self << Skylight.new(nil, skylight)
+      end
+    end
+  end
+
   class Skylight < BaseElement
     ATTRS = [:id, :area, :azimuth, :orientation, :frame_type, :aluminum_thermal_break, :glass_layers,
              :glass_type, :gas_fill, :ufactor, :shgc, :exterior_shading, :roof_idref]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       skylights = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Skylights"])
       skylight = XMLHelper.add_element(skylights, "Skylight")
       sys_id = XMLHelper.add_element(skylight, "SystemIdentifier")
@@ -1017,11 +1210,26 @@ class HPXML < Object
     end
   end
 
+  class Doors < BaseArrayElement
+    def add(hash)
+      self << Door.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Doors/Door") do |door|
+        self << Door.new(nil, door)
+      end
+    end
+  end
+
   class Door < BaseElement
     ATTRS = [:id, :wall_idref, :area, :azimuth, :r_value]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       doors = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Doors"])
       door = XMLHelper.add_element(doors, "Door")
       sys_id = XMLHelper.add_element(door, "SystemIdentifier")
@@ -1046,6 +1254,20 @@ class HPXML < Object
     end
   end
 
+  class HeatingSystems < BaseArrayElement
+    def add(hash)
+      self << HeatingSystem.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem") do |heating_system|
+        self << HeatingSystem.new(nil, heating_system)
+      end
+    end
+  end
+
   class HeatingSystem < BaseElement
     ATTRS = [:id, :distribution_system_idref, :year_installed, :heating_system_type,
              :heating_system_fuel, :heating_capacity, :heating_efficiency_afue,
@@ -1054,6 +1276,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       hvac_plant = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
       heating_system = XMLHelper.add_element(hvac_plant, "HeatingSystem")
       sys_id = XMLHelper.add_element(heating_system, "SystemIdentifier")
@@ -1109,6 +1332,20 @@ class HPXML < Object
     end
   end
 
+  class CoolingSystems < BaseArrayElement
+    def add(hash)
+      self << CoolingSystem.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem") do |cooling_system|
+        self << CoolingSystem.new(nil, cooling_system)
+      end
+    end
+  end
+
   class CoolingSystem < BaseElement
     ATTRS = [:id, :distribution_system_idref, :year_installed, :cooling_system_type,
              :cooling_system_fuel, :cooling_capacity, :compressor_type, :fraction_cool_load_served,
@@ -1117,6 +1354,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       hvac_plant = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
       cooling_system = XMLHelper.add_element(hvac_plant, "CoolingSystem")
       sys_id = XMLHelper.add_element(cooling_system, "SystemIdentifier")
@@ -1171,6 +1409,20 @@ class HPXML < Object
     end
   end
 
+  class HeatPumps < BaseArrayElement
+    def add(hash)
+      self << HeatPump.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |heat_pump|
+        self << HeatPump.new(nil, heat_pump)
+      end
+    end
+  end
+
   class HeatPump < BaseElement
     ATTRS = [:id, :distribution_system_idref, :year_installed, :heat_pump_type, :heat_pump_fuel,
              :heating_capacity, :heating_capacity_17F, :cooling_capacity, :compressor_type,
@@ -1182,6 +1434,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       hvac_plant = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
       heat_pump = XMLHelper.add_element(hvac_plant, "HeatPump")
       sys_id = XMLHelper.add_element(heat_pump, "SystemIdentifier")
@@ -1278,6 +1531,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       hvac = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC"])
       hvac_control = XMLHelper.add_element(hvac, "HVACControl")
       sys_id = XMLHelper.add_element(hvac_control, "SystemIdentifier")
@@ -1315,12 +1569,33 @@ class HPXML < Object
     end
   end
 
+  class HVACDistributions < BaseArrayElement
+    def add(hash)
+      self << HVACDistribution.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACDistribution") do |hvac_distribution|
+        self << HVACDistribution.new(nil, hvac_distribution)
+      end
+    end
+  end
+
   class HVACDistribution < BaseElement
+    def initialize(*args)
+      @duct_leakage_measurements = DuctLeakageMeasurements.new if @duct_leakage_measurements.nil?
+      @ducts = Ducts.new if @ducts.nil?
+      super(*args)
+    end
     ATTRS = [:id, :distribution_system_type, :distribution_system_type, :annual_heating_dse,
-             :annual_cooling_dse, :duct_system_sealed, :duct_leakage_measurements, :ducts]
+             :annual_cooling_dse, :duct_system_sealed]
     attr_accessor(*ATTRS)
+    attr_reader(:duct_leakage_measurements, :ducts)
 
     def to_rexml(doc)
+      return if self.nil?
       hvac = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC"])
       hvac_distribution = XMLHelper.add_element(hvac, "HVACDistribution")
       sys_id = XMLHelper.add_element(hvac_distribution, "SystemIdentifier")
@@ -1339,13 +1614,8 @@ class HPXML < Object
       air_distribution = hvac_distribution.elements["DistributionSystemType/AirDistribution"]
       return if air_distribution.nil?
 
-      @duct_leakage_measurements.each do |duct_leakage_measurement|
-        duct_leakage_measurement.to_rexml(air_distribution)
-      end
-
-      @ducts.each do |duct|
-        duct.to_rexml(air_distribution)
-      end
+      @duct_leakage_measurements.to_rexml(air_distribution)
+      @ducts.to_rexml(air_distribution)
     end
 
     def from_hpxml(hvac_distribution)
@@ -1360,14 +1630,21 @@ class HPXML < Object
       @annual_cooling_dse = _to_float_or_nil(XMLHelper.get_value(hvac_distribution, "AnnualCoolingDistributionSystemEfficiency"))
       @duct_system_sealed = _to_bool_or_nil(XMLHelper.get_value(hvac_distribution, "HVACDistributionImprovement/DuctSystemSealed"))
 
-      @duct_leakage_measurements = []
-      hvac_distribution.elements.each("DistributionSystemType/AirDistribution/DuctLeakageMeasurement") do |duct_leakage_measurement|
-        @duct_leakage_measurements << DuctLeakageMeasurement.new(nil, duct_leakage_measurement)
-      end
+      @duct_leakage_measurements.from_hpxml(hvac_distribution)
+      @ducts.from_hpxml(hvac_distribution)
+    end
+  end
 
-      @ducts = []
-      hvac_distribution.elements.each("DistributionSystemType/AirDistribution/Ducts") do |duct|
-        @ducts << Duct.new(nil, duct)
+  class DuctLeakageMeasurements < BaseArrayElement
+    def add(hash)
+      self << DuctLeakageMeasurement.new(hash)
+    end
+
+    def from_hpxml(hvac_distribution)
+      return if hvac_distribution.nil?
+
+      hvac_distribution.elements.each("DistributionSystemType/AirDistribution/DuctLeakageMeasurement") do |duct_leakage_measurement|
+        self << DuctLeakageMeasurement.new(nil, duct_leakage_measurement)
       end
     end
   end
@@ -1399,6 +1676,20 @@ class HPXML < Object
     end
   end
 
+  class Ducts < BaseArrayElement
+    def add(hash)
+      self << Duct.new(hash)
+    end
+
+    def from_hpxml(hvac_distribution)
+      return if hvac_distribution.nil?
+
+      hvac_distribution.elements.each("DistributionSystemType/AirDistribution/Ducts") do |duct|
+        self << Duct.new(nil, duct)
+      end
+    end
+  end
+
   class Duct < BaseElement
     ATTRS = [:duct_type, :duct_insulation_r_value, :duct_insulation_material, :duct_location,
              :duct_fraction_area, :duct_surface_area]
@@ -1424,6 +1715,20 @@ class HPXML < Object
     end
   end
 
+  class VentilationFans < BaseArrayElement
+    def add(hash)
+      self << VentilationFan.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan") do |ventilation_fan|
+        self << VentilationFan.new(nil, ventilation_fan)
+      end
+    end
+  end
+
   class VentilationFan < BaseElement
     ATTRS = [:id, :fan_type, :rated_flow_rate, :tested_flow_rate, :hours_in_operation,
              :used_for_whole_building_ventilation, :used_for_seasonal_cooling_load_reduction,
@@ -1433,6 +1738,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       ventilation_fans = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "MechanicalVentilation", "VentilationFans"])
       ventilation_fan = XMLHelper.add_element(ventilation_fans, "VentilationFan")
       sys_id = XMLHelper.add_element(ventilation_fan, "SystemIdentifier")
@@ -1473,6 +1779,20 @@ class HPXML < Object
     end
   end
 
+  class WaterHeatingSystems < BaseArrayElement
+    def add(hash)
+      self << WaterHeatingSystem.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem") do |water_heating_system|
+        self << WaterHeatingSystem.new(nil, water_heating_system)
+      end
+    end
+  end
+
   class WaterHeatingSystem < BaseElement
     ATTRS = [:id, :year_installed, :fuel_type, :water_heater_type, :location, :performance_adjustment,
              :tank_volume, :fraction_dhw_load_served, :heating_capacity, :energy_factor,
@@ -1481,6 +1801,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       water_heating = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
       water_heating_system = XMLHelper.add_element(water_heating, "WaterHeatingSystem")
       sys_id = XMLHelper.add_element(water_heating_system, "SystemIdentifier")
@@ -1541,6 +1862,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       water_heating = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
       hot_water_distribution = XMLHelper.add_element(water_heating, "HotWaterDistribution")
       sys_id = XMLHelper.add_element(hot_water_distribution, "SystemIdentifier")
@@ -1592,11 +1914,26 @@ class HPXML < Object
     end
   end
 
+  class WaterFixtures < BaseArrayElement
+    def add(hash)
+      self << WaterFixture.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("BuildingDetails/Systems/WaterHeating/WaterFixture") do |water_fixture|
+        self << WaterFixture.new(nil, water_fixture)
+      end
+    end
+  end
+
   class WaterFixture < BaseElement
     ATTRS = [:id, :water_fixture_type, :low_flow]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       water_heating = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
       water_fixture = XMLHelper.add_element(water_heating, "WaterFixture")
       sys_id = XMLHelper.add_element(water_fixture, "SystemIdentifier")
@@ -1621,6 +1958,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       solar_thermal = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "SolarThermal"])
       solar_thermal_system = XMLHelper.add_element(solar_thermal, "SolarThermalSystem")
       sys_id = XMLHelper.add_element(solar_thermal_system, "SystemIdentifier")
@@ -1662,6 +2000,20 @@ class HPXML < Object
     end
   end
 
+  class PVSystems < BaseArrayElement
+    def add(hash)
+      self << PVSystem.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Systems/Photovoltaics/PVSystem") do |pv_system|
+        self << PVSystem.new(nil, pv_system)
+      end
+    end
+  end
+
   class PVSystem < BaseElement
     ATTRS = [:id, :location, :module_type, :tracking, :array_orientation, :array_azimuth, :array_tilt,
              :max_power_output, :inverter_efficiency, :system_losses_fraction, :number_of_panels,
@@ -1669,6 +2021,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       photovoltaics = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "Photovoltaics"])
       pv_system = XMLHelper.add_element(photovoltaics, "PVSystem")
       sys_id = XMLHelper.add_element(pv_system, "SystemIdentifier")
@@ -1708,6 +2061,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
       clothes_washer = XMLHelper.add_element(appliances, "ClothesWasher")
       sys_id = XMLHelper.add_element(clothes_washer, "SystemIdentifier")
@@ -1745,6 +2099,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
       clothes_dryer = XMLHelper.add_element(appliances, "ClothesDryer")
       sys_id = XMLHelper.add_element(clothes_dryer, "SystemIdentifier")
@@ -1776,6 +2131,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
       dishwasher = XMLHelper.add_element(appliances, "Dishwasher")
       sys_id = XMLHelper.add_element(dishwasher, "SystemIdentifier")
@@ -1803,6 +2159,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
       refrigerator = XMLHelper.add_element(appliances, "Refrigerator")
       sys_id = XMLHelper.add_element(refrigerator, "SystemIdentifier")
@@ -1831,6 +2188,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
       cooking_range = XMLHelper.add_element(appliances, "CookingRange")
       sys_id = XMLHelper.add_element(cooking_range, "SystemIdentifier")
@@ -1856,6 +2214,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
       oven = XMLHelper.add_element(appliances, "Oven")
       sys_id = XMLHelper.add_element(oven, "SystemIdentifier")
@@ -1880,6 +2239,7 @@ class HPXML < Object
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       if not @fraction_tier_i_interior.nil?
         lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
         lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
@@ -1956,11 +2316,26 @@ class HPXML < Object
     end
   end
 
+  class CeilingFans < BaseArrayElement
+    def add(hash)
+      self << CeilingFan.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/Lighting/CeilingFan") do |ceiling_fan|
+        self << CeilingFan.new(nil, ceiling_fan)
+      end
+    end
+  end
+
   class CeilingFan < BaseElement
     ATTRS = [:id, :efficiency, :quantity]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
       ceiling_fan = XMLHelper.add_element(lighting, "CeilingFan")
       sys_id = XMLHelper.add_element(ceiling_fan, "SystemIdentifier")
@@ -1980,11 +2355,26 @@ class HPXML < Object
     end
   end
 
+  class PlugLoads < BaseArrayElement
+    def add(hash)
+      self << PlugLoad.new(hash)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hpxml.elements.each("Building/BuildingDetails/MiscLoads/PlugLoad") do |plug_load|
+        self << PlugLoad.new(nil, plug_load)
+      end
+    end
+  end
+
   class PlugLoad < BaseElement
     ATTRS = [:id, :plug_load_type, :kWh_per_year, :frac_sensible, :frac_latent]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       misc_loads = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "MiscLoads"])
       plug_load = XMLHelper.add_element(misc_loads, "PlugLoad")
       sys_id = XMLHelper.add_element(plug_load, "SystemIdentifier")
@@ -2009,11 +2399,12 @@ class HPXML < Object
     end
   end
 
-  class MiscLoads < BaseElement
+  class MiscLoadsSchedule < BaseElement
     ATTRS = [:weekday_fractions, :weekend_fractions, :monthly_multipliers]
     attr_accessor(*ATTRS)
 
     def to_rexml(doc)
+      return if self.nil?
       misc_loads = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "MiscLoads"])
       _add_extension(parent: misc_loads,
                      extensions: { "WeekdayScheduleFractions" => @weekday_fractions,
@@ -2066,17 +2457,10 @@ class HPXML < Object
                        :exposed_perimeter]
 
     # Look for pairs of surfaces that can be collapsed
-    area_adjustments = {}
-    exposed_perimeter_adjustments = {}
     surf_types.each do |surf_type, surfaces|
-      area_adjustments[surf_type] = {}
-      exposed_perimeter_adjustments[surf_type] = {}
       for i in 0..surfaces.size - 1
         surf = surfaces[i]
         next if surf.nil?
-
-        area_adjustments[surf_type][i] = 0
-        exposed_perimeter_adjustments[surf_type][i] = 0
 
         for j in (surfaces.size - 1).downto(i + 1)
           surf2 = surfaces[j]
@@ -2093,26 +2477,26 @@ class HPXML < Object
           next unless match
 
           # Update Area/ExposedPerimeter
-          area_adjustments[surf_type][i] += surf2.area
+          surf.area += surf2.area
           if surf_type == :slabs
-            exposed_perimeter_adjustments[surf_type][i] += surf2.exposed_perimeter
+            surf.exposed_perimeter += surf2.exposed_perimeter
           end
 
           # Update subsurface idrefs as appropriate
           if [:walls, :foundation_walls].include? surf_type
             [:windows, :doors].each do |subsurf_type|
-              surf_types[subsurf_type].each_with_index do |subsurf, idx|
+              surf_types[subsurf_type].each do |subsurf, idx|
                 next unless subsurf.wall_idref == surf2.id
 
-                surf_types[subsurf_type][idx].wall_idref = surf.id
+                subsurf.wall_idref = surf.id
               end
             end
           elsif [:roofs].include? surf_type
             [:skylights].each do |subsurf_type|
-              surf_types[subsurf_type].each_with_index do |subsurf, idx|
+              surf_types[subsurf_type].each do |subsurf|
                 next unless subsurf.roof_idref == surf2.id
 
-                surf_types[subsurf_type][idx].roof_idref = surf.id
+                subsurf.roof_idref = surf.id
               end
             end
           end
@@ -2122,22 +2506,16 @@ class HPXML < Object
         end
       end
     end
-
-    area_adjustments.keys.each do |surf_type|
-      area_adjustments[surf_type].each do |idx, area_adjustment|
-        next unless area_adjustment > 0
-
-        surf_types[surf_type][idx].area += area_adjustment
-      end
-    end
-    exposed_perimeter_adjustments.keys.each do |surf_type|
-      exposed_perimeter_adjustments[surf_type].each do |idx, exposed_perimeter_adjustment|
-        next unless exposed_perimeter_adjustment > 0
-
-        surf_types[surf_type][idx].exposed_perimeter += exposed_perimeter_adjustment
-      end
-    end
   end
+
+  attr_reader(:header, :site, :neighbor_buildings, :building_occupancy, :building_construction,
+              :climate_and_risk_zones, :air_infiltration_measurements, :attics, :foundations,
+              :roofs, :rim_joists, :walls, :foundation_walls, :frame_floors, :slabs, :windows,
+              :skylights, :doors, :heating_systems, :cooling_systems, :heat_pumps, :hvac_control,
+              :hvac_distributions, :ventilation_fans, :water_heating_systems, :hot_water_distribution,
+              :water_fixtures, :solar_thermal_system, :pv_systems, :clothes_washer, :clothes_dryer,
+              :dishwasher, :refrigerator, :cooking_range, :oven, :lighting, :ceiling_fans,
+              :plug_loads, :misc_loads_schedule, :doc)
 end
 
 # Helper methods
@@ -2189,7 +2567,16 @@ def _to_bool_or_nil(value)
   return Boolean(value)
 end
 
+# TODO: Move into appropriate class above
 def is_thermal_boundary(surface)
+  def is_adjacent_to_conditioned(adjacent_to)
+    if ["living space", "basement - conditioned"].include? adjacent_to
+      return true
+    end
+
+    return false
+  end
+
   if surface.exterior_adjacent_to.start_with? "other housing unit"
     return false # adiabatic
   end
@@ -2197,22 +2584,4 @@ def is_thermal_boundary(surface)
   interior_conditioned = is_adjacent_to_conditioned(surface.interior_adjacent_to)
   exterior_conditioned = is_adjacent_to_conditioned(surface.exterior_adjacent_to)
   return (interior_conditioned != exterior_conditioned)
-end
-
-def is_adjacent_to_conditioned(adjacent_to)
-  if ["living space", "basement - conditioned"].include? adjacent_to
-    return true
-  end
-
-  return false
-end
-
-def hpxml_frame_floor_is_ceiling(interior_adjacent_to, exterior_adjacent_to)
-  if ["attic - vented", "attic - unvented"].include? interior_adjacent_to
-    return true
-  elsif ["attic - vented", "attic - unvented", "other housing unit above"].include? exterior_adjacent_to
-    return true
-  end
-
-  return false
 end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1,12 +1,39 @@
 require_relative 'xmlhelper'
 
-# TODO: Move various calculations/code blocks into these classes
-# Some examples:
-# - wall.windows or indirect_water_heater.related_hvac (idrefs)
-# - wall.is_thermal_boundary and wall.is_exterior_thermal_boundary
-# - wall.above_grade_boundary_area
-# - hpxml.predominant_heating_fuel
-# - hpxml.has_space_type
+'''
+
+Example Usage:
+
+-----------------
+Reading from file
+-----------------
+
+hpxml = HPXML.new(hpxml_path: ...)
+
+# Singleton elements
+puts hpxml.building_construction.number_of_bedrooms
+
+# Array elements
+hpxml.walls.each do |wall|
+  puts wall.area
+end
+puts hpxml.walls[0].area
+
+---------------------
+Creating from scratch
+---------------------
+
+hpxml = HPXML.new()
+
+# Singleton elements
+hpxml.set_building_construction(:number_of_bedrooms => 3)
+
+# Array elements
+hpxml.walls.add(:id => "WallNorth", :area => 500)
+hpxml.walls.add(:id => "WallSouth", :area => 500)
+hpxml.walls.delete_at(1)
+
+'''
 
 class HPXML < Object
   def initialize(hpxml_path: nil, collapse_enclosure: true)

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1,489 +1,2124 @@
 require_relative 'xmlhelper'
 
-# TODO: Replace hashes with structures
-# TODO: Replace .empty? with .nil?
+class HPXML < Object
+  attr_accessor(:header, :site, :neighbor_buildings, :building_occupancy, :building_construction,
+                :climate_and_risk_zones, :air_infiltration_measurements, :attics, :foundations,
+                :roofs, :rim_joists, :walls, :foundation_walls, :frame_floors, :slabs, :windows,
+                :skylights, :doors, :heating_systems, :cooling_systems, :heat_pumps, :hvac_control,
+                :hvac_distributions, :ventilation_fans, :water_heating_systems, :hot_water_distribution,
+                :water_fixtures, :solar_thermal_system, :pv_systems, :clothes_washer, :clothes_dryer,
+                :dishwasher, :refrigerator, :cooking_range, :oven, :lighting, :ceiling_fans,
+                :plug_loads, :misc_load_schedule, :doc)
 
-class HPXML
-  @data = nil
-  @doc = nil
-
-  def initialize(hpxml_path: nil, hpxml_data: nil)
-    if not hpxml_path.nil?
-      @data = _convert_file_to_data(hpxml_path)
-    elsif not hpxml_data.nil?
-      @data = hpxml_data
-    else
-      @data = _convert_file_to_data(nil)
+  def initialize(hpxml_path: nil, collapse_enclosure: true)
+    @doc = nil
+    @hpxml_path = hpxml_path
+    from_hpxml(hpxml_path)
+    if collapse_enclosure
+      _collapse_enclosure_surfaces()
     end
   end
 
-  def method_missing(method_name, *args, &block)
-    if @data.keys.include? method_name
-      return @data[method_name.to_sym]
-    else
-      super
-    end
+  # TODO: Create classes for Array elements (e.g., Walls, HeatingSystems, etc.) to simplify code.
+
+  def to_rexml()
+    # Note: In HPXML, order of elements matters.
+    @doc = _create_rexml_document()
+    @header.to_rexml(doc) unless @header.nil?
+    @site.to_rexml(@doc) unless @site.nil?
+    @neighbor_buildings.each { |o| o.to_rexml(@doc) }
+    @building_occupancy.to_rexml(@doc) unless @building_occupancy.nil?
+    @building_construction.to_rexml(@doc) unless @building_construction.nil?
+    @climate_and_risk_zones.to_rexml(@doc) unless @climate_and_risk_zones.nil?
+    @air_infiltration_measurements.each { |o| o.to_rexml(@doc) }
+    @attics.each { |o| o.to_rexml(@doc) }
+    @foundations.each { |o| o.to_rexml(@doc) }
+    @roofs.each { |o| o.to_rexml(@doc) }
+    @rim_joists.each { |o| o.to_rexml(@doc) }
+    @walls.each { |o| o.to_rexml(@doc) }
+    @foundation_walls.each { |o| o.to_rexml(@doc) }
+    @frame_floors.each { |o| o.to_rexml(@doc) }
+    @slabs.each { |o| o.to_rexml(@doc) }
+    @windows.each { |o| o.to_rexml(@doc) }
+    @skylights.each { |o| o.to_rexml(@doc) }
+    @doors.each { |o| o.to_rexml(@doc) }
+    @heating_systems.each { |o| o.to_rexml(@doc) }
+    @cooling_systems.each { |o| o.to_rexml(@doc) }
+    @heat_pumps.each { |o| o.to_rexml(@doc) }
+    @hvac_control.to_rexml(@doc) unless @hvac_control.nil?
+    @hvac_distributions.each { |o| o.to_rexml(@doc) }
+    @ventilation_fans.each { |o| o.to_rexml(@doc) }
+    @water_heating_systems.each { |o| o.to_rexml(@doc) }
+    @hot_water_distribution.to_rexml(@doc) unless @hot_water_distribution.nil?
+    @water_fixtures.each { |o| o.to_rexml(@doc) }
+    @solar_thermal_system.to_rexml(@doc) unless @solar_thermal_system.nil?
+    @pv_systems.each { |o| o.to_rexml(@doc) }
+    @clothes_washer.to_rexml(@doc) unless @clothes_washer.nil?
+    @clothes_dryer.to_rexml(@doc) unless @clothes_dryer.nil?
+    @dishwasher.to_rexml(@doc) unless @dishwasher.nil?
+    @refrigerator.to_rexml(@doc) unless @refrigerator.nil?
+    @cooking_range.to_rexml(@doc) unless @cooking_range.nil?
+    @oven.to_rexml(@doc) unless @oven.nil?
+    @lighting.to_rexml(@doc) unless @lighting.nil?
+    @ceiling_fans.each { |o| o.to_rexml(@doc) }
+    @plug_loads.each { |o| o.to_rexml(@doc) }
+    @misc_load_schedule.to_rexml(@doc) unless @misc_load_schedule.nil?
+    return @doc
   end
 
-  def collapse_enclosure()
-    # TODO: Always do this automatically in initialize?
-    _collapse_enclosure()
-  end
-
-  def to_object()
-    return _convert_data_to_object()
-  end
-
-  attr_accessor(:doc)
-
-  private
-
-  def _convert_file_to_data(hpxml_path)
-    data = {}
-
+  def from_hpxml(hpxml_path)
     hpxml = nil
     if not hpxml_path.nil?
       @doc = XMLHelper.parse_file(hpxml_path)
       hpxml = @doc.elements['/HPXML']
     end
 
-    data[:header] = _get_object_header_values(hpxml: hpxml)
-    data[:site] = _get_object_site_values(hpxml: hpxml)
-    data[:neighbor_buildings] = _get_object_neighbor_buildings_values(hpxml: hpxml)
-    data[:building_occupants] = _get_object_building_occupancy_values(hpxml: hpxml)
-    data[:building_construction] = _get_object_building_construction_values(hpxml: hpxml)
-    data[:climate_and_risk_zones] = _get_object_climate_and_risk_zones_values(hpxml: hpxml)
-    data[:air_infiltration_measurements] = _get_object_air_infiltration_measurements_values(hpxml: hpxml)
-    data[:attics] = _get_object_attics_values(hpxml: hpxml)
-    data[:foundations] = _get_object_foundations_values(hpxml: hpxml)
-    data[:roofs] = _get_object_roofs_values(hpxml: hpxml)
-    data[:rim_joists] = _get_object_rim_joists_values(hpxml: hpxml)
-    data[:walls] = _get_object_walls_values(hpxml: hpxml)
-    data[:foundation_walls] = _get_object_foundation_walls_values(hpxml: hpxml)
-    data[:frame_floors] = _get_object_frame_floors_values(hpxml: hpxml)
-    data[:slabs] = _get_object_slabs_values(hpxml: hpxml)
-    data[:windows] = _get_object_windows_values(hpxml: hpxml)
-    data[:skylights] = _get_object_skylights_values(hpxml: hpxml)
-    data[:doors] = _get_object_doors_values(hpxml: hpxml)
-    data[:heating_systems] = _get_object_heating_systems_values(hpxml: hpxml)
-    data[:cooling_systems] = _get_object_cooling_systems_values(hpxml: hpxml)
-    data[:heat_pumps] = _get_object_heat_pumps_values(hpxml: hpxml)
-    data[:hvac_control] = _get_object_hvac_control_values(hpxml: hpxml)
-    data[:hvac_distributions] = _get_object_hvac_distributions_values(hpxml: hpxml)
-    data[:ventilation_fans] = _get_object_ventilation_fans_values(hpxml: hpxml)
-    data[:water_heating_systems] = _get_object_water_heating_systems_values(hpxml: hpxml)
-    data[:hot_water_distribution] = _get_object_hot_water_distribution_values(hpxml: hpxml)
-    data[:water_fixtures] = _get_object_water_fixtures_values(hpxml: hpxml)
-    data[:solar_thermal_system] = _get_object_solar_thermal_system_values(hpxml: hpxml)
-    data[:pv_systems] = _get_object_pv_systems_values(hpxml: hpxml)
-    data[:clothes_washer] = _get_object_clothes_washer_values(hpxml: hpxml)
-    data[:clothes_dryer] = _get_object_clothes_dryer_values(hpxml: hpxml)
-    data[:dishwasher] = _get_object_dishwasher_values(hpxml: hpxml)
-    data[:refrigerator] = _get_object_refrigerator_values(hpxml: hpxml)
-    data[:cooking_range] = _get_object_cooking_range_values(hpxml: hpxml)
-    data[:oven] = _get_object_oven_values(hpxml: hpxml)
-    data[:lighting] = _get_object_lighting_values(hpxml: hpxml)
-    data[:ceiling_fans] = _get_object_ceiling_fans_values(hpxml: hpxml)
-    data[:plug_loads] = _get_object_plug_loads_values(hpxml: hpxml)
-    data[:misc_load_schedule] = _get_object_misc_loads_schedule_values(hpxml: hpxml)
+    # Single elements
+    @header = Header.new(nil, hpxml)
+    @site = Site.new(nil, hpxml)
+    @building_occupancy = BuildingOccupancy.new(nil, hpxml)
+    @building_construction = BuildingConstruction.new(nil, hpxml)
+    @climate_and_risk_zones = ClimateandRiskZones.new(nil, hpxml)
+    @hvac_control = HVACControl.new(nil, hpxml)
+    @hot_water_distribution = HotWaterDistribution.new(nil, hpxml)
+    @solar_thermal_system = SolarThermalSystem.new(nil, hpxml)
+    @clothes_washer = ClothesWasher.new(nil, hpxml)
+    @clothes_dryer = ClothesDryer.new(nil, hpxml)
+    @dishwasher = Dishwasher.new(nil, hpxml)
+    @refrigerator = Refrigerator.new(nil, hpxml)
+    @cooking_range = CookingRange.new(nil, hpxml)
+    @oven = Oven.new(nil, hpxml)
+    @lighting = Lighting.new(nil, hpxml)
+    @misc_load_schedule = MiscLoads.new(nil, hpxml)
 
-    return data
+    # Arrays
+    @neighbor_buildings = []
+    @air_infiltration_measurements = []
+    @attics = []
+    @foundations = []
+    @roofs = []
+    @rim_joists = []
+    @walls = []
+    @foundation_walls = []
+    @frame_floors = []
+    @slabs = []
+    @windows = []
+    @skylights = []
+    @doors = []
+    @heating_systems = []
+    @cooling_systems = []
+    @heat_pumps = []
+    @hvac_distributions = []
+    @ventilation_fans = []
+    @water_heating_systems = []
+    @water_fixtures = []
+    @pv_systems = []
+    @ceiling_fans = []
+    @plug_loads = []
+    if not hpxml.nil?
+      hpxml.elements.each("Building/BuildingDetails/BuildingSummary/Site/extension/Neighbors/NeighborBuilding") do |neighbor_building|
+        @neighbor_buildings << NeighborBuilding.new(nil, neighbor_building)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement") do |air_infiltration_measurement|
+        @air_infiltration_measurements << AirInfiltrationMeasurement.new(nil, air_infiltration_measurement)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Attics/Attic") do |attic|
+        @attics << Attic.new(nil, attic)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Foundations/Foundation") do |foundation|
+        @foundations << Foundation.new(nil, foundation)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Roofs/Roof") do |roof|
+        @roofs << Roof.new(nil, roof)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/RimJoists/RimJoist") do |rim_joist|
+        @rim_joists << RimJoist.new(nil, rim_joist)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Walls/Wall") do |wall|
+        @walls << Wall.new(nil, wall)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/FoundationWalls/FoundationWall") do |foundation_wall|
+        @foundation_walls << FoundationWall.new(nil, foundation_wall)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor") do |frame_floor|
+        @frame_floors << FrameFloor.new(nil, frame_floor)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Slabs/Slab") do |slab|
+        @slabs << Slab.new(nil, slab)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Windows/Window") do |window|
+        @windows << Window.new(nil, window)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Skylights/Skylight") do |skylight|
+        @skylights << Skylight.new(nil, skylight)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Enclosure/Doors/Door") do |door|
+        @doors << Door.new(nil, door)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem") do |heating_system|
+        @heating_systems << HeatingSystem.new(nil, heating_system)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem") do |cooling_system|
+        @cooling_systems << CoolingSystem.new(nil, cooling_system)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |heat_pump|
+        @heat_pumps << HeatPump.new(nil, heat_pump)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACDistribution") do |hvac_distribution|
+        @hvac_distributions << HVACDistribution.new(nil, hvac_distribution)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan") do |ventilation_fan|
+        @ventilation_fans << VentilationFan.new(nil, ventilation_fan)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem") do |water_heating_system|
+        @water_heating_systems << WaterHeatingSystem.new(nil, water_heating_system)
+      end
+      hpxml.elements.each("BuildingDetails/Systems/WaterHeating/WaterFixture") do |water_fixture|
+        @water_fixtures << WaterFixture.new(nil, water_fixture)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Systems/Photovoltaics/PVSystem") do |pv_system|
+        @pv_systems << PVSystem.new(nil, pv_system)
+      end
+      hpxml.elements.each("Building/BuildingDetails/Lighting/CeilingFan") do |ceiling_fan|
+        @ceiling_fans << CeilingFan.new(nil, ceiling_fan)
+      end
+      hpxml.elements.each("Building/BuildingDetails/MiscLoads/PlugLoad") do |plug_load|
+        @plug_loads << PlugLoad.new(nil, plug_load)
+      end
+    end
   end
 
-  def _convert_data_to_object()
-    @object = _create_object(**@data[:header])
-    _add_object_site(**@data[:site]) unless @data[:site].nil?
-    @data[:neighbor_buildings].each do |neighbor_building_values|
-      _add_object_neighbor_building(**neighbor_building_values)
+  class BaseElement
+    def initialize(hash = nil, hpxml = nil)
+      if not hash.nil?
+        # Reset all attributes to nil
+        self.class::ATTRS.each do |attribute|
+          self.send(attribute.to_s + "=", nil)
+        end
+        # Set values from hash
+        hash.each do |k, v|
+          self.send(k.to_s + "=", v)
+        end
+      elsif not hpxml.nil?
+        # Set values from HPXML object
+        from_hpxml(hpxml)
+      end
     end
-    _add_object_building_occupancy(**@data[:building_occupants]) unless @data[:building_occupants].empty?
-    _add_object_building_construction(**@data[:building_construction])
-    _add_object_climate_and_risk_zones(**@data[:climate_and_risk_zones])
-    @data[:air_infiltration_measurements].each do |air_infiltration_measurement_values|
-      _add_object_air_infiltration_measurement(**air_infiltration_measurement_values)
+
+    def to_h
+      h = {}
+      self.class::ATTRS.each do |attribute|
+        h[attribute] = self.send(attribute)
+      end
+      return h
     end
-    @data[:attics].each do |attic_values|
-      _add_object_attic(**attic_values)
+
+    def to_s
+      puts to_h.to_s
     end
-    @data[:foundations].each do |foundation_values|
-      _add_object_foundation(**foundation_values)
+
+    def nil?
+      # Returns true if all attributes are nil
+      to_h.each do |k, v|
+        return false if not v.nil?
+      end
+      return true
     end
-    @data[:roofs].each do |roof_values|
-      _add_object_roof(**roof_values)
-    end
-    @data[:rim_joists].each do |rim_joist_values|
-      _add_object_rim_joist(**rim_joist_values)
-    end
-    @data[:walls].each do |wall_values|
-      _add_object_wall(**wall_values)
-    end
-    @data[:foundation_walls].each do |foundation_wall_values|
-      _add_object_foundation_wall(**foundation_wall_values)
-    end
-    @data[:frame_floors].each do |frame_floor_values|
-      _add_object_frame_floor(**frame_floor_values)
-    end
-    @data[:slabs].each do |slab_values|
-      _add_object_slab(**slab_values)
-    end
-    @data[:windows].each do |window_values|
-      _add_object_window(**window_values)
-    end
-    @data[:skylights].each do |skylight_values|
-      _add_object_skylight(**skylight_values)
-    end
-    @data[:doors].each do |door_values|
-      _add_object_door(**door_values)
-    end
-    @data[:heating_systems].each do |heating_system_values|
-      _add_object_heating_system(**heating_system_values)
-    end
-    @data[:cooling_systems].each do |cooling_system_values|
-      _add_object_cooling_system(**cooling_system_values)
-    end
-    @data[:heat_pumps].each do |heat_pump_values|
-      _add_object_heat_pump(**heat_pump_values)
-    end
-    _add_object_hvac_control(**@data[:hvac_control]) unless @data[:hvac_control].empty?
-    @data[:hvac_distributions].each_with_index do |hvac_distribution_values, i|
-      hvac_distribution = _add_object_hvac_distribution(**hvac_distribution_values)
-    end
-    @data[:ventilation_fans].each do |ventilation_fan_values|
-      _add_object_ventilation_fan(**ventilation_fan_values)
-    end
-    @data[:water_heating_systems].each do |water_heating_system_values|
-      _add_object_water_heating_system(**water_heating_system_values)
-    end
-    _add_object_hot_water_distribution(**@data[:hot_water_distribution]) unless @data[:hot_water_distribution].empty?
-    @data[:water_fixtures].each do |water_fixture_values|
-      _add_object_water_fixture(**water_fixture_values)
-    end
-    _add_object_solar_thermal_system(**@data[:solar_thermal_system]) unless @data[:solar_thermal_system].empty?
-    @data[:pv_systems].each do |pv_system_values|
-      _add_object_pv_system(**pv_system_values)
-    end
-    _add_object_clothes_washer(**@data[:clothes_washer]) unless @data[:clothes_washer].empty?
-    _add_object_clothes_dryer(**@data[:clothes_dryer]) unless @data[:clothes_dryer].empty?
-    _add_object_dishwasher(**@data[:dishwasher]) unless @data[:dishwasher].empty?
-    _add_object_refrigerator(**@data[:refrigerator]) unless @data[:refrigerator].empty?
-    _add_object_cooking_range(**@data[:cooking_range]) unless @data[:cooking_range].empty?
-    _add_object_oven(**@data[:oven]) unless @data[:oven].empty?
-    _add_object_lighting(**@data[:lighting]) unless @data[:lighting].empty?
-    @data[:ceiling_fans].each do |ceiling_fan_values|
-      _add_object_ceiling_fan(**ceiling_fan_values)
-    end
-    @data[:plug_loads].each do |plug_load_values|
-      _add_object_plug_load(**plug_load_values)
-    end
-    _add_object_misc_loads_schedule(**@data[:misc_load_schedule]) unless @data[:misc_load_schedule].empty?
-    return @object
   end
 
-  def _create_object(xml_type:,
-                     xml_generated_by:,
-                     transaction:,
-                     software_program_used: nil,
-                     software_program_version: nil,
-                     eri_calculation_version: nil,
-                     eri_design: nil,
-                     timestep: nil,
-                     building_id:,
-                     event_type:,
-                     created_date_and_time: nil)
+  class Header < BaseElement
+    ATTRS = [:xml_type, :xml_generated_by, :created_date_and_time, :transaction,
+             :software_program_used, :software_program_version, :eri_calculation_version,
+             :eri_design, :timestep, :building_id, :event_type]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      hpxml = doc.elements["/HPXML"]
+      header = XMLHelper.add_element(hpxml, "XMLTransactionHeaderInformation")
+      XMLHelper.add_element(header, "XMLType", @xml_type)
+      XMLHelper.add_element(header, "XMLGeneratedBy", @xml_generated_by)
+      if not @created_date_and_time.nil?
+        XMLHelper.add_element(header, "CreatedDateAndTime", @created_date_and_time)
+      else
+        XMLHelper.add_element(header, "CreatedDateAndTime", Time.now.strftime("%Y-%m-%dT%H:%M:%S%:z"))
+      end
+      XMLHelper.add_element(header, "Transaction", @transaction)
+
+      software_info = XMLHelper.add_element(hpxml, "SoftwareInfo")
+      XMLHelper.add_element(software_info, "SoftwareProgramUsed", @software_program_used) unless @software_program_used.nil?
+      XMLHelper.add_element(software_info, "SoftwareProgramVersion", software_program_version) unless software_program_version.nil?
+      _add_extension(parent: software_info,
+                     extensions: { "ERICalculation/Version" => @eri_calculation_version,
+                                   "ERICalculation/Design" => @eri_design,
+                                   "SimulationControl/Timestep" => _to_integer_or_nil(@timestep) })
+
+      building = XMLHelper.add_element(hpxml, "Building")
+      building_building_id = XMLHelper.add_element(building, "BuildingID")
+      XMLHelper.add_attribute(building_building_id, "id", @building_id)
+      project_status = XMLHelper.add_element(building, "ProjectStatus")
+      XMLHelper.add_element(project_status, "EventType", @event_type)
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      @xml_type = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/XMLType")
+      @xml_generated_by = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/XMLGeneratedBy")
+      @created_date_and_time = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/CreatedDateAndTime")
+      @transaction = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/Transaction")
+      @software_program_used = XMLHelper.get_value(hpxml, "SoftwareInfo/SoftwareProgramUsed")
+      @software_program_version = XMLHelper.get_value(hpxml, "SoftwareInfo/SoftwareProgramVersion")
+      @eri_calculation_version = XMLHelper.get_value(hpxml, "SoftwareInfo/extension/ERICalculation/Version")
+      @eri_design = XMLHelper.get_value(hpxml, "SoftwareInfo/extension/ERICalculation/Design")
+      @timestep = _to_integer_or_nil(XMLHelper.get_value(hpxml, "SoftwareInfo/extension/SimulationControl/Timestep"))
+      @building_id = _get_id(hpxml, "Building/BuildingID")
+      @event_type = XMLHelper.get_value(hpxml, "Building/ProjectStatus/EventType")
+    end
+  end
+
+  class Site < BaseElement
+    ATTRS = [:surroundings, :orientation_of_front_of_home, :fuels, :shelter_coefficient]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      site = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "Site"])
+      if not @fuels.empty?
+        fuel_types_available = XMLHelper.add_element(site, "FuelTypesAvailable")
+        @fuels.each do |fuel|
+          XMLHelper.add_element(fuel_types_available, "Fuel", fuel)
+        end
+      end
+      _add_extension(parent: site,
+                     extensions: { "ShelterCoefficient" => _to_float_or_nil(@shelter_coefficient) })
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      site = hpxml.elements["Building/BuildingDetails/BuildingSummary/Site"]
+      return if site.nil?
+
+      @surroundings = XMLHelper.get_value(site, "Surroundings")
+      @orientation_of_front_of_home = XMLHelper.get_value(site, "OrientationOfFrontOfHome")
+      @fuels = XMLHelper.get_values(site, "FuelTypesAvailable/Fuel")
+      @shelter_coefficient = _to_float_or_nil(XMLHelper.get_value(site, "extension/ShelterCoefficient"))
+    end
+  end
+
+  class NeighborBuilding < BaseElement
+    ATTRS = [:azimuth, :distance, :height]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      neighbors = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "Site", "extension", "Neighbors"])
+      neighbor_building = XMLHelper.add_element(neighbors, "NeighborBuilding")
+      XMLHelper.add_element(neighbor_building, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
+      XMLHelper.add_element(neighbor_building, "Distance", Float(@distance)) unless @distance.nil?
+      XMLHelper.add_element(neighbor_building, "Height", Float(@height)) unless @height.nil?
+    end
+
+    def from_hpxml(neighbor_building)
+      return if neighbor_building.nil?
+
+      @azimuth = _to_integer_or_nil(XMLHelper.get_value(neighbor_building, "Azimuth"))
+      @distance = _to_float_or_nil(XMLHelper.get_value(neighbor_building, "Distance"))
+      @height = _to_float_or_nil(XMLHelper.get_value(neighbor_building, "Height"))
+    end
+  end
+
+  class BuildingOccupancy < BaseElement
+    ATTRS = [:number_of_residents]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      building_occupancy = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "BuildingOccupancy"])
+      XMLHelper.add_element(building_occupancy, "NumberofResidents", Float(@number_of_residents)) unless @number_of_residents.nil?
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      building_occupancy = hpxml.elements["Building/BuildingDetails/BuildingSummary/BuildingOccupancy"]
+      return if building_occupancy.nil?
+
+      @number_of_residents = _to_float_or_nil(XMLHelper.get_value(building_occupancy, "NumberofResidents"))
+    end
+  end
+
+  class BuildingConstruction < BaseElement
+    ATTRS = [:year_built, :number_of_conditioned_floors, :number_of_conditioned_floors_above_grade,
+             :average_ceiling_height, :number_of_bedrooms, :number_of_bathrooms,
+             :conditioned_floor_area, :conditioned_building_volume, :use_only_ideal_air_system,
+             :residential_facility_type, :fraction_of_operable_window_area]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      building_construction = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "BuildingConstruction"])
+      XMLHelper.add_element(building_construction, "NumberofConditionedFloors", Integer(@number_of_conditioned_floors)) unless @number_of_conditioned_floors.nil?
+      XMLHelper.add_element(building_construction, "NumberofConditionedFloorsAboveGrade", Integer(@number_of_conditioned_floors_above_grade)) unless @number_of_conditioned_floors_above_grade.nil?
+      XMLHelper.add_element(building_construction, "NumberofBedrooms", Integer(@number_of_bedrooms)) unless @number_of_bedrooms.nil?
+      XMLHelper.add_element(building_construction, "NumberofBathrooms", Integer(@number_of_bathrooms)) unless @number_of_bathrooms.nil?
+      XMLHelper.add_element(building_construction, "ConditionedFloorArea", Float(@conditioned_floor_area)) unless @conditioned_floor_area.nil?
+      XMLHelper.add_element(building_construction, "ConditionedBuildingVolume", Float(@conditioned_building_volume)) unless @conditioned_building_volume.nil?
+      _add_extension(parent: building_construction,
+                     extensions: { "FractionofOperableWindowArea" => _to_float_or_nil(@fraction_of_operable_window_area),
+                                   "UseOnlyIdealAirSystem" => _to_bool_or_nil(@use_only_ideal_air_system) })
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      building_construction = hpxml.elements["Building/BuildingDetails/BuildingSummary/BuildingConstruction"]
+      return if building_construction.nil?
+
+      @year_built = _to_integer_or_nil(XMLHelper.get_value(building_construction, "YearBuilt"))
+      @number_of_conditioned_floors = _to_integer_or_nil(XMLHelper.get_value(building_construction, "NumberofConditionedFloors"))
+      @number_of_conditioned_floors_above_grade = _to_integer_or_nil(XMLHelper.get_value(building_construction, "NumberofConditionedFloorsAboveGrade"))
+      @average_ceiling_height = _to_float_or_nil(XMLHelper.get_value(building_construction, "AverageCeilingHeight"))
+      @number_of_bedrooms = _to_integer_or_nil(XMLHelper.get_value(building_construction, "NumberofBedrooms"))
+      @number_of_bathrooms = _to_integer_or_nil(XMLHelper.get_value(building_construction, "NumberofBathrooms"))
+      @conditioned_floor_area = _to_float_or_nil(XMLHelper.get_value(building_construction, "ConditionedFloorArea"))
+      @conditioned_building_volume = _to_float_or_nil(XMLHelper.get_value(building_construction, "ConditionedBuildingVolume"))
+      @use_only_ideal_air_system = _to_bool_or_nil(XMLHelper.get_value(building_construction, "extension/UseOnlyIdealAirSystem"))
+      @residential_facility_type = XMLHelper.get_value(building_construction, "ResidentialFacilityType")
+      @fraction_of_operable_window_area = _to_float_or_nil(XMLHelper.get_value(building_construction, "extension/FractionofOperableWindowArea"))
+    end
+  end
+
+  class ClimateandRiskZones < BaseElement
+    ATTRS = [:iecc2006, :iecc2012, :weather_station_id, :weather_station_name, :weather_station_wmo,
+             :weather_station_epw_filename]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      climate_and_risk_zones = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "ClimateandRiskZones"])
+
+      climate_zones = { 2006 => @iecc2006,
+                        2012 => @iecc2012 }
+      climate_zones.each do |year, zone|
+        next if zone.nil?
+
+        climate_zone_iecc = XMLHelper.add_element(climate_and_risk_zones, "ClimateZoneIECC")
+        XMLHelper.add_element(climate_zone_iecc, "Year", Integer(year)) unless year.nil?
+        XMLHelper.add_element(climate_zone_iecc, "ClimateZone", zone) unless zone.nil?
+      end
+
+      if not @weather_station_id.nil?
+        weather_station = XMLHelper.add_element(climate_and_risk_zones, "WeatherStation")
+        sys_id = XMLHelper.add_element(weather_station, "SystemIdentifier")
+        XMLHelper.add_attribute(sys_id, "id", @weather_station_id)
+        XMLHelper.add_element(weather_station, "Name", @weather_station_name) unless @weather_station_name.nil?
+        XMLHelper.add_element(weather_station, "WMO", @weather_station_wmo) unless @weather_station_wmo.nil?
+        _add_extension(parent: weather_station,
+                       extensions: { "EPWFileName" => @weather_station_epw_filename })
+      end
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      climate_and_risk_zones = hpxml.elements["Building/BuildingDetails/ClimateandRiskZones"]
+      return if climate_and_risk_zones.nil?
+
+      @iecc2006 = XMLHelper.get_value(climate_and_risk_zones, "ClimateZoneIECC[Year=2006]/ClimateZone")
+      @iecc2012 = XMLHelper.get_value(climate_and_risk_zones, "ClimateZoneIECC[Year=2012]/ClimateZone")
+      weather_station = climate_and_risk_zones.elements["WeatherStation"]
+      if not weather_station.nil?
+        @weather_station_id = _get_id(weather_station)
+        @weather_station_name = XMLHelper.get_value(weather_station, "Name")
+        @weather_station_wmo = XMLHelper.get_value(weather_station, "WMO")
+        @weather_station_epw_filename = XMLHelper.get_value(weather_station, "extension/EPWFileName")
+      end
+    end
+  end
+
+  class AirInfiltrationMeasurement < BaseElement
+    ATTRS = [:id, :house_pressure, :unit_of_measure, :air_leakage, :effective_leakage_area,
+             :infiltration_volume, :constant_ach_natural, :leakiness_description]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      air_infiltration = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "AirInfiltration"])
+      air_infiltration_measurement = XMLHelper.add_element(air_infiltration, "AirInfiltrationMeasurement")
+      sys_id = XMLHelper.add_element(air_infiltration_measurement, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(air_infiltration_measurement, "HousePressure", Float(@house_pressure)) unless @house_pressure.nil?
+      if not @unit_of_measure.nil? and not @air_leakage.nil?
+        building_air_leakage = XMLHelper.add_element(air_infiltration_measurement, "BuildingAirLeakage")
+        XMLHelper.add_element(building_air_leakage, "UnitofMeasure", @unit_of_measure)
+        XMLHelper.add_element(building_air_leakage, "AirLeakage", Float(@air_leakage))
+      end
+      XMLHelper.add_element(air_infiltration_measurement, "EffectiveLeakageArea", Float(@effective_leakage_area)) unless @effective_leakage_area.nil?
+      XMLHelper.add_element(air_infiltration_measurement, "InfiltrationVolume", Float(@infiltration_volume)) unless @infiltration_volume.nil?
+      _add_extension(parent: air_infiltration_measurement,
+                     extensions: { "ConstantACHnatural" => _to_float_or_nil(@constant_ach_natural) })
+    end
+
+    def from_hpxml(air_infiltration_measurement)
+      return if air_infiltration_measurement.nil?
+
+      @id = _get_id(air_infiltration_measurement)
+      @house_pressure = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "HousePressure"))
+      @unit_of_measure = XMLHelper.get_value(air_infiltration_measurement, "BuildingAirLeakage/UnitofMeasure")
+      @air_leakage = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "BuildingAirLeakage/AirLeakage"))
+      @effective_leakage_area = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "EffectiveLeakageArea"))
+      @infiltration_volume = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "InfiltrationVolume"))
+      @constant_ach_natural = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "extension/ConstantACHnatural"))
+      @leakiness_description = XMLHelper.get_value(air_infiltration_measurement, "LeakinessDescription")
+    end
+  end
+
+  class Attic < BaseElement
+    ATTRS = [:id, :attic_type, :vented_attic_sla, :vented_attic_constant_ach]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      attics = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Attics"])
+      attic = XMLHelper.add_element(attics, "Attic")
+      sys_id = XMLHelper.add_element(attic, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      if not @attic_type.nil?
+        attic_type_e = XMLHelper.add_element(attic, "AtticType")
+        if @attic_type == "UnventedAttic"
+          attic_type_attic = XMLHelper.add_element(attic_type_e, "Attic")
+          XMLHelper.add_element(attic_type_attic, "Vented", false)
+        elsif @attic_type == "VentedAttic"
+          attic_type_attic = XMLHelper.add_element(attic_type_e, "Attic")
+          XMLHelper.add_element(attic_type_attic, "Vented", true)
+          if not @vented_attic_sla.nil?
+            ventilation_rate = XMLHelper.add_element(attic, "VentilationRate")
+            XMLHelper.add_element(ventilation_rate, "UnitofMeasure", "SLA")
+            XMLHelper.add_element(ventilation_rate, "Value", Float(@vented_attic_sla))
+          end
+          if not @vented_attic_constant_ach.nil?
+            XMLHelper.add_element(attic, "extension/ConstantACHnatural", Float(@vented_attic_constant_ach))
+          end
+        elsif @attic_type == "FlatRoof" or @attic_type == "CathedralCeiling"
+          XMLHelper.add_element(attic_type_e, @attic_type)
+        else
+          fail "Unhandled attic type '#{@attic_type}'."
+        end
+      end
+    end
+
+    def from_hpxml(attic)
+      return if attic.nil?
+
+      @id = _get_id(attic)
+      if XMLHelper.has_element(attic, "AtticType/Attic[Vented='false']")
+        @attic_type = "UnventedAttic"
+      elsif XMLHelper.has_element(attic, "AtticType/Attic[Vented='true']")
+        @attic_type = "VentedAttic"
+      elsif XMLHelper.has_element(attic, "AtticType/Attic[Conditioned='true']")
+        @attic_type = "ConditionedAttic"
+      elsif XMLHelper.has_element(attic, "AtticType/FlatRoof")
+        @attic_type = "FlatRoof"
+      elsif XMLHelper.has_element(attic, "AtticType/CathedralCeiling")
+        @attic_type = "CathedralCeiling"
+      end
+      @vented_attic_sla = _to_float_or_nil(XMLHelper.get_value(attic, "[AtticType/Attic[Vented='true']]VentilationRate[UnitofMeasure='SLA']/Value"))
+      @vented_attic_constant_ach = _to_float_or_nil(XMLHelper.get_value(attic, "[AtticType/Attic[Vented='true']]extension/ConstantACHnatural"))
+    end
+  end
+
+  class Foundation < BaseElement
+    ATTRS = [:id, :foundation_type, :vented_crawlspace_sla, :unconditioned_basement_thermal_boundary]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      foundations = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Foundations"])
+      foundation = XMLHelper.add_element(foundations, "Foundation")
+      sys_id = XMLHelper.add_element(foundation, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      if not @foundation_type.nil?
+        foundation_type_e = XMLHelper.add_element(foundation, "FoundationType")
+        if ["SlabOnGrade", "Ambient"].include? @foundation_type
+          XMLHelper.add_element(foundation_type_e, @foundation_type)
+        elsif @foundation_type == "ConditionedBasement"
+          basement = XMLHelper.add_element(foundation_type_e, "Basement")
+          XMLHelper.add_element(basement, "Conditioned", true)
+        elsif @foundation_type == "UnconditionedBasement"
+          basement = XMLHelper.add_element(foundation_type_e, "Basement")
+          XMLHelper.add_element(basement, "Conditioned", false)
+          XMLHelper.add_element(foundation, "ThermalBoundary", @unconditioned_basement_thermal_boundary) unless @unconditioned_basement_thermal_boundary.nil?
+        elsif @foundation_type == "VentedCrawlspace"
+          crawlspace = XMLHelper.add_element(foundation_type_e, "Crawlspace")
+          XMLHelper.add_element(crawlspace, "Vented", true)
+          if not @vented_crawlspace_sla.nil?
+            ventilation_rate = XMLHelper.add_element(foundation, "VentilationRate")
+            XMLHelper.add_element(ventilation_rate, "UnitofMeasure", "SLA")
+            XMLHelper.add_element(ventilation_rate, "Value", Float(@vented_crawlspace_sla))
+          end
+        elsif @foundation_type == "UnventedCrawlspace"
+          crawlspace = XMLHelper.add_element(foundation_type_e, "Crawlspace")
+          XMLHelper.add_element(crawlspace, "Vented", false)
+        else
+          fail "Unhandled foundation type '#{@foundation_type}'."
+        end
+      end
+    end
+
+    def from_hpxml(foundation)
+      return if foundation.nil?
+
+      @id = _get_id(foundation)
+      if XMLHelper.has_element(foundation, "FoundationType/SlabOnGrade")
+        @foundation_type = "SlabOnGrade"
+      elsif XMLHelper.has_element(foundation, "FoundationType/Basement[Conditioned='false']")
+        @foundation_type = "UnconditionedBasement"
+      elsif XMLHelper.has_element(foundation, "FoundationType/Basement[Conditioned='true']")
+        @foundation_type = "ConditionedBasement"
+      elsif XMLHelper.has_element(foundation, "FoundationType/Crawlspace[Vented='false']")
+        @foundation_type = "UnventedCrawlspace"
+      elsif XMLHelper.has_element(foundation, "FoundationType/Crawlspace[Vented='true']")
+        @foundation_type = "VentedCrawlspace"
+      elsif XMLHelper.has_element(foundation, "FoundationType/Ambient")
+        @foundation_type = "Ambient"
+      end
+      @vented_crawlspace_sla = _to_float_or_nil(XMLHelper.get_value(foundation, "[FoundationType/Crawlspace[Vented='true']]VentilationRate[UnitofMeasure='SLA']/Value"))
+      @unconditioned_basement_thermal_boundary = XMLHelper.get_value(foundation, "[FoundationType/Basement[Conditioned='false']]ThermalBoundary")
+    end
+  end
+
+  class Roof < BaseElement
+    ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :area, :azimuth, :roof_type,
+             :roof_color, :solar_absorptance, :emittance, :pitch, :radiant_barrier,
+             :insulation_id, :insulation_assembly_r_value, :insulation_cavity_r_value,
+             :insulation_continuous_r_value]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      roofs = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Roofs"])
+      roof = XMLHelper.add_element(roofs, "Roof")
+      sys_id = XMLHelper.add_element(roof, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(roof, "InteriorAdjacentTo", @interior_adjacent_to) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(roof, "Area", Float(@area)) unless @area.nil?
+      XMLHelper.add_element(roof, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
+      XMLHelper.add_element(roof, "SolarAbsorptance", Float(@solar_absorptance)) unless @solar_absorptance.nil?
+      XMLHelper.add_element(roof, "Emittance", Float(@emittance)) unless @emittance.nil?
+      XMLHelper.add_element(roof, "Pitch", Float(@pitch)) unless @pitch.nil?
+      XMLHelper.add_element(roof, "RadiantBarrier", Boolean(@radiant_barrier)) unless @radiant_barrier.nil?
+      insulation = XMLHelper.add_element(roof, "Insulation")
+      sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
+      if not @insulation_id.nil?
+        XMLHelper.add_attribute(sys_id, "id", @insulation_id)
+      else
+        XMLHelper.add_attribute(sys_id, "id", @id + "Insulation")
+      end
+      XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+    end
+
+    def from_hpxml(roof)
+      return if roof.nil?
+
+      @id = _get_id(roof)
+      @exterior_adjacent_to = "outside"
+      @interior_adjacent_to = XMLHelper.get_value(roof, "InteriorAdjacentTo")
+      @area = _to_float_or_nil(XMLHelper.get_value(roof, "Area"))
+      @azimuth = _to_integer_or_nil(XMLHelper.get_value(roof, "Azimuth"))
+      @roof_type = XMLHelper.get_value(roof, "RoofType")
+      @roof_color = XMLHelper.get_value(roof, "RoofColor")
+      @solar_absorptance = _to_float_or_nil(XMLHelper.get_value(roof, "SolarAbsorptance"))
+      @emittance = _to_float_or_nil(XMLHelper.get_value(roof, "Emittance"))
+      @pitch = _to_float_or_nil(XMLHelper.get_value(roof, "Pitch"))
+      @radiant_barrier = _to_bool_or_nil(XMLHelper.get_value(roof, "RadiantBarrier"))
+      insulation = roof.elements["Insulation"]
+      if not insulation.nil?
+        insulation_id = _get_id(insulation)
+        @insulation_assembly_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
+        @insulation_cavity_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
+        @insulation_continuous_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+      end
+    end
+  end
+
+  class RimJoist < BaseElement
+    ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :area, :azimuth, :solar_absorptance,
+             :emittance, :insulation_id, :insulation_assembly_r_value]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      rim_joists = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "RimJoists"])
+      rim_joist = XMLHelper.add_element(rim_joists, "RimJoist")
+      sys_id = XMLHelper.add_element(rim_joist, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(rim_joist, "ExteriorAdjacentTo", @exterior_adjacent_to) unless @exterior_adjacent_to.nil?
+      XMLHelper.add_element(rim_joist, "InteriorAdjacentTo", @interior_adjacent_to) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(rim_joist, "Area", Float(@area)) unless @area.nil?
+      XMLHelper.add_element(rim_joist, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
+      XMLHelper.add_element(rim_joist, "SolarAbsorptance", Float(@solar_absorptance)) unless @solar_absorptance.nil?
+      XMLHelper.add_element(rim_joist, "Emittance", Float(@emittance)) unless @emittance.nil?
+      insulation = XMLHelper.add_element(rim_joist, "Insulation")
+      sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
+      if not @insulation_id.nil?
+        XMLHelper.add_attribute(sys_id, "id", @insulation_id)
+      else
+        XMLHelper.add_attribute(sys_id, "id", @id + "Insulation")
+      end
+      XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+    end
+
+    def from_hpxml(rim_joist)
+      return if rim_joist.nil?
+
+      @id = _get_id(rim_joist)
+      @exterior_adjacent_to = XMLHelper.get_value(rim_joist, "ExteriorAdjacentTo")
+      @interior_adjacent_to = XMLHelper.get_value(rim_joist, "InteriorAdjacentTo")
+      @area = _to_float_or_nil(XMLHelper.get_value(rim_joist, "Area"))
+      @azimuth = _to_integer_or_nil(XMLHelper.get_value(rim_joist, "Azimuth"))
+      @solar_absorptance = _to_float_or_nil(XMLHelper.get_value(rim_joist, "SolarAbsorptance"))
+      @emittance = _to_float_or_nil(XMLHelper.get_value(rim_joist, "Emittance"))
+      insulation = rim_joist.elements["Insulation"]
+      if not insulation.nil?
+        insulation_id = _get_id(insulation)
+        @insulation_assembly_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
+      end
+    end
+  end
+
+  class Wall < BaseElement
+    ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :wall_type, :optimum_value_engineering,
+             :area, :orientation, :azimuth, :siding, :solar_absorptance, :emittance, :insulation_id,
+             :insulation_assembly_r_value, :insulation_cavity_r_value, :insulation_continuous_r_value]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      walls = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Walls"])
+      wall = XMLHelper.add_element(walls, "Wall")
+      sys_id = XMLHelper.add_element(wall, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(wall, "ExteriorAdjacentTo", @exterior_adjacent_to) unless @exterior_adjacent_to.nil?
+      XMLHelper.add_element(wall, "InteriorAdjacentTo", @interior_adjacent_to) unless @interior_adjacent_to.nil?
+      if not @wall_type.nil?
+        wall_type_e = XMLHelper.add_element(wall, "WallType")
+        XMLHelper.add_element(wall_type_e, @wall_type)
+      end
+      XMLHelper.add_element(wall, "Area", Float(@area)) unless @area.nil?
+      XMLHelper.add_element(wall, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
+      XMLHelper.add_element(wall, "SolarAbsorptance", Float(@solar_absorptance)) unless @solar_absorptance.nil?
+      XMLHelper.add_element(wall, "Emittance", Float(@emittance)) unless @emittance.nil?
+      insulation = XMLHelper.add_element(wall, "Insulation")
+      sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
+      if not @insulation_id.nil?
+        XMLHelper.add_attribute(sys_id, "id", @insulation_id)
+      else
+        XMLHelper.add_attribute(sys_id, "id", @id + "Insulation")
+      end
+      XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(@insulation_assembly_r_value))
+    end
+
+    def from_hpxml(wall)
+      return if wall.nil?
+
+      @id = _get_id(wall)
+      @exterior_adjacent_to = XMLHelper.get_value(wall, "ExteriorAdjacentTo")
+      @interior_adjacent_to = XMLHelper.get_value(wall, "InteriorAdjacentTo")
+      @wall_type = XMLHelper.get_child_name(wall, "WallType")
+      @optimum_value_engineering = _to_bool_or_nil(XMLHelper.get_value(wall, "WallType/WoodStud/OptimumValueEngineering"))
+      @area = _to_float_or_nil(XMLHelper.get_value(wall, "Area"))
+      @orientation = XMLHelper.get_value(wall, "Orientation")
+      @azimuth = _to_integer_or_nil(XMLHelper.get_value(wall, "Azimuth"))
+      @siding = XMLHelper.get_value(wall, "Siding")
+      @solar_absorptance = _to_float_or_nil(XMLHelper.get_value(wall, "SolarAbsorptance"))
+      @emittance = _to_float_or_nil(XMLHelper.get_value(wall, "Emittance"))
+      insulation = wall.elements["Insulation"]
+      if not insulation.nil?
+        insulation_id = _get_id(insulation)
+        @insulation_assembly_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
+        @insulation_cavity_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
+        @insulation_continuous_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+      end
+    end
+  end
+
+  class FoundationWall < BaseElement
+    ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :height, :area, :azimuth, :thickness,
+             :depth_below_grade, :insulation_id, :insulation_r_value, :insulation_interior_r_value,
+             :insulation_interior_distance_to_top, :insulation_interior_distance_to_bottom,
+             :insulation_exterior_r_value, :insulation_exterior_distance_to_top,
+             :insulation_exterior_distance_to_bottom, :insulation_assembly_r_value]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      foundation_walls = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "FoundationWalls"])
+      foundation_wall = XMLHelper.add_element(foundation_walls, "FoundationWall")
+      sys_id = XMLHelper.add_element(foundation_wall, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(foundation_wall, "ExteriorAdjacentTo", @exterior_adjacent_to) unless @exterior_adjacent_to.nil?
+      XMLHelper.add_element(foundation_wall, "InteriorAdjacentTo", @interior_adjacent_to) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(foundation_wall, "Height", Float(@height)) unless @height.nil?
+      XMLHelper.add_element(foundation_wall, "Area", Float(@area)) unless @area.nil?
+      XMLHelper.add_element(foundation_wall, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
+      XMLHelper.add_element(foundation_wall, "Thickness", Float(@thickness)) unless @thickness.nil?
+      XMLHelper.add_element(foundation_wall, "DepthBelowGrade", Float(@depth_below_grade)) unless @depth_below_grade.nil?
+      insulation = XMLHelper.add_element(foundation_wall, "Insulation")
+      sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
+      if not @insulation_id.nil?
+        XMLHelper.add_attribute(sys_id, "id", @insulation_id)
+      else
+        XMLHelper.add_attribute(sys_id, "id", @id + "Insulation")
+      end
+      XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+      if not @insulation_exterior_r_value.nil?
+        layer = XMLHelper.add_element(insulation, "Layer")
+        XMLHelper.add_element(layer, "InstallationType", "continuous - exterior")
+        XMLHelper.add_element(layer, "NominalRValue", Float(@insulation_exterior_r_value))
+        _add_extension(parent: layer,
+                       extensions: { "DistanceToTopOfInsulation" => _to_float_or_nil(@insulation_exterior_distance_to_top),
+                                     "DistanceToBottomOfInsulation" => _to_float_or_nil(@insulation_exterior_distance_to_bottom) })
+      end
+      if not @insulation_interior_r_value.nil?
+        layer = XMLHelper.add_element(insulation, "Layer")
+        XMLHelper.add_element(layer, "InstallationType", "continuous - interior")
+        XMLHelper.add_element(layer, "NominalRValue", Float(@insulation_interior_r_value))
+        _add_extension(parent: layer,
+                       extensions: { "DistanceToTopOfInsulation" => _to_float_or_nil(@insulation_interior_distance_to_top),
+                                     "DistanceToBottomOfInsulation" => _to_float_or_nil(@insulation_interior_distance_to_bottom) })
+      end
+    end
+
+    def from_hpxml(foundation_wall)
+      return if foundation_wall.nil?
+
+      @id = _get_id(foundation_wall)
+      @exterior_adjacent_to = XMLHelper.get_value(foundation_wall, "ExteriorAdjacentTo")
+      @interior_adjacent_to = XMLHelper.get_value(foundation_wall, "InteriorAdjacentTo")
+      @height = _to_float_or_nil(XMLHelper.get_value(foundation_wall, "Height"))
+      @area = _to_float_or_nil(XMLHelper.get_value(foundation_wall, "Area"))
+      @azimuth = _to_integer_or_nil(XMLHelper.get_value(foundation_wall, "Azimuth"))
+      @thickness = _to_float_or_nil(XMLHelper.get_value(foundation_wall, "Thickness"))
+      @depth_below_grade = _to_float_or_nil(XMLHelper.get_value(foundation_wall, "DepthBelowGrade"))
+      insulation = foundation_wall.elements["Insulation"]
+      if not insulation.nil?
+        insulation_id = _get_id(insulation)
+        @insulation_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+        @insulation_interior_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/NominalRValue"))
+        @insulation_interior_distance_to_top = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/extension/DistanceToTopOfInsulation"))
+        @insulation_interior_distance_to_bottom = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/extension/DistanceToBottomOfInsulation"))
+        @insulation_exterior_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/NominalRValue"))
+        @insulation_exterior_distance_to_top = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/extension/DistanceToTopOfInsulation"))
+        @insulation_exterior_distance_to_bottom = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/extension/DistanceToBottomOfInsulation"))
+        @insulation_assembly_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
+      end
+    end
+  end
+
+  class FrameFloor < BaseElement
+    ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :area, :insulation_id,
+             :insulation_assembly_r_value, :insulation_cavity_r_value, :insulation_continuous_r_value]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      frame_floors = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "FrameFloors"])
+      frame_floor = XMLHelper.add_element(frame_floors, "FrameFloor")
+      sys_id = XMLHelper.add_element(frame_floor, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(frame_floor, "ExteriorAdjacentTo", @exterior_adjacent_to) unless @exterior_adjacent_to.nil?
+      XMLHelper.add_element(frame_floor, "InteriorAdjacentTo", @interior_adjacent_to) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(frame_floor, "Area", Float(@area)) unless @area.nil?
+      insulation = XMLHelper.add_element(frame_floor, "Insulation")
+      sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
+      if not @insulation_id.nil?
+        XMLHelper.add_attribute(sys_id, "id", @insulation_id)
+      else
+        XMLHelper.add_attribute(sys_id, "id", @id + "Insulation")
+      end
+      XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+    end
+
+    def from_hpxml(frame_floor)
+      return if frame_floor.nil?
+
+      @id = _get_id(frame_floor)
+      @exterior_adjacent_to = XMLHelper.get_value(frame_floor, "ExteriorAdjacentTo")
+      @interior_adjacent_to = XMLHelper.get_value(frame_floor, "InteriorAdjacentTo")
+      @area = _to_float_or_nil(XMLHelper.get_value(frame_floor, "Area"))
+      insulation = frame_floor.elements["Insulation"]
+      if not insulation.nil?
+        insulation_id = _get_id(insulation)
+        @insulation_assembly_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
+        @insulation_cavity_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
+        @insulation_continuous_r_value = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+      end
+    end
+  end
+
+  class Slab < BaseElement
+    ATTRS = [:id, :interior_adjacent_to, :exterior_adjacent_to, :area, :thickness, :exposed_perimeter,
+             :perimeter_insulation_depth, :under_slab_insulation_width,
+             :under_slab_insulation_spans_entire_slab, :depth_below_grade, :carpet_fraction,
+             :carpet_r_value, :perimeter_insulation_id, :perimeter_insulation_r_value,
+             :under_slab_insulation_id, :under_slab_insulation_r_value]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      slabs = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Slabs"])
+      slab = XMLHelper.add_element(slabs, "Slab")
+      sys_id = XMLHelper.add_element(slab, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(slab, "InteriorAdjacentTo", @interior_adjacent_to) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(slab, "Area", Float(@area)) unless @area.nil?
+      XMLHelper.add_element(slab, "Thickness", Float(@thickness)) unless @thickness.nil?
+      XMLHelper.add_element(slab, "ExposedPerimeter", Float(@exposed_perimeter)) unless @exposed_perimeter.nil?
+      XMLHelper.add_element(slab, "PerimeterInsulationDepth", Float(@perimeter_insulation_depth)) unless @perimeter_insulation_depth.nil?
+      XMLHelper.add_element(slab, "UnderSlabInsulationWidth", Float(@under_slab_insulation_width)) unless @under_slab_insulation_width.nil?
+      XMLHelper.add_element(slab, "UnderSlabInsulationSpansEntireSlab", Boolean(@under_slab_insulation_spans_entire_slab)) unless @under_slab_insulation_spans_entire_slab.nil?
+      XMLHelper.add_element(slab, "DepthBelowGrade", Float(@depth_below_grade)) unless @depth_below_grade.nil?
+      insulation = XMLHelper.add_element(slab, "PerimeterInsulation")
+      sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
+      if not @perimeter_insulation_id.nil?
+        XMLHelper.add_attribute(sys_id, "id", @perimeter_insulation_id)
+      else
+        XMLHelper.add_attribute(sys_id, "id", @id + "PerimeterInsulation")
+      end
+      layer = XMLHelper.add_element(insulation, "Layer")
+      XMLHelper.add_element(layer, "InstallationType", "continuous")
+      XMLHelper.add_element(layer, "NominalRValue", Float(@perimeter_insulation_r_value)) unless @perimeter_insulation_r_value.nil?
+      insulation = XMLHelper.add_element(slab, "UnderSlabInsulation")
+      sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
+      if not @under_slab_insulation_id.nil?
+        XMLHelper.add_attribute(sys_id, "id", @under_slab_insulation_id)
+      else
+        XMLHelper.add_attribute(sys_id, "id", @id + "UnderSlabInsulation")
+      end
+      layer = XMLHelper.add_element(insulation, "Layer")
+      XMLHelper.add_element(layer, "InstallationType", "continuous")
+      XMLHelper.add_element(layer, "NominalRValue", Float(@under_slab_insulation_r_value)) unless @under_slab_insulation_r_value.nil?
+      _add_extension(parent: slab,
+                     extensions: { "CarpetFraction" => _to_float_or_nil(@carpet_fraction),
+                                   "CarpetRValue" => _to_float_or_nil(@carpet_r_value) })
+    end
+
+    def from_hpxml(slab)
+      return if slab.nil?
+
+      @id = _get_id(slab)
+      @interior_adjacent_to = XMLHelper.get_value(slab, "InteriorAdjacentTo")
+      @exterior_adjacent_to = "outside"
+      @area = _to_float_or_nil(XMLHelper.get_value(slab, "Area"))
+      @thickness = _to_float_or_nil(XMLHelper.get_value(slab, "Thickness"))
+      @exposed_perimeter = _to_float_or_nil(XMLHelper.get_value(slab, "ExposedPerimeter"))
+      @perimeter_insulation_depth = _to_float_or_nil(XMLHelper.get_value(slab, "PerimeterInsulationDepth"))
+      @under_slab_insulation_width = _to_float_or_nil(XMLHelper.get_value(slab, "UnderSlabInsulationWidth"))
+      @under_slab_insulation_spans_entire_slab = _to_bool_or_nil(XMLHelper.get_value(slab, "UnderSlabInsulationSpansEntireSlab"))
+      @depth_below_grade = _to_float_or_nil(XMLHelper.get_value(slab, "DepthBelowGrade"))
+      @carpet_fraction = _to_float_or_nil(XMLHelper.get_value(slab, "extension/CarpetFraction"))
+      @carpet_r_value = _to_float_or_nil(XMLHelper.get_value(slab, "extension/CarpetRValue"))
+      perimeter_insulation = slab.elements["PerimeterInsulation"]
+      if not perimeter_insulation.nil?
+        perimeter_insulation_id = _get_id(perimeter_insulation)
+        @perimeter_insulation_r_value = _to_float_or_nil(XMLHelper.get_value(perimeter_insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+      end
+      under_slab_insulation = slab.elements["UnderSlabInsulation"]
+      if not under_slab_insulation.nil?
+        under_slab_insulation_id = _get_id(under_slab_insulation)
+        @under_slab_insulation_r_value = _to_float_or_nil(XMLHelper.get_value(under_slab_insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+      end
+    end
+  end
+
+  class Window < BaseElement
+    ATTRS = [:id, :area, :azimuth, :orientation, :frame_type, :aluminum_thermal_break, :glass_layers,
+             :glass_type, :gas_fill, :ufactor, :shgc, :interior_shading_factor_summer,
+             :interior_shading_factor_winter, :exterior_shading, :overhangs_depth,
+             :overhangs_distance_to_top_of_window, :overhangs_distance_to_bottom_of_window,
+             :wall_idref]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      windows = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Windows"])
+      window = XMLHelper.add_element(windows, "Window")
+      sys_id = XMLHelper.add_element(window, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(window, "Area", Float(@area)) unless @area.nil?
+      XMLHelper.add_element(window, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
+      XMLHelper.add_element(window, "UFactor", Float(@ufactor)) unless @ufactor.nil?
+      XMLHelper.add_element(window, "SHGC", Float(@shgc)) unless @shgc.nil?
+      if not @interior_shading_factor_summer.nil? or not @interior_shading_factor_winter.nil?
+        interior_shading = XMLHelper.add_element(window, "InteriorShading")
+        sys_id = XMLHelper.add_element(interior_shading, "SystemIdentifier")
+        XMLHelper.add_attribute(sys_id, "id", "#{id}InteriorShading")
+        XMLHelper.add_element(interior_shading, "SummerShadingCoefficient", Float(@interior_shading_factor_summer)) unless @interior_shading_factor_summer.nil?
+        XMLHelper.add_element(interior_shading, "WinterShadingCoefficient", Float(@interior_shading_factor_winter)) unless @interior_shading_factor_winter.nil?
+      end
+      if not @overhangs_depth.nil? or not @overhangs_distance_to_top_of_window.nil? or not @overhangs_distance_to_bottom_of_window.nil?
+        overhangs = XMLHelper.add_element(window, "Overhangs")
+        XMLHelper.add_element(overhangs, "Depth", Float(@overhangs_depth)) unless @overhangs_depth.nil?
+        XMLHelper.add_element(overhangs, "DistanceToTopOfWindow", Float(@overhangs_distance_to_top_of_window)) unless @overhangs_distance_to_top_of_window.nil?
+        XMLHelper.add_element(overhangs, "DistanceToBottomOfWindow", Float(@overhangs_distance_to_bottom_of_window)) unless @overhangs_distance_to_bottom_of_window.nil?
+      end
+      if not @wall_idref.nil?
+        attached_to_wall = XMLHelper.add_element(window, "AttachedToWall")
+        XMLHelper.add_attribute(attached_to_wall, "idref", @wall_idref)
+      end
+    end
+
+    def from_hpxml(window)
+      return if window.nil?
+
+      @id = _get_id(window)
+      @area = _to_float_or_nil(XMLHelper.get_value(window, "Area"))
+      @azimuth = _to_integer_or_nil(XMLHelper.get_value(window, "Azimuth"))
+      @orientation = XMLHelper.get_value(window, "Orientation")
+      @frame_type = XMLHelper.get_child_name(window, "FrameType")
+      @aluminum_thermal_break = _to_bool_or_nil(XMLHelper.get_value(window, "FrameType/Aluminum/ThermalBreak"))
+      @glass_layers = XMLHelper.get_value(window, "GlassLayers")
+      @glass_type = XMLHelper.get_value(window, "GlassType")
+      @gas_fill = XMLHelper.get_value(window, "GasFill")
+      @ufactor = _to_float_or_nil(XMLHelper.get_value(window, "UFactor"))
+      @shgc = _to_float_or_nil(XMLHelper.get_value(window, "SHGC"))
+      @interior_shading_factor_summer = _to_float_or_nil(XMLHelper.get_value(window, "InteriorShading/SummerShadingCoefficient"))
+      @interior_shading_factor_winter = _to_float_or_nil(XMLHelper.get_value(window, "InteriorShading/WinterShadingCoefficient"))
+      @exterior_shading = XMLHelper.get_value(window, "ExteriorShading/Type")
+      @overhangs_depth = _to_float_or_nil(XMLHelper.get_value(window, "Overhangs/Depth"))
+      @overhangs_distance_to_top_of_window = _to_float_or_nil(XMLHelper.get_value(window, "Overhangs/DistanceToTopOfWindow"))
+      @overhangs_distance_to_bottom_of_window = _to_float_or_nil(XMLHelper.get_value(window, "Overhangs/DistanceToBottomOfWindow"))
+      @wall_idref = _get_idref(window, "AttachedToWall")
+    end
+  end
+
+  class Skylight < BaseElement
+    ATTRS = [:id, :area, :azimuth, :orientation, :frame_type, :aluminum_thermal_break, :glass_layers,
+             :glass_type, :gas_fill, :ufactor, :shgc, :exterior_shading, :roof_idref]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      skylights = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Skylights"])
+      skylight = XMLHelper.add_element(skylights, "Skylight")
+      sys_id = XMLHelper.add_element(skylight, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(skylight, "Area", Float(@area)) unless @area.nil?
+      XMLHelper.add_element(skylight, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
+      XMLHelper.add_element(skylight, "UFactor", Float(@ufactor)) unless @ufactor.nil?
+      XMLHelper.add_element(skylight, "SHGC", Float(@shgc)) unless @shgc.nil?
+      if not @roof_idref.nil?
+        attached_to_roof = XMLHelper.add_element(skylight, "AttachedToRoof")
+        XMLHelper.add_attribute(attached_to_roof, "idref", @roof_idref)
+      end
+    end
+
+    def from_hpxml(skylight)
+      return if skylight.nil?
+
+      @id = _get_id(skylight)
+      @area = _to_float_or_nil(XMLHelper.get_value(skylight, "Area"))
+      @azimuth = _to_integer_or_nil(XMLHelper.get_value(skylight, "Azimuth"))
+      @orientation = XMLHelper.get_value(skylight, "Orientation")
+      @frame_type = XMLHelper.get_child_name(skylight, "FrameType")
+      @aluminum_thermal_break = _to_bool_or_nil(XMLHelper.get_value(skylight, "FrameType/Aluminum/ThermalBreak"))
+      @glass_layers = XMLHelper.get_value(skylight, "GlassLayers")
+      @glass_type = XMLHelper.get_value(skylight, "GlassType")
+      @gas_fill = XMLHelper.get_value(skylight, "GasFill")
+      @ufactor = _to_float_or_nil(XMLHelper.get_value(skylight, "UFactor"))
+      @shgc = _to_float_or_nil(XMLHelper.get_value(skylight, "SHGC"))
+      @exterior_shading = XMLHelper.get_value(skylight, "ExteriorShading/Type")
+      @roof_idref = _get_idref(skylight, "AttachedToRoof")
+    end
+  end
+
+  class Door < BaseElement
+    ATTRS = [:id, :wall_idref, :area, :azimuth, :r_value]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      doors = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Doors"])
+      door = XMLHelper.add_element(doors, "Door")
+      sys_id = XMLHelper.add_element(door, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      if not @wall_idref.nil?
+        attached_to_wall = XMLHelper.add_element(door, "AttachedToWall")
+        XMLHelper.add_attribute(attached_to_wall, "idref", @wall_idref)
+      end
+      XMLHelper.add_element(door, "Area", Float(@area)) unless @area.nil?
+      XMLHelper.add_element(door, "Azimuth", Integer(@azimuth)) unless @azimuth.nil?
+      XMLHelper.add_element(door, "RValue", Float(@r_value)) unless @r_value.nil?
+    end
+
+    def from_hpxml(door)
+      return if door.nil?
+
+      @id = _get_id(door)
+      @wall_idref = _get_idref(door, "AttachedToWall")
+      @area = _to_float_or_nil(XMLHelper.get_value(door, "Area"))
+      @azimuth = _to_integer_or_nil(XMLHelper.get_value(door, "Azimuth"))
+      @r_value = _to_float_or_nil(XMLHelper.get_value(door, "RValue"))
+    end
+  end
+
+  class HeatingSystem < BaseElement
+    ATTRS = [:id, :distribution_system_idref, :year_installed, :heating_system_type,
+             :heating_system_fuel, :heating_capacity, :heating_efficiency_afue,
+             :heating_efficiency_percent, :fraction_heat_load_served, :electric_auxiliary_energy,
+             :heating_cfm, :energy_star, :seed_id]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      hvac_plant = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
+      heating_system = XMLHelper.add_element(hvac_plant, "HeatingSystem")
+      sys_id = XMLHelper.add_element(heating_system, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      if not @distribution_system_idref.nil?
+        distribution_system = XMLHelper.add_element(heating_system, "DistributionSystem")
+        XMLHelper.add_attribute(distribution_system, "idref", @distribution_system_idref)
+      end
+      if not @heating_system_type.nil?
+        heating_system_type_e = XMLHelper.add_element(heating_system, "HeatingSystemType")
+        XMLHelper.add_element(heating_system_type_e, @heating_system_type)
+      end
+      XMLHelper.add_element(heating_system, "HeatingSystemFuel", @heating_system_fuel) unless @heating_system_fuel.nil?
+      XMLHelper.add_element(heating_system, "HeatingCapacity", Float(@heating_capacity)) unless @heating_capacity.nil?
+
+      efficiency_units = nil
+      efficiency_value = nil
+      if ["Furnace", "WallFurnace", "Boiler"].include? @heating_system_type
+        efficiency_units = "AFUE"
+        efficiency_value = @heating_efficiency_afue
+      elsif ["ElectricResistance", "Stove", "PortableHeater"].include? @heating_system_type
+        efficiency_units = "Percent"
+        efficiency_value = @heating_efficiency_percent
+      end
+      if not efficiency_value.nil?
+        annual_efficiency = XMLHelper.add_element(heating_system, "AnnualHeatingEfficiency")
+        XMLHelper.add_element(annual_efficiency, "Units", efficiency_units)
+        XMLHelper.add_element(annual_efficiency, "Value", Float(efficiency_value))
+      end
+
+      XMLHelper.add_element(heating_system, "FractionHeatLoadServed", Float(@fraction_heat_load_served)) unless @fraction_heat_load_served.nil?
+      XMLHelper.add_element(heating_system, "ElectricAuxiliaryEnergy", Float(@electric_auxiliary_energy)) unless @electric_auxiliary_energy.nil?
+      _add_extension(parent: heating_system,
+                     extensions: { "HeatingFlowRate" => _to_float_or_nil(@heating_cfm) })
+    end
+
+    def from_hpxml(heating_system)
+      return if heating_system.nil?
+
+      @id = _get_id(heating_system)
+      @distribution_system_idref = _get_idref(heating_system, "DistributionSystem")
+      @year_installed = _to_integer_or_nil(XMLHelper.get_value(heating_system, "YearInstalled"))
+      @heating_system_type = XMLHelper.get_child_name(heating_system, "HeatingSystemType")
+      @heating_system_fuel = XMLHelper.get_value(heating_system, "HeatingSystemFuel")
+      @heating_capacity = _to_float_or_nil(XMLHelper.get_value(heating_system, "HeatingCapacity"))
+      @heating_efficiency_afue = _to_float_or_nil(XMLHelper.get_value(heating_system, "[HeatingSystemType[Furnace | WallFurnace | Boiler]]AnnualHeatingEfficiency[Units='AFUE']/Value"))
+      @heating_efficiency_percent = _to_float_or_nil(XMLHelper.get_value(heating_system, "[HeatingSystemType[ElectricResistance | Stove | PortableHeater]]AnnualHeatingEfficiency[Units='Percent']/Value"))
+      @fraction_heat_load_served = _to_float_or_nil(XMLHelper.get_value(heating_system, "FractionHeatLoadServed"))
+      @electric_auxiliary_energy = _to_float_or_nil(XMLHelper.get_value(heating_system, "ElectricAuxiliaryEnergy"))
+      @heating_cfm = _to_float_or_nil(XMLHelper.get_value(heating_system, "extension/HeatingFlowRate"))
+      @energy_star = XMLHelper.get_values(heating_system, "ThirdPartyCertification").include?("Energy Star")
+      @seed_id = XMLHelper.get_value(heating_system, "extension/SeedId")
+    end
+  end
+
+  class CoolingSystem < BaseElement
+    ATTRS = [:id, :distribution_system_idref, :year_installed, :cooling_system_type,
+             :cooling_system_fuel, :cooling_capacity, :compressor_type, :fraction_cool_load_served,
+             :cooling_efficiency_seer, :cooling_efficiency_eer, :cooling_shr, :cooling_cfm,
+             :energy_star, :seed_id]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      hvac_plant = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
+      cooling_system = XMLHelper.add_element(hvac_plant, "CoolingSystem")
+      sys_id = XMLHelper.add_element(cooling_system, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      if not @distribution_system_idref.nil?
+        distribution_system = XMLHelper.add_element(cooling_system, "DistributionSystem")
+        XMLHelper.add_attribute(distribution_system, "idref", @distribution_system_idref)
+      end
+      XMLHelper.add_element(cooling_system, "CoolingSystemType", @cooling_system_type) unless @cooling_system_type.nil?
+      XMLHelper.add_element(cooling_system, "CoolingSystemFuel", @cooling_system_fuel) unless @cooling_system_fuel.nil?
+      XMLHelper.add_element(cooling_system, "CoolingCapacity", Float(@cooling_capacity)) unless @cooling_capacity.nil?
+      XMLHelper.add_element(cooling_system, "CompressorType", @compressor_type) unless @compressor_type.nil?
+      XMLHelper.add_element(cooling_system, "FractionCoolLoadServed", Float(@fraction_cool_load_served)) unless @fraction_cool_load_served.nil?
+
+      efficiency_units = nil
+      efficiency_value = nil
+      if ["central air conditioner"].include? @cooling_system_type
+        efficiency_units = "SEER"
+        efficiency_value = @cooling_efficiency_seer
+      elsif ["room air conditioner"].include? @cooling_system_type
+        efficiency_units = "EER"
+        efficiency_value = @cooling_efficiency_eer
+      end
+      if not efficiency_value.nil?
+        annual_efficiency = XMLHelper.add_element(cooling_system, "AnnualCoolingEfficiency")
+        XMLHelper.add_element(annual_efficiency, "Units", efficiency_units)
+        XMLHelper.add_element(annual_efficiency, "Value", Float(efficiency_value))
+      end
+
+      XMLHelper.add_element(cooling_system, "SensibleHeatFraction", Float(@cooling_shr)) unless @cooling_shr.nil?
+      _add_extension(parent: cooling_system,
+                     extensions: { "CoolingFlowRate" => _to_float_or_nil(@cooling_cfm) })
+    end
+
+    def from_hpxml(cooling_system)
+      return if cooling_system.nil?
+
+      @id = _get_id(cooling_system)
+      @distribution_system_idref = _get_idref(cooling_system, "DistributionSystem")
+      @year_installed = _to_integer_or_nil(XMLHelper.get_value(cooling_system, "YearInstalled"))
+      @cooling_system_type = XMLHelper.get_value(cooling_system, "CoolingSystemType")
+      @cooling_system_fuel = XMLHelper.get_value(cooling_system, "CoolingSystemFuel")
+      @cooling_capacity = _to_float_or_nil(XMLHelper.get_value(cooling_system, "CoolingCapacity"))
+      @compressor_type = XMLHelper.get_value(cooling_system, "CompressorType")
+      @fraction_cool_load_served = _to_float_or_nil(XMLHelper.get_value(cooling_system, "FractionCoolLoadServed"))
+      @cooling_efficiency_seer = _to_float_or_nil(XMLHelper.get_value(cooling_system, "[CoolingSystemType='central air conditioner']AnnualCoolingEfficiency[Units='SEER']/Value"))
+      @cooling_efficiency_eer = _to_float_or_nil(XMLHelper.get_value(cooling_system, "[CoolingSystemType='room air conditioner']AnnualCoolingEfficiency[Units='EER']/Value"))
+      @cooling_shr = _to_float_or_nil(XMLHelper.get_value(cooling_system, "SensibleHeatFraction"))
+      @cooling_cfm = _to_float_or_nil(XMLHelper.get_value(cooling_system, "extension/CoolingFlowRate"))
+      @energy_star = XMLHelper.get_values(cooling_system, "ThirdPartyCertification").include?("Energy Star")
+      @seed_id = XMLHelper.get_value(cooling_system, "extension/SeedId")
+    end
+  end
+
+  class HeatPump < BaseElement
+    ATTRS = [:id, :distribution_system_idref, :year_installed, :heat_pump_type, :heat_pump_fuel,
+             :heating_capacity, :heating_capacity_17F, :cooling_capacity, :compressor_type,
+             :cooling_shr, :backup_heating_fuel, :backup_heating_capacity,
+             :backup_heating_efficiency_percent, :backup_heating_efficiency_afue,
+             :backup_heating_switchover_temp, :fraction_heat_load_served, :fraction_cool_load_served,
+             :cooling_efficiency_seer, :cooling_efficiency_eer, :heating_efficiency_hspf,
+             :heating_efficiency_cop, :energy_star, :seed_id]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      hvac_plant = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
+      heat_pump = XMLHelper.add_element(hvac_plant, "HeatPump")
+      sys_id = XMLHelper.add_element(heat_pump, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      if not @distribution_system_idref.nil?
+        distribution_system = XMLHelper.add_element(heat_pump, "DistributionSystem")
+        XMLHelper.add_attribute(distribution_system, "idref", @distribution_system_idref)
+      end
+      XMLHelper.add_element(heat_pump, "HeatPumpType", @heat_pump_type) unless @heat_pump_type.nil?
+      XMLHelper.add_element(heat_pump, "HeatPumpFuel", @heat_pump_fuel) unless @heat_pump_fuel.nil?
+      XMLHelper.add_element(heat_pump, "HeatingCapacity", Float(@heating_capacity)) unless @heating_capacity.nil?
+      XMLHelper.add_element(heat_pump, "HeatingCapacity17F", Float(@heating_capacity_17F)) unless @heating_capacity_17F.nil?
+      XMLHelper.add_element(heat_pump, "CoolingCapacity", Float(@cooling_capacity)) unless @cooling_capacity.nil?
+      XMLHelper.add_element(heat_pump, "CompressorType", @compressor_type) unless @compressor_type.nil?
+      XMLHelper.add_element(heat_pump, "CoolingSensibleHeatFraction", Float(@cooling_shr)) unless @cooling_shr.nil?
+      if not @backup_heating_fuel.nil?
+        XMLHelper.add_element(heat_pump, "BackupSystemFuel", @backup_heating_fuel)
+        efficiencies = { "Percent" => @backup_heating_efficiency_percent,
+                         "AFUE" => @backup_heating_efficiency_afue }
+        efficiencies.each do |units, value|
+          next if value.nil?
+
+          backup_eff = XMLHelper.add_element(heat_pump, "BackupAnnualHeatingEfficiency")
+          XMLHelper.add_element(backup_eff, "Units", units)
+          XMLHelper.add_element(backup_eff, "Value", Float(value))
+        end
+        XMLHelper.add_element(heat_pump, "BackupHeatingCapacity", Float(@backup_heating_capacity)) unless @backup_heating_capacity.nil?
+        XMLHelper.add_element(heat_pump, "BackupHeatingSwitchoverTemperature", Float(@backup_heating_switchover_temp)) unless @backup_heating_switchover_temp.nil?
+      end
+      XMLHelper.add_element(heat_pump, "FractionHeatLoadServed", Float(@fraction_heat_load_served)) unless @fraction_heat_load_served.nil?
+      XMLHelper.add_element(heat_pump, "FractionCoolLoadServed", Float(@fraction_cool_load_served)) unless @fraction_cool_load_served.nil?
+
+      clg_efficiency_units = nil
+      clg_efficiency_value = nil
+      htg_efficiency_units = nil
+      htg_efficiency_value = nil
+      if ["air-to-air", "mini-split"].include? @heat_pump_type
+        clg_efficiency_units = "SEER"
+        clg_efficiency_value = @cooling_efficiency_seer
+        htg_efficiency_units = "HSPF"
+        htg_efficiency_value = @heating_efficiency_hspf
+      elsif ["ground-to-air"].include? @heat_pump_type
+        clg_efficiency_units = "EER"
+        clg_efficiency_value = @cooling_efficiency_eer
+        htg_efficiency_units = "COP"
+        htg_efficiency_value = @heating_efficiency_cop
+      end
+      if not clg_efficiency_value.nil?
+        annual_efficiency = XMLHelper.add_element(heat_pump, "AnnualCoolingEfficiency")
+        XMLHelper.add_element(annual_efficiency, "Units", clg_efficiency_units)
+        XMLHelper.add_element(annual_efficiency, "Value", Float(clg_efficiency_value))
+      end
+      if not htg_efficiency_value.nil?
+        annual_efficiency = XMLHelper.add_element(heat_pump, "AnnualHeatingEfficiency")
+        XMLHelper.add_element(annual_efficiency, "Units", htg_efficiency_units)
+        XMLHelper.add_element(annual_efficiency, "Value", Float(htg_efficiency_value))
+      end
+    end
+
+    def from_hpxml(heat_pump)
+      return if heat_pump.nil?
+
+      @id = _get_id(heat_pump)
+      @distribution_system_idref = _get_idref(heat_pump, "DistributionSystem")
+      @year_installed = _to_integer_or_nil(XMLHelper.get_value(heat_pump, "YearInstalled"))
+      @heat_pump_type = XMLHelper.get_value(heat_pump, "HeatPumpType")
+      @heat_pump_fuel = XMLHelper.get_value(heat_pump, "HeatPumpFuel")
+      @heating_capacity = _to_float_or_nil(XMLHelper.get_value(heat_pump, "HeatingCapacity"))
+      @heating_capacity_17F = _to_float_or_nil(XMLHelper.get_value(heat_pump, "HeatingCapacity17F"))
+      @cooling_capacity = _to_float_or_nil(XMLHelper.get_value(heat_pump, "CoolingCapacity"))
+      @compressor_type = XMLHelper.get_value(heat_pump, "CompressorType")
+      @cooling_shr = _to_float_or_nil(XMLHelper.get_value(heat_pump, "CoolingSensibleHeatFraction"))
+      @backup_heating_fuel = XMLHelper.get_value(heat_pump, "BackupSystemFuel")
+      @backup_heating_capacity = _to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupHeatingCapacity"))
+      @backup_heating_efficiency_percent = _to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='Percent']/Value"))
+      @backup_heating_efficiency_afue = _to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='AFUE']/Value"))
+      @backup_heating_switchover_temp = _to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupHeatingSwitchoverTemperature"))
+      @fraction_heat_load_served = _to_float_or_nil(XMLHelper.get_value(heat_pump, "FractionHeatLoadServed"))
+      @fraction_cool_load_served = _to_float_or_nil(XMLHelper.get_value(heat_pump, "FractionCoolLoadServed"))
+      @cooling_efficiency_seer = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='air-to-air' or HeatPumpType='mini-split']AnnualCoolingEfficiency[Units='SEER']/Value"))
+      @cooling_efficiency_eer = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='ground-to-air']AnnualCoolingEfficiency[Units='EER']/Value"))
+      @heating_efficiency_hspf = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='air-to-air' or HeatPumpType='mini-split']AnnualHeatingEfficiency[Units='HSPF']/Value"))
+      @heating_efficiency_cop = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='ground-to-air']AnnualHeatingEfficiency[Units='COP']/Value"))
+      @energy_star = XMLHelper.get_values(heat_pump, "ThirdPartyCertification").include?("Energy Star")
+      @seed_id = XMLHelper.get_value(heat_pump, "extension/SeedId")
+    end
+  end
+
+  class HVACControl < BaseElement
+    ATTRS = [:id, :control_type, :heating_setpoint_temp, :heating_setback_temp,
+             :heating_setback_hours_per_week, :heating_setback_start_hour, :cooling_setpoint_temp,
+             :cooling_setup_temp, :cooling_setup_hours_per_week, :cooling_setup_start_hour,
+             :ceiling_fan_cooling_setpoint_temp_offset]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      hvac = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC"])
+      hvac_control = XMLHelper.add_element(hvac, "HVACControl")
+      sys_id = XMLHelper.add_element(hvac_control, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(hvac_control, "ControlType", @control_type) unless @control_type.nil?
+      XMLHelper.add_element(hvac_control, "SetpointTempHeatingSeason", Float(@heating_setpoint_temp)) unless @heating_setpoint_temp.nil?
+      XMLHelper.add_element(hvac_control, "SetbackTempHeatingSeason", Float(@heating_setback_temp)) unless @heating_setback_temp.nil?
+      XMLHelper.add_element(hvac_control, "TotalSetbackHoursperWeekHeating", Integer(@heating_setback_hours_per_week)) unless @heating_setback_hours_per_week.nil?
+      XMLHelper.add_element(hvac_control, "SetupTempCoolingSeason", Float(@cooling_setup_temp)) unless @cooling_setup_temp.nil?
+      XMLHelper.add_element(hvac_control, "SetpointTempCoolingSeason", Float(@cooling_setpoint_temp)) unless @cooling_setpoint_temp.nil?
+      XMLHelper.add_element(hvac_control, "TotalSetupHoursperWeekCooling", Integer(@cooling_setup_hours_per_week)) unless @cooling_setup_hours_per_week.nil?
+      _add_extension(parent: hvac_control,
+                     extensions: { "SetbackStartHourHeating" => _to_integer_or_nil(@heating_setback_start_hour),
+                                   "SetupStartHourCooling" => _to_integer_or_nil(@cooling_setup_start_hour),
+                                   "CeilingFanSetpointTempCoolingSeasonOffset" => _to_float_or_nil(@ceiling_fan_cooling_setpoint_temp_offset) })
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hvac_control = hpxml.elements["Building/BuildingDetails/Systems/HVAC/HVACControl"]
+      return if hvac_control.nil?
+
+      @id = _get_id(hvac_control)
+      @control_type = XMLHelper.get_value(hvac_control, "ControlType")
+      @heating_setpoint_temp = _to_float_or_nil(XMLHelper.get_value(hvac_control, "SetpointTempHeatingSeason"))
+      @heating_setback_temp = _to_float_or_nil(XMLHelper.get_value(hvac_control, "SetbackTempHeatingSeason"))
+      @heating_setback_hours_per_week = _to_integer_or_nil(XMLHelper.get_value(hvac_control, "TotalSetbackHoursperWeekHeating"))
+      @heating_setback_start_hour = _to_integer_or_nil(XMLHelper.get_value(hvac_control, "extension/SetbackStartHourHeating"))
+      @cooling_setpoint_temp = _to_float_or_nil(XMLHelper.get_value(hvac_control, "SetpointTempCoolingSeason"))
+      @cooling_setup_temp = _to_float_or_nil(XMLHelper.get_value(hvac_control, "SetupTempCoolingSeason"))
+      @cooling_setup_hours_per_week = _to_integer_or_nil(XMLHelper.get_value(hvac_control, "TotalSetupHoursperWeekCooling"))
+      @cooling_setup_start_hour = _to_integer_or_nil(XMLHelper.get_value(hvac_control, "extension/SetupStartHourCooling"))
+      @ceiling_fan_cooling_setpoint_temp_offset = _to_float_or_nil(XMLHelper.get_value(hvac_control, "extension/CeilingFanSetpointTempCoolingSeasonOffset"))
+    end
+  end
+
+  class HVACDistribution < BaseElement
+    ATTRS = [:id, :distribution_system_type, :distribution_system_type, :annual_heating_dse,
+             :annual_cooling_dse, :duct_system_sealed, :duct_leakage_measurements, :ducts]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      hvac = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC"])
+      hvac_distribution = XMLHelper.add_element(hvac, "HVACDistribution")
+      sys_id = XMLHelper.add_element(hvac_distribution, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      distribution_system_type_e = XMLHelper.add_element(hvac_distribution, "DistributionSystemType")
+      if ["AirDistribution", "HydronicDistribution"].include? @distribution_system_type
+        XMLHelper.add_element(distribution_system_type_e, @distribution_system_type)
+      elsif ["DSE"].include? distribution_system_type
+        XMLHelper.add_element(distribution_system_type_e, "Other", @distribution_system_type)
+        XMLHelper.add_element(hvac_distribution, "AnnualHeatingDistributionSystemEfficiency", Float(@annual_heating_dse)) unless @annual_heating_dse.nil?
+        XMLHelper.add_element(hvac_distribution, "AnnualCoolingDistributionSystemEfficiency", Float(@annual_cooling_dse)) unless @annual_cooling_dse.nil?
+      else
+        fail "Unexpected distribution_system_type '#{@distribution_system_type}'."
+      end
+
+      air_distribution = hvac_distribution.elements["DistributionSystemType/AirDistribution"]
+      return if air_distribution.nil?
+
+      @duct_leakage_measurements.each do |duct_leakage_measurement|
+        duct_leakage_measurement.to_rexml(air_distribution)
+      end
+
+      @ducts.each do |duct|
+        duct.to_rexml(air_distribution)
+      end
+    end
+
+    def from_hpxml(hvac_distribution)
+      return if hvac_distribution.nil?
+
+      @id = _get_id(hvac_distribution)
+      @distribution_system_type = XMLHelper.get_child_name(hvac_distribution, "DistributionSystemType")
+      if @distribution_system_type == "Other"
+        @distribution_system_type = XMLHelper.get_value(hvac_distribution.elements["DistributionSystemType"], "Other")
+      end
+      @annual_heating_dse = _to_float_or_nil(XMLHelper.get_value(hvac_distribution, "AnnualHeatingDistributionSystemEfficiency"))
+      @annual_cooling_dse = _to_float_or_nil(XMLHelper.get_value(hvac_distribution, "AnnualCoolingDistributionSystemEfficiency"))
+      @duct_system_sealed = _to_bool_or_nil(XMLHelper.get_value(hvac_distribution, "HVACDistributionImprovement/DuctSystemSealed"))
+
+      @duct_leakage_measurements = []
+      hvac_distribution.elements.each("DistributionSystemType/AirDistribution/DuctLeakageMeasurement") do |duct_leakage_measurement|
+        @duct_leakage_measurements << DuctLeakageMeasurement.new(nil, duct_leakage_measurement)
+      end
+
+      @ducts = []
+      hvac_distribution.elements.each("DistributionSystemType/AirDistribution/Ducts") do |duct|
+        @ducts << Duct.new(nil, duct)
+      end
+    end
+  end
+
+  class DuctLeakageMeasurement < BaseElement
+    ATTRS = [:duct_type, :duct_leakage_test_method, :duct_leakage_units, :duct_leakage_value,
+             :duct_leakage_total_or_to_outside]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(air_distribution)
+      duct_leakage_measurement_el = XMLHelper.add_element(air_distribution, "DuctLeakageMeasurement")
+      XMLHelper.add_element(duct_leakage_measurement_el, "DuctType", @duct_type)
+      if not @duct_leakage_value.nil?
+        duct_leakage_el = XMLHelper.add_element(duct_leakage_measurement_el, "DuctLeakage")
+        XMLHelper.add_element(duct_leakage_el, "Units", @duct_leakage_units)
+        XMLHelper.add_element(duct_leakage_el, "Value", Float(@duct_leakage_value))
+        XMLHelper.add_element(duct_leakage_el, "TotalOrToOutside", "to outside")
+      end
+    end
+
+    def from_hpxml(duct_leakage_measurement)
+      return if duct_leakage_measurement.nil?
+
+      @duct_type = XMLHelper.get_value(duct_leakage_measurement, "DuctType")
+      @duct_leakage_test_method = XMLHelper.get_value(duct_leakage_measurement, "DuctLeakageTestMethod")
+      @duct_leakage_units = XMLHelper.get_value(duct_leakage_measurement, "DuctLeakage/Units")
+      @duct_leakage_value = _to_float_or_nil(XMLHelper.get_value(duct_leakage_measurement, "DuctLeakage/Value"))
+      @duct_leakage_total_or_to_outside = XMLHelper.get_value(duct_leakage_measurement, "DuctLeakage/TotalOrToOutside")
+    end
+  end
+
+  class Duct < BaseElement
+    ATTRS = [:duct_type, :duct_insulation_r_value, :duct_insulation_material, :duct_location,
+             :duct_fraction_area, :duct_surface_area]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(air_distribution)
+      ducts_el = XMLHelper.add_element(air_distribution, "Ducts")
+      XMLHelper.add_element(ducts_el, "DuctType", @duct_type) unless @duct_type.nil?
+      XMLHelper.add_element(ducts_el, "DuctInsulationRValue", Float(@duct_insulation_r_value)) unless @duct_insulation_r_value.nil?
+      XMLHelper.add_element(ducts_el, "DuctLocation", @duct_location) unless @duct_location.nil?
+      XMLHelper.add_element(ducts_el, "DuctSurfaceArea", Float(@duct_surface_area)) unless @duct_surface_area.nil?
+    end
+
+    def from_hpxml(duct)
+      return if duct.nil?
+
+      @duct_type = XMLHelper.get_value(duct, "DuctType")
+      @duct_insulation_r_value = _to_float_or_nil(XMLHelper.get_value(duct, "DuctInsulationRValue"))
+      @duct_insulation_material = XMLHelper.get_child_name(duct, "DuctInsulationMaterial")
+      @duct_location = XMLHelper.get_value(duct, "DuctLocation")
+      @duct_fraction_area = _to_float_or_nil(XMLHelper.get_value(duct, "FractionDuctArea"))
+      @duct_surface_area = _to_float_or_nil(XMLHelper.get_value(duct, "DuctSurfaceArea"))
+    end
+  end
+
+  class VentilationFan < BaseElement
+    ATTRS = [:id, :fan_type, :rated_flow_rate, :tested_flow_rate, :hours_in_operation,
+             :used_for_whole_building_ventilation, :used_for_seasonal_cooling_load_reduction,
+             :total_recovery_efficiency, :total_recovery_efficiency_adjusted,
+             :sensible_recovery_efficiency, :sensible_recovery_efficiency_adjusted,
+             :fan_power, :distribution_system_idref]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      ventilation_fans = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "MechanicalVentilation", "VentilationFans"])
+      ventilation_fan = XMLHelper.add_element(ventilation_fans, "VentilationFan")
+      sys_id = XMLHelper.add_element(ventilation_fan, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(ventilation_fan, "FanType", @fan_type) unless @fan_type.nil?
+      XMLHelper.add_element(ventilation_fan, "RatedFlowRate", Float(@rated_flow_rate)) unless @rated_flow_rate.nil?
+      XMLHelper.add_element(ventilation_fan, "TestedFlowRate", Float(@tested_flow_rate)) unless @tested_flow_rate.nil?
+      XMLHelper.add_element(ventilation_fan, "HoursInOperation", Float(@hours_in_operation)) unless @hours_in_operation.nil?
+      XMLHelper.add_element(ventilation_fan, "UsedForWholeBuildingVentilation", Boolean(@used_for_whole_building_ventilation)) unless @used_for_whole_building_ventilation.nil?
+      XMLHelper.add_element(ventilation_fan, "UsedForSeasonalCoolingLoadReduction", Boolean(@used_for_seasonal_cooling_load_reduction)) unless @used_for_seasonal_cooling_load_reduction.nil?
+      XMLHelper.add_element(ventilation_fan, "TotalRecoveryEfficiency", Float(@total_recovery_efficiency)) unless @total_recovery_efficiency.nil?
+      XMLHelper.add_element(ventilation_fan, "SensibleRecoveryEfficiency", Float(@sensible_recovery_efficiency)) unless @sensible_recovery_efficiency.nil?
+      XMLHelper.add_element(ventilation_fan, "AdjustedTotalRecoveryEfficiency", Float(@total_recovery_efficiency_adjusted)) unless @total_recovery_efficiency_adjusted.nil?
+      XMLHelper.add_element(ventilation_fan, "AdjustedSensibleRecoveryEfficiency", Float(@sensible_recovery_efficiency_adjusted)) unless @sensible_recovery_efficiency_adjusted.nil?
+      XMLHelper.add_element(ventilation_fan, "FanPower", Float(@fan_power)) unless @fan_power.nil?
+      if not @distribution_system_idref.nil?
+        attached_to_hvac_distribution_system = XMLHelper.add_element(ventilation_fan, "AttachedToHVACDistributionSystem")
+        XMLHelper.add_attribute(attached_to_hvac_distribution_system, "idref", @distribution_system_idref)
+      end
+    end
+
+    def from_hpxml(ventilation_fan)
+      return if ventilation_fan.nil?
+
+      @id = _get_id(ventilation_fan)
+      @fan_type = XMLHelper.get_value(ventilation_fan, "FanType")
+      @rated_flow_rate = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "RatedFlowRate"))
+      @tested_flow_rate = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "TestedFlowRate"))
+      @hours_in_operation = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "HoursInOperation"))
+      @used_for_whole_building_ventilation = _to_bool_or_nil(XMLHelper.get_value(ventilation_fan, "UsedForWholeBuildingVentilation"))
+      @used_for_seasonal_cooling_load_reduction = _to_bool_or_nil(XMLHelper.get_value(ventilation_fan, "UsedForSeasonalCoolingLoadReduction"))
+      @total_recovery_efficiency = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "TotalRecoveryEfficiency"))
+      @total_recovery_efficiency_adjusted = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "AdjustedTotalRecoveryEfficiency"))
+      @sensible_recovery_efficiency = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "SensibleRecoveryEfficiency"))
+      @sensible_recovery_efficiency_adjusted = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "AdjustedSensibleRecoveryEfficiency"))
+      @fan_power = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "FanPower"))
+      @distribution_system_idref = _get_idref(ventilation_fan, "AttachedToHVACDistributionSystem")
+    end
+  end
+
+  class WaterHeatingSystem < BaseElement
+    ATTRS = [:id, :year_installed, :fuel_type, :water_heater_type, :location, :performance_adjustment,
+             :tank_volume, :fraction_dhw_load_served, :heating_capacity, :energy_factor,
+             :uniform_energy_factor, :recovery_efficiency, :uses_desuperheater, :jacket_r_value,
+             :related_hvac, :energy_star, :standby_loss, :temperature]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      water_heating = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
+      water_heating_system = XMLHelper.add_element(water_heating, "WaterHeatingSystem")
+      sys_id = XMLHelper.add_element(water_heating_system, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(water_heating_system, "FuelType", @fuel_type) unless @fuel_type.nil?
+      XMLHelper.add_element(water_heating_system, "WaterHeaterType", @water_heater_type) unless @water_heater_type.nil?
+      XMLHelper.add_element(water_heating_system, "Location", @location) unless @location.nil?
+      XMLHelper.add_element(water_heating_system, "PerformanceAdjustment", Float(@performance_adjustment)) unless @performance_adjustment.nil?
+      XMLHelper.add_element(water_heating_system, "TankVolume", Float(@tank_volume)) unless @tank_volume.nil?
+      XMLHelper.add_element(water_heating_system, "FractionDHWLoadServed", Float(@fraction_dhw_load_served)) unless @fraction_dhw_load_served.nil?
+      XMLHelper.add_element(water_heating_system, "HeatingCapacity", Float(@heating_capacity)) unless @heating_capacity.nil?
+      XMLHelper.add_element(water_heating_system, "EnergyFactor", Float(@energy_factor)) unless @energy_factor.nil?
+      XMLHelper.add_element(water_heating_system, "UniformEnergyFactor", Float(@uniform_energy_factor)) unless @uniform_energy_factor.nil?
+      XMLHelper.add_element(water_heating_system, "RecoveryEfficiency", Float(@recovery_efficiency)) unless @recovery_efficiency.nil?
+      if not @jacket_r_value.nil?
+        water_heater_insulation = XMLHelper.add_element(water_heating_system, "WaterHeaterInsulation")
+        jacket = XMLHelper.add_element(water_heater_insulation, "Jacket")
+        XMLHelper.add_element(jacket, "JacketRValue", @jacket_r_value)
+      end
+      XMLHelper.add_element(water_heating_system, "StandbyLoss", Float(@standby_loss)) unless @standby_loss.nil?
+      XMLHelper.add_element(water_heating_system, "HotWaterTemperature", Float(@temperature)) unless @temperature.nil?
+      XMLHelper.add_element(water_heating_system, "UsesDesuperheater", Boolean(@uses_desuperheater)) unless @uses_desuperheater.nil?
+      if not @related_hvac.nil?
+        related_hvac_el = XMLHelper.add_element(water_heating_system, "RelatedHVACSystem")
+        XMLHelper.add_attribute(related_hvac_el, "idref", @related_hvac)
+      end
+    end
+
+    def from_hpxml(water_heating_system)
+      return if water_heating_system.nil?
+
+      @id = _get_id(water_heating_system)
+      @year_installed = _to_integer_or_nil(XMLHelper.get_value(water_heating_system, "YearInstalled"))
+      @fuel_type = XMLHelper.get_value(water_heating_system, "FuelType")
+      @water_heater_type = XMLHelper.get_value(water_heating_system, "WaterHeaterType")
+      @location = XMLHelper.get_value(water_heating_system, "Location")
+      @performance_adjustment = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "PerformanceAdjustment"))
+      @tank_volume = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "TankVolume"))
+      @fraction_dhw_load_served = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "FractionDHWLoadServed"))
+      @heating_capacity = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "HeatingCapacity"))
+      @energy_factor = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "EnergyFactor"))
+      @uniform_energy_factor = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "UniformEnergyFactor"))
+      @recovery_efficiency = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "RecoveryEfficiency"))
+      @uses_desuperheater = _to_bool_or_nil(XMLHelper.get_value(water_heating_system, "UsesDesuperheater"))
+      @jacket_r_value = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "WaterHeaterInsulation/Jacket/JacketRValue"))
+      @related_hvac = _get_idref(water_heating_system, "RelatedHVACSystem")
+      @energy_star = XMLHelper.get_values(water_heating_system, "ThirdPartyCertification").include?("Energy Star")
+      @standby_loss = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "StandbyLoss"))
+      @temperature = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "HotWaterTemperature"))
+    end
+  end
+
+  class HotWaterDistribution < BaseElement
+    ATTRS = [:id, :system_type, :pipe_r_value, :standard_piping_length, :recirculation_control_type,
+             :recirculation_piping_length, :recirculation_branch_piping_length,
+             :recirculation_pump_power, :dwhr_facilities_connected, :dwhr_equal_flow,
+             :dwhr_efficiency]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      water_heating = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
+      hot_water_distribution = XMLHelper.add_element(water_heating, "HotWaterDistribution")
+      sys_id = XMLHelper.add_element(hot_water_distribution, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      if not @system_type.nil?
+        system_type_e = XMLHelper.add_element(hot_water_distribution, "SystemType")
+        if @system_type == "Standard"
+          standard = XMLHelper.add_element(system_type_e, @system_type)
+          XMLHelper.add_element(standard, "PipingLength", Float(@standard_piping_length)) unless @standard_piping_length.nil?
+        elsif system_type == "Recirculation"
+          recirculation = XMLHelper.add_element(system_type_e, @system_type)
+          XMLHelper.add_element(recirculation, "ControlType", @recirculation_control_type) unless @recirculation_control_type.nil?
+          XMLHelper.add_element(recirculation, "RecirculationPipingLoopLength", Float(@recirculation_piping_length)) unless @recirculation_piping_length.nil?
+          XMLHelper.add_element(recirculation, "BranchPipingLoopLength", Float(@recirculation_branch_piping_length)) unless @recirculation_branch_piping_length.nil?
+          XMLHelper.add_element(recirculation, "PumpPower", Float(@recirculation_pump_power)) unless @recirculation_pump_power.nil?
+        else
+          fail "Unhandled hot water distribution type '#{@system_type}'."
+        end
+      end
+      if not @pipe_r_value.nil?
+        pipe_insulation = XMLHelper.add_element(hot_water_distribution, "PipeInsulation")
+        XMLHelper.add_element(pipe_insulation, "PipeRValue", Float(@pipe_r_value))
+      end
+      if not @dwhr_facilities_connected.nil? or not @dwhr_equal_flow.nil? or not @dwhr_efficiency.nil?
+        drain_water_heat_recovery = XMLHelper.add_element(hot_water_distribution, "DrainWaterHeatRecovery")
+        XMLHelper.add_element(drain_water_heat_recovery, "FacilitiesConnected", @dwhr_facilities_connected) unless @dwhr_facilities_connected.nil?
+        XMLHelper.add_element(drain_water_heat_recovery, "EqualFlow", Boolean(@dwhr_equal_flow)) unless @dwhr_equal_flow.nil?
+        XMLHelper.add_element(drain_water_heat_recovery, "Efficiency", Float(@dwhr_efficiency)) unless @dwhr_efficiency.nil?
+      end
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      hot_water_distribution = hpxml.elements["Building/BuildingDetails/Systems/WaterHeating/HotWaterDistribution"]
+      return if hot_water_distribution.nil?
+
+      @id = _get_id(hot_water_distribution)
+      @system_type = XMLHelper.get_child_name(hot_water_distribution, "SystemType")
+      @pipe_r_value = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "PipeInsulation/PipeRValue"))
+      @standard_piping_length = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "SystemType/Standard/PipingLength"))
+      @recirculation_control_type = XMLHelper.get_value(hot_water_distribution, "SystemType/Recirculation/ControlType")
+      @recirculation_piping_length = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "SystemType/Recirculation/RecirculationPipingLoopLength"))
+      @recirculation_branch_piping_length = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "SystemType/Recirculation/BranchPipingLoopLength"))
+      @recirculation_pump_power = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "SystemType/Recirculation/PumpPower"))
+      @dwhr_facilities_connected = XMLHelper.get_value(hot_water_distribution, "DrainWaterHeatRecovery/FacilitiesConnected")
+      @dwhr_equal_flow = _to_bool_or_nil(XMLHelper.get_value(hot_water_distribution, "DrainWaterHeatRecovery/EqualFlow"))
+      @dwhr_efficiency = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "DrainWaterHeatRecovery/Efficiency"))
+    end
+  end
+
+  class WaterFixture < BaseElement
+    ATTRS = [:id, :water_fixture_type, :low_flow]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      water_heating = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
+      water_fixture = XMLHelper.add_element(water_heating, "WaterFixture")
+      sys_id = XMLHelper.add_element(water_fixture, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(water_fixture, "WaterFixtureType", @water_fixture_type) unless @water_fixture_type.nil?
+      XMLHelper.add_element(water_fixture, "LowFlow", Boolean(@low_flow)) unless @low_flow.nil?
+    end
+
+    def from_hpxml(water_fixture)
+      return if water_fixture.nil?
+
+      @id = _get_id(water_fixture)
+      @water_fixture_type = XMLHelper.get_value(water_fixture, "WaterFixtureType")
+      @low_flow = _to_bool_or_nil(XMLHelper.get_value(water_fixture, "LowFlow"))
+    end
+  end
+
+  class SolarThermalSystem < BaseElement
+    ATTRS = [:id, :system_type, :collector_area, :collector_loop_type, :collector_azimuth,
+             :collector_type, :collector_tilt, :collector_frta, :collector_frul, :storage_volume,
+             :water_heating_system_idref, :solar_fraction]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      solar_thermal = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "SolarThermal"])
+      solar_thermal_system = XMLHelper.add_element(solar_thermal, "SolarThermalSystem")
+      sys_id = XMLHelper.add_element(solar_thermal_system, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(solar_thermal_system, "SystemType", @system_type) unless @system_type.nil?
+      XMLHelper.add_element(solar_thermal_system, "CollectorArea", Float(@collector_area)) unless @collector_area.nil?
+      XMLHelper.add_element(solar_thermal_system, "CollectorLoopType", @collector_loop_type) unless @collector_loop_type.nil?
+      XMLHelper.add_element(solar_thermal_system, "CollectorType", @collector_type) unless @collector_type.nil?
+      XMLHelper.add_element(solar_thermal_system, "CollectorAzimuth", Integer(@collector_azimuth)) unless @collector_azimuth.nil?
+      XMLHelper.add_element(solar_thermal_system, "CollectorTilt", Float(@collector_tilt)) unless @collector_tilt.nil?
+      XMLHelper.add_element(solar_thermal_system, "CollectorRatedOpticalEfficiency", Float(@collector_frta)) unless @collector_frta.nil?
+      XMLHelper.add_element(solar_thermal_system, "CollectorRatedThermalLosses", Float(@collector_frul)) unless @collector_frul.nil?
+      XMLHelper.add_element(solar_thermal_system, "StorageVolume", Float(@storage_volume)) unless @storage_volume.nil?
+      if not @water_heating_system_idref.nil?
+        connected_to = XMLHelper.add_element(solar_thermal_system, "ConnectedTo")
+        XMLHelper.add_attribute(connected_to, "idref", @water_heating_system_idref)
+      end
+      XMLHelper.add_element(solar_thermal_system, "SolarFraction", Float(@solar_fraction)) unless @solar_fraction.nil?
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      solar_thermal_system = hpxml.elements["Building/BuildingDetails/Systems/SolarThermal/SolarThermalSystem"]
+      return if solar_thermal_system.nil?
+
+      @id = _get_id(solar_thermal_system)
+      @system_type = XMLHelper.get_value(solar_thermal_system, "SystemType")
+      @collector_area = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorArea"))
+      @collector_loop_type = XMLHelper.get_value(solar_thermal_system, "CollectorLoopType")
+      @collector_azimuth = _to_integer_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorAzimuth"))
+      @collector_type = XMLHelper.get_value(solar_thermal_system, "CollectorType")
+      @collector_tilt = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorTilt"))
+      @collector_frta = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorRatedOpticalEfficiency"))
+      @collector_frul = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorRatedThermalLosses"))
+      @storage_volume = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "StorageVolume"))
+      @water_heating_system_idref = _get_idref(solar_thermal_system, "ConnectedTo")
+      @solar_fraction = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "SolarFraction"))
+    end
+  end
+
+  class PVSystem < BaseElement
+    ATTRS = [:id, :location, :module_type, :tracking, :array_orientation, :array_azimuth, :array_tilt,
+             :max_power_output, :inverter_efficiency, :system_losses_fraction, :number_of_panels,
+             :year_modules_manufactured]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      photovoltaics = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Systems", "Photovoltaics"])
+      pv_system = XMLHelper.add_element(photovoltaics, "PVSystem")
+      sys_id = XMLHelper.add_element(pv_system, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(pv_system, "Location", @location) unless @location.nil?
+      XMLHelper.add_element(pv_system, "ModuleType", @module_type) unless @module_type.nil?
+      XMLHelper.add_element(pv_system, "Tracking", @tracking) unless @tracking.nil?
+      XMLHelper.add_element(pv_system, "ArrayAzimuth", Integer(@array_azimuth)) unless @array_azimuth.nil?
+      XMLHelper.add_element(pv_system, "ArrayTilt", Float(@array_tilt)) unless @array_tilt.nil?
+      XMLHelper.add_element(pv_system, "MaxPowerOutput", Float(@max_power_output)) unless @max_power_output.nil?
+      XMLHelper.add_element(pv_system, "InverterEfficiency", Float(@inverter_efficiency)) unless @inverter_efficiency.nil?
+      XMLHelper.add_element(pv_system, "SystemLossesFraction", Float(@system_losses_fraction)) unless @system_losses_fraction.nil?
+    end
+
+    def from_hpxml(pv_system)
+      return if pv_system.nil?
+
+      @id = _get_id(pv_system)
+      @location = XMLHelper.get_value(pv_system, "Location")
+      @module_type = XMLHelper.get_value(pv_system, "ModuleType")
+      @tracking = XMLHelper.get_value(pv_system, "Tracking")
+      @array_orientation = XMLHelper.get_value(pv_system, "ArrayOrientation")
+      @array_azimuth = _to_integer_or_nil(XMLHelper.get_value(pv_system, "ArrayAzimuth"))
+      @array_tilt = _to_float_or_nil(XMLHelper.get_value(pv_system, "ArrayTilt"))
+      @max_power_output = _to_float_or_nil(XMLHelper.get_value(pv_system, "MaxPowerOutput"))
+      @inverter_efficiency = _to_float_or_nil(XMLHelper.get_value(pv_system, "InverterEfficiency"))
+      @system_losses_fraction = _to_float_or_nil(XMLHelper.get_value(pv_system, "SystemLossesFraction"))
+      @number_of_panels = _to_integer_or_nil(XMLHelper.get_value(pv_system, "NumberOfPanels"))
+      @year_modules_manufactured = _to_integer_or_nil(XMLHelper.get_value(pv_system, "YearModulesManufactured"))
+    end
+  end
+
+  class ClothesWasher < BaseElement
+    ATTRS = [:id, :location, :modified_energy_factor, :integrated_modified_energy_factor,
+             :rated_annual_kwh, :label_electric_rate, :label_gas_rate, :label_annual_gas_cost,
+             :capacity]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
+      clothes_washer = XMLHelper.add_element(appliances, "ClothesWasher")
+      sys_id = XMLHelper.add_element(clothes_washer, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(clothes_washer, "Location", @location) unless @location.nil?
+      XMLHelper.add_element(clothes_washer, "ModifiedEnergyFactor", Float(@modified_energy_factor)) unless @modified_energy_factor.nil?
+      XMLHelper.add_element(clothes_washer, "IntegratedModifiedEnergyFactor", Float(@integrated_modified_energy_factor)) unless @integrated_modified_energy_factor.nil?
+      XMLHelper.add_element(clothes_washer, "RatedAnnualkWh", Float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(clothes_washer, "LabelElectricRate", Float(@label_electric_rate)) unless @label_electric_rate.nil?
+      XMLHelper.add_element(clothes_washer, "LabelGasRate", Float(@label_gas_rate)) unless @label_gas_rate.nil?
+      XMLHelper.add_element(clothes_washer, "LabelAnnualGasCost", Float(@label_annual_gas_cost)) unless @label_annual_gas_cost.nil?
+      XMLHelper.add_element(clothes_washer, "Capacity", Float(@capacity)) unless @capacity.nil?
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      clothes_washer = hpxml.elements["Building/BuildingDetails/Appliances/ClothesWasher"]
+      return if clothes_washer.nil?
+
+      @id = _get_id(clothes_washer)
+      @location = XMLHelper.get_value(clothes_washer, "Location")
+      @modified_energy_factor = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "ModifiedEnergyFactor"))
+      @integrated_modified_energy_factor = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "IntegratedModifiedEnergyFactor"))
+      @rated_annual_kwh = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "RatedAnnualkWh"))
+      @label_electric_rate = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "LabelElectricRate"))
+      @label_gas_rate = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "LabelGasRate"))
+      @label_annual_gas_cost = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "LabelAnnualGasCost"))
+      @capacity = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "Capacity"))
+    end
+  end
+
+  class ClothesDryer < BaseElement
+    ATTRS = [:id, :location, :fuel_type, :energy_factor, :combined_energy_factor, :control_type]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
+      clothes_dryer = XMLHelper.add_element(appliances, "ClothesDryer")
+      sys_id = XMLHelper.add_element(clothes_dryer, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(clothes_dryer, "Location", @location) unless @location.nil?
+      XMLHelper.add_element(clothes_dryer, "FuelType", @fuel_type) unless @fuel_type.nil?
+      XMLHelper.add_element(clothes_dryer, "EnergyFactor", Float(@energy_factor)) unless @energy_factor.nil?
+      XMLHelper.add_element(clothes_dryer, "CombinedEnergyFactor", Float(@combined_energy_factor)) unless @combined_energy_factor.nil?
+      XMLHelper.add_element(clothes_dryer, "ControlType", @control_type) unless @control_type.nil?
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      clothes_dryer = hpxml.elements["Building/BuildingDetails/Appliances/ClothesDryer"]
+      return if clothes_dryer.nil?
+
+      @id = _get_id(clothes_dryer)
+      @location = XMLHelper.get_value(clothes_dryer, "Location")
+      @fuel_type = XMLHelper.get_value(clothes_dryer, "FuelType")
+      @energy_factor = _to_float_or_nil(XMLHelper.get_value(clothes_dryer, "EnergyFactor"))
+      @combined_energy_factor = _to_float_or_nil(XMLHelper.get_value(clothes_dryer, "CombinedEnergyFactor"))
+      @control_type = XMLHelper.get_value(clothes_dryer, "ControlType")
+    end
+  end
+
+  class Dishwasher < BaseElement
+    ATTRS = [:id, :energy_factor, :rated_annual_kwh, :place_setting_capacity]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
+      dishwasher = XMLHelper.add_element(appliances, "Dishwasher")
+      sys_id = XMLHelper.add_element(dishwasher, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(dishwasher, "EnergyFactor", Float(@energy_factor)) unless @energy_factor.nil?
+      XMLHelper.add_element(dishwasher, "RatedAnnualkWh", Float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(dishwasher, "PlaceSettingCapacity", Integer(@place_setting_capacity)) unless @place_setting_capacity.nil?
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      dishwasher = hpxml.elements["Building/BuildingDetails/Appliances/Dishwasher"]
+      return if dishwasher.nil?
+
+      @id = _get_id(dishwasher)
+      @energy_factor = _to_float_or_nil(XMLHelper.get_value(dishwasher, "EnergyFactor"))
+      @rated_annual_kwh = _to_float_or_nil(XMLHelper.get_value(dishwasher, "RatedAnnualkWh"))
+      @place_setting_capacity = _to_integer_or_nil(XMLHelper.get_value(dishwasher, "PlaceSettingCapacity"))
+    end
+  end
+
+  class Refrigerator < BaseElement
+    ATTRS = [:id, :location, :rated_annual_kwh, :adjusted_annual_kwh]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
+      refrigerator = XMLHelper.add_element(appliances, "Refrigerator")
+      sys_id = XMLHelper.add_element(refrigerator, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(refrigerator, "Location", @location) unless @location.nil?
+      XMLHelper.add_element(refrigerator, "RatedAnnualkWh", Float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
+      _add_extension(parent: refrigerator,
+                     extensions: { "AdjustedAnnualkWh" => _to_float_or_nil(@adjusted_annual_kwh) })
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      refrigerator = hpxml.elements["Building/BuildingDetails/Appliances/Refrigerator"]
+      return if refrigerator.nil?
+
+      @id = _get_id(refrigerator)
+      @location = XMLHelper.get_value(refrigerator, "Location")
+      @rated_annual_kwh = _to_float_or_nil(XMLHelper.get_value(refrigerator, "RatedAnnualkWh"))
+      @adjusted_annual_kwh = _to_float_or_nil(XMLHelper.get_value(refrigerator, "extension/AdjustedAnnualkWh"))
+    end
+  end
+
+  class CookingRange < BaseElement
+    ATTRS = [:id, :fuel_type, :is_induction]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
+      cooking_range = XMLHelper.add_element(appliances, "CookingRange")
+      sys_id = XMLHelper.add_element(cooking_range, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(cooking_range, "FuelType", @fuel_type) unless @fuel_type.nil?
+      XMLHelper.add_element(cooking_range, "IsInduction", Boolean(@is_induction)) unless @is_induction.nil?
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      cooking_range = hpxml.elements["Building/BuildingDetails/Appliances/CookingRange"]
+      return if cooking_range.nil?
+
+      @id = _get_id(cooking_range)
+      @fuel_type = XMLHelper.get_value(cooking_range, "FuelType")
+      @is_induction = _to_bool_or_nil(XMLHelper.get_value(cooking_range, "IsInduction"))
+    end
+  end
+
+  class Oven < BaseElement
+    ATTRS = [:id, :is_convection]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      appliances = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Appliances"])
+      oven = XMLHelper.add_element(appliances, "Oven")
+      sys_id = XMLHelper.add_element(oven, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(oven, "IsConvection", Boolean(@is_convection)) unless @is_convection.nil?
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      oven = hpxml.elements["Building/BuildingDetails/Appliances/Oven"]
+      return if oven.nil?
+
+      @id = _get_id(oven)
+      @is_convection = _to_bool_or_nil(XMLHelper.get_value(oven, "IsConvection"))
+    end
+  end
+
+  class Lighting < BaseElement
+    ATTRS = [:fraction_tier_i_interior, :fraction_tier_i_exterior, :fraction_tier_i_garage,
+             :fraction_tier_ii_interior, :fraction_tier_ii_exterior, :fraction_tier_ii_garage]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      if not @fraction_tier_i_interior.nil?
+        lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
+        lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
+        sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
+        XMLHelper.add_attribute(sys_id, "id", "Lighting_TierI_Interior")
+        XMLHelper.add_element(lighting_group, "Location", "interior")
+        XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(@fraction_tier_i_interior))
+        XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier I")
+      end
+
+      if not @fraction_tier_i_exterior.nil?
+        lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
+        lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
+        sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
+        XMLHelper.add_attribute(sys_id, "id", "Lighting_TierI_Exterior")
+        XMLHelper.add_element(lighting_group, "Location", "exterior")
+        XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(@fraction_tier_i_exterior))
+        XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier I")
+      end
+
+      if not @fraction_tier_i_garage.nil?
+        lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
+        lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
+        sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
+        XMLHelper.add_attribute(sys_id, "id", "Lighting_TierI_Garage")
+        XMLHelper.add_element(lighting_group, "Location", "garage")
+        XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(@fraction_tier_i_garage))
+        XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier I")
+      end
+
+      if not @fraction_tier_ii_interior.nil?
+        lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
+        lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
+        sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
+        XMLHelper.add_attribute(sys_id, "id", "Lighting_TierII_Interior")
+        XMLHelper.add_element(lighting_group, "Location", "interior")
+        XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(@fraction_tier_ii_interior))
+        XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier II")
+      end
+
+      if not @fraction_tier_ii_exterior.nil?
+        lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
+        lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
+        sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
+        XMLHelper.add_attribute(sys_id, "id", "Lighting_TierII_Exterior")
+        XMLHelper.add_element(lighting_group, "Location", "exterior")
+        XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(@fraction_tier_ii_exterior))
+        XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier II")
+      end
+
+      if not @fraction_tier_ii_garage.nil?
+        lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
+        lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
+        sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
+        XMLHelper.add_attribute(sys_id, "id", "Lighting_TierII_Garage")
+        XMLHelper.add_element(lighting_group, "Location", "garage")
+        XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(@fraction_tier_ii_garage))
+        XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier II")
+      end
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      lighting = hpxml.elements["Building/BuildingDetails/Lighting"]
+      return if lighting.nil?
+
+      @fraction_tier_i_interior = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier I' and Location='interior']/FractionofUnitsInLocation"))
+      @fraction_tier_i_exterior = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier I' and Location='exterior']/FractionofUnitsInLocation"))
+      @fraction_tier_i_garage = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier I' and Location='garage']/FractionofUnitsInLocation"))
+      @fraction_tier_ii_interior = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier II' and Location='interior']/FractionofUnitsInLocation"))
+      @fraction_tier_ii_exterior = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier II' and Location='exterior']/FractionofUnitsInLocation"))
+      @fraction_tier_ii_garage = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier II' and Location='garage']/FractionofUnitsInLocation"))
+    end
+  end
+
+  class CeilingFan < BaseElement
+    ATTRS = [:id, :efficiency, :quantity]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      lighting = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "Lighting"])
+      ceiling_fan = XMLHelper.add_element(lighting, "CeilingFan")
+      sys_id = XMLHelper.add_element(ceiling_fan, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      if not @efficiency.nil?
+        airflow = XMLHelper.add_element(ceiling_fan, "Airflow")
+        XMLHelper.add_element(airflow, "FanSpeed", "medium")
+        XMLHelper.add_element(airflow, "Efficiency", Float(@efficiency))
+      end
+      XMLHelper.add_element(ceiling_fan, "Quantity", Integer(@quantity)) unless @quantity.nil?
+    end
+
+    def from_hpxml(ceiling_fan)
+      @id = _get_id(ceiling_fan)
+      @efficiency = _to_float_or_nil(XMLHelper.get_value(ceiling_fan, "Airflow[FanSpeed='medium']/Efficiency"))
+      @quantity = _to_integer_or_nil(XMLHelper.get_value(ceiling_fan, "Quantity"))
+    end
+  end
+
+  class PlugLoad < BaseElement
+    ATTRS = [:id, :plug_load_type, :kWh_per_year, :frac_sensible, :frac_latent]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      misc_loads = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "MiscLoads"])
+      plug_load = XMLHelper.add_element(misc_loads, "PlugLoad")
+      sys_id = XMLHelper.add_element(plug_load, "SystemIdentifier")
+      XMLHelper.add_attribute(sys_id, "id", @id)
+      XMLHelper.add_element(plug_load, "PlugLoadType", @plug_load_type) unless @plug_load_type.nil?
+      if not @kWh_per_year.nil?
+        load = XMLHelper.add_element(plug_load, "Load")
+        XMLHelper.add_element(load, "Units", "kWh/year")
+        XMLHelper.add_element(load, "Value", Float(@kWh_per_year))
+      end
+      _add_extension(parent: plug_load,
+                     extensions: { "FracSensible" => _to_float_or_nil(@frac_sensible),
+                                   "FracLatent" => _to_float_or_nil(@frac_latent) })
+    end
+
+    def from_hpxml(plug_load)
+      @id = _get_id(plug_load)
+      @plug_load_type = XMLHelper.get_value(plug_load, "PlugLoadType")
+      @kWh_per_year = _to_float_or_nil(XMLHelper.get_value(plug_load, "Load[Units='kWh/year']/Value"))
+      @frac_sensible = _to_float_or_nil(XMLHelper.get_value(plug_load, "extension/FracSensible"))
+      @frac_latent = _to_float_or_nil(XMLHelper.get_value(plug_load, "extension/FracLatent"))
+    end
+  end
+
+  class MiscLoads < BaseElement
+    ATTRS = [:weekday_fractions, :weekend_fractions, :monthly_multipliers]
+    attr_accessor(*ATTRS)
+
+    def to_rexml(doc)
+      misc_loads = XMLHelper.create_elements_as_needed(doc, ["HPXML", "Building", "BuildingDetails", "MiscLoads"])
+      _add_extension(parent: misc_loads,
+                     extensions: { "WeekdayScheduleFractions" => @weekday_fractions,
+                                   "WeekendScheduleFractions" => @weekend_fractions,
+                                   "MonthlyScheduleMultipliers" => @monthly_multipliers })
+    end
+
+    def from_hpxml(hpxml)
+      return if hpxml.nil?
+
+      misc_loads = hpxml.elements["Building/BuildingDetails/MiscLoads"]
+      return if misc_loads.nil?
+
+      @weekday_fractions = XMLHelper.get_value(misc_loads, "extension/WeekdayScheduleFractions")
+      @weekend_fractions = XMLHelper.get_value(misc_loads, "extension/WeekendScheduleFractions")
+      @monthly_multipliers = XMLHelper.get_value(misc_loads, "extension/MonthlyScheduleMultipliers")
+    end
+  end
+
+  def _create_rexml_document()
     doc = XMLHelper.create_doc(version = "1.0", encoding = "UTF-8")
     hpxml = XMLHelper.add_element(doc, "HPXML")
     XMLHelper.add_attribute(hpxml, "xmlns", "http://hpxmlonline.com/2019/10")
     XMLHelper.add_attribute(hpxml, "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
     XMLHelper.add_attribute(hpxml, "xsi:schemaLocation", "http://hpxmlonline.com/2019/10")
     XMLHelper.add_attribute(hpxml, "schemaVersion", "3.0")
-
-    header = XMLHelper.add_element(hpxml, "XMLTransactionHeaderInformation")
-    XMLHelper.add_element(header, "XMLType", xml_type)
-    XMLHelper.add_element(header, "XMLGeneratedBy", xml_generated_by)
-    if not created_date_and_time.nil?
-      XMLHelper.add_element(header, "CreatedDateAndTime", created_date_and_time)
-    else
-      XMLHelper.add_element(header, "CreatedDateAndTime", Time.now.strftime("%Y-%m-%dT%H:%M:%S%:z"))
-    end
-    XMLHelper.add_element(header, "Transaction", transaction)
-
-    software_info = XMLHelper.add_element(hpxml, "SoftwareInfo")
-    XMLHelper.add_element(software_info, "SoftwareProgramUsed", software_program_used) unless software_program_used.nil?
-    XMLHelper.add_element(software_info, "SoftwareProgramVersion", software_program_version) unless software_program_version.nil?
-    _add_object_extension(parent: software_info,
-                          extensions: { "ERICalculation/Version" => eri_calculation_version,
-                                        "ERICalculation/Design" => eri_design,
-                                        "SimulationControl/Timestep" => _to_integer_or_nil(timestep) })
-
-    building = XMLHelper.add_element(hpxml, "Building")
-    building_building_id = XMLHelper.add_element(building, "BuildingID")
-    XMLHelper.add_attribute(building_building_id, "id", building_id)
-    project_status = XMLHelper.add_element(building, "ProjectStatus")
-    XMLHelper.add_element(project_status, "EventType", event_type)
-
     return doc
   end
 
-  def _get_object_header_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    vals[:schema_version] = hpxml.attributes["schemaVersion"]
-    vals[:xml_type] = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/XMLType")
-    vals[:xml_generated_by] = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/XMLGeneratedBy")
-    vals[:created_date_and_time] = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/CreatedDateAndTime")
-    vals[:transaction] = XMLHelper.get_value(hpxml, "XMLTransactionHeaderInformation/Transaction")
-    vals[:software_program_used] = XMLHelper.get_value(hpxml, "SoftwareInfo/SoftwareProgramUsed")
-    vals[:software_program_version] = XMLHelper.get_value(hpxml, "SoftwareInfo/SoftwareProgramVersion")
-    vals[:eri_calculation_version] = XMLHelper.get_value(hpxml, "SoftwareInfo/extension/ERICalculation/Version")
-    vals[:eri_design] = XMLHelper.get_value(hpxml, "SoftwareInfo/extension/ERICalculation/Design")
-    vals[:timestep] = _to_integer_or_nil(XMLHelper.get_value(hpxml, "SoftwareInfo/extension/SimulationControl/Timestep"))
-    vals[:building_id] = _get_object_id(hpxml, "Building/BuildingID")
-    vals[:event_type] = XMLHelper.get_value(hpxml, "Building/ProjectStatus/EventType")
-    return vals
-  end
-
-  def _add_object_site(fuels: [],
-                       shelter_coefficient: nil)
-    site = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "Site"])
-    unless fuels.empty?
-      fuel_types_available = XMLHelper.add_element(site, "FuelTypesAvailable")
-      fuels.each do |fuel|
-        XMLHelper.add_element(fuel_types_available, "Fuel", fuel)
-      end
-    end
-    _add_object_extension(parent: site,
-                          extensions: { "ShelterCoefficient" => _to_float_or_nil(shelter_coefficient) })
-
-    return site
-  end
-
-  def _get_object_site_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    site = hpxml.elements["Building/BuildingDetails/BuildingSummary/Site"]
-    return vals if site.nil?
-
-    vals[:surroundings] = XMLHelper.get_value(site, "Surroundings")
-    vals[:orientation_of_front_of_home] = XMLHelper.get_value(site, "OrientationOfFrontOfHome")
-    vals[:fuels] = XMLHelper.get_values(site, "FuelTypesAvailable/Fuel")
-    vals[:shelter_coefficient] = _to_float_or_nil(XMLHelper.get_value(site, "extension/ShelterCoefficient"))
-    return vals
-  end
-
-  def _add_object_neighbor_building(azimuth:,
-                                    distance:,
-                                    height: nil)
-    neighbors = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "Site", "extension", "Neighbors"])
-    neighbor_building = XMLHelper.add_element(neighbors, "NeighborBuilding")
-    XMLHelper.add_element(neighbor_building, "Azimuth", Integer(azimuth))
-    XMLHelper.add_element(neighbor_building, "Distance", Float(distance))
-    XMLHelper.add_element(neighbor_building, "Height", Float(height)) unless height.nil?
-
-    return neighbor_building
-  end
-
-  def _get_object_neighbor_buildings_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/BuildingSummary/Site/extension/Neighbors/NeighborBuilding") do |neighbor_building|
-      child_vals = {}
-      child_vals[:azimuth] = _to_integer_or_nil(XMLHelper.get_value(neighbor_building, "Azimuth"))
-      child_vals[:distance] = _to_float_or_nil(XMLHelper.get_value(neighbor_building, "Distance"))
-      child_vals[:height] = _to_float_or_nil(XMLHelper.get_value(neighbor_building, "Height"))
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_building_occupancy(number_of_residents: nil)
-    building_occupancy = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "BuildingOccupancy"])
-    XMLHelper.add_element(building_occupancy, "NumberofResidents", Float(number_of_residents)) unless number_of_residents.nil?
-
-    return building_occupancy
-  end
-
-  def _get_object_building_occupancy_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    building_occupancy = hpxml.elements["Building/BuildingDetails/BuildingSummary/BuildingOccupancy"]
-    return vals if building_occupancy.nil?
-
-    vals[:number_of_residents] = _to_float_or_nil(XMLHelper.get_value(building_occupancy, "NumberofResidents"))
-    return vals
-  end
-
-  def _add_object_building_construction(number_of_conditioned_floors:,
-                                        number_of_conditioned_floors_above_grade:,
-                                        number_of_bedrooms:,
-                                        number_of_bathrooms: nil,
-                                        conditioned_floor_area:,
-                                        conditioned_building_volume:,
-                                        fraction_of_operable_window_area: nil,
-                                        use_only_ideal_air_system: nil)
-    building_construction = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "BuildingSummary", "BuildingConstruction"])
-    XMLHelper.add_element(building_construction, "NumberofConditionedFloors", Integer(number_of_conditioned_floors))
-    XMLHelper.add_element(building_construction, "NumberofConditionedFloorsAboveGrade", Integer(number_of_conditioned_floors_above_grade))
-    XMLHelper.add_element(building_construction, "NumberofBedrooms", Integer(number_of_bedrooms))
-    XMLHelper.add_element(building_construction, "NumberofBathrooms", Integer(number_of_bathrooms)) unless number_of_bathrooms.nil?
-    XMLHelper.add_element(building_construction, "ConditionedFloorArea", Float(conditioned_floor_area))
-    XMLHelper.add_element(building_construction, "ConditionedBuildingVolume", Float(conditioned_building_volume))
-    _add_object_extension(parent: building_construction,
-                          extensions: { "FractionofOperableWindowArea" => _to_float_or_nil(fraction_of_operable_window_area),
-                                        "UseOnlyIdealAirSystem" => _to_bool_or_nil(use_only_ideal_air_system) })
-
-    return building_construction
-  end
-
-  def _get_object_building_construction_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    building_construction = hpxml.elements["Building/BuildingDetails/BuildingSummary/BuildingConstruction"]
-    return vals if building_construction.nil?
-
-    vals[:year_built] = _to_integer_or_nil(XMLHelper.get_value(building_construction, "YearBuilt"))
-    vals[:number_of_conditioned_floors] = _to_integer_or_nil(XMLHelper.get_value(building_construction, "NumberofConditionedFloors"))
-    vals[:number_of_conditioned_floors_above_grade] = _to_integer_or_nil(XMLHelper.get_value(building_construction, "NumberofConditionedFloorsAboveGrade"))
-    vals[:average_ceiling_height] = _to_float_or_nil(XMLHelper.get_value(building_construction, "AverageCeilingHeight"))
-    vals[:number_of_bedrooms] = _to_integer_or_nil(XMLHelper.get_value(building_construction, "NumberofBedrooms"))
-    vals[:number_of_bathrooms] = _to_integer_or_nil(XMLHelper.get_value(building_construction, "NumberofBathrooms"))
-    vals[:conditioned_floor_area] = _to_float_or_nil(XMLHelper.get_value(building_construction, "ConditionedFloorArea"))
-    vals[:conditioned_building_volume] = _to_float_or_nil(XMLHelper.get_value(building_construction, "ConditionedBuildingVolume"))
-    vals[:use_only_ideal_air_system] = _to_bool_or_nil(XMLHelper.get_value(building_construction, "extension/UseOnlyIdealAirSystem"))
-    vals[:residential_facility_type] = XMLHelper.get_value(building_construction, "ResidentialFacilityType")
-    vals[:fraction_of_operable_window_area] = _to_float_or_nil(XMLHelper.get_value(building_construction, "extension/FractionofOperableWindowArea"))
-    return vals
-  end
-
-  def _add_object_climate_and_risk_zones(iecc2006: nil,
-                                         iecc2012: nil,
-                                         weather_station_id:,
-                                         weather_station_name:,
-                                         weather_station_wmo: nil,
-                                         weather_station_epw_filename: nil)
-    climate_and_risk_zones = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "ClimateandRiskZones"])
-
-    climate_zones = { 2006 => iecc2006,
-                      2012 => iecc2012 }
-    climate_zones.each do |year, zone|
-      next if zone.nil?
-
-      climate_zone_iecc = XMLHelper.add_element(climate_and_risk_zones, "ClimateZoneIECC")
-      XMLHelper.add_element(climate_zone_iecc, "Year", Integer(year)) unless year.nil?
-      XMLHelper.add_element(climate_zone_iecc, "ClimateZone", zone) unless zone.nil?
-    end
-
-    weather_station = XMLHelper.add_element(climate_and_risk_zones, "WeatherStation")
-    sys_id = XMLHelper.add_element(weather_station, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", weather_station_id)
-    XMLHelper.add_element(weather_station, "Name", weather_station_name)
-    XMLHelper.add_element(weather_station, "WMO", weather_station_wmo) unless weather_station_wmo.nil?
-    _add_object_extension(parent: weather_station,
-                          extensions: { "EPWFileName" => weather_station_epw_filename })
-
-    return climate_and_risk_zones
-  end
-
-  def _get_object_climate_and_risk_zones_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    climate_and_risk_zones = hpxml.elements["Building/BuildingDetails/ClimateandRiskZones"]
-    return vals if climate_and_risk_zones.nil?
-
-    vals[:iecc2006] = XMLHelper.get_value(climate_and_risk_zones, "ClimateZoneIECC[Year=2006]/ClimateZone")
-    vals[:iecc2012] = XMLHelper.get_value(climate_and_risk_zones, "ClimateZoneIECC[Year=2012]/ClimateZone")
-    weather_station = climate_and_risk_zones.elements["WeatherStation"]
-    if not weather_station.nil?
-      vals[:weather_station_id] = _get_object_id(weather_station)
-      vals[:weather_station_name] = XMLHelper.get_value(weather_station, "Name")
-      vals[:weather_station_wmo] = XMLHelper.get_value(weather_station, "WMO")
-      vals[:weather_station_epw_filename] = XMLHelper.get_value(weather_station, "extension/EPWFileName")
-    end
-    return vals
-  end
-
-  def _collapse_enclosure()
+  def _collapse_enclosure_surfaces()
     # Collapses like surfaces into a single surface with, e.g., aggregate surface area.
     # This can significantly speed up performance for HPXML files with lots of individual
     # surfaces (e.g., windows).
 
-    surf_types = [:roofs,
-                  :walls,
-                  :rim_joists,
-                  :foundation_walls,
-                  :frame_floors,
-                  :slabs,
-                  :windows,
-                  :skylights,
-                  :doors]
+    surf_types = { :roofs => @roofs,
+                   :walls => @walls,
+                   :rim_joists => @rim_joists,
+                   :foundation_walls => @foundation_walls,
+                   :frame_floors => @frame_floors,
+                   :slabs => @slabs,
+                   :windows => @windows,
+                   :skylights => @skylights,
+                   :doors => @doors }
 
-    keys_to_ignore = [:id,
-                      :insulation_id,
-                      :perimeter_insulation_id,
-                      :under_slab_insulation_id,
-                      :area,
-                      :exposed_perimeter]
+    attrs_to_ignore = [:id,
+                       :insulation_id,
+                       :perimeter_insulation_id,
+                       :under_slab_insulation_id,
+                       :area,
+                       :exposed_perimeter]
 
     # Look for pairs of surfaces that can be collapsed
     area_adjustments = {}
     exposed_perimeter_adjustments = {}
-    surf_types.each do |surf_type|
+    surf_types.each do |surf_type, surfaces|
       area_adjustments[surf_type] = {}
       exposed_perimeter_adjustments[surf_type] = {}
-      for i in 0..@data[surf_type].size - 1
-        surf_values = @data[surf_type][i]
-        next if surf_values.nil?
+      for i in 0..surfaces.size - 1
+        surf = surfaces[i]
+        next if surf.nil?
 
         area_adjustments[surf_type][i] = 0
         exposed_perimeter_adjustments[surf_type][i] = 0
 
-        for j in (@data[surf_type].size - 1).downto(i + 1)
-          surf_values2 = @data[surf_type][j]
-          next if surf_values2.nil?
-          next unless surf_values.keys.sort == surf_values2.keys.sort
+        for j in (surfaces.size - 1).downto(i + 1)
+          surf2 = surfaces[j]
+          next if surf2.nil?
 
           match = true
-          surf_values.keys.each do |key|
-            next if keys_to_ignore.include? key
-            next if surf_type == :foundation_walls and key == :azimuth # Azimuth of foundation walls is irrelevant
-            next if surf_values[key] == surf_values2[key]
+          surf.class::ATTRS.each do |attribute|
+            next if attrs_to_ignore.include? attribute
+            next if surf_type == :foundation_walls and attribute == :azimuth # Azimuth of foundation walls is irrelevant
+            next if surf.send(attribute) == surf2.send(attribute)
 
             match = false
           end
           next unless match
 
           # Update Area/ExposedPerimeter
-          area_adjustments[surf_type][i] += surf_values2[:area]
-          if not surf_values[:exposed_perimeter].nil?
-            exposed_perimeter_adjustments[surf_type][i] += surf_values2[:exposed_perimeter]
+          area_adjustments[surf_type][i] += surf2.area
+          if surf_type == :slabs
+            exposed_perimeter_adjustments[surf_type][i] += surf2.exposed_perimeter
           end
 
           # Update subsurface idrefs as appropriate
           if [:walls, :foundation_walls].include? surf_type
             [:windows, :doors].each do |subsurf_type|
-              @data[subsurf_type].each_with_index do |subsurf_values, idx|
-                next unless subsurf_values[:wall_idref] == surf_values2[:id]
+              surf_types[subsurf_type].each_with_index do |subsurf, idx|
+                next unless subsurf.wall_idref == surf2.id
 
-                @data[subsurf_type][idx][:wall_idref] = surf_values[:id]
+                surf_types[subsurf_type][idx].wall_idref = surf.id
               end
             end
           elsif [:roofs].include? surf_type
             [:skylights].each do |subsurf_type|
-              @data[subsurf_type].each_with_index do |subsurf_values, idx|
-                next unless subsurf_values[:roof_idref] == surf_values2[:id]
+              surf_types[subsurf_type].each_with_index do |subsurf, idx|
+                next unless subsurf.roof_idref == surf2.id
 
-                @data[subsurf_type][idx][:roof_idref] = surf_values[:id]
+                surf_types[subsurf_type][idx].roof_idref = surf.id
               end
             end
           end
 
           # Remove old surface
-          @data[surf_type].delete_at(j)
+          surfaces.delete_at(j)
         end
       end
     end
@@ -492,1872 +2127,75 @@ class HPXML
       area_adjustments[surf_type].each do |idx, area_adjustment|
         next unless area_adjustment > 0
 
-        @data[surf_type][idx][:area] += area_adjustment
+        surf_types[surf_type][idx].area += area_adjustment
       end
     end
     exposed_perimeter_adjustments.keys.each do |surf_type|
       exposed_perimeter_adjustments[surf_type].each do |idx, exposed_perimeter_adjustment|
         next unless exposed_perimeter_adjustment > 0
 
-        @data[surf_type][idx][:exposed_perimeter] += exposed_perimeter_adjustment
+        surf_types[surf_type][idx].exposed_perimeter += exposed_perimeter_adjustment
       end
     end
-  end
-
-  def _add_object_air_infiltration_measurement(id:,
-                                               house_pressure: nil,
-                                               unit_of_measure: nil,
-                                               air_leakage: nil,
-                                               effective_leakage_area: nil,
-                                               constant_ach_natural: nil,
-                                               infiltration_volume: nil)
-    air_infiltration = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "AirInfiltration"])
-    air_infiltration_measurement = XMLHelper.add_element(air_infiltration, "AirInfiltrationMeasurement")
-    sys_id = XMLHelper.add_element(air_infiltration_measurement, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(air_infiltration_measurement, "HousePressure", Float(house_pressure)) unless house_pressure.nil?
-    if not unit_of_measure.nil? and not air_leakage.nil?
-      building_air_leakage = XMLHelper.add_element(air_infiltration_measurement, "BuildingAirLeakage")
-      XMLHelper.add_element(building_air_leakage, "UnitofMeasure", unit_of_measure)
-      XMLHelper.add_element(building_air_leakage, "AirLeakage", Float(air_leakage))
-    end
-    XMLHelper.add_element(air_infiltration_measurement, "EffectiveLeakageArea", Float(effective_leakage_area)) unless effective_leakage_area.nil?
-    XMLHelper.add_element(air_infiltration_measurement, "InfiltrationVolume", Float(infiltration_volume)) unless infiltration_volume.nil?
-    _add_object_extension(parent: air_infiltration_measurement,
-                          extensions: { "ConstantACHnatural" => _to_float_or_nil(constant_ach_natural) })
-
-    return air_infiltration_measurement
-  end
-
-  def _get_object_air_infiltration_measurements_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement") do |air_infiltration_measurement|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(air_infiltration_measurement)
-      child_vals[:house_pressure] = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "HousePressure"))
-      child_vals[:unit_of_measure] = XMLHelper.get_value(air_infiltration_measurement, "BuildingAirLeakage/UnitofMeasure")
-      child_vals[:air_leakage] = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "BuildingAirLeakage/AirLeakage"))
-      child_vals[:effective_leakage_area] = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "EffectiveLeakageArea"))
-      child_vals[:infiltration_volume] = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "InfiltrationVolume"))
-      child_vals[:constant_ach_natural] = _to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, "extension/ConstantACHnatural"))
-      child_vals[:leakiness_description] = XMLHelper.get_value(air_infiltration_measurement, "LeakinessDescription")
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_attic(id:,
-                        attic_type:,
-                        vented_attic_sla: nil,
-                        vented_attic_constant_ach: nil)
-    attics = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Attics"])
-    attic = XMLHelper.add_element(attics, "Attic")
-    sys_id = XMLHelper.add_element(attic, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    unless attic_type.nil?
-      attic_type_e = XMLHelper.add_element(attic, "AtticType")
-      if attic_type == "UnventedAttic"
-        attic_type_attic = XMLHelper.add_element(attic_type_e, "Attic")
-        XMLHelper.add_element(attic_type_attic, "Vented", false)
-      elsif attic_type == "VentedAttic"
-        attic_type_attic = XMLHelper.add_element(attic_type_e, "Attic")
-        XMLHelper.add_element(attic_type_attic, "Vented", true)
-        if not vented_attic_sla.nil?
-          ventilation_rate = XMLHelper.add_element(attic, "VentilationRate")
-          XMLHelper.add_element(ventilation_rate, "UnitofMeasure", "SLA")
-          XMLHelper.add_element(ventilation_rate, "Value", Float(vented_attic_sla))
-        elsif not vented_attic_constant_ach.nil?
-          XMLHelper.add_element(attic, "extension/ConstantACHnatural", Float(vented_attic_constant_ach))
-        end
-      elsif attic_type == "FlatRoof" or attic_type == "CathedralCeiling"
-        XMLHelper.add_element(attic_type_e, attic_type)
-      else
-        fail "Unhandled attic type '#{attic_type}'."
-      end
-    end
-
-    return attic
-  end
-
-  def _get_object_attics_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/Attics/Attic") do |attic|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(attic)
-      if XMLHelper.has_element(attic, "AtticType/Attic[Vented='false']")
-        child_vals[:attic_type] = "UnventedAttic"
-      elsif XMLHelper.has_element(attic, "AtticType/Attic[Vented='true']")
-        child_vals[:attic_type] = "VentedAttic"
-      elsif XMLHelper.has_element(attic, "AtticType/Attic[Conditioned='true']")
-        child_vals[:attic_type] = "ConditionedAttic"
-      elsif XMLHelper.has_element(attic, "AtticType/FlatRoof")
-        child_vals[:attic_type] = "FlatRoof"
-      elsif XMLHelper.has_element(attic, "AtticType/CathedralCeiling")
-        child_vals[:attic_type] = "CathedralCeiling"
-      end
-      child_vals[:vented_attic_sla] = _to_float_or_nil(XMLHelper.get_value(attic, "[AtticType/Attic[Vented='true']]VentilationRate[UnitofMeasure='SLA']/Value"))
-      child_vals[:vented_attic_constant_ach] = _to_float_or_nil(XMLHelper.get_value(attic, "[AtticType/Attic[Vented='true']]extension/ConstantACHnatural"))
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_foundation(id:,
-                             foundation_type:,
-                             vented_crawlspace_sla: nil,
-                             unconditioned_basement_thermal_boundary: nil)
-    foundations = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Foundations"])
-    foundation = XMLHelper.add_element(foundations, "Foundation")
-    sys_id = XMLHelper.add_element(foundation, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    unless foundation_type.nil?
-      foundation_type_e = XMLHelper.add_element(foundation, "FoundationType")
-      if ["SlabOnGrade", "Ambient"].include? foundation_type
-        XMLHelper.add_element(foundation_type_e, foundation_type)
-      elsif foundation_type == "ConditionedBasement"
-        basement = XMLHelper.add_element(foundation_type_e, "Basement")
-        XMLHelper.add_element(basement, "Conditioned", true)
-      elsif foundation_type == "UnconditionedBasement"
-        basement = XMLHelper.add_element(foundation_type_e, "Basement")
-        XMLHelper.add_element(basement, "Conditioned", false)
-        XMLHelper.add_element(foundation, "ThermalBoundary", unconditioned_basement_thermal_boundary)
-      elsif foundation_type == "VentedCrawlspace"
-        crawlspace = XMLHelper.add_element(foundation_type_e, "Crawlspace")
-        XMLHelper.add_element(crawlspace, "Vented", true)
-        if not vented_crawlspace_sla.nil?
-          ventilation_rate = XMLHelper.add_element(foundation, "VentilationRate")
-          XMLHelper.add_element(ventilation_rate, "UnitofMeasure", "SLA")
-          XMLHelper.add_element(ventilation_rate, "Value", Float(vented_crawlspace_sla))
-        end
-      elsif foundation_type == "UnventedCrawlspace"
-        crawlspace = XMLHelper.add_element(foundation_type_e, "Crawlspace")
-        XMLHelper.add_element(crawlspace, "Vented", false)
-      else
-        fail "Unhandled foundation type '#{foundation_type}'."
-      end
-    end
-
-    return foundation
-  end
-
-  def _get_object_foundations_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/Foundations/Foundation") do |foundation|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(foundation)
-      if XMLHelper.has_element(foundation, "FoundationType/SlabOnGrade")
-        child_vals[:foundation_type] = "SlabOnGrade"
-      elsif XMLHelper.has_element(foundation, "FoundationType/Basement[Conditioned='false']")
-        child_vals[:foundation_type] = "UnconditionedBasement"
-      elsif XMLHelper.has_element(foundation, "FoundationType/Basement[Conditioned='true']")
-        child_vals[:foundation_type] = "ConditionedBasement"
-      elsif XMLHelper.has_element(foundation, "FoundationType/Crawlspace[Vented='false']")
-        child_vals[:foundation_type] = "UnventedCrawlspace"
-      elsif XMLHelper.has_element(foundation, "FoundationType/Crawlspace[Vented='true']")
-        child_vals[:foundation_type] = "VentedCrawlspace"
-      elsif XMLHelper.has_element(foundation, "FoundationType/Ambient")
-        child_vals[:foundation_type] = "Ambient"
-      end
-      child_vals[:vented_crawlspace_sla] = _to_float_or_nil(XMLHelper.get_value(foundation, "[FoundationType/Crawlspace[Vented='true']]VentilationRate[UnitofMeasure='SLA']/Value"))
-      child_vals[:unconditioned_basement_thermal_boundary] = XMLHelper.get_value(foundation, "[FoundationType/Basement[Conditioned='false']]ThermalBoundary")
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_roof(id:,
-                       interior_adjacent_to:,
-                       area:,
-                       azimuth: nil,
-                       solar_absorptance:,
-                       emittance:,
-                       pitch:,
-                       radiant_barrier:,
-                       insulation_id: nil,
-                       insulation_assembly_r_value:)
-    roofs = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Roofs"])
-    roof = XMLHelper.add_element(roofs, "Roof")
-    sys_id = XMLHelper.add_element(roof, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(roof, "InteriorAdjacentTo", interior_adjacent_to)
-    XMLHelper.add_element(roof, "Area", Float(area))
-    XMLHelper.add_element(roof, "Azimuth", Integer(azimuth)) unless azimuth.nil?
-    XMLHelper.add_element(roof, "SolarAbsorptance", Float(solar_absorptance))
-    XMLHelper.add_element(roof, "Emittance", Float(emittance))
-    XMLHelper.add_element(roof, "Pitch", Float(pitch))
-    XMLHelper.add_element(roof, "RadiantBarrier", Boolean(radiant_barrier))
-    insulation = XMLHelper.add_element(roof, "Insulation")
-    sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
-    unless insulation_id.nil?
-      XMLHelper.add_attribute(sys_id, "id", insulation_id)
-    else
-      XMLHelper.add_attribute(sys_id, "id", id + "Insulation")
-    end
-    XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(insulation_assembly_r_value))
-
-    return roof
-  end
-
-  def _get_object_roofs_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/Roofs/Roof") do |roof|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(roof)
-      child_vals[:exterior_adjacent_to] = "outside"
-      child_vals[:interior_adjacent_to] = XMLHelper.get_value(roof, "InteriorAdjacentTo")
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(roof, "Area"))
-      child_vals[:azimuth] = _to_integer_or_nil(XMLHelper.get_value(roof, "Azimuth"))
-      child_vals[:roof_type] = XMLHelper.get_value(roof, "RoofType")
-      child_vals[:roof_color] = XMLHelper.get_value(roof, "RoofColor")
-      child_vals[:solar_absorptance] = _to_float_or_nil(XMLHelper.get_value(roof, "SolarAbsorptance"))
-      child_vals[:emittance] = _to_float_or_nil(XMLHelper.get_value(roof, "Emittance"))
-      child_vals[:pitch] = _to_float_or_nil(XMLHelper.get_value(roof, "Pitch"))
-      child_vals[:radiant_barrier] = _to_bool_or_nil(XMLHelper.get_value(roof, "RadiantBarrier"))
-      insulation = roof.elements["Insulation"]
-      if not insulation.nil?
-        child_vals[:insulation_id] = _get_object_id(insulation)
-        child_vals[:insulation_assembly_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
-        child_vals[:insulation_cavity_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
-        child_vals[:insulation_continuous_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
-      end
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_rim_joist(id:,
-                            exterior_adjacent_to:,
-                            interior_adjacent_to:,
-                            area:,
-                            azimuth: nil,
-                            solar_absorptance:,
-                            emittance:,
-                            insulation_id: nil,
-                            insulation_assembly_r_value:)
-    rim_joists = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "RimJoists"])
-    rim_joist = XMLHelper.add_element(rim_joists, "RimJoist")
-    sys_id = XMLHelper.add_element(rim_joist, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(rim_joist, "ExteriorAdjacentTo", exterior_adjacent_to)
-    XMLHelper.add_element(rim_joist, "InteriorAdjacentTo", interior_adjacent_to)
-    XMLHelper.add_element(rim_joist, "Area", Float(area))
-    XMLHelper.add_element(rim_joist, "Azimuth", Integer(azimuth)) unless azimuth.nil?
-    XMLHelper.add_element(rim_joist, "SolarAbsorptance", Float(solar_absorptance))
-    XMLHelper.add_element(rim_joist, "Emittance", Float(emittance))
-    insulation = XMLHelper.add_element(rim_joist, "Insulation")
-    sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
-    unless insulation_id.nil?
-      XMLHelper.add_attribute(sys_id, "id", insulation_id)
-    else
-      XMLHelper.add_attribute(sys_id, "id", id + "Insulation")
-    end
-    XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(insulation_assembly_r_value))
-
-    return rim_joist
-  end
-
-  def _get_object_rim_joists_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/RimJoists/RimJoist") do |rim_joist|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(rim_joist)
-      child_vals[:exterior_adjacent_to] = XMLHelper.get_value(rim_joist, "ExteriorAdjacentTo")
-      child_vals[:interior_adjacent_to] = XMLHelper.get_value(rim_joist, "InteriorAdjacentTo")
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(rim_joist, "Area"))
-      child_vals[:azimuth] = _to_integer_or_nil(XMLHelper.get_value(rim_joist, "Azimuth"))
-      child_vals[:solar_absorptance] = _to_float_or_nil(XMLHelper.get_value(rim_joist, "SolarAbsorptance"))
-      child_vals[:emittance] = _to_float_or_nil(XMLHelper.get_value(rim_joist, "Emittance"))
-      insulation = rim_joist.elements["Insulation"]
-      if not insulation.nil?
-        child_vals[:insulation_id] = _get_object_id(insulation)
-        child_vals[:insulation_assembly_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
-      end
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_wall(id:,
-                       exterior_adjacent_to:,
-                       interior_adjacent_to:,
-                       wall_type:,
-                       area:,
-                       azimuth: nil,
-                       solar_absorptance:,
-                       emittance:,
-                       insulation_id: nil,
-                       insulation_assembly_r_value:)
-    walls = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Walls"])
-    wall = XMLHelper.add_element(walls, "Wall")
-    sys_id = XMLHelper.add_element(wall, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(wall, "ExteriorAdjacentTo", exterior_adjacent_to)
-    XMLHelper.add_element(wall, "InteriorAdjacentTo", interior_adjacent_to)
-    wall_type_e = XMLHelper.add_element(wall, "WallType")
-    XMLHelper.add_element(wall_type_e, wall_type)
-    XMLHelper.add_element(wall, "Area", Float(area))
-    XMLHelper.add_element(wall, "Azimuth", Integer(azimuth)) unless azimuth.nil?
-    XMLHelper.add_element(wall, "SolarAbsorptance", Float(solar_absorptance))
-    XMLHelper.add_element(wall, "Emittance", Float(emittance))
-    insulation = XMLHelper.add_element(wall, "Insulation")
-    sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
-    unless insulation_id.nil?
-      XMLHelper.add_attribute(sys_id, "id", insulation_id)
-    else
-      XMLHelper.add_attribute(sys_id, "id", id + "Insulation")
-    end
-    XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(insulation_assembly_r_value))
-
-    return wall
-  end
-
-  def _get_object_walls_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/Walls/Wall") do |wall|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(wall)
-      child_vals[:exterior_adjacent_to] = XMLHelper.get_value(wall, "ExteriorAdjacentTo")
-      child_vals[:interior_adjacent_to] = XMLHelper.get_value(wall, "InteriorAdjacentTo")
-      child_vals[:wall_type] = XMLHelper.get_child_name(wall, "WallType")
-      child_vals[:optimum_value_engineering] = _to_bool_or_nil(XMLHelper.get_value(wall, "WallType/WoodStud/OptimumValueEngineering"))
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(wall, "Area"))
-      child_vals[:orientation] = XMLHelper.get_value(wall, "Orientation")
-      child_vals[:azimuth] = _to_integer_or_nil(XMLHelper.get_value(wall, "Azimuth"))
-      child_vals[:siding] = XMLHelper.get_value(wall, "Siding")
-      child_vals[:solar_absorptance] = _to_float_or_nil(XMLHelper.get_value(wall, "SolarAbsorptance"))
-      child_vals[:emittance] = _to_float_or_nil(XMLHelper.get_value(wall, "Emittance"))
-      insulation = wall.elements["Insulation"]
-      if not insulation.nil?
-        child_vals[:insulation_id] = _get_object_id(insulation)
-        child_vals[:insulation_assembly_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
-        child_vals[:insulation_cavity_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
-        child_vals[:insulation_continuous_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
-      end
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_foundation_wall(id:,
-                                  exterior_adjacent_to:,
-                                  interior_adjacent_to:,
-                                  height:,
-                                  area:,
-                                  azimuth: nil,
-                                  thickness:,
-                                  depth_below_grade:,
-                                  insulation_id: nil,
-                                  insulation_interior_r_value: nil,
-                                  insulation_interior_distance_to_top: nil,
-                                  insulation_interior_distance_to_bottom: nil,
-                                  insulation_exterior_r_value: nil,
-                                  insulation_exterior_distance_to_top: nil,
-                                  insulation_exterior_distance_to_bottom: nil,
-                                  insulation_assembly_r_value: nil)
-    foundation_walls = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "FoundationWalls"])
-    foundation_wall = XMLHelper.add_element(foundation_walls, "FoundationWall")
-    sys_id = XMLHelper.add_element(foundation_wall, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(foundation_wall, "ExteriorAdjacentTo", exterior_adjacent_to)
-    XMLHelper.add_element(foundation_wall, "InteriorAdjacentTo", interior_adjacent_to)
-    XMLHelper.add_element(foundation_wall, "Height", Float(height))
-    XMLHelper.add_element(foundation_wall, "Area", Float(area))
-    XMLHelper.add_element(foundation_wall, "Azimuth", Integer(azimuth)) unless azimuth.nil?
-    XMLHelper.add_element(foundation_wall, "Thickness", Float(thickness))
-    XMLHelper.add_element(foundation_wall, "DepthBelowGrade", Float(depth_below_grade))
-    insulation = XMLHelper.add_element(foundation_wall, "Insulation")
-    sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
-    unless insulation_id.nil?
-      XMLHelper.add_attribute(sys_id, "id", insulation_id)
-    else
-      XMLHelper.add_attribute(sys_id, "id", id + "Insulation")
-    end
-    XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(insulation_assembly_r_value)) unless insulation_assembly_r_value.nil?
-    unless insulation_exterior_r_value.nil?
-      layer = XMLHelper.add_element(insulation, "Layer")
-      XMLHelper.add_element(layer, "InstallationType", "continuous - exterior")
-      XMLHelper.add_element(layer, "NominalRValue", Float(insulation_exterior_r_value))
-      _add_object_extension(parent: layer,
-                            extensions: { "DistanceToTopOfInsulation" => _to_float_or_nil(insulation_exterior_distance_to_top),
-                                          "DistanceToBottomOfInsulation" => _to_float_or_nil(insulation_exterior_distance_to_bottom) })
-    end
-    unless insulation_interior_r_value.nil?
-      layer = XMLHelper.add_element(insulation, "Layer")
-      XMLHelper.add_element(layer, "InstallationType", "continuous - interior")
-      XMLHelper.add_element(layer, "NominalRValue", Float(insulation_interior_r_value))
-      _add_object_extension(parent: layer,
-                            extensions: { "DistanceToTopOfInsulation" => _to_float_or_nil(insulation_interior_distance_to_top),
-                                          "DistanceToBottomOfInsulation" => _to_float_or_nil(insulation_interior_distance_to_bottom) })
-    end
-
-    return foundation_wall
-  end
-
-  def _get_object_foundation_walls_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/FoundationWalls/FoundationWall") do |foundation_wall|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(foundation_wall)
-      child_vals[:exterior_adjacent_to] = XMLHelper.get_value(foundation_wall, "ExteriorAdjacentTo")
-      child_vals[:interior_adjacent_to] = XMLHelper.get_value(foundation_wall, "InteriorAdjacentTo")
-      child_vals[:height] = _to_float_or_nil(XMLHelper.get_value(foundation_wall, "Height"))
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(foundation_wall, "Area"))
-      child_vals[:azimuth] = _to_integer_or_nil(XMLHelper.get_value(foundation_wall, "Azimuth"))
-      child_vals[:thickness] = _to_float_or_nil(XMLHelper.get_value(foundation_wall, "Thickness"))
-      child_vals[:depth_below_grade] = _to_float_or_nil(XMLHelper.get_value(foundation_wall, "DepthBelowGrade"))
-      insulation = foundation_wall.elements["Insulation"]
-      if not insulation.nil?
-        child_vals[:insulation_id] = _get_object_id(insulation)
-        child_vals[:insulation_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
-        child_vals[:insulation_interior_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/NominalRValue"))
-        child_vals[:insulation_interior_distance_to_top] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/extension/DistanceToTopOfInsulation"))
-        child_vals[:insulation_interior_distance_to_bottom] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/extension/DistanceToBottomOfInsulation"))
-        child_vals[:insulation_exterior_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/NominalRValue"))
-        child_vals[:insulation_exterior_distance_to_top] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/extension/DistanceToTopOfInsulation"))
-        child_vals[:insulation_exterior_distance_to_bottom] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/extension/DistanceToBottomOfInsulation"))
-        child_vals[:insulation_assembly_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
-      end
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_frame_floor(id:,
-                              exterior_adjacent_to:,
-                              interior_adjacent_to:,
-                              area:,
-                              insulation_id: nil,
-                              insulation_assembly_r_value:)
-    frame_floors = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "FrameFloors"])
-    frame_floor = XMLHelper.add_element(frame_floors, "FrameFloor")
-    sys_id = XMLHelper.add_element(frame_floor, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(frame_floor, "ExteriorAdjacentTo", exterior_adjacent_to)
-    XMLHelper.add_element(frame_floor, "InteriorAdjacentTo", interior_adjacent_to)
-    XMLHelper.add_element(frame_floor, "Area", Float(area))
-    insulation = XMLHelper.add_element(frame_floor, "Insulation")
-    sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
-    unless insulation_id.nil?
-      XMLHelper.add_attribute(sys_id, "id", insulation_id)
-    else
-      XMLHelper.add_attribute(sys_id, "id", id + "Insulation")
-    end
-    XMLHelper.add_element(insulation, "AssemblyEffectiveRValue", Float(insulation_assembly_r_value))
-
-    return frame_floor
-  end
-
-  def _get_object_frame_floors_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor") do |frame_floor|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(frame_floor)
-      child_vals[:exterior_adjacent_to] = XMLHelper.get_value(frame_floor, "ExteriorAdjacentTo")
-      child_vals[:interior_adjacent_to] = XMLHelper.get_value(frame_floor, "InteriorAdjacentTo")
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(frame_floor, "Area"))
-      insulation = frame_floor.elements["Insulation"]
-      if not insulation.nil?
-        child_vals[:insulation_id] = _get_object_id(insulation)
-        child_vals[:insulation_assembly_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "AssemblyEffectiveRValue"))
-        child_vals[:insulation_cavity_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
-        child_vals[:insulation_continuous_r_value] = _to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
-      end
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_slab(id:,
-                       interior_adjacent_to:,
-                       area:,
-                       thickness:,
-                       exposed_perimeter:,
-                       perimeter_insulation_depth:,
-                       under_slab_insulation_width: nil,
-                       under_slab_insulation_spans_entire_slab: nil,
-                       depth_below_grade: nil,
-                       carpet_fraction:,
-                       carpet_r_value:,
-                       perimeter_insulation_id: nil,
-                       perimeter_insulation_r_value:,
-                       under_slab_insulation_id: nil,
-                       under_slab_insulation_r_value:)
-    slabs = foundation_walls = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Slabs"])
-    slab = XMLHelper.add_element(slabs, "Slab")
-    sys_id = XMLHelper.add_element(slab, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(slab, "InteriorAdjacentTo", interior_adjacent_to)
-    XMLHelper.add_element(slab, "Area", Float(area))
-    XMLHelper.add_element(slab, "Thickness", Float(thickness))
-    XMLHelper.add_element(slab, "ExposedPerimeter", Float(exposed_perimeter))
-    XMLHelper.add_element(slab, "PerimeterInsulationDepth", Float(perimeter_insulation_depth))
-    XMLHelper.add_element(slab, "UnderSlabInsulationWidth", Float(under_slab_insulation_width)) unless under_slab_insulation_width.nil?
-    XMLHelper.add_element(slab, "UnderSlabInsulationSpansEntireSlab", Boolean(under_slab_insulation_spans_entire_slab)) unless under_slab_insulation_spans_entire_slab.nil?
-    XMLHelper.add_element(slab, "DepthBelowGrade", Float(depth_below_grade)) unless depth_below_grade.nil?
-    insulation = XMLHelper.add_element(slab, "PerimeterInsulation")
-    sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
-    unless perimeter_insulation_id.nil?
-      XMLHelper.add_attribute(sys_id, "id", perimeter_insulation_id)
-    else
-      XMLHelper.add_attribute(sys_id, "id", id + "PerimeterInsulation")
-    end
-    layer = XMLHelper.add_element(insulation, "Layer")
-    XMLHelper.add_element(layer, "InstallationType", "continuous")
-    XMLHelper.add_element(layer, "NominalRValue", Float(perimeter_insulation_r_value))
-    insulation = XMLHelper.add_element(slab, "UnderSlabInsulation")
-    sys_id = XMLHelper.add_element(insulation, "SystemIdentifier")
-    unless under_slab_insulation_id.nil?
-      XMLHelper.add_attribute(sys_id, "id", under_slab_insulation_id)
-    else
-      XMLHelper.add_attribute(sys_id, "id", id + "UnderSlabInsulation")
-    end
-    layer = XMLHelper.add_element(insulation, "Layer")
-    XMLHelper.add_element(layer, "InstallationType", "continuous")
-    XMLHelper.add_element(layer, "NominalRValue", Float(under_slab_insulation_r_value))
-    _add_object_extension(parent: slab,
-                          extensions: { "CarpetFraction" => _to_float_or_nil(carpet_fraction),
-                                        "CarpetRValue" => _to_float_or_nil(carpet_r_value) })
-
-    return slab
-  end
-
-  def _get_object_slabs_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/Slabs/Slab") do |slab|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(slab)
-      child_vals[:interior_adjacent_to] = XMLHelper.get_value(slab, "InteriorAdjacentTo")
-      child_vals[:exterior_adjacent_to] = "outside"
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(slab, "Area"))
-      child_vals[:thickness] = _to_float_or_nil(XMLHelper.get_value(slab, "Thickness"))
-      child_vals[:exposed_perimeter] = _to_float_or_nil(XMLHelper.get_value(slab, "ExposedPerimeter"))
-      child_vals[:perimeter_insulation_depth] = _to_float_or_nil(XMLHelper.get_value(slab, "PerimeterInsulationDepth"))
-      child_vals[:under_slab_insulation_width] = _to_float_or_nil(XMLHelper.get_value(slab, "UnderSlabInsulationWidth"))
-      child_vals[:under_slab_insulation_spans_entire_slab] = _to_bool_or_nil(XMLHelper.get_value(slab, "UnderSlabInsulationSpansEntireSlab"))
-      child_vals[:depth_below_grade] = _to_float_or_nil(XMLHelper.get_value(slab, "DepthBelowGrade"))
-      child_vals[:carpet_fraction] = _to_float_or_nil(XMLHelper.get_value(slab, "extension/CarpetFraction"))
-      child_vals[:carpet_r_value] = _to_float_or_nil(XMLHelper.get_value(slab, "extension/CarpetRValue"))
-      perimeter_insulation = slab.elements["PerimeterInsulation"]
-      if not perimeter_insulation.nil?
-        child_vals[:perimeter_insulation_id] = _get_object_id(perimeter_insulation)
-        child_vals[:perimeter_insulation_r_value] = _to_float_or_nil(XMLHelper.get_value(perimeter_insulation, "Layer[InstallationType='continuous']/NominalRValue"))
-      end
-      under_slab_insulation = slab.elements["UnderSlabInsulation"]
-      if not under_slab_insulation.nil?
-        child_vals[:under_slab_insulation_id] = _get_object_id(under_slab_insulation)
-        child_vals[:under_slab_insulation_r_value] = _to_float_or_nil(XMLHelper.get_value(under_slab_insulation, "Layer[InstallationType='continuous']/NominalRValue"))
-      end
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_window(id:,
-                         area:,
-                         azimuth:,
-                         ufactor:,
-                         shgc:,
-                         overhangs_depth: nil,
-                         overhangs_distance_to_top_of_window: nil,
-                         overhangs_distance_to_bottom_of_window: nil,
-                         interior_shading_factor_summer: nil,
-                         interior_shading_factor_winter: nil,
-                         wall_idref:)
-    windows = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Windows"])
-    window = XMLHelper.add_element(windows, "Window")
-    sys_id = XMLHelper.add_element(window, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(window, "Area", Float(area))
-    XMLHelper.add_element(window, "Azimuth", Integer(azimuth))
-    XMLHelper.add_element(window, "UFactor", Float(ufactor))
-    XMLHelper.add_element(window, "SHGC", Float(shgc))
-    if not interior_shading_factor_summer.nil? or not interior_shading_factor_winter.nil?
-      interior_shading = XMLHelper.add_element(window, "InteriorShading")
-      sys_id = XMLHelper.add_element(interior_shading, "SystemIdentifier")
-      XMLHelper.add_attribute(sys_id, "id", "#{id}InteriorShading")
-      XMLHelper.add_element(interior_shading, "SummerShadingCoefficient", Float(interior_shading_factor_summer)) unless interior_shading_factor_summer.nil?
-      XMLHelper.add_element(interior_shading, "WinterShadingCoefficient", Float(interior_shading_factor_winter)) unless interior_shading_factor_winter.nil?
-    end
-    if not overhangs_depth.nil? or not overhangs_distance_to_top_of_window.nil? or not overhangs_distance_to_bottom_of_window.nil?
-      overhangs = XMLHelper.add_element(window, "Overhangs")
-      XMLHelper.add_element(overhangs, "Depth", Float(overhangs_depth))
-      XMLHelper.add_element(overhangs, "DistanceToTopOfWindow", Float(overhangs_distance_to_top_of_window))
-      XMLHelper.add_element(overhangs, "DistanceToBottomOfWindow", Float(overhangs_distance_to_bottom_of_window))
-    end
-    attached_to_wall = XMLHelper.add_element(window, "AttachedToWall")
-    XMLHelper.add_attribute(attached_to_wall, "idref", wall_idref)
-
-    return window
-  end
-
-  def _get_object_windows_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/Windows/Window") do |window|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(window)
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(window, "Area"))
-      child_vals[:azimuth] = _to_integer_or_nil(XMLHelper.get_value(window, "Azimuth"))
-      child_vals[:orientation] = XMLHelper.get_value(window, "Orientation")
-      child_vals[:frame_type] = XMLHelper.get_child_name(window, "FrameType")
-      child_vals[:aluminum_thermal_break] = _to_bool_or_nil(XMLHelper.get_value(window, "FrameType/Aluminum/ThermalBreak"))
-      child_vals[:glass_layers] = XMLHelper.get_value(window, "GlassLayers")
-      child_vals[:glass_type] = XMLHelper.get_value(window, "GlassType")
-      child_vals[:gas_fill] = XMLHelper.get_value(window, "GasFill")
-      child_vals[:ufactor] = _to_float_or_nil(XMLHelper.get_value(window, "UFactor"))
-      child_vals[:shgc] = _to_float_or_nil(XMLHelper.get_value(window, "SHGC"))
-      child_vals[:interior_shading_factor_summer] = _to_float_or_nil(XMLHelper.get_value(window, "InteriorShading/SummerShadingCoefficient"))
-      child_vals[:interior_shading_factor_winter] = _to_float_or_nil(XMLHelper.get_value(window, "InteriorShading/WinterShadingCoefficient"))
-      child_vals[:exterior_shading] = XMLHelper.get_value(window, "ExteriorShading/Type")
-      child_vals[:overhangs_depth] = _to_float_or_nil(XMLHelper.get_value(window, "Overhangs/Depth"))
-      child_vals[:overhangs_distance_to_top_of_window] = _to_float_or_nil(XMLHelper.get_value(window, "Overhangs/DistanceToTopOfWindow"))
-      child_vals[:overhangs_distance_to_bottom_of_window] = _to_float_or_nil(XMLHelper.get_value(window, "Overhangs/DistanceToBottomOfWindow"))
-      child_vals[:wall_idref] = _get_object_idref(window, "AttachedToWall")
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_skylight(id:,
-                           area:,
-                           azimuth:,
-                           ufactor:,
-                           shgc:,
-                           roof_idref:)
-    skylights = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Skylights"])
-    skylight = XMLHelper.add_element(skylights, "Skylight")
-    sys_id = XMLHelper.add_element(skylight, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(skylight, "Area", Float(area))
-    XMLHelper.add_element(skylight, "Azimuth", Integer(azimuth))
-    XMLHelper.add_element(skylight, "UFactor", Float(ufactor))
-    XMLHelper.add_element(skylight, "SHGC", Float(shgc))
-    attached_to_roof = XMLHelper.add_element(skylight, "AttachedToRoof")
-    XMLHelper.add_attribute(attached_to_roof, "idref", roof_idref)
-
-    return skylight
-  end
-
-  def _get_object_skylights_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/Skylights/Skylight") do |skylight|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(skylight)
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(skylight, "Area"))
-      child_vals[:azimuth] = _to_integer_or_nil(XMLHelper.get_value(skylight, "Azimuth"))
-      child_vals[:orientation] = XMLHelper.get_value(skylight, "Orientation")
-      child_vals[:frame_type] = XMLHelper.get_child_name(skylight, "FrameType")
-      child_vals[:aluminum_thermal_break] = _to_bool_or_nil(XMLHelper.get_value(skylight, "FrameType/Aluminum/ThermalBreak"))
-      child_vals[:glass_layers] = XMLHelper.get_value(skylight, "GlassLayers")
-      child_vals[:glass_type] = XMLHelper.get_value(skylight, "GlassType")
-      child_vals[:gas_fill] = XMLHelper.get_value(skylight, "GasFill")
-      child_vals[:ufactor] = _to_float_or_nil(XMLHelper.get_value(skylight, "UFactor"))
-      child_vals[:shgc] = _to_float_or_nil(XMLHelper.get_value(skylight, "SHGC"))
-      child_vals[:exterior_shading] = XMLHelper.get_value(skylight, "ExteriorShading/Type")
-      child_vals[:roof_idref] = _get_object_idref(skylight, "AttachedToRoof")
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_door(id:,
-                       wall_idref:,
-                       area:,
-                       azimuth:,
-                       r_value:)
-    doors = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Enclosure", "Doors"])
-    door = XMLHelper.add_element(doors, "Door")
-    sys_id = XMLHelper.add_element(door, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    attached_to_wall = XMLHelper.add_element(door, "AttachedToWall")
-    XMLHelper.add_attribute(attached_to_wall, "idref", wall_idref)
-    XMLHelper.add_element(door, "Area", Float(area))
-    XMLHelper.add_element(door, "Azimuth", Integer(azimuth))
-    XMLHelper.add_element(door, "RValue", Float(r_value))
-
-    return door
-  end
-
-  def _get_object_doors_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Enclosure/Doors/Door") do |door|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(door)
-      child_vals[:wall_idref] = _get_object_idref(door, "AttachedToWall")
-      child_vals[:area] = _to_float_or_nil(XMLHelper.get_value(door, "Area"))
-      child_vals[:azimuth] = _to_integer_or_nil(XMLHelper.get_value(door, "Azimuth"))
-      child_vals[:r_value] = _to_float_or_nil(XMLHelper.get_value(door, "RValue"))
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_heating_system(id:,
-                                 distribution_system_idref: nil,
-                                 heating_system_type:,
-                                 heating_system_fuel:,
-                                 heating_capacity:,
-                                 heating_efficiency_afue: nil,
-                                 heating_efficiency_percent: nil,
-                                 fraction_heat_load_served:,
-                                 electric_auxiliary_energy: nil,
-                                 heating_cfm: nil)
-    hvac_plant = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
-    heating_system = XMLHelper.add_element(hvac_plant, "HeatingSystem")
-    sys_id = XMLHelper.add_element(heating_system, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    unless distribution_system_idref.nil?
-      distribution_system = XMLHelper.add_element(heating_system, "DistributionSystem")
-      XMLHelper.add_attribute(distribution_system, "idref", distribution_system_idref)
-    end
-    heating_system_type_e = XMLHelper.add_element(heating_system, "HeatingSystemType")
-    XMLHelper.add_element(heating_system_type_e, heating_system_type)
-    XMLHelper.add_element(heating_system, "HeatingSystemFuel", heating_system_fuel)
-    XMLHelper.add_element(heating_system, "HeatingCapacity", Float(heating_capacity))
-
-    efficiency_units = nil
-    efficiency_value = nil
-    if ["Furnace", "WallFurnace", "Boiler"].include? heating_system_type
-      efficiency_units = "AFUE"
-      efficiency_value = heating_efficiency_afue
-    elsif ["ElectricResistance", "Stove", "PortableHeater"].include? heating_system_type
-      efficiency_units = "Percent"
-      efficiency_value = heating_efficiency_percent
-    end
-    if not efficiency_value.nil?
-      annual_efficiency = XMLHelper.add_element(heating_system, "AnnualHeatingEfficiency")
-      XMLHelper.add_element(annual_efficiency, "Units", efficiency_units)
-      XMLHelper.add_element(annual_efficiency, "Value", Float(efficiency_value))
-    end
-
-    XMLHelper.add_element(heating_system, "FractionHeatLoadServed", Float(fraction_heat_load_served))
-    XMLHelper.add_element(heating_system, "ElectricAuxiliaryEnergy", Float(electric_auxiliary_energy)) unless electric_auxiliary_energy.nil?
-    _add_object_extension(parent: heating_system,
-                          extensions: { "HeatingFlowRate" => _to_float_or_nil(heating_cfm) })
-
-    return heating_system
-  end
-
-  def _get_object_heating_systems_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem") do |heating_system|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(heating_system)
-      child_vals[:distribution_system_idref] = _get_object_idref(heating_system, "DistributionSystem")
-      child_vals[:year_installed] = _to_integer_or_nil(XMLHelper.get_value(heating_system, "YearInstalled"))
-      child_vals[:heating_system_type] = XMLHelper.get_child_name(heating_system, "HeatingSystemType")
-      child_vals[:heating_system_fuel] = XMLHelper.get_value(heating_system, "HeatingSystemFuel")
-      child_vals[:heating_capacity] = _to_float_or_nil(XMLHelper.get_value(heating_system, "HeatingCapacity"))
-      child_vals[:heating_efficiency_afue] = _to_float_or_nil(XMLHelper.get_value(heating_system, "[HeatingSystemType[Furnace | WallFurnace | Boiler]]AnnualHeatingEfficiency[Units='AFUE']/Value"))
-      child_vals[:heating_efficiency_percent] = _to_float_or_nil(XMLHelper.get_value(heating_system, "[HeatingSystemType[ElectricResistance | Stove | PortableHeater]]AnnualHeatingEfficiency[Units='Percent']/Value"))
-      child_vals[:fraction_heat_load_served] = _to_float_or_nil(XMLHelper.get_value(heating_system, "FractionHeatLoadServed"))
-      child_vals[:electric_auxiliary_energy] = _to_float_or_nil(XMLHelper.get_value(heating_system, "ElectricAuxiliaryEnergy"))
-      child_vals[:heating_cfm] = _to_float_or_nil(XMLHelper.get_value(heating_system, "extension/HeatingFlowRate"))
-      child_vals[:energy_star] = XMLHelper.get_values(heating_system, "ThirdPartyCertification").include?("Energy Star")
-      child_vals[:seed_id] = XMLHelper.get_value(heating_system, "extension/SeedId")
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_cooling_system(id:,
-                                 distribution_system_idref: nil,
-                                 cooling_system_type:,
-                                 cooling_system_fuel:,
-                                 compressor_type: nil,
-                                 cooling_capacity: nil,
-                                 fraction_cool_load_served:,
-                                 cooling_efficiency_seer: nil,
-                                 cooling_efficiency_eer: nil,
-                                 cooling_shr: nil,
-                                 cooling_cfm: nil)
-    hvac_plant = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
-    cooling_system = XMLHelper.add_element(hvac_plant, "CoolingSystem")
-    sys_id = XMLHelper.add_element(cooling_system, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    unless distribution_system_idref.nil?
-      distribution_system = XMLHelper.add_element(cooling_system, "DistributionSystem")
-      XMLHelper.add_attribute(distribution_system, "idref", distribution_system_idref)
-    end
-    XMLHelper.add_element(cooling_system, "CoolingSystemType", cooling_system_type)
-    XMLHelper.add_element(cooling_system, "CoolingSystemFuel", cooling_system_fuel)
-    XMLHelper.add_element(cooling_system, "CoolingCapacity", Float(cooling_capacity)) unless cooling_capacity.nil?
-    XMLHelper.add_element(cooling_system, "CompressorType", compressor_type) unless compressor_type.nil?
-    XMLHelper.add_element(cooling_system, "FractionCoolLoadServed", Float(fraction_cool_load_served))
-
-    efficiency_units = nil
-    efficiency_value = nil
-    if ["central air conditioner"].include? cooling_system_type
-      efficiency_units = "SEER"
-      efficiency_value = cooling_efficiency_seer
-    elsif ["room air conditioner"].include? cooling_system_type
-      efficiency_units = "EER"
-      efficiency_value = cooling_efficiency_eer
-    end
-    if not efficiency_value.nil?
-      annual_efficiency = XMLHelper.add_element(cooling_system, "AnnualCoolingEfficiency")
-      XMLHelper.add_element(annual_efficiency, "Units", efficiency_units)
-      XMLHelper.add_element(annual_efficiency, "Value", Float(efficiency_value))
-    end
-
-    XMLHelper.add_element(cooling_system, "SensibleHeatFraction", Float(cooling_shr)) unless cooling_shr.nil?
-    _add_object_extension(parent: cooling_system,
-                          extensions: { "CoolingFlowRate" => _to_float_or_nil(cooling_cfm) })
-
-    return cooling_system
-  end
-
-  def _get_object_cooling_systems_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem") do |cooling_system|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(cooling_system)
-      child_vals[:distribution_system_idref] = _get_object_idref(cooling_system, "DistributionSystem")
-      child_vals[:year_installed] = _to_integer_or_nil(XMLHelper.get_value(cooling_system, "YearInstalled"))
-      child_vals[:cooling_system_type] = XMLHelper.get_value(cooling_system, "CoolingSystemType")
-      child_vals[:cooling_system_fuel] = XMLHelper.get_value(cooling_system, "CoolingSystemFuel")
-      child_vals[:cooling_capacity] = _to_float_or_nil(XMLHelper.get_value(cooling_system, "CoolingCapacity"))
-      child_vals[:compressor_type] = XMLHelper.get_value(cooling_system, "CompressorType")
-      child_vals[:fraction_cool_load_served] = _to_float_or_nil(XMLHelper.get_value(cooling_system, "FractionCoolLoadServed"))
-      child_vals[:cooling_efficiency_seer] = _to_float_or_nil(XMLHelper.get_value(cooling_system, "[CoolingSystemType='central air conditioner']AnnualCoolingEfficiency[Units='SEER']/Value"))
-      child_vals[:cooling_efficiency_eer] = _to_float_or_nil(XMLHelper.get_value(cooling_system, "[CoolingSystemType='room air conditioner']AnnualCoolingEfficiency[Units='EER']/Value"))
-      child_vals[:cooling_shr] = _to_float_or_nil(XMLHelper.get_value(cooling_system, "SensibleHeatFraction"))
-      child_vals[:cooling_cfm] = _to_float_or_nil(XMLHelper.get_value(cooling_system, "extension/CoolingFlowRate"))
-      child_vals[:energy_star] = XMLHelper.get_values(cooling_system, "ThirdPartyCertification").include?("Energy Star")
-      child_vals[:seed_id] = XMLHelper.get_value(cooling_system, "extension/SeedId")
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_heat_pump(id:,
-                            distribution_system_idref: nil,
-                            heat_pump_type:,
-                            heat_pump_fuel:,
-                            compressor_type: nil,
-                            heating_capacity: nil,
-                            heating_capacity_17F: nil,
-                            cooling_capacity:,
-                            cooling_shr: nil,
-                            backup_heating_fuel: nil,
-                            backup_heating_capacity: nil,
-                            backup_heating_efficiency_percent: nil,
-                            backup_heating_efficiency_afue: nil,
-                            backup_heating_switchover_temp: nil,
-                            fraction_heat_load_served:,
-                            fraction_cool_load_served:,
-                            cooling_efficiency_seer: nil,
-                            cooling_efficiency_eer: nil,
-                            heating_efficiency_hspf: nil,
-                            heating_efficiency_cop: nil)
-    hvac_plant = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC", "HVACPlant"])
-    heat_pump = XMLHelper.add_element(hvac_plant, "HeatPump")
-    sys_id = XMLHelper.add_element(heat_pump, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    unless distribution_system_idref.nil?
-      distribution_system = XMLHelper.add_element(heat_pump, "DistributionSystem")
-      XMLHelper.add_attribute(distribution_system, "idref", distribution_system_idref)
-    end
-    XMLHelper.add_element(heat_pump, "HeatPumpType", heat_pump_type)
-    XMLHelper.add_element(heat_pump, "HeatPumpFuel", heat_pump_fuel)
-    XMLHelper.add_element(heat_pump, "HeatingCapacity", Float(heating_capacity)) unless heating_capacity.nil?
-    XMLHelper.add_element(heat_pump, "HeatingCapacity17F", Float(heating_capacity_17F)) unless heating_capacity_17F.nil?
-    XMLHelper.add_element(heat_pump, "CoolingCapacity", Float(cooling_capacity))
-    XMLHelper.add_element(heat_pump, "CompressorType", compressor_type) unless compressor_type.nil?
-    XMLHelper.add_element(heat_pump, "CoolingSensibleHeatFraction", Float(cooling_shr)) unless cooling_shr.nil?
-    if not backup_heating_fuel.nil?
-      XMLHelper.add_element(heat_pump, "BackupSystemFuel", backup_heating_fuel)
-      efficiencies = { "Percent" => backup_heating_efficiency_percent,
-                       "AFUE" => backup_heating_efficiency_afue }
-      efficiencies.each do |units, value|
-        next if value.nil?
-
-        backup_eff = XMLHelper.add_element(heat_pump, "BackupAnnualHeatingEfficiency")
-        XMLHelper.add_element(backup_eff, "Units", units)
-        XMLHelper.add_element(backup_eff, "Value", Float(value))
-      end
-      XMLHelper.add_element(heat_pump, "BackupHeatingCapacity", Float(backup_heating_capacity))
-      XMLHelper.add_element(heat_pump, "BackupHeatingSwitchoverTemperature", Float(backup_heating_switchover_temp)) unless backup_heating_switchover_temp.nil?
-    end
-    XMLHelper.add_element(heat_pump, "FractionHeatLoadServed", Float(fraction_heat_load_served))
-    XMLHelper.add_element(heat_pump, "FractionCoolLoadServed", Float(fraction_cool_load_served))
-
-    clg_efficiency_units = nil
-    clg_efficiency_value = nil
-    htg_efficiency_units = nil
-    htg_efficiency_value = nil
-    if ["air-to-air", "mini-split"].include? heat_pump_type
-      clg_efficiency_units = "SEER"
-      clg_efficiency_value = cooling_efficiency_seer
-      htg_efficiency_units = "HSPF"
-      htg_efficiency_value = heating_efficiency_hspf
-    elsif ["ground-to-air"].include? heat_pump_type
-      clg_efficiency_units = "EER"
-      clg_efficiency_value = cooling_efficiency_eer
-      htg_efficiency_units = "COP"
-      htg_efficiency_value = heating_efficiency_cop
-    end
-    if not clg_efficiency_value.nil?
-      annual_efficiency = XMLHelper.add_element(heat_pump, "AnnualCoolingEfficiency")
-      XMLHelper.add_element(annual_efficiency, "Units", clg_efficiency_units)
-      XMLHelper.add_element(annual_efficiency, "Value", Float(clg_efficiency_value))
-    end
-    if not htg_efficiency_value.nil?
-      annual_efficiency = XMLHelper.add_element(heat_pump, "AnnualHeatingEfficiency")
-      XMLHelper.add_element(annual_efficiency, "Units", htg_efficiency_units)
-      XMLHelper.add_element(annual_efficiency, "Value", Float(htg_efficiency_value))
-    end
-
-    return heat_pump
-  end
-
-  def _get_object_heat_pumps_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |heat_pump|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(heat_pump)
-      child_vals[:distribution_system_idref] = _get_object_idref(heat_pump, "DistributionSystem")
-      child_vals[:year_installed] = _to_integer_or_nil(XMLHelper.get_value(heat_pump, "YearInstalled"))
-      child_vals[:heat_pump_type] = XMLHelper.get_value(heat_pump, "HeatPumpType")
-      child_vals[:heat_pump_fuel] = XMLHelper.get_value(heat_pump, "HeatPumpFuel")
-      child_vals[:heating_capacity] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "HeatingCapacity"))
-      child_vals[:heating_capacity_17F] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "HeatingCapacity17F"))
-      child_vals[:cooling_capacity] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "CoolingCapacity"))
-      child_vals[:compressor_type] = XMLHelper.get_value(heat_pump, "CompressorType")
-      child_vals[:cooling_shr] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "CoolingSensibleHeatFraction"))
-      child_vals[:backup_heating_fuel] = XMLHelper.get_value(heat_pump, "BackupSystemFuel")
-      child_vals[:backup_heating_capacity] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupHeatingCapacity"))
-      child_vals[:backup_heating_efficiency_percent] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='Percent']/Value"))
-      child_vals[:backup_heating_efficiency_afue] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='AFUE']/Value"))
-      child_vals[:backup_heating_switchover_temp] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupHeatingSwitchoverTemperature"))
-      child_vals[:fraction_heat_load_served] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "FractionHeatLoadServed"))
-      child_vals[:fraction_cool_load_served] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "FractionCoolLoadServed"))
-      child_vals[:cooling_efficiency_seer] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='air-to-air' or HeatPumpType='mini-split']AnnualCoolingEfficiency[Units='SEER']/Value"))
-      child_vals[:cooling_efficiency_eer] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='ground-to-air']AnnualCoolingEfficiency[Units='EER']/Value"))
-      child_vals[:heating_efficiency_hspf] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='air-to-air' or HeatPumpType='mini-split']AnnualHeatingEfficiency[Units='HSPF']/Value"))
-      child_vals[:heating_efficiency_cop] = _to_float_or_nil(XMLHelper.get_value(heat_pump, "[HeatPumpType='ground-to-air']AnnualHeatingEfficiency[Units='COP']/Value"))
-      child_vals[:energy_star] = XMLHelper.get_values(heat_pump, "ThirdPartyCertification").include?("Energy Star")
-      child_vals[:seed_id] = XMLHelper.get_value(heat_pump, "extension/SeedId")
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_hvac_control(id:,
-                               control_type: nil,
-                               heating_setpoint_temp: nil,
-                               heating_setback_temp: nil,
-                               heating_setback_hours_per_week: nil,
-                               heating_setback_start_hour: nil,
-                               cooling_setpoint_temp: nil,
-                               cooling_setup_temp: nil,
-                               cooling_setup_hours_per_week: nil,
-                               cooling_setup_start_hour: nil,
-                               ceiling_fan_cooling_setpoint_temp_offset: nil)
-    hvac = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC"])
-    hvac_control = XMLHelper.add_element(hvac, "HVACControl")
-    sys_id = XMLHelper.add_element(hvac_control, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(hvac_control, "ControlType", control_type) unless control_type.nil?
-    XMLHelper.add_element(hvac_control, "SetpointTempHeatingSeason", Float(heating_setpoint_temp)) unless heating_setpoint_temp.nil?
-    XMLHelper.add_element(hvac_control, "SetbackTempHeatingSeason", Float(heating_setback_temp)) unless heating_setback_temp.nil?
-    XMLHelper.add_element(hvac_control, "TotalSetbackHoursperWeekHeating", Integer(heating_setback_hours_per_week)) unless heating_setback_hours_per_week.nil?
-    XMLHelper.add_element(hvac_control, "SetupTempCoolingSeason", Float(cooling_setup_temp)) unless cooling_setup_temp.nil?
-    XMLHelper.add_element(hvac_control, "SetpointTempCoolingSeason", Float(cooling_setpoint_temp)) unless cooling_setpoint_temp.nil?
-    XMLHelper.add_element(hvac_control, "TotalSetupHoursperWeekCooling", Integer(cooling_setup_hours_per_week)) unless cooling_setup_hours_per_week.nil?
-    _add_object_extension(parent: hvac_control,
-                          extensions: { "SetbackStartHourHeating" => _to_integer_or_nil(heating_setback_start_hour),
-                                        "SetupStartHourCooling" => _to_integer_or_nil(cooling_setup_start_hour),
-                                        "CeilingFanSetpointTempCoolingSeasonOffset" => _to_float_or_nil(ceiling_fan_cooling_setpoint_temp_offset) })
-
-    return hvac_control
-  end
-
-  def _get_object_hvac_control_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    hvac_control = hpxml.elements["Building/BuildingDetails/Systems/HVAC/HVACControl"]
-    return vals if hvac_control.nil?
-
-    vals[:id] = _get_object_id(hvac_control)
-    vals[:control_type] = XMLHelper.get_value(hvac_control, "ControlType")
-    vals[:heating_setpoint_temp] = _to_float_or_nil(XMLHelper.get_value(hvac_control, "SetpointTempHeatingSeason"))
-    vals[:heating_setback_temp] = _to_float_or_nil(XMLHelper.get_value(hvac_control, "SetbackTempHeatingSeason"))
-    vals[:heating_setback_hours_per_week] = _to_integer_or_nil(XMLHelper.get_value(hvac_control, "TotalSetbackHoursperWeekHeating"))
-    vals[:heating_setback_start_hour] = _to_integer_or_nil(XMLHelper.get_value(hvac_control, "extension/SetbackStartHourHeating"))
-    vals[:cooling_setpoint_temp] = _to_float_or_nil(XMLHelper.get_value(hvac_control, "SetpointTempCoolingSeason"))
-    vals[:cooling_setup_temp] = _to_float_or_nil(XMLHelper.get_value(hvac_control, "SetupTempCoolingSeason"))
-    vals[:cooling_setup_hours_per_week] = _to_integer_or_nil(XMLHelper.get_value(hvac_control, "TotalSetupHoursperWeekCooling"))
-    vals[:cooling_setup_start_hour] = _to_integer_or_nil(XMLHelper.get_value(hvac_control, "extension/SetupStartHourCooling"))
-    vals[:ceiling_fan_cooling_setpoint_temp_offset] = _to_float_or_nil(XMLHelper.get_value(hvac_control, "extension/CeilingFanSetpointTempCoolingSeasonOffset"))
-    return vals
-  end
-
-  def _add_object_hvac_distribution(id:,
-                                    distribution_system_type:,
-                                    annual_heating_dse: nil,
-                                    annual_cooling_dse: nil,
-                                    duct_leakage_measurements:,
-                                    ducts:)
-    hvac = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "HVAC"])
-    hvac_distribution = XMLHelper.add_element(hvac, "HVACDistribution")
-    sys_id = XMLHelper.add_element(hvac_distribution, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    distribution_system_type_e = XMLHelper.add_element(hvac_distribution, "DistributionSystemType")
-    if ["AirDistribution", "HydronicDistribution"].include? distribution_system_type
-      XMLHelper.add_element(distribution_system_type_e, distribution_system_type)
-    elsif ["DSE"].include? distribution_system_type
-      XMLHelper.add_element(distribution_system_type_e, "Other", distribution_system_type)
-      XMLHelper.add_element(hvac_distribution, "AnnualHeatingDistributionSystemEfficiency", Float(annual_heating_dse)) unless annual_heating_dse.nil?
-      XMLHelper.add_element(hvac_distribution, "AnnualCoolingDistributionSystemEfficiency", Float(annual_cooling_dse)) unless annual_cooling_dse.nil?
-    else
-      fail "Unexpected distribution_system_type '#{distribution_system_type}'."
-    end
-
-    air_distribution = hvac_distribution.elements["DistributionSystemType/AirDistribution"]
-    return hvac_distribution if air_distribution.nil?
-
-    duct_leakage_measurements.each do |duct_leakage_measurement_values|
-      duct_leakage_measurement_el = XMLHelper.add_element(air_distribution, "DuctLeakageMeasurement")
-      XMLHelper.add_element(duct_leakage_measurement_el, "DuctType", duct_leakage_measurement_values[:duct_type])
-      duct_leakage_el = XMLHelper.add_element(duct_leakage_measurement_el, "DuctLeakage")
-      XMLHelper.add_element(duct_leakage_el, "Units", duct_leakage_measurement_values[:duct_leakage_units])
-      XMLHelper.add_element(duct_leakage_el, "Value", Float(duct_leakage_measurement_values[:duct_leakage_value]))
-      XMLHelper.add_element(duct_leakage_el, "TotalOrToOutside", "to outside")
-    end
-
-    ducts.each do |duct_values|
-      ducts_el = XMLHelper.add_element(air_distribution, "Ducts")
-      XMLHelper.add_element(ducts_el, "DuctType", duct_values[:duct_type])
-      XMLHelper.add_element(ducts_el, "DuctInsulationRValue", Float(duct_values[:duct_insulation_r_value]))
-      XMLHelper.add_element(ducts_el, "DuctLocation", duct_values[:duct_location])
-      XMLHelper.add_element(ducts_el, "DuctSurfaceArea", Float(duct_values[:duct_surface_area]))
-    end
-
-    return hvac_distribution
-  end
-
-  def _get_object_hvac_distributions_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Systems/HVAC/HVACDistribution") do |hvac_distribution|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(hvac_distribution)
-      child_vals[:distribution_system_type] = XMLHelper.get_child_name(hvac_distribution, "DistributionSystemType")
-      if child_vals[:distribution_system_type] == "Other"
-        child_vals[:distribution_system_type] = XMLHelper.get_value(hvac_distribution.elements["DistributionSystemType"], "Other")
-      end
-      child_vals[:annual_heating_dse] = _to_float_or_nil(XMLHelper.get_value(hvac_distribution, "AnnualHeatingDistributionSystemEfficiency"))
-      child_vals[:annual_cooling_dse] = _to_float_or_nil(XMLHelper.get_value(hvac_distribution, "AnnualCoolingDistributionSystemEfficiency"))
-      child_vals[:duct_system_sealed] = _to_bool_or_nil(XMLHelper.get_value(hvac_distribution, "HVACDistributionImprovement/DuctSystemSealed"))
-
-      child_vals[:duct_leakage_measurements] = []
-      hvac_distribution.elements.each("DistributionSystemType/AirDistribution/DuctLeakageMeasurement") do |duct_leakage_measurement|
-        child2_vals = {}
-        child2_vals[:duct_type] = XMLHelper.get_value(duct_leakage_measurement, "DuctType")
-        child2_vals[:duct_leakage_test_method] = XMLHelper.get_value(duct_leakage_measurement, "DuctLeakageTestMethod")
-        child2_vals[:duct_leakage_units] = XMLHelper.get_value(duct_leakage_measurement, "DuctLeakage/Units")
-        child2_vals[:duct_leakage_value] = _to_float_or_nil(XMLHelper.get_value(duct_leakage_measurement, "DuctLeakage/Value"))
-        child2_vals[:duct_leakage_total_or_to_outside] = XMLHelper.get_value(duct_leakage_measurement, "DuctLeakage/TotalOrToOutside")
-        child_vals[:duct_leakage_measurements] << child2_vals
-      end
-
-      child_vals[:ducts] = []
-      hvac_distribution.elements.each("DistributionSystemType/AirDistribution/Ducts") do |ducts|
-        child2_vals = {}
-        child2_vals[:duct_type] = XMLHelper.get_value(ducts, "DuctType")
-        child2_vals[:duct_insulation_r_value] = _to_float_or_nil(XMLHelper.get_value(ducts, "DuctInsulationRValue"))
-        child2_vals[:duct_insulation_material] = XMLHelper.get_child_name(ducts, "DuctInsulationMaterial")
-        child2_vals[:duct_location] = XMLHelper.get_value(ducts, "DuctLocation")
-        child2_vals[:duct_fraction_area] = _to_float_or_nil(XMLHelper.get_value(ducts, "FractionDuctArea"))
-        child2_vals[:duct_surface_area] = _to_float_or_nil(XMLHelper.get_value(ducts, "DuctSurfaceArea"))
-        child_vals[:ducts] << child2_vals
-      end
-
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_ventilation_fan(id:,
-                                  fan_type: nil,
-                                  rated_flow_rate: nil,
-                                  tested_flow_rate: nil,
-                                  hours_in_operation: nil,
-                                  used_for_whole_building_ventilation: nil,
-                                  used_for_seasonal_cooling_load_reduction: nil,
-                                  total_recovery_efficiency: nil,
-                                  total_recovery_efficiency_adjusted: nil,
-                                  sensible_recovery_efficiency: nil,
-                                  sensible_recovery_efficiency_adjusted: nil,
-                                  fan_power: nil,
-                                  distribution_system_idref: nil)
-    ventilation_fans = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "MechanicalVentilation", "VentilationFans"])
-    ventilation_fan = XMLHelper.add_element(ventilation_fans, "VentilationFan")
-    sys_id = XMLHelper.add_element(ventilation_fan, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(ventilation_fan, "FanType", fan_type) unless fan_type.nil?
-    XMLHelper.add_element(ventilation_fan, "RatedFlowRate", Float(rated_flow_rate)) unless rated_flow_rate.nil?
-    XMLHelper.add_element(ventilation_fan, "TestedFlowRate", Float(tested_flow_rate)) unless tested_flow_rate.nil?
-    XMLHelper.add_element(ventilation_fan, "HoursInOperation", Float(hours_in_operation)) unless hours_in_operation.nil?
-    XMLHelper.add_element(ventilation_fan, "UsedForWholeBuildingVentilation", Boolean(used_for_whole_building_ventilation)) unless used_for_whole_building_ventilation.nil?
-    XMLHelper.add_element(ventilation_fan, "UsedForSeasonalCoolingLoadReduction", Boolean(used_for_seasonal_cooling_load_reduction)) unless used_for_seasonal_cooling_load_reduction.nil?
-    XMLHelper.add_element(ventilation_fan, "TotalRecoveryEfficiency", Float(total_recovery_efficiency)) unless total_recovery_efficiency.nil?
-    XMLHelper.add_element(ventilation_fan, "SensibleRecoveryEfficiency", Float(sensible_recovery_efficiency)) unless sensible_recovery_efficiency.nil?
-    XMLHelper.add_element(ventilation_fan, "AdjustedTotalRecoveryEfficiency", Float(total_recovery_efficiency_adjusted)) unless total_recovery_efficiency_adjusted.nil?
-    XMLHelper.add_element(ventilation_fan, "AdjustedSensibleRecoveryEfficiency", Float(sensible_recovery_efficiency_adjusted)) unless sensible_recovery_efficiency_adjusted.nil?
-    XMLHelper.add_element(ventilation_fan, "FanPower", Float(fan_power)) unless fan_power.nil?
-    unless distribution_system_idref.nil?
-      attached_to_hvac_distribution_system = XMLHelper.add_element(ventilation_fan, "AttachedToHVACDistributionSystem")
-      XMLHelper.add_attribute(attached_to_hvac_distribution_system, "idref", distribution_system_idref)
-    end
-
-    return ventilation_fan
-  end
-
-  def _get_object_ventilation_fans_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan") do |ventilation_fan|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(ventilation_fan)
-      child_vals[:fan_type] = XMLHelper.get_value(ventilation_fan, "FanType")
-      child_vals[:rated_flow_rate] = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "RatedFlowRate"))
-      child_vals[:tested_flow_rate] = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "TestedFlowRate"))
-      child_vals[:hours_in_operation] = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "HoursInOperation"))
-      child_vals[:used_for_whole_building_ventilation] = _to_bool_or_nil(XMLHelper.get_value(ventilation_fan, "UsedForWholeBuildingVentilation"))
-      child_vals[:used_for_seasonal_cooling_load_reduction] = _to_bool_or_nil(XMLHelper.get_value(ventilation_fan, "UsedForSeasonalCoolingLoadReduction"))
-      child_vals[:total_recovery_efficiency] = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "TotalRecoveryEfficiency"))
-      child_vals[:total_recovery_efficiency_adjusted] = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "AdjustedTotalRecoveryEfficiency"))
-      child_vals[:sensible_recovery_efficiency] = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "SensibleRecoveryEfficiency"))
-      child_vals[:sensible_recovery_efficiency_adjusted] = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "AdjustedSensibleRecoveryEfficiency"))
-      child_vals[:fan_power] = _to_float_or_nil(XMLHelper.get_value(ventilation_fan, "FanPower"))
-      child_vals[:distribution_system_idref] = _get_object_idref(ventilation_fan, "AttachedToHVACDistributionSystem")
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_water_heating_system(id:,
-                                       fuel_type: nil,
-                                       water_heater_type:,
-                                       location:,
-                                       performance_adjustment: nil,
-                                       tank_volume: nil,
-                                       fraction_dhw_load_served:,
-                                       heating_capacity: nil,
-                                       energy_factor: nil,
-                                       uniform_energy_factor: nil,
-                                       recovery_efficiency: nil,
-                                       uses_desuperheater: nil,
-                                       jacket_r_value: nil,
-                                       temperature: nil,
-                                       related_hvac: nil,
-                                       standby_loss: nil)
-    water_heating = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
-    water_heating_system = XMLHelper.add_element(water_heating, "WaterHeatingSystem")
-    sys_id = XMLHelper.add_element(water_heating_system, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(water_heating_system, "FuelType", fuel_type) unless fuel_type.nil?
-    XMLHelper.add_element(water_heating_system, "WaterHeaterType", water_heater_type)
-    XMLHelper.add_element(water_heating_system, "Location", location)
-    XMLHelper.add_element(water_heating_system, "PerformanceAdjustment", Float(performance_adjustment)) unless performance_adjustment.nil?
-    XMLHelper.add_element(water_heating_system, "TankVolume", Float(tank_volume)) unless tank_volume.nil?
-    XMLHelper.add_element(water_heating_system, "FractionDHWLoadServed", Float(fraction_dhw_load_served))
-    XMLHelper.add_element(water_heating_system, "HeatingCapacity", Float(heating_capacity)) unless heating_capacity.nil?
-    XMLHelper.add_element(water_heating_system, "EnergyFactor", Float(energy_factor)) unless energy_factor.nil?
-    XMLHelper.add_element(water_heating_system, "UniformEnergyFactor", Float(uniform_energy_factor)) unless uniform_energy_factor.nil?
-    XMLHelper.add_element(water_heating_system, "RecoveryEfficiency", Float(recovery_efficiency)) unless recovery_efficiency.nil?
-    unless jacket_r_value.nil?
-      water_heater_insulation = XMLHelper.add_element(water_heating_system, "WaterHeaterInsulation")
-      jacket = XMLHelper.add_element(water_heater_insulation, "Jacket")
-      XMLHelper.add_element(jacket, "JacketRValue", jacket_r_value)
-    end
-    XMLHelper.add_element(water_heating_system, "StandbyLoss", Float(standby_loss)) unless standby_loss.nil?
-    XMLHelper.add_element(water_heating_system, "HotWaterTemperature", Float(temperature)) unless temperature.nil?
-    XMLHelper.add_element(water_heating_system, "UsesDesuperheater", Boolean(uses_desuperheater)) unless uses_desuperheater.nil?
-    unless related_hvac.nil?
-      related_hvac_el = XMLHelper.add_element(water_heating_system, "RelatedHVACSystem")
-      XMLHelper.add_attribute(related_hvac_el, "idref", related_hvac)
-    end
-
-    return water_heating_system
-  end
-
-  def _get_object_water_heating_systems_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem") do |water_heating_system|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(water_heating_system)
-      child_vals[:year_installed] = _to_integer_or_nil(XMLHelper.get_value(water_heating_system, "YearInstalled"))
-      child_vals[:fuel_type] = XMLHelper.get_value(water_heating_system, "FuelType")
-      child_vals[:water_heater_type] = XMLHelper.get_value(water_heating_system, "WaterHeaterType")
-      child_vals[:location] = XMLHelper.get_value(water_heating_system, "Location")
-      child_vals[:performance_adjustment] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "PerformanceAdjustment"))
-      child_vals[:tank_volume] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "TankVolume"))
-      child_vals[:fraction_dhw_load_served] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "FractionDHWLoadServed"))
-      child_vals[:heating_capacity] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "HeatingCapacity"))
-      child_vals[:energy_factor] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "EnergyFactor"))
-      child_vals[:uniform_energy_factor] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "UniformEnergyFactor"))
-      child_vals[:recovery_efficiency] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "RecoveryEfficiency"))
-      child_vals[:uses_desuperheater] = _to_bool_or_nil(XMLHelper.get_value(water_heating_system, "UsesDesuperheater"))
-      child_vals[:jacket_r_value] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "WaterHeaterInsulation/Jacket/JacketRValue"))
-      child_vals[:related_hvac] = _get_object_idref(water_heating_system, "RelatedHVACSystem")
-      child_vals[:energy_star] = XMLHelper.get_values(water_heating_system, "ThirdPartyCertification").include?("Energy Star")
-      child_vals[:standby_loss] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "StandbyLoss"))
-      child_vals[:temperature] = _to_float_or_nil(XMLHelper.get_value(water_heating_system, "HotWaterTemperature"))
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_hot_water_distribution(id:,
-                                         system_type:,
-                                         pipe_r_value:,
-                                         standard_piping_length: nil,
-                                         recirculation_control_type: nil,
-                                         recirculation_piping_length: nil,
-                                         recirculation_branch_piping_length: nil,
-                                         recirculation_pump_power: nil,
-                                         dwhr_facilities_connected: nil,
-                                         dwhr_equal_flow: nil,
-                                         dwhr_efficiency: nil)
-    water_heating = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
-    hot_water_distribution = XMLHelper.add_element(water_heating, "HotWaterDistribution")
-    sys_id = XMLHelper.add_element(hot_water_distribution, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    system_type_e = XMLHelper.add_element(hot_water_distribution, "SystemType")
-    if system_type == "Standard"
-      standard = XMLHelper.add_element(system_type_e, system_type)
-      XMLHelper.add_element(standard, "PipingLength", Float(standard_piping_length))
-    elsif system_type == "Recirculation"
-      recirculation = XMLHelper.add_element(system_type_e, system_type)
-      XMLHelper.add_element(recirculation, "ControlType", recirculation_control_type)
-      XMLHelper.add_element(recirculation, "RecirculationPipingLoopLength", Float(recirculation_piping_length))
-      XMLHelper.add_element(recirculation, "BranchPipingLoopLength", Float(recirculation_branch_piping_length))
-      XMLHelper.add_element(recirculation, "PumpPower", Float(recirculation_pump_power))
-    else
-      fail "Unhandled hot water distribution type '#{system_type}'."
-    end
-    pipe_insulation = XMLHelper.add_element(hot_water_distribution, "PipeInsulation")
-    XMLHelper.add_element(pipe_insulation, "PipeRValue", Float(pipe_r_value))
-    if not dwhr_facilities_connected.nil? or not dwhr_equal_flow.nil? or not dwhr_efficiency.nil?
-      drain_water_heat_recovery = XMLHelper.add_element(hot_water_distribution, "DrainWaterHeatRecovery")
-      XMLHelper.add_element(drain_water_heat_recovery, "FacilitiesConnected", dwhr_facilities_connected)
-      XMLHelper.add_element(drain_water_heat_recovery, "EqualFlow", Boolean(dwhr_equal_flow))
-      XMLHelper.add_element(drain_water_heat_recovery, "Efficiency", Float(dwhr_efficiency))
-    end
-
-    return hot_water_distribution
-  end
-
-  def _get_object_hot_water_distribution_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    hot_water_distribution = hpxml.elements["Building/BuildingDetails/Systems/WaterHeating/HotWaterDistribution"]
-    return vals if hot_water_distribution.nil?
-
-    vals[:id] = _get_object_id(hot_water_distribution)
-    vals[:system_type] = XMLHelper.get_child_name(hot_water_distribution, "SystemType")
-    vals[:pipe_r_value] = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "PipeInsulation/PipeRValue"))
-    vals[:standard_piping_length] = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "SystemType/Standard/PipingLength"))
-    vals[:recirculation_control_type] = XMLHelper.get_value(hot_water_distribution, "SystemType/Recirculation/ControlType")
-    vals[:recirculation_piping_length] = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "SystemType/Recirculation/RecirculationPipingLoopLength"))
-    vals[:recirculation_branch_piping_length] = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "SystemType/Recirculation/BranchPipingLoopLength"))
-    vals[:recirculation_pump_power] = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "SystemType/Recirculation/PumpPower"))
-    vals[:dwhr_facilities_connected] = XMLHelper.get_value(hot_water_distribution, "DrainWaterHeatRecovery/FacilitiesConnected")
-    vals[:dwhr_equal_flow] = _to_bool_or_nil(XMLHelper.get_value(hot_water_distribution, "DrainWaterHeatRecovery/EqualFlow"))
-    vals[:dwhr_efficiency] = _to_float_or_nil(XMLHelper.get_value(hot_water_distribution, "DrainWaterHeatRecovery/Efficiency"))
-    return vals
-  end
-
-  def _add_object_water_fixture(id:,
-                                water_fixture_type:,
-                                low_flow:)
-    water_heating = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "WaterHeating"])
-    water_fixture = XMLHelper.add_element(water_heating, "WaterFixture")
-    sys_id = XMLHelper.add_element(water_fixture, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(water_fixture, "WaterFixtureType", water_fixture_type)
-    XMLHelper.add_element(water_fixture, "LowFlow", Boolean(low_flow))
-
-    return water_fixture
-  end
-
-  def _get_object_water_fixtures_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("BuildingDetails/Systems/WaterHeating/WaterFixture") do |water_fixture|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(water_fixture)
-      child_vals[:water_fixture_type] = XMLHelper.get_value(water_fixture, "WaterFixtureType")
-      child_vals[:low_flow] = _to_bool_or_nil(XMLHelper.get_value(water_fixture, "LowFlow"))
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_solar_thermal_system(id:,
-                                       system_type:,
-                                       collector_area: nil,
-                                       collector_loop_type: nil,
-                                       collector_azimuth: nil,
-                                       collector_type: nil,
-                                       collector_tilt: nil,
-                                       collector_frta: nil,
-                                       collector_frul: nil,
-                                       storage_volume: nil,
-                                       water_heating_system_idref:,
-                                       solar_fraction: nil)
-
-    solar_thermal = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "SolarThermal"])
-    solar_thermal_system = XMLHelper.add_element(solar_thermal, "SolarThermalSystem")
-    sys_id = XMLHelper.add_element(solar_thermal_system, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(solar_thermal_system, "SystemType", system_type)
-    XMLHelper.add_element(solar_thermal_system, "CollectorArea", Float(collector_area)) unless collector_area.nil?
-    XMLHelper.add_element(solar_thermal_system, "CollectorLoopType", collector_loop_type) unless collector_loop_type.nil?
-    XMLHelper.add_element(solar_thermal_system, "CollectorType", collector_type) unless collector_type.nil?
-    XMLHelper.add_element(solar_thermal_system, "CollectorAzimuth", Integer(collector_azimuth)) unless collector_azimuth.nil?
-    XMLHelper.add_element(solar_thermal_system, "CollectorTilt", Float(collector_tilt)) unless collector_tilt.nil?
-    XMLHelper.add_element(solar_thermal_system, "CollectorRatedOpticalEfficiency", Float(collector_frta)) unless collector_frta.nil?
-    XMLHelper.add_element(solar_thermal_system, "CollectorRatedThermalLosses", Float(collector_frul)) unless collector_frul.nil?
-    XMLHelper.add_element(solar_thermal_system, "StorageVolume", Float(storage_volume)) unless storage_volume.nil?
-    connected_to = XMLHelper.add_element(solar_thermal_system, "ConnectedTo")
-    XMLHelper.add_attribute(connected_to, "idref", water_heating_system_idref)
-    XMLHelper.add_element(solar_thermal_system, "SolarFraction", Float(solar_fraction)) unless solar_fraction.nil?
-
-    return solar_thermal_system
-  end
-
-  def _get_object_solar_thermal_system_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    solar_thermal_system = hpxml.elements["Building/BuildingDetails/Systems/SolarThermal/SolarThermalSystem"]
-    return vals if solar_thermal_system.nil?
-
-    vals[:id] = _get_object_id(solar_thermal_system)
-    vals[:system_type] = XMLHelper.get_value(solar_thermal_system, "SystemType")
-    vals[:collector_area] = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorArea"))
-    vals[:collector_loop_type] = XMLHelper.get_value(solar_thermal_system, "CollectorLoopType")
-    vals[:collector_azimuth] = _to_integer_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorAzimuth"))
-    vals[:collector_type] = XMLHelper.get_value(solar_thermal_system, "CollectorType")
-    vals[:collector_tilt] = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorTilt"))
-    vals[:collector_frta] = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorRatedOpticalEfficiency"))
-    vals[:collector_frul] = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "CollectorRatedThermalLosses"))
-    vals[:storage_volume] = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "StorageVolume"))
-    vals[:water_heating_system_idref] = _get_object_idref(solar_thermal_system, "ConnectedTo")
-    vals[:solar_fraction] = _to_float_or_nil(XMLHelper.get_value(solar_thermal_system, "SolarFraction"))
-    return vals
-  end
-
-  def _add_object_pv_system(id:,
-                            location:,
-                            module_type:,
-                            tracking:,
-                            array_azimuth:,
-                            array_tilt:,
-                            max_power_output:,
-                            inverter_efficiency:,
-                            system_losses_fraction:)
-    photovoltaics = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Systems", "Photovoltaics"])
-    pv_system = XMLHelper.add_element(photovoltaics, "PVSystem")
-    sys_id = XMLHelper.add_element(pv_system, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(pv_system, "Location", location)
-    XMLHelper.add_element(pv_system, "ModuleType", module_type)
-    XMLHelper.add_element(pv_system, "Tracking", tracking)
-    XMLHelper.add_element(pv_system, "ArrayAzimuth", Integer(array_azimuth))
-    XMLHelper.add_element(pv_system, "ArrayTilt", Float(array_tilt))
-    XMLHelper.add_element(pv_system, "MaxPowerOutput", Float(max_power_output))
-    XMLHelper.add_element(pv_system, "InverterEfficiency", Float(inverter_efficiency))
-    XMLHelper.add_element(pv_system, "SystemLossesFraction", Float(system_losses_fraction))
-
-    return pv_system
-  end
-
-  def _get_object_pv_systems_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Systems/Photovoltaics/PVSystem") do |pv_system|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(pv_system)
-      child_vals[:location] = XMLHelper.get_value(pv_system, "Location")
-      child_vals[:module_type] = XMLHelper.get_value(pv_system, "ModuleType")
-      child_vals[:tracking] = XMLHelper.get_value(pv_system, "Tracking")
-      child_vals[:array_orientation] = XMLHelper.get_value(pv_system, "ArrayOrientation")
-      child_vals[:array_azimuth] = _to_integer_or_nil(XMLHelper.get_value(pv_system, "ArrayAzimuth"))
-      child_vals[:array_tilt] = _to_float_or_nil(XMLHelper.get_value(pv_system, "ArrayTilt"))
-      child_vals[:max_power_output] = _to_float_or_nil(XMLHelper.get_value(pv_system, "MaxPowerOutput"))
-      child_vals[:inverter_efficiency] = _to_float_or_nil(XMLHelper.get_value(pv_system, "InverterEfficiency"))
-      child_vals[:system_losses_fraction] = _to_float_or_nil(XMLHelper.get_value(pv_system, "SystemLossesFraction"))
-      child_vals[:number_of_panels] = _to_integer_or_nil(XMLHelper.get_value(pv_system, "NumberOfPanels"))
-      child_vals[:year_modules_manufactured] = _to_integer_or_nil(XMLHelper.get_value(pv_system, "YearModulesManufactured"))
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_clothes_washer(id:,
-                                 location:,
-                                 modified_energy_factor: nil,
-                                 integrated_modified_energy_factor: nil,
-                                 rated_annual_kwh:,
-                                 label_electric_rate:,
-                                 label_gas_rate:,
-                                 label_annual_gas_cost:,
-                                 capacity:)
-    appliances = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Appliances"])
-    clothes_washer = XMLHelper.add_element(appliances, "ClothesWasher")
-    sys_id = XMLHelper.add_element(clothes_washer, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(clothes_washer, "Location", location)
-    if not modified_energy_factor.nil?
-      XMLHelper.add_element(clothes_washer, "ModifiedEnergyFactor", Float(modified_energy_factor))
-    elsif not integrated_modified_energy_factor.nil?
-      XMLHelper.add_element(clothes_washer, "IntegratedModifiedEnergyFactor", Float(integrated_modified_energy_factor))
-    else
-      fail "Either modified_energy_factor or integrated_modified_energy_factor must be provided."
-    end
-    XMLHelper.add_element(clothes_washer, "RatedAnnualkWh", Float(rated_annual_kwh))
-    XMLHelper.add_element(clothes_washer, "LabelElectricRate", Float(label_electric_rate))
-    XMLHelper.add_element(clothes_washer, "LabelGasRate", Float(label_gas_rate))
-    XMLHelper.add_element(clothes_washer, "LabelAnnualGasCost", Float(label_annual_gas_cost))
-    XMLHelper.add_element(clothes_washer, "Capacity", Float(capacity))
-
-    return clothes_washer
-  end
-
-  def _get_object_clothes_washer_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    clothes_washer = hpxml.elements["Building/BuildingDetails/Appliances/ClothesWasher"]
-    return vals if clothes_washer.nil?
-
-    vals[:id] = _get_object_id(clothes_washer)
-    vals[:location] = XMLHelper.get_value(clothes_washer, "Location")
-    vals[:modified_energy_factor] = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "ModifiedEnergyFactor"))
-    vals[:integrated_modified_energy_factor] = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "IntegratedModifiedEnergyFactor"))
-    vals[:rated_annual_kwh] = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "RatedAnnualkWh"))
-    vals[:label_electric_rate] = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "LabelElectricRate"))
-    vals[:label_gas_rate] = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "LabelGasRate"))
-    vals[:label_annual_gas_cost] = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "LabelAnnualGasCost"))
-    vals[:capacity] = _to_float_or_nil(XMLHelper.get_value(clothes_washer, "Capacity"))
-    return vals
-  end
-
-  def _add_object_clothes_dryer(id:,
-                                location:,
-                                fuel_type:,
-                                energy_factor: nil,
-                                combined_energy_factor: nil,
-                                control_type:)
-    appliances = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Appliances"])
-    clothes_dryer = XMLHelper.add_element(appliances, "ClothesDryer")
-    sys_id = XMLHelper.add_element(clothes_dryer, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(clothes_dryer, "Location", location)
-    XMLHelper.add_element(clothes_dryer, "FuelType", fuel_type)
-    if not energy_factor.nil?
-      XMLHelper.add_element(clothes_dryer, "EnergyFactor", Float(energy_factor))
-    elsif not combined_energy_factor.nil?
-      XMLHelper.add_element(clothes_dryer, "CombinedEnergyFactor", Float(combined_energy_factor))
-    else
-      fail "Either energy_factor or combined_energy_factor must be provided."
-    end
-    XMLHelper.add_element(clothes_dryer, "ControlType", control_type)
-
-    return clothes_dryer
-  end
-
-  def _get_object_clothes_dryer_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    clothes_dryer = hpxml.elements["Building/BuildingDetails/Appliances/ClothesDryer"]
-    return vals if clothes_dryer.nil?
-
-    vals[:id] = _get_object_id(clothes_dryer)
-    vals[:location] = XMLHelper.get_value(clothes_dryer, "Location")
-    vals[:fuel_type] = XMLHelper.get_value(clothes_dryer, "FuelType")
-    vals[:energy_factor] = _to_float_or_nil(XMLHelper.get_value(clothes_dryer, "EnergyFactor"))
-    vals[:combined_energy_factor] = _to_float_or_nil(XMLHelper.get_value(clothes_dryer, "CombinedEnergyFactor"))
-    vals[:control_type] = XMLHelper.get_value(clothes_dryer, "ControlType")
-    return vals
-  end
-
-  def _add_object_dishwasher(id:,
-                             energy_factor: nil,
-                             rated_annual_kwh: nil,
-                             place_setting_capacity:)
-    appliances = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Appliances"])
-    dishwasher = XMLHelper.add_element(appliances, "Dishwasher")
-    sys_id = XMLHelper.add_element(dishwasher, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    if not energy_factor.nil?
-      XMLHelper.add_element(dishwasher, "EnergyFactor", Float(energy_factor))
-    elsif not rated_annual_kwh.nil?
-      XMLHelper.add_element(dishwasher, "RatedAnnualkWh", Float(rated_annual_kwh))
-    else
-      fail "Either energy_factor or rated_annual_kwh must be provided."
-    end
-    XMLHelper.add_element(dishwasher, "PlaceSettingCapacity", Integer(place_setting_capacity)) unless place_setting_capacity.nil?
-
-    return dishwasher
-  end
-
-  def _get_object_dishwasher_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    dishwasher = hpxml.elements["Building/BuildingDetails/Appliances/Dishwasher"]
-    return vals if dishwasher.nil?
-
-    vals[:id] = _get_object_id(dishwasher)
-    vals[:energy_factor] = _to_float_or_nil(XMLHelper.get_value(dishwasher, "EnergyFactor"))
-    vals[:rated_annual_kwh] = _to_float_or_nil(XMLHelper.get_value(dishwasher, "RatedAnnualkWh"))
-    vals[:place_setting_capacity] = _to_integer_or_nil(XMLHelper.get_value(dishwasher, "PlaceSettingCapacity"))
-    return vals
-  end
-
-  def _add_object_refrigerator(id:,
-                               location:,
-                               rated_annual_kwh: nil,
-                               adjusted_annual_kwh: nil)
-    appliances = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Appliances"])
-    refrigerator = XMLHelper.add_element(appliances, "Refrigerator")
-    sys_id = XMLHelper.add_element(refrigerator, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(refrigerator, "Location", location)
-    XMLHelper.add_element(refrigerator, "RatedAnnualkWh", Float(rated_annual_kwh)) unless rated_annual_kwh.nil?
-    _add_object_extension(parent: refrigerator,
-                          extensions: { "AdjustedAnnualkWh" => _to_float_or_nil(adjusted_annual_kwh) })
-
-    return refrigerator
-  end
-
-  def _get_object_refrigerator_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    refrigerator = hpxml.elements["Building/BuildingDetails/Appliances/Refrigerator"]
-    return vals if refrigerator.nil?
-
-    vals[:id] = _get_object_id(refrigerator)
-    vals[:location] = XMLHelper.get_value(refrigerator, "Location")
-    vals[:rated_annual_kwh] = _to_float_or_nil(XMLHelper.get_value(refrigerator, "RatedAnnualkWh"))
-    vals[:adjusted_annual_kwh] = _to_float_or_nil(XMLHelper.get_value(refrigerator, "extension/AdjustedAnnualkWh"))
-    return vals
-  end
-
-  def _add_object_cooking_range(id:,
-                                fuel_type:,
-                                is_induction:)
-    appliances = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Appliances"])
-    cooking_range = XMLHelper.add_element(appliances, "CookingRange")
-    sys_id = XMLHelper.add_element(cooking_range, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(cooking_range, "FuelType", fuel_type)
-    XMLHelper.add_element(cooking_range, "IsInduction", Boolean(is_induction))
-
-    return cooking_range
-  end
-
-  def _get_object_cooking_range_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    cooking_range = hpxml.elements["Building/BuildingDetails/Appliances/CookingRange"]
-    return vals if cooking_range.nil?
-
-    vals[:id] = _get_object_id(cooking_range)
-    vals[:fuel_type] = XMLHelper.get_value(cooking_range, "FuelType")
-    vals[:is_induction] = _to_bool_or_nil(XMLHelper.get_value(cooking_range, "IsInduction"))
-    return vals
-  end
-
-  def _add_object_oven(id:,
-                       is_convection:)
-    appliances = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Appliances"])
-    oven = XMLHelper.add_element(appliances, "Oven")
-    sys_id = XMLHelper.add_element(oven, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(oven, "IsConvection", Boolean(is_convection))
-
-    return oven
-  end
-
-  def _get_object_oven_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    oven = hpxml.elements["Building/BuildingDetails/Appliances/Oven"]
-    return vals if oven.nil?
-
-    vals[:id] = _get_object_id(oven)
-    vals[:is_convection] = _to_bool_or_nil(XMLHelper.get_value(oven, "IsConvection"))
-    return vals
-  end
-
-  def _add_object_lighting(fraction_tier_i_interior:,
-                           fraction_tier_i_exterior:,
-                           fraction_tier_i_garage:,
-                           fraction_tier_ii_interior:,
-                           fraction_tier_ii_exterior:,
-                           fraction_tier_ii_garage:)
-    lighting = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Lighting"])
-
-    lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
-    sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", "Lighting_TierI_Interior")
-    XMLHelper.add_element(lighting_group, "Location", "interior")
-    XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(fraction_tier_i_interior))
-    XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier I")
-
-    lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
-    sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", "Lighting_TierI_Exterior")
-    XMLHelper.add_element(lighting_group, "Location", "exterior")
-    XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(fraction_tier_i_exterior))
-    XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier I")
-
-    lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
-    sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", "Lighting_TierI_Garage")
-    XMLHelper.add_element(lighting_group, "Location", "garage")
-    XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(fraction_tier_i_garage))
-    XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier I")
-
-    lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
-    sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", "Lighting_TierII_Interior")
-    XMLHelper.add_element(lighting_group, "Location", "interior")
-    XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(fraction_tier_ii_interior))
-    XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier II")
-
-    lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
-    sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", "Lighting_TierII_Exterior")
-    XMLHelper.add_element(lighting_group, "Location", "exterior")
-    XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(fraction_tier_ii_exterior))
-    XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier II")
-
-    lighting_group = XMLHelper.add_element(lighting, "LightingGroup")
-    sys_id = XMLHelper.add_element(lighting_group, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", "Lighting_TierII_Garage")
-    XMLHelper.add_element(lighting_group, "Location", "garage")
-    XMLHelper.add_element(lighting_group, "FractionofUnitsInLocation", Float(fraction_tier_ii_garage))
-    XMLHelper.add_element(lighting_group, "ThirdPartyCertification", "ERI Tier II")
-
-    return lighting_group
-  end
-
-  def _get_object_lighting_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    lighting = hpxml.elements["Building/BuildingDetails/Lighting"]
-    return vals if lighting.nil?
-
-    vals[:fraction_tier_i_interior] = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier I' and Location='interior']/FractionofUnitsInLocation"))
-    vals[:fraction_tier_i_exterior] = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier I' and Location='exterior']/FractionofUnitsInLocation"))
-    vals[:fraction_tier_i_garage] = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier I' and Location='garage']/FractionofUnitsInLocation"))
-    vals[:fraction_tier_ii_interior] = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier II' and Location='interior']/FractionofUnitsInLocation"))
-    vals[:fraction_tier_ii_exterior] = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier II' and Location='exterior']/FractionofUnitsInLocation"))
-    vals[:fraction_tier_ii_garage] = _to_float_or_nil(XMLHelper.get_value(lighting, "LightingGroup[ThirdPartyCertification='ERI Tier II' and Location='garage']/FractionofUnitsInLocation"))
-    return vals
-  end
-
-  def _add_object_ceiling_fan(id:,
-                              efficiency: nil,
-                              quantity: nil)
-    lighting = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "Lighting"])
-    ceiling_fan = XMLHelper.add_element(lighting, "CeilingFan")
-    sys_id = XMLHelper.add_element(ceiling_fan, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    if not efficiency.nil?
-      airflow = XMLHelper.add_element(ceiling_fan, "Airflow")
-      XMLHelper.add_element(airflow, "FanSpeed", "medium")
-      XMLHelper.add_element(airflow, "Efficiency", Float(efficiency))
-    end
-    XMLHelper.add_element(ceiling_fan, "Quantity", Integer(quantity)) unless quantity.nil?
-
-    return ceiling_fan
-  end
-
-  def _get_object_ceiling_fans_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/Lighting/CeilingFan") do |ceiling_fan|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(ceiling_fan)
-      child_vals[:efficiency] = _to_float_or_nil(XMLHelper.get_value(ceiling_fan, "Airflow[FanSpeed='medium']/Efficiency"))
-      child_vals[:quantity] = _to_integer_or_nil(XMLHelper.get_value(ceiling_fan, "Quantity"))
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_plug_load(id:,
-                            plug_load_type: nil,
-                            kWh_per_year: nil,
-                            frac_sensible: nil,
-                            frac_latent: nil)
-    misc_loads = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "MiscLoads"])
-    plug_load = XMLHelper.add_element(misc_loads, "PlugLoad")
-    sys_id = XMLHelper.add_element(plug_load, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", id)
-    XMLHelper.add_element(plug_load, "PlugLoadType", plug_load_type) unless plug_load_type.nil?
-    if not kWh_per_year.nil?
-      load = XMLHelper.add_element(plug_load, "Load")
-      XMLHelper.add_element(load, "Units", "kWh/year")
-      XMLHelper.add_element(load, "Value", Float(kWh_per_year))
-    end
-    _add_object_extension(parent: plug_load,
-                          extensions: { "FracSensible" => _to_float_or_nil(frac_sensible),
-                                        "FracLatent" => _to_float_or_nil(frac_latent) })
-
-    return plug_load
-  end
-
-  def _get_object_plug_loads_values(hpxml:)
-    vals = []
-    return vals if hpxml.nil?
-
-    hpxml.elements.each("Building/BuildingDetails/MiscLoads/PlugLoad") do |plug_load|
-      child_vals = {}
-      child_vals[:id] = _get_object_id(plug_load)
-      child_vals[:plug_load_type] = XMLHelper.get_value(plug_load, "PlugLoadType")
-      child_vals[:kWh_per_year] = _to_float_or_nil(XMLHelper.get_value(plug_load, "Load[Units='kWh/year']/Value"))
-      child_vals[:frac_sensible] = _to_float_or_nil(XMLHelper.get_value(plug_load, "extension/FracSensible"))
-      child_vals[:frac_latent] = _to_float_or_nil(XMLHelper.get_value(plug_load, "extension/FracLatent"))
-      vals << child_vals
-    end
-    return vals
-  end
-
-  def _add_object_misc_loads_schedule(weekday_fractions: nil,
-                                      weekend_fractions: nil,
-                                      monthly_multipliers: nil)
-    misc_loads = XMLHelper.create_elements_as_needed(@object, ["HPXML", "Building", "BuildingDetails", "MiscLoads"])
-    _add_object_extension(parent: misc_loads,
-                          extensions: { "WeekdayScheduleFractions" => weekday_fractions,
-                                        "WeekendScheduleFractions" => weekend_fractions,
-                                        "MonthlyScheduleMultipliers" => monthly_multipliers })
-
-    return misc_loads
-  end
-
-  def _get_object_misc_loads_schedule_values(hpxml:)
-    vals = {}
-    return vals if hpxml.nil?
-
-    misc_loads = hpxml.elements["Building/BuildingDetails/MiscLoads"]
-    return vals if misc_loads.nil?
-
-    vals[:weekday_fractions] = XMLHelper.get_value(misc_loads, "extension/WeekdayScheduleFractions")
-    vals[:weekend_fractions] = XMLHelper.get_value(misc_loads, "extension/WeekendScheduleFractions")
-    vals[:monthly_multipliers] = XMLHelper.get_value(misc_loads, "extension/MonthlyScheduleMultipliers")
-    return vals
-  end
-
-  def _add_object_extension(parent:,
-                            extensions: {})
-    extension = nil
-    unless extensions.empty?
-      extensions.each do |name, value|
-        next if value.nil?
-
-        extension = parent.elements["extension"]
-        if extension.nil?
-          extension = XMLHelper.add_element(parent, "extension")
-        end
-        XMLHelper.add_element(extension, "#{name}", value) unless value.nil?
-      end
-    end
-
-    return extension
-  end
-
-  def _get_object_id(parent, element_name = "SystemIdentifier")
-    return parent.elements[element_name].attributes["id"]
-  end
-
-  def _get_object_idref(parent, element_name)
-    element = parent.elements[element_name]
-    return if element.nil?
-
-    return element.attributes["idref"]
-  end
-
-  def _to_float_or_nil(value)
-    return nil if value.nil?
-
-    return Float(value)
-  end
-
-  def _to_integer_or_nil(value)
-    return nil if value.nil?
-
-    return Integer(Float(value))
-  end
-
-  def _to_bool_or_nil(value)
-    return nil if value.nil?
-
-    return Boolean(value)
   end
 end
 
 # Helper methods
 
-def is_thermal_boundary(surface_values)
-  if ["other housing unit", "other housing unit above", "other housing unit below"].include? surface_values[:exterior_adjacent_to]
+def _add_extension(parent:,
+                   extensions: {})
+  extension = nil
+  if not extensions.empty?
+    extensions.each do |name, value|
+      next if value.nil?
+
+      extension = parent.elements["extension"]
+      if extension.nil?
+        extension = XMLHelper.add_element(parent, "extension")
+      end
+      XMLHelper.add_element(extension, "#{name}", value) unless value.nil?
+    end
+  end
+
+  return extension
+end
+
+def _get_id(parent, element_name = "SystemIdentifier")
+  return parent.elements[element_name].attributes["id"]
+end
+
+def _get_idref(parent, element_name)
+  element = parent.elements[element_name]
+  return if element.nil?
+
+  return element.attributes["idref"]
+end
+
+def _to_float_or_nil(value)
+  return nil if value.nil?
+
+  return Float(value)
+end
+
+def _to_integer_or_nil(value)
+  return nil if value.nil?
+
+  return Integer(Float(value))
+end
+
+def _to_bool_or_nil(value)
+  return nil if value.nil?
+
+  return Boolean(value)
+end
+
+def is_thermal_boundary(surface)
+  if surface.exterior_adjacent_to.start_with? "other housing unit"
     return false # adiabatic
   end
 
-  interior_conditioned = is_adjacent_to_conditioned(surface_values[:interior_adjacent_to])
-  exterior_conditioned = is_adjacent_to_conditioned(surface_values[:exterior_adjacent_to])
+  interior_conditioned = is_adjacent_to_conditioned(surface.interior_adjacent_to)
+  exterior_conditioned = is_adjacent_to_conditioned(surface.exterior_adjacent_to)
   return (interior_conditioned != exterior_conditioned)
 end
 
@@ -2369,10 +2207,10 @@ def is_adjacent_to_conditioned(adjacent_to)
   return false
 end
 
-def hpxml_frame_floor_is_ceiling(floor_interior_adjacent_to, floor_exterior_adjacent_to)
-  if ["attic - vented", "attic - unvented"].include? floor_interior_adjacent_to
+def hpxml_frame_floor_is_ceiling(interior_adjacent_to, exterior_adjacent_to)
+  if ["attic - vented", "attic - unvented"].include? interior_adjacent_to
     return true
-  elsif ["attic - vented", "attic - unvented", "other housing unit above"].include? floor_exterior_adjacent_to
+  elsif ["attic - vented", "attic - unvented", "other housing unit above"].include? exterior_adjacent_to
     return true
   end
 

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -2108,7 +2108,7 @@ class HVAC
       return "variable speed"
     end
   end
-  
+
   def self.apply_dehumidifier(model, runner, energy_factor, water_removal_rate,
                               air_flow_rate, humidity_setpoint, control_zone)
 

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -1376,24 +1376,6 @@ class Waterheater
     return 120.0
   end
 
-  def self.get_combi_system_fuel(idref, orig_details)
-    orig_details.elements.each("Systems/HVAC/HVACPlant/HeatingSystem") do |heating_system|
-      heating_system_values = HPXML.get_heating_system_values(heating_system: heating_system)
-      next unless heating_system_values[:id] == idref
-
-      return heating_system_values[:heating_system_fuel]
-    end
-  end
-
-  def self.get_combi_system_afue(idref, orig_details)
-    orig_details.elements.each("Systems/HVAC/HVACPlant/HeatingSystem") do |heating_system|
-      heating_system_values = HPXML.get_heating_system_values(heating_system: heating_system)
-      next unless heating_system_values[:id] == idref
-
-      return heating_system_values[:heating_efficiency_afue]
-    end
-  end
-
   def self.get_tankless_cycling_derate()
     return 0.08
   end

--- a/HPXMLtoOpenStudio/resources/xmlhelper.rb
+++ b/HPXMLtoOpenStudio/resources/xmlhelper.rb
@@ -147,7 +147,7 @@ class XMLHelper
     formatter = REXML::Formatters::Pretty.new(2)
     formatter.compact = true
     formatter.width = 1000
-    File.open(out_path, 'w') do |f|
+    File.open(out_path, 'w', newline: :crlf) do |f|
       formatter.write(doc, f)
     end
   end

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -3,6 +3,7 @@
 
 require_relative "resources/constants.rb"
 require_relative "../HPXMLtoOpenStudio/resources/constants.rb"
+require_relative "../HPXMLtoOpenStudio/resources/hpxml.rb"
 require_relative "../HPXMLtoOpenStudio/resources/unit_conversions.rb"
 
 # start the measure
@@ -249,12 +250,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     setup_outputs
 
     hpxml_path = @model.getBuilding.additionalProperties.getFeatureAsString("hpxml_path").get
-    @hpxml_doc = XMLHelper.parse_file(hpxml_path)
+    @hpxml = HPXML.new(hpxml_path: hpxml_path)
 
     get_object_maps()
 
     # Set paths
-    @eri_design = XMLHelper.get_value(@hpxml_doc, "/HPXML/SoftwareInfo/extension/ERICalculation/Design")
+    @eri_design = @hpxml.header[:eri_design]
     if not @eri_design.nil?
       # ERI run, store files in a particular location
       output_dir = File.dirname(hpxml_path)
@@ -317,13 +318,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
 
     # HPXML Summary
-    bldg_details = @hpxml_doc.elements["/HPXML/Building/BuildingDetails"]
-    outputs[:hpxml_cfa] = Float(XMLHelper.get_value(bldg_details, "BuildingSummary/BuildingConstruction/ConditionedFloorArea"))
-    outputs[:hpxml_nbr] = Float(XMLHelper.get_value(bldg_details, "BuildingSummary/BuildingConstruction/NumberofBedrooms"))
-    outputs[:hpxml_nst] = Float(XMLHelper.get_value(bldg_details, "BuildingSummary/BuildingConstruction/NumberofConditionedFloorsAboveGrade"))
+    outputs[:hpxml_cfa] = @hpxml.building_construction[:conditioned_floor_area]
+    outputs[:hpxml_nbr] = @hpxml.building_construction[:number_of_bedrooms]
+    outputs[:hpxml_nst] = @hpxml.building_construction[:number_of_conditioned_floors_above_grade]
 
     # HPXML Systems
-    set_hpxml_systems()
     if not @eri_design.nil?
       outputs[:hpxml_eec_heats] = get_hpxml_eec_heats()
       outputs[:hpxml_eec_cools] = get_hpxml_eec_cools()
@@ -831,30 +830,6 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     runner.registerInfo("Wrote timeseries output results to #{csv_path}.")
   end
 
-  def set_hpxml_systems()
-    @htgs = []
-    @clgs = []
-    @hp_htgs = []
-    @hp_clgs = []
-    @dhws = []
-
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem[FractionHeatLoadServed > 0]") do |htg_system|
-      @htgs << htg_system
-    end
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump[FractionHeatLoadServed > 0]") do |heat_pump|
-      @hp_htgs << heat_pump
-    end
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem[FractionCoolLoadServed > 0]") do |clg_system|
-      @clgs << clg_system
-    end
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump[FractionCoolLoadServed > 0]") do |heat_pump|
-      @hp_clgs << heat_pump
-    end
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem[FractionDHWLoadServed > 0]") do |dhw_system|
-      @dhws << dhw_system
-    end
-  end
-
   def get_hpxml_dse_heats(heat_sys_ids)
     dse_heats = {}
 
@@ -862,24 +837,25 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       dse_heats[sys_id] = 1.0 # Init
     end
 
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/HVAC/HVACDistribution") do |hvac_dist|
-      dist_id = hvac_dist.elements["SystemIdentifier"].attributes["id"]
-      dse_heat = XMLHelper.get_value(hvac_dist, "AnnualHeatingDistributionSystemEfficiency")
-      next if dse_heat.nil?
+    @hpxml.hvac_distributions.each do |hvac_dist|
+      dist_id = hvac_dist[:id]
+      next if hvac_dist[:annual_heating_dse].nil?
 
-      dse_heat = Float(dse_heat)
+      dse_heat = hvac_dist[:annual_heating_dse]
 
       # Get all HVAC systems attached to it
-      @htgs.each do |htg_system|
-        next if htg_system.elements["DistributionSystem"].nil?
-        next unless dist_id == htg_system.elements["DistributionSystem"].attributes["idref"]
+      @hpxml.heating_systems.each do |htg_system|
+        next unless htg_system[:fraction_heat_load_served] > 0
+        next if htg_system[:distribution_system_idref].nil?
+        next unless dist_id == htg_system[:distribution_system_idref]
 
         sys_id = get_system_or_seed_id(htg_system)
         dse_heats[sys_id] = dse_heat
       end
-      @hp_htgs.each do |heat_pump|
-        next if heat_pump.elements["DistributionSystem"].nil?
-        next unless dist_id == heat_pump.elements["DistributionSystem"].attributes["idref"]
+      @hpxml.heat_pumps.each do |heat_pump|
+        next unless heat_pump[:fraction_heat_load_served] > 0
+        next if heat_pump[:distribution_system_idref].nil?
+        next unless dist_id == heat_pump[:distribution_system_idref]
 
         sys_id = get_system_or_seed_id(heat_pump)
         dse_heats[sys_id] = dse_heat
@@ -902,24 +878,25 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       dse_cools[sys_id] = 1.0
     end
 
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/HVAC/HVACDistribution") do |hvac_dist|
-      dist_id = hvac_dist.elements["SystemIdentifier"].attributes["id"]
-      dse_cool = XMLHelper.get_value(hvac_dist, "AnnualCoolingDistributionSystemEfficiency")
-      next if dse_cool.nil?
+    @hpxml.hvac_distributions.each do |hvac_dist|
+      dist_id = hvac_dist[:id]
+      next if hvac_dist[:annual_cooling_dse].nil?
 
-      dse_cool = Float(dse_cool)
+      dse_cool = hvac_dist[:annual_cooling_dse]
 
       # Get all HVAC systems attached to it
-      @clgs.each do |clg_system|
-        next if clg_system.elements["DistributionSystem"].nil?
-        next unless dist_id == clg_system.elements["DistributionSystem"].attributes["idref"]
+      @hpxml.cooling_systems.each do |clg_system|
+        next unless clg_system[:fraction_cool_load_served] > 0
+        next if clg_system[:distribution_system_idref].nil?
+        next unless dist_id == clg_system[:distribution_system_idref]
 
         sys_id = get_system_or_seed_id(clg_system)
         dse_cools[sys_id] = dse_cool
       end
-      @hp_clgs.each do |heat_pump|
-        next if heat_pump.elements["DistributionSystem"].nil?
-        next unless dist_id == heat_pump.elements["DistributionSystem"].attributes["idref"]
+      @hpxml.heat_pumps.each do |heat_pump|
+        next unless heat_pump[:fraction_cool_load_served] > 0
+        next if heat_pump[:distribution_system_idref].nil?
+        next unless dist_id == heat_pump[:distribution_system_idref]
 
         sys_id = get_system_or_seed_id(heat_pump)
         dse_cools[sys_id] = dse_cool
@@ -932,15 +909,17 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_hpxml_heat_fuels()
     heat_fuels = {}
 
-    @htgs.each do |htg_system|
+    @hpxml.heating_systems.each do |htg_system|
+      next unless htg_system[:fraction_heat_load_served] > 0
       sys_id = get_system_or_seed_id(htg_system)
-      heat_fuels[sys_id] = XMLHelper.get_value(htg_system, "HeatingSystemFuel")
+      heat_fuels[sys_id] = htg_system[:heating_system_fuel]
     end
-    @hp_htgs.each do |heat_pump|
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump[:fraction_heat_load_served] > 0
       sys_id = get_system_or_seed_id(heat_pump)
-      heat_fuels[sys_id] = XMLHelper.get_value(heat_pump, "HeatPumpFuel")
+      heat_fuels[sys_id] = heat_pump[:heat_pump_fuel]
       if is_dfhp(heat_pump)
-        heat_fuels[dfhp_backup_sys_id(sys_id)] = XMLHelper.get_value(heat_pump, "BackupSystemFuel")
+        heat_fuels[dfhp_backup_sys_id(sys_id)] = heat_pump[:backup_heating_fuel]
       end
     end
 
@@ -950,14 +929,17 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_hpxml_dhw_fuels()
     dhw_fuels = {}
 
-    @dhws.each do |dhw_system|
-      sys_id = dhw_system.elements["SystemIdentifier"].attributes["id"]
-      if ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? XMLHelper.get_value(dhw_system, "WaterHeaterType")
-        orig_details = @hpxml_doc.elements["/HPXML/Building/BuildingDetails"]
-        hvac_idref = dhw_system.elements["RelatedHVACSystem"].attributes["idref"]
-        dhw_fuels[sys_id] = Waterheater.get_combi_system_fuel(hvac_idref, orig_details)
+    @hpxml.water_heating_systems.each do |dhw_system|
+      next unless dhw_system[:fraction_dhw_load_served] > 0
+      sys_id = dhw_system[:id]
+      if ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? dhw_system[:water_heater_type]
+        @hpxml.heating_systems.each do |heating_system|
+          next unless dhw_system[:related_hvac] == heating_system[:id]
+          
+          dhw_fuels[sys_id] = heating_system[:heating_system_fuel]
+        end
       else
-        dhw_fuels[sys_id] = XMLHelper.get_value(dhw_system, "FuelType")
+        dhw_fuels[sys_id] = dhw_system[:fuel_type]
       end
     end
 
@@ -967,10 +949,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_hpxml_heat_sys_ids()
     sys_ids = []
 
-    @htgs.each do |htg_system|
+    @hpxml.heating_systems.each do |htg_system|
+      next unless htg_system[:fraction_heat_load_served] > 0
       sys_ids << get_system_or_seed_id(htg_system)
     end
-    @hp_htgs.each do |heat_pump|
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump[:fraction_heat_load_served] > 0
       sys_ids << get_system_or_seed_id(heat_pump)
       if is_dfhp(heat_pump)
         sys_ids << dfhp_backup_sys_id(sys_ids[-1])
@@ -983,10 +967,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_hpxml_cool_sys_ids()
     sys_ids = []
 
-    @clgs.each do |clg_system|
+    @hpxml.cooling_systems.each do |clg_system|
+      next unless clg_system[:fraction_cool_load_served] > 0
       sys_ids << get_system_or_seed_id(clg_system)
     end
-    @hp_clgs.each do |heat_pump|
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump[:fraction_cool_load_served] > 0
       sys_ids << get_system_or_seed_id(heat_pump)
     end
 
@@ -996,8 +982,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_hpxml_dhw_sys_ids()
     sys_ids = []
 
-    @dhws.each do |dhw_system|
-      sys_ids << dhw_system.elements["SystemIdentifier"].attributes["id"]
+    @hpxml.water_heating_systems.each do |dhw_system|
+      next unless dhw_system[:fraction_dhw_load_served] > 0
+      sys_ids << dhw_system[:id]
     end
 
     return sys_ids
@@ -1006,31 +993,28 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_hpxml_eec_heats()
     eec_heats = {}
 
-    units = ['HSPF', 'COP', 'AFUE', 'Percent']
-
-    @htgs.each do |htg_system|
+    @hpxml.heating_systems.each do |htg_system|
+      next unless htg_system[:fraction_heat_load_served] > 0
       sys_id = get_system_or_seed_id(htg_system)
-      units.each do |unit|
-        value = XMLHelper.get_value(htg_system, "AnnualHeatingEfficiency[Units='#{unit}']/Value")
-        next if value.nil?
-
-        eec_heats[sys_id] = get_eri_eec_value_numerator(unit) / Float(value)
+      if not htg_system[:heating_efficiency_afue].nil?
+        eec_heats[sys_id] = get_eri_eec_value_numerator('AFUE') / htg_system[:heating_efficiency_afue]
+      elsif not htg_system[:heating_efficiency_percent].nil?
+        eec_heats[sys_id] = get_eri_eec_value_numerator('Percent') / htg_system[:heating_efficiency_afue]
       end
     end
-    @hp_htgs.each do |heat_pump|
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump[:fraction_heat_load_served] > 0
       sys_id = get_system_or_seed_id(heat_pump)
-      units.each do |unit|
-        value = XMLHelper.get_value(heat_pump, "AnnualHeatingEfficiency[Units='#{unit}']/Value")
-        next if value.nil?
-
-        eec_heats[sys_id] = get_eri_eec_value_numerator(unit) / Float(value)
+      if not heat_pump[:heating_efficiency_hspf].nil?
+        eec_heats[sys_id] = get_eri_eec_value_numerator('HSPF') / heat_pump[:heating_efficiency_hspf]
+      elsif not heat_pump[:heating_efficiency_cop].nil?
+        eec_heats[sys_id] = get_eri_eec_value_numerator('COP') / heat_pump[:heating_efficiency_cop]
       end
       if is_dfhp(heat_pump)
-        units.each do |unit|
-          value = XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='#{unit}']/Value")
-          next if value.nil?
-
-          eec_heats[dfhp_backup_sys_id(sys_id)] = get_eri_eec_value_numerator(unit) / Float(value)
+        if not heat_pump[:backup_heating_efficiency_afue].nil?
+          eec_heats[dfhp_backup_sys_id(sys_id)] = get_eri_eec_value_numerator('AFUE') / heat_pump[:backup_heating_efficiency_afue]
+        elsif not heat_pump[:backup_heating_efficiency_percent].nil?
+          eec_heats[dfhp_backup_sys_id(sys_id)] = get_eri_eec_value_numerator('Percent') / heat_pump[:backup_heating_efficiency_percent]
         end
       end
     end
@@ -1041,28 +1025,26 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_hpxml_eec_cools()
     eec_cools = {}
 
-    units = ['SEER', 'COP', 'EER']
-
-    @clgs.each do |clg_system|
+    @hpxml.cooling_systems.each do |clg_system|
+      next unless clg_system[:fraction_cool_load_served] > 0
       sys_id = get_system_or_seed_id(clg_system)
-      units.each do |unit|
-        value = XMLHelper.get_value(clg_system, "AnnualCoolingEfficiency[Units='#{unit}']/Value")
-        next if value.nil?
-
-        eec_cools[sys_id] = get_eri_eec_value_numerator(unit) / Float(value)
+      if not clg_system[:cooling_efficiency_seer].nil?
+        eec_cools[sys_id] = get_eri_eec_value_numerator('SEER') / clg_system[:cooling_efficiency_seer]
+      elsif not clg_system[:cooling_efficiency_eer].nil?
+        eec_cools[sys_id] = get_eri_eec_value_numerator('EER') / clg_system[:cooling_efficiency_eer]
       end
 
-      if XMLHelper.get_value(clg_system, "CoolingSystemType") == "evaporative cooler"
+      if clg_system[:cooling_system_type] == "evaporative cooler"
         eec_cools[sys_id] = get_eri_eec_value_numerator("SEER") / 15.0 # Arbitrary
       end
     end
-    @hp_clgs.each do |heat_pump|
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump[:fraction_cool_load_served] > 0
       sys_id = get_system_or_seed_id(heat_pump)
-      units.each do |unit|
-        value = XMLHelper.get_value(heat_pump, "AnnualCoolingEfficiency[Units='#{unit}']/Value")
-        next if value.nil?
-
-        eec_cools[sys_id] = get_eri_eec_value_numerator(unit) / Float(value)
+      if not heat_pump[:cooling_efficiency_seer].nil?
+        eec_cools[sys_id] = get_eri_eec_value_numerator('SEER') / heat_pump[:cooling_efficiency_seer]
+      elsif not heat_pump[:cooling_efficiency_eer].nil?
+        eec_cools[sys_id] = get_eri_eec_value_numerator('EER') / heat_pump[:cooling_efficiency_eer]
       end
     end
 
@@ -1072,12 +1054,13 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_hpxml_eec_dhws()
     eec_dhws = {}
 
-    @dhws.each do |dhw_system|
-      sys_id = dhw_system.elements["SystemIdentifier"].attributes["id"]
-      value = XMLHelper.get_value(dhw_system, "EnergyFactor")
-      wh_type = XMLHelper.get_value(dhw_system, "WaterHeaterType")
+    @hpxml.water_heating_systems.each do |dhw_system|
+      next unless dhw_system[:fraction_dhw_load_served] > 0
+      sys_id = dhw_system[:id]
+      value = dhw_system[:energy_factor]
+      wh_type = dhw_system[:water_heater_type]
       if wh_type == "instantaneous water heater"
-        cycling_derate = Float(XMLHelper.get_value(dhw_system, "PerformanceAdjustment"))
+        cycling_derate = dhw_system[:performance_adjustment]
         value_adj = 1.0 - cycling_derate
       else
         value_adj = 1.0
@@ -1114,7 +1097,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
         return XMLHelper.get_value(sys, "extension/SeedId")
       end
     end
-    return sys.elements["SystemIdentifier"].attributes["id"]
+    return sys[:id]
   end
 
   def get_report_meter_data_annual_mbtu(variable)
@@ -1189,11 +1172,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def get_combi_hvac_id(sys_id)
-    @dhws.each do |dhw_system|
-      next unless sys_id == dhw_system.elements["SystemIdentifier"].attributes["id"]
-      next unless ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? XMLHelper.get_value(dhw_system, "WaterHeaterType")
+    @hpxml.water_heating_systems.each do |dhw_system|
+      next unless dhw_system[:fraction_dhw_load_served] > 0
+      next unless sys_id == dhw_system[:id]
+      next unless ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? dhw_system[:water_heater_type]
 
-      return dhw_system.elements["RelatedHVACSystem"].attributes["idref"]
+      return water_heater_type[:related_hvac]
     end
 
     return nil
@@ -1223,12 +1207,14 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def split_htg_load_to_system_by_fraction(sys_id, bldg_load, dfhp_loads)
-    @htgs.each do |htg_system|
+    @hpxml.heating_systems.each do |htg_system|
+      next unless htg_system[:fraction_heat_load_served] > 0
       next unless get_system_or_seed_id(htg_system) == sys_id
 
       return bldg_load * Float(XMLHelper.get_value(htg_system, "FractionHeatLoadServed"))
     end
-    @hp_htgs.each do |heat_pump|
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump[:fraction_heat_load_served] > 0
       load_fraction = 1.0
       if is_dfhp(heat_pump)
         if dfhp_primary_sys_id(sys_id) == sys_id
@@ -1245,12 +1231,14 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def split_clg_load_to_system_by_fraction(sys_id, bldg_load)
-    @clgs.each do |clg_system|
+    @hpxml.cooling_systems.each do |clg_system|
+      next unless clg_system[:fraction_cool_load_served] > 0
       next unless get_system_or_seed_id(clg_system) == sys_id
 
       return bldg_load * Float(XMLHelper.get_value(clg_system, "FractionCoolLoadServed"))
     end
-    @hp_clgs.each do |heat_pump|
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump[:fraction_cool_load_served] > 0
       next unless get_system_or_seed_id(heat_pump) == sys_id
 
       return bldg_load * Float(XMLHelper.get_value(heat_pump, "FractionCoolLoadServed"))
@@ -1285,10 +1273,10 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
   def get_dhw_solar_fraction(sys_id)
     solar_fraction = 0.0
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/SolarThermal/SolarThermalSystem") do |system|
-      next unless sys_id == system.elements["ConnectedTo"].attributes["idref"]
-
-      solar_fraction = XMLHelper.get_value(system, "SolarFraction").to_f
+    if not @hpxml.solar_thermal_system.empty?
+      if @hpxml.solar_thermal_system[:water_heating_system_idref] == sys_id
+        solar_fraction = @hpxml.solar_thermal_system[:solar_fraction].to_f
+      end
     end
     return solar_fraction
   end
@@ -1296,20 +1284,19 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_ep_output_names_for_hvac_heating(sys_id)
     dfhp_primary = false
     dfhp_backup = false
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem |
-                             /HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |system|
+    (@hpxml.heating_systems + @hpxml.heat_pumps).each do |system|
       # This is super ugly. Can we simplify it?
       if is_dfhp(system)
-        if dfhp_primary_sys_id(sys_id) == sys_id and [XMLHelper.get_value(system, "extension/SeedId"), system.elements["SystemIdentifier"].attributes["id"]].include? sys_id
+        if dfhp_primary_sys_id(sys_id) == sys_id and [system[:seed_id], system[:id]].include? sys_id
           dfhp_primary = true
-        elsif [XMLHelper.get_value(system, "extension/SeedId"), system.elements["SystemIdentifier"].attributes["id"]].include? dfhp_primary_sys_id(sys_id)
+        elsif [system[:seed_id], system[:id]].include? dfhp_primary_sys_id(sys_id)
           dfhp_backup = true
           sys_id = dfhp_primary_sys_id(sys_id)
         end
       end
-      next unless XMLHelper.get_value(system, "extension/SeedId") == sys_id
+      next unless system[:seed_id] == sys_id
 
-      sys_id = system.elements["SystemIdentifier"].attributes["id"]
+      sys_id = system[:id]
       break
     end
 
@@ -1333,11 +1320,10 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def get_ep_output_names_for_hvac_cooling(sys_id)
-    @hpxml_doc.elements.each("/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem |
-                             /HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump") do |system|
-      next unless XMLHelper.get_value(system, "extension/SeedId") == sys_id
+    (@hpxml.cooling_systems + @hpxml.heat_pumps).each do |system|
+      next unless system[:seed_id] == sys_id
 
-      sys_id = system.elements["SystemIdentifier"].attributes["id"]
+      sys_id = system[:id]
       break
     end
 

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -1255,7 +1255,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def is_dfhp(system)
-    if system.class.to_s != "HeatPump"
+    if system.class != HPXML::HeatPump
       return false
     end
     if not system.backup_heating_switchover_temp.nil? and system.backup_heating_fuel != "electricity"

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -610,7 +610,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def check_for_errors(runner, outputs)
-    all_total = @fuels.values.map { |f| f.annual_output }.inject(:+)
+    all_total = @fuels.values.map { |x| x.annual_output }.inject(:+)
+    all_total += @unmet_loads.values.map { |x| x.annual_output }.inject(:+)
     if all_total == 0
       runner.registerError("Simulation unsuccessful.")
       return false
@@ -935,7 +936,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       if ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? dhw_system.water_heater_type
         @hpxml.heating_systems.each do |heating_system|
           next unless dhw_system.related_hvac == heating_system.id
-          
+
           dhw_fuels[sys_id] = heating_system.heating_system_fuel
         end
       else
@@ -999,7 +1000,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       if not htg_system.heating_efficiency_afue.nil?
         eec_heats[sys_id] = get_eri_eec_value_numerator('AFUE') / htg_system.heating_efficiency_afue
       elsif not htg_system.heating_efficiency_percent.nil?
-        eec_heats[sys_id] = get_eri_eec_value_numerator('Percent') / htg_system.heating_efficiency_afue
+        eec_heats[sys_id] = get_eri_eec_value_numerator('Percent') / htg_system.heating_efficiency_percent
       end
     end
     @hpxml.heat_pumps.each do |heat_pump|

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -1093,8 +1093,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_system_or_seed_id(sys)
     if [Constants.CalcTypeERIReferenceHome,
         Constants.CalcTypeERIIndexAdjustmentReferenceHome].include? @eri_design
-      if XMLHelper.has_element(sys, "extension/SeedId")
-        return XMLHelper.get_value(sys, "extension/SeedId")
+      if not sys[:seed_id].nil?
+        return sys[:seed_id]
       end
     end
     return sys[:id]
@@ -1177,7 +1177,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       next unless sys_id == dhw_system[:id]
       next unless ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? dhw_system[:water_heater_type]
 
-      return water_heater_type[:related_hvac]
+      return dhw_system[:related_hvac]
     end
 
     return nil
@@ -1211,7 +1211,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       next unless htg_system[:fraction_heat_load_served] > 0
       next unless get_system_or_seed_id(htg_system) == sys_id
 
-      return bldg_load * Float(XMLHelper.get_value(htg_system, "FractionHeatLoadServed"))
+      return bldg_load * htg_system[:fraction_heat_load_served]
     end
     @hpxml.heat_pumps.each do |heat_pump|
       next unless heat_pump[:fraction_heat_load_served] > 0
@@ -1226,7 +1226,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       end
       next unless get_system_or_seed_id(heat_pump) == sys_id
 
-      return bldg_load * Float(XMLHelper.get_value(heat_pump, "FractionHeatLoadServed")) * load_fraction
+      return bldg_load * heat_pump[:fraction_heat_load_served] * load_fraction
     end
   end
 
@@ -1235,13 +1235,13 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       next unless clg_system[:fraction_cool_load_served] > 0
       next unless get_system_or_seed_id(clg_system) == sys_id
 
-      return bldg_load * Float(XMLHelper.get_value(clg_system, "FractionCoolLoadServed"))
+      return bldg_load * clg_system[:fraction_cool_load_served]
     end
     @hpxml.heat_pumps.each do |heat_pump|
       next unless heat_pump[:fraction_cool_load_served] > 0
       next unless get_system_or_seed_id(heat_pump) == sys_id
 
-      return bldg_load * Float(XMLHelper.get_value(heat_pump, "FractionCoolLoadServed"))
+      return bldg_load * heat_pump[:fraction_cool_load_served]
     end
   end
 
@@ -1254,7 +1254,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def is_dfhp(system)
-    if not XMLHelper.get_value(system, "BackupHeatingSwitchoverTemperature").nil? and XMLHelper.get_value(system, "BackupSystemFuel") != "electricity"
+    if not system[:backup_heating_switchover_temp].nil? and system[:backup_heating_fuel] != "electricity"
       return true
     end
 

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -255,7 +255,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     get_object_maps()
 
     # Set paths
-    @eri_design = @hpxml.header[:eri_design]
+    @eri_design = @hpxml.header.eri_design
     if not @eri_design.nil?
       # ERI run, store files in a particular location
       output_dir = File.dirname(hpxml_path)
@@ -318,9 +318,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
 
     # HPXML Summary
-    outputs[:hpxml_cfa] = @hpxml.building_construction[:conditioned_floor_area]
-    outputs[:hpxml_nbr] = @hpxml.building_construction[:number_of_bedrooms]
-    outputs[:hpxml_nst] = @hpxml.building_construction[:number_of_conditioned_floors_above_grade]
+    outputs[:hpxml_cfa] = @hpxml.building_construction.conditioned_floor_area
+    outputs[:hpxml_nbr] = @hpxml.building_construction.number_of_bedrooms
+    outputs[:hpxml_nst] = @hpxml.building_construction.number_of_conditioned_floors_above_grade
 
     # HPXML Systems
     if not @eri_design.nil?
@@ -838,24 +838,24 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
 
     @hpxml.hvac_distributions.each do |hvac_dist|
-      dist_id = hvac_dist[:id]
-      next if hvac_dist[:annual_heating_dse].nil?
+      dist_id = hvac_dist.id
+      next if hvac_dist.annual_heating_dse.nil?
 
-      dse_heat = hvac_dist[:annual_heating_dse]
+      dse_heat = hvac_dist.annual_heating_dse
 
       # Get all HVAC systems attached to it
       @hpxml.heating_systems.each do |htg_system|
-        next unless htg_system[:fraction_heat_load_served] > 0
-        next if htg_system[:distribution_system_idref].nil?
-        next unless dist_id == htg_system[:distribution_system_idref]
+        next unless htg_system.fraction_heat_load_served > 0
+        next if htg_system.distribution_system_idref.nil?
+        next unless dist_id == htg_system.distribution_system_idref
 
         sys_id = get_system_or_seed_id(htg_system)
         dse_heats[sys_id] = dse_heat
       end
       @hpxml.heat_pumps.each do |heat_pump|
-        next unless heat_pump[:fraction_heat_load_served] > 0
-        next if heat_pump[:distribution_system_idref].nil?
-        next unless dist_id == heat_pump[:distribution_system_idref]
+        next unless heat_pump.fraction_heat_load_served > 0
+        next if heat_pump.distribution_system_idref.nil?
+        next unless dist_id == heat_pump.distribution_system_idref
 
         sys_id = get_system_or_seed_id(heat_pump)
         dse_heats[sys_id] = dse_heat
@@ -879,24 +879,24 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
 
     @hpxml.hvac_distributions.each do |hvac_dist|
-      dist_id = hvac_dist[:id]
-      next if hvac_dist[:annual_cooling_dse].nil?
+      dist_id = hvac_dist.id
+      next if hvac_dist.annual_cooling_dse.nil?
 
-      dse_cool = hvac_dist[:annual_cooling_dse]
+      dse_cool = hvac_dist.annual_cooling_dse
 
       # Get all HVAC systems attached to it
       @hpxml.cooling_systems.each do |clg_system|
-        next unless clg_system[:fraction_cool_load_served] > 0
-        next if clg_system[:distribution_system_idref].nil?
-        next unless dist_id == clg_system[:distribution_system_idref]
+        next unless clg_system.fraction_cool_load_served > 0
+        next if clg_system.distribution_system_idref.nil?
+        next unless dist_id == clg_system.distribution_system_idref
 
         sys_id = get_system_or_seed_id(clg_system)
         dse_cools[sys_id] = dse_cool
       end
       @hpxml.heat_pumps.each do |heat_pump|
-        next unless heat_pump[:fraction_cool_load_served] > 0
-        next if heat_pump[:distribution_system_idref].nil?
-        next unless dist_id == heat_pump[:distribution_system_idref]
+        next unless heat_pump.fraction_cool_load_served > 0
+        next if heat_pump.distribution_system_idref.nil?
+        next unless dist_id == heat_pump.distribution_system_idref
 
         sys_id = get_system_or_seed_id(heat_pump)
         dse_cools[sys_id] = dse_cool
@@ -910,16 +910,16 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     heat_fuels = {}
 
     @hpxml.heating_systems.each do |htg_system|
-      next unless htg_system[:fraction_heat_load_served] > 0
+      next unless htg_system.fraction_heat_load_served > 0
       sys_id = get_system_or_seed_id(htg_system)
-      heat_fuels[sys_id] = htg_system[:heating_system_fuel]
+      heat_fuels[sys_id] = htg_system.heating_system_fuel
     end
     @hpxml.heat_pumps.each do |heat_pump|
-      next unless heat_pump[:fraction_heat_load_served] > 0
+      next unless heat_pump.fraction_heat_load_served > 0
       sys_id = get_system_or_seed_id(heat_pump)
-      heat_fuels[sys_id] = heat_pump[:heat_pump_fuel]
+      heat_fuels[sys_id] = heat_pump.heat_pump_fuel
       if is_dfhp(heat_pump)
-        heat_fuels[dfhp_backup_sys_id(sys_id)] = heat_pump[:backup_heating_fuel]
+        heat_fuels[dfhp_backup_sys_id(sys_id)] = heat_pump.backup_heating_fuel
       end
     end
 
@@ -930,16 +930,16 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     dhw_fuels = {}
 
     @hpxml.water_heating_systems.each do |dhw_system|
-      next unless dhw_system[:fraction_dhw_load_served] > 0
-      sys_id = dhw_system[:id]
-      if ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? dhw_system[:water_heater_type]
+      next unless dhw_system.fraction_dhw_load_served > 0
+      sys_id = dhw_system.id
+      if ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? dhw_system.water_heater_type
         @hpxml.heating_systems.each do |heating_system|
-          next unless dhw_system[:related_hvac] == heating_system[:id]
+          next unless dhw_system.related_hvac == heating_system.id
           
-          dhw_fuels[sys_id] = heating_system[:heating_system_fuel]
+          dhw_fuels[sys_id] = heating_system.heating_system_fuel
         end
       else
-        dhw_fuels[sys_id] = dhw_system[:fuel_type]
+        dhw_fuels[sys_id] = dhw_system.fuel_type
       end
     end
 
@@ -950,11 +950,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     sys_ids = []
 
     @hpxml.heating_systems.each do |htg_system|
-      next unless htg_system[:fraction_heat_load_served] > 0
+      next unless htg_system.fraction_heat_load_served > 0
       sys_ids << get_system_or_seed_id(htg_system)
     end
     @hpxml.heat_pumps.each do |heat_pump|
-      next unless heat_pump[:fraction_heat_load_served] > 0
+      next unless heat_pump.fraction_heat_load_served > 0
       sys_ids << get_system_or_seed_id(heat_pump)
       if is_dfhp(heat_pump)
         sys_ids << dfhp_backup_sys_id(sys_ids[-1])
@@ -968,11 +968,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     sys_ids = []
 
     @hpxml.cooling_systems.each do |clg_system|
-      next unless clg_system[:fraction_cool_load_served] > 0
+      next unless clg_system.fraction_cool_load_served > 0
       sys_ids << get_system_or_seed_id(clg_system)
     end
     @hpxml.heat_pumps.each do |heat_pump|
-      next unless heat_pump[:fraction_cool_load_served] > 0
+      next unless heat_pump.fraction_cool_load_served > 0
       sys_ids << get_system_or_seed_id(heat_pump)
     end
 
@@ -983,8 +983,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     sys_ids = []
 
     @hpxml.water_heating_systems.each do |dhw_system|
-      next unless dhw_system[:fraction_dhw_load_served] > 0
-      sys_ids << dhw_system[:id]
+      next unless dhw_system.fraction_dhw_load_served > 0
+      sys_ids << dhw_system.id
     end
 
     return sys_ids
@@ -994,27 +994,27 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     eec_heats = {}
 
     @hpxml.heating_systems.each do |htg_system|
-      next unless htg_system[:fraction_heat_load_served] > 0
+      next unless htg_system.fraction_heat_load_served > 0
       sys_id = get_system_or_seed_id(htg_system)
-      if not htg_system[:heating_efficiency_afue].nil?
-        eec_heats[sys_id] = get_eri_eec_value_numerator('AFUE') / htg_system[:heating_efficiency_afue]
-      elsif not htg_system[:heating_efficiency_percent].nil?
-        eec_heats[sys_id] = get_eri_eec_value_numerator('Percent') / htg_system[:heating_efficiency_afue]
+      if not htg_system.heating_efficiency_afue.nil?
+        eec_heats[sys_id] = get_eri_eec_value_numerator('AFUE') / htg_system.heating_efficiency_afue
+      elsif not htg_system.heating_efficiency_percent.nil?
+        eec_heats[sys_id] = get_eri_eec_value_numerator('Percent') / htg_system.heating_efficiency_afue
       end
     end
     @hpxml.heat_pumps.each do |heat_pump|
-      next unless heat_pump[:fraction_heat_load_served] > 0
+      next unless heat_pump.fraction_heat_load_served > 0
       sys_id = get_system_or_seed_id(heat_pump)
-      if not heat_pump[:heating_efficiency_hspf].nil?
-        eec_heats[sys_id] = get_eri_eec_value_numerator('HSPF') / heat_pump[:heating_efficiency_hspf]
-      elsif not heat_pump[:heating_efficiency_cop].nil?
-        eec_heats[sys_id] = get_eri_eec_value_numerator('COP') / heat_pump[:heating_efficiency_cop]
+      if not heat_pump.heating_efficiency_hspf.nil?
+        eec_heats[sys_id] = get_eri_eec_value_numerator('HSPF') / heat_pump.heating_efficiency_hspf
+      elsif not heat_pump.heating_efficiency_cop.nil?
+        eec_heats[sys_id] = get_eri_eec_value_numerator('COP') / heat_pump.heating_efficiency_cop
       end
       if is_dfhp(heat_pump)
-        if not heat_pump[:backup_heating_efficiency_afue].nil?
-          eec_heats[dfhp_backup_sys_id(sys_id)] = get_eri_eec_value_numerator('AFUE') / heat_pump[:backup_heating_efficiency_afue]
-        elsif not heat_pump[:backup_heating_efficiency_percent].nil?
-          eec_heats[dfhp_backup_sys_id(sys_id)] = get_eri_eec_value_numerator('Percent') / heat_pump[:backup_heating_efficiency_percent]
+        if not heat_pump.backup_heating_efficiency_afue.nil?
+          eec_heats[dfhp_backup_sys_id(sys_id)] = get_eri_eec_value_numerator('AFUE') / heat_pump.backup_heating_efficiency_afue
+        elsif not heat_pump.backup_heating_efficiency_percent.nil?
+          eec_heats[dfhp_backup_sys_id(sys_id)] = get_eri_eec_value_numerator('Percent') / heat_pump.backup_heating_efficiency_percent
         end
       end
     end
@@ -1026,25 +1026,25 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     eec_cools = {}
 
     @hpxml.cooling_systems.each do |clg_system|
-      next unless clg_system[:fraction_cool_load_served] > 0
+      next unless clg_system.fraction_cool_load_served > 0
       sys_id = get_system_or_seed_id(clg_system)
-      if not clg_system[:cooling_efficiency_seer].nil?
-        eec_cools[sys_id] = get_eri_eec_value_numerator('SEER') / clg_system[:cooling_efficiency_seer]
-      elsif not clg_system[:cooling_efficiency_eer].nil?
-        eec_cools[sys_id] = get_eri_eec_value_numerator('EER') / clg_system[:cooling_efficiency_eer]
+      if not clg_system.cooling_efficiency_seer.nil?
+        eec_cools[sys_id] = get_eri_eec_value_numerator('SEER') / clg_system.cooling_efficiency_seer
+      elsif not clg_system.cooling_efficiency_eer.nil?
+        eec_cools[sys_id] = get_eri_eec_value_numerator('EER') / clg_system.cooling_efficiency_eer
       end
 
-      if clg_system[:cooling_system_type] == "evaporative cooler"
+      if clg_system.cooling_system_type == "evaporative cooler"
         eec_cools[sys_id] = get_eri_eec_value_numerator("SEER") / 15.0 # Arbitrary
       end
     end
     @hpxml.heat_pumps.each do |heat_pump|
-      next unless heat_pump[:fraction_cool_load_served] > 0
+      next unless heat_pump.fraction_cool_load_served > 0
       sys_id = get_system_or_seed_id(heat_pump)
-      if not heat_pump[:cooling_efficiency_seer].nil?
-        eec_cools[sys_id] = get_eri_eec_value_numerator('SEER') / heat_pump[:cooling_efficiency_seer]
-      elsif not heat_pump[:cooling_efficiency_eer].nil?
-        eec_cools[sys_id] = get_eri_eec_value_numerator('EER') / heat_pump[:cooling_efficiency_eer]
+      if not heat_pump.cooling_efficiency_seer.nil?
+        eec_cools[sys_id] = get_eri_eec_value_numerator('SEER') / heat_pump.cooling_efficiency_seer
+      elsif not heat_pump.cooling_efficiency_eer.nil?
+        eec_cools[sys_id] = get_eri_eec_value_numerator('EER') / heat_pump.cooling_efficiency_eer
       end
     end
 
@@ -1055,12 +1055,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     eec_dhws = {}
 
     @hpxml.water_heating_systems.each do |dhw_system|
-      next unless dhw_system[:fraction_dhw_load_served] > 0
-      sys_id = dhw_system[:id]
-      value = dhw_system[:energy_factor]
-      wh_type = dhw_system[:water_heater_type]
+      next unless dhw_system.fraction_dhw_load_served > 0
+      sys_id = dhw_system.id
+      value = dhw_system.energy_factor
+      wh_type = dhw_system.water_heater_type
       if wh_type == "instantaneous water heater"
-        cycling_derate = dhw_system[:performance_adjustment]
+        cycling_derate = dhw_system.performance_adjustment
         value_adj = 1.0 - cycling_derate
       else
         value_adj = 1.0
@@ -1093,11 +1093,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def get_system_or_seed_id(sys)
     if [Constants.CalcTypeERIReferenceHome,
         Constants.CalcTypeERIIndexAdjustmentReferenceHome].include? @eri_design
-      if not sys[:seed_id].nil?
-        return sys[:seed_id]
+      if not sys.seed_id.nil?
+        return sys.seed_id
       end
     end
-    return sys[:id]
+    return sys.id
   end
 
   def get_report_meter_data_annual_mbtu(variable)
@@ -1173,11 +1173,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
   def get_combi_hvac_id(sys_id)
     @hpxml.water_heating_systems.each do |dhw_system|
-      next unless dhw_system[:fraction_dhw_load_served] > 0
-      next unless sys_id == dhw_system[:id]
-      next unless ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? dhw_system[:water_heater_type]
+      next unless dhw_system.fraction_dhw_load_served > 0
+      next unless sys_id == dhw_system.id
+      next unless ['space-heating boiler with tankless coil', 'space-heating boiler with storage tank'].include? dhw_system.water_heater_type
 
-      return dhw_system[:related_hvac]
+      return dhw_system.related_hvac
     end
 
     return nil
@@ -1208,13 +1208,13 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
   def split_htg_load_to_system_by_fraction(sys_id, bldg_load, dfhp_loads)
     @hpxml.heating_systems.each do |htg_system|
-      next unless htg_system[:fraction_heat_load_served] > 0
+      next unless htg_system.fraction_heat_load_served > 0
       next unless get_system_or_seed_id(htg_system) == sys_id
 
-      return bldg_load * htg_system[:fraction_heat_load_served]
+      return bldg_load * htg_system.fraction_heat_load_served
     end
     @hpxml.heat_pumps.each do |heat_pump|
-      next unless heat_pump[:fraction_heat_load_served] > 0
+      next unless heat_pump.fraction_heat_load_served > 0
       load_fraction = 1.0
       if is_dfhp(heat_pump)
         if dfhp_primary_sys_id(sys_id) == sys_id
@@ -1226,22 +1226,22 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       end
       next unless get_system_or_seed_id(heat_pump) == sys_id
 
-      return bldg_load * heat_pump[:fraction_heat_load_served] * load_fraction
+      return bldg_load * heat_pump.fraction_heat_load_served * load_fraction
     end
   end
 
   def split_clg_load_to_system_by_fraction(sys_id, bldg_load)
     @hpxml.cooling_systems.each do |clg_system|
-      next unless clg_system[:fraction_cool_load_served] > 0
+      next unless clg_system.fraction_cool_load_served > 0
       next unless get_system_or_seed_id(clg_system) == sys_id
 
-      return bldg_load * clg_system[:fraction_cool_load_served]
+      return bldg_load * clg_system.fraction_cool_load_served
     end
     @hpxml.heat_pumps.each do |heat_pump|
-      next unless heat_pump[:fraction_cool_load_served] > 0
+      next unless heat_pump.fraction_cool_load_served > 0
       next unless get_system_or_seed_id(heat_pump) == sys_id
 
-      return bldg_load * heat_pump[:fraction_cool_load_served]
+      return bldg_load * heat_pump.fraction_cool_load_served
     end
   end
 
@@ -1254,10 +1254,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def is_dfhp(system)
-    if not system[:backup_heating_switchover_temp].nil? and system[:backup_heating_fuel] != "electricity"
+    if system.class.to_s != "HeatPump"
+      return false
+    end
+    if not system.backup_heating_switchover_temp.nil? and system.backup_heating_fuel != "electricity"
       return true
     end
-
     return false
   end
 
@@ -1273,9 +1275,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
   def get_dhw_solar_fraction(sys_id)
     solar_fraction = 0.0
-    if not @hpxml.solar_thermal_system.empty?
-      if @hpxml.solar_thermal_system[:water_heating_system_idref] == sys_id
-        solar_fraction = @hpxml.solar_thermal_system[:solar_fraction].to_f
+    if not @hpxml.solar_thermal_system.nil?
+      if @hpxml.solar_thermal_system.water_heating_system_idref == sys_id
+        solar_fraction = @hpxml.solar_thermal_system.solar_fraction.to_f
       end
     end
     return solar_fraction
@@ -1287,16 +1289,16 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     (@hpxml.heating_systems + @hpxml.heat_pumps).each do |system|
       # This is super ugly. Can we simplify it?
       if is_dfhp(system)
-        if dfhp_primary_sys_id(sys_id) == sys_id and [system[:seed_id], system[:id]].include? sys_id
+        if dfhp_primary_sys_id(sys_id) == sys_id and [system.seed_id, system.id].include? sys_id
           dfhp_primary = true
-        elsif [system[:seed_id], system[:id]].include? dfhp_primary_sys_id(sys_id)
+        elsif [system.seed_id, system.id].include? dfhp_primary_sys_id(sys_id)
           dfhp_backup = true
           sys_id = dfhp_primary_sys_id(sys_id)
         end
       end
-      next unless system[:seed_id] == sys_id
+      next unless system.seed_id == sys_id
 
-      sys_id = system[:id]
+      sys_id = system.id
       break
     end
 
@@ -1321,9 +1323,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
   def get_ep_output_names_for_hvac_cooling(sys_id)
     (@hpxml.cooling_systems + @hpxml.heat_pumps).each do |system|
-      next unless system[:seed_id] == sys_id
+      next unless system.seed_id == sys_id
 
-      sys_id = system[:id]
+      sys_id = system.id
       break
     end
 

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>1c81c106-7918-4fb9-abbc-6cd85eb495be</version_id>
-  <version_modified>20200305T203057Z</version_modified>
+  <version_id>c2987a9c-c2bb-4fda-9aa3-6a1c9eaffd6e</version_id>
+  <version_modified>20200306T230913Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -433,7 +433,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>42A59C61</checksum>
+      <checksum>E98DFEEA</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>ffad811d-44ed-43bd-bec9-098097f74e29</version_id>
-  <version_modified>20200308T174019Z</version_modified>
+  <version_id>92251292-4313-4ce8-9b4f-9d8fca6f94d3</version_id>
+  <version_modified>20200309T035850Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -433,7 +433,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>BF7190C0</checksum>
+      <checksum>0A184404</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>5345ca46-98a8-43fe-af24-9f1e3420e964</version_id>
-  <version_modified>20200302T204150Z</version_modified>
+  <version_id>596d2a06-abae-4175-998e-b5f87ad6df51</version_id>
+  <version_modified>20200305T164018Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -419,6 +419,12 @@
       <checksum>90C6EBF8</checksum>
     </file>
     <file>
+      <filename>output_report_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>96B05BBE</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.9.1</identifier>
@@ -427,13 +433,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>77105D44</checksum>
-    </file>
-    <file>
-      <filename>output_report_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>96B05BBE</checksum>
+      <checksum>447B349B</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>c2987a9c-c2bb-4fda-9aa3-6a1c9eaffd6e</version_id>
-  <version_modified>20200306T230913Z</version_modified>
+  <version_id>ffad811d-44ed-43bd-bec9-098097f74e29</version_id>
+  <version_modified>20200308T174019Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -433,7 +433,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E98DFEEA</checksum>
+      <checksum>BF7190C0</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>596d2a06-abae-4175-998e-b5f87ad6df51</version_id>
-  <version_modified>20200305T164018Z</version_modified>
+  <version_id>1c81c106-7918-4fb9-abbc-6cd85eb495be</version_id>
+  <version_modified>20200305T203057Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -433,7 +433,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>447B349B</checksum>
+      <checksum>42A59C61</checksum>
     </file>
   </files>
 </measure>

--- a/tasks.rb
+++ b/tasks.rb
@@ -375,185 +375,55 @@ def create_hpxmls
         end
       end
 
-      hpxml_values = {}
-      site_values = {}
-      site_neighbors_values = []
-      building_occupancy_values = {}
-      building_construction_values = {}
-      climate_and_risk_zones_values = {}
-      air_infiltration_measurement_values = {}
-      attic_values = {}
-      foundation_values = {}
-      roofs_values = []
-      rim_joists_values = []
-      walls_values = []
-      foundation_walls_values = []
-      framefloors_values = []
-      slabs_values = []
-      windows_values = []
-      skylights_values = []
-      doors_values = []
-      heating_systems_values = []
-      cooling_systems_values = []
-      heat_pumps_values = []
-      hvac_control_values = {}
-      hvac_distributions_values = []
-      duct_leakage_measurements_values = []
-      ducts_values = []
-      ventilation_fans_values = []
-      water_heating_systems_values = []
-      hot_water_distribution_values = {}
-      water_fixtures_values = []
-      solar_thermal_system_values = {}
-      pv_systems_values = []
-      clothes_washer_values = {}
-      clothes_dryer_values = {}
-      dishwasher_values = {}
-      refrigerator_values = {}
-      cooking_range_values = {}
-      oven_values = {}
-      lighting_values = {}
-      ceiling_fans_values = []
-      plug_loads_values = []
-      misc_load_schedule_values = {}
+      hpxml_data = {}
       hpxml_files.each do |hpxml_file|
-        hpxml_values = get_hpxml_file_hpxml_values(hpxml_file, hpxml_values)
-        site_values = get_hpxml_file_site_values(hpxml_file, site_values)
-        site_neighbors_values = get_hpxml_file_site_neighbor_values(hpxml_file, site_neighbors_values)
-        building_occupancy_values = get_hpxml_file_building_occupancy_values(hpxml_file, building_occupancy_values)
-        building_construction_values = get_hpxml_file_building_construction_values(hpxml_file, building_construction_values)
-        climate_and_risk_zones_values = get_hpxml_file_climate_and_risk_zones_values(hpxml_file, climate_and_risk_zones_values)
-        attic_values = get_hpxml_file_attic_values(hpxml_file, attic_values)
-        foundation_values = get_hpxml_file_foundation_values(hpxml_file, foundation_values)
-        air_infiltration_measurement_values = get_hpxml_file_air_infiltration_measurement_values(hpxml_file, air_infiltration_measurement_values, building_construction_values)
-        roofs_values = get_hpxml_file_roofs_values(hpxml_file, roofs_values)
-        rim_joists_values = get_hpxml_file_rim_joists_values(hpxml_file, rim_joists_values)
-        walls_values = get_hpxml_file_walls_values(hpxml_file, walls_values)
-        foundation_walls_values = get_hpxml_file_foundation_walls_values(hpxml_file, foundation_walls_values)
-        framefloors_values = get_hpxml_file_framefloors_values(hpxml_file, framefloors_values)
-        slabs_values = get_hpxml_file_slabs_values(hpxml_file, slabs_values)
-        windows_values = get_hpxml_file_windows_values(hpxml_file, windows_values)
-        skylights_values = get_hpxml_file_skylights_values(hpxml_file, skylights_values)
-        doors_values = get_hpxml_file_doors_values(hpxml_file, doors_values)
-        heating_systems_values = get_hpxml_file_heating_systems_values(hpxml_file, heating_systems_values)
-        cooling_systems_values = get_hpxml_file_cooling_systems_values(hpxml_file, cooling_systems_values)
-        heat_pumps_values = get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
-        hvac_control_values = get_hpxml_file_hvac_control_values(hpxml_file, hvac_control_values)
-        hvac_distributions_values = get_hpxml_file_hvac_distributions_values(hpxml_file, hvac_distributions_values)
-        duct_leakage_measurements_values = get_hpxml_file_duct_leakage_measurements_values(hpxml_file, duct_leakage_measurements_values)
-        ducts_values = get_hpxml_file_ducts_values(hpxml_file, ducts_values)
-        ventilation_fans_values = get_hpxml_file_ventilation_fan_values(hpxml_file, ventilation_fans_values)
-        water_heating_systems_values = get_hpxml_file_water_heating_system_values(hpxml_file, water_heating_systems_values)
-        hot_water_distribution_values = get_hpxml_file_hot_water_distribution_values(hpxml_file, hot_water_distribution_values)
-        water_fixtures_values = get_hpxml_file_water_fixtures_values(hpxml_file, water_fixtures_values)
-        solar_thermal_system_values = get_hpxml_file_solar_thermal_system_values(hpxml_file, solar_thermal_system_values)
-        pv_systems_values = get_hpxml_file_pv_system_values(hpxml_file, pv_systems_values)
-        clothes_washer_values = get_hpxml_file_clothes_washer_values(hpxml_file, clothes_washer_values)
-        clothes_dryer_values = get_hpxml_file_clothes_dryer_values(hpxml_file, clothes_dryer_values)
-        dishwasher_values = get_hpxml_file_dishwasher_values(hpxml_file, dishwasher_values)
-        refrigerator_values = get_hpxml_file_refrigerator_values(hpxml_file, refrigerator_values)
-        cooking_range_values = get_hpxml_file_cooking_range_values(hpxml_file, cooking_range_values)
-        oven_values = get_hpxml_file_oven_values(hpxml_file, oven_values)
-        lighting_values = get_hpxml_file_lighting_values(hpxml_file, lighting_values)
-        ceiling_fans_values = get_hpxml_file_ceiling_fan_values(hpxml_file, ceiling_fans_values)
-        plug_loads_values = get_hpxml_file_plug_loads_values(hpxml_file, plug_loads_values)
-        misc_load_schedule_values = get_hpxml_file_misc_load_schedule_values(hpxml_file, misc_load_schedule_values)
+        set_hpxml_data_header_values(hpxml_file, hpxml_data)
+        set_hpxml_data_site_values(hpxml_file, hpxml_data)
+        set_hpxml_data_neighbor_buildings_values(hpxml_file, hpxml_data)
+        set_hpxml_data_building_occupancy_values(hpxml_file, hpxml_data)
+        set_hpxml_data_building_construction_values(hpxml_file, hpxml_data)
+        set_hpxml_data_climate_and_risk_zones_values(hpxml_file, hpxml_data)
+        set_hpxml_data_attics_values(hpxml_file, hpxml_data)
+        set_hpxml_data_foundations_values(hpxml_file, hpxml_data)
+        set_hpxml_data_air_infiltration_measurements_values(hpxml_file, hpxml_data)
+        set_hpxml_data_roofs_values(hpxml_file, hpxml_data)
+        set_hpxml_data_rim_joists_values(hpxml_file, hpxml_data)
+        set_hpxml_data_walls_values(hpxml_file, hpxml_data)
+        set_hpxml_data_foundation_walls_values(hpxml_file, hpxml_data)
+        set_hpxml_data_frame_floors_values(hpxml_file, hpxml_data)
+        set_hpxml_data_slabs_values(hpxml_file, hpxml_data)
+        set_hpxml_data_windows_values(hpxml_file, hpxml_data)
+        set_hpxml_data_skylights_values(hpxml_file, hpxml_data)
+        set_hpxml_data_doors_values(hpxml_file, hpxml_data)
+        set_hpxml_data_heating_systems_values(hpxml_file, hpxml_data)
+        set_hpxml_data_cooling_systems_values(hpxml_file, hpxml_data)
+        set_hpxml_data_heat_pumps_values(hpxml_file, hpxml_data)
+        set_hpxml_data_hvac_control_values(hpxml_file, hpxml_data)
+        set_hpxml_data_hvac_distributions_values(hpxml_file, hpxml_data)
+        set_hpxml_data_ventilation_fans_values(hpxml_file, hpxml_data)
+        set_hpxml_data_water_heating_systems_values(hpxml_file, hpxml_data)
+        set_hpxml_data_hot_water_distribution_values(hpxml_file, hpxml_data)
+        set_hpxml_data_water_fixtures_values(hpxml_file, hpxml_data)
+        set_hpxml_data_solar_thermal_system_values(hpxml_file, hpxml_data)
+        set_hpxml_data_pv_systems_values(hpxml_file, hpxml_data)
+        set_hpxml_data_clothes_washer_values(hpxml_file, hpxml_data)
+        set_hpxml_data_clothes_dryer_values(hpxml_file, hpxml_data)
+        set_hpxml_data_dishwasher_values(hpxml_file, hpxml_data)
+        set_hpxml_data_refrigerator_values(hpxml_file, hpxml_data)
+        set_hpxml_data_cooking_range_values(hpxml_file, hpxml_data)
+        set_hpxml_data_oven_values(hpxml_file, hpxml_data)
+        set_hpxml_data_lighting_values(hpxml_file, hpxml_data)
+        set_hpxml_data_ceiling_fans_values(hpxml_file, hpxml_data)
+        set_hpxml_data_plug_loads_values(hpxml_file, hpxml_data)
+        set_hpxml_data_misc_load_schedule_values(hpxml_file, hpxml_data)
       end
 
-      hpxml_doc = HPXML.create_hpxml(**hpxml_values)
-      hpxml = hpxml_doc.elements["HPXML"]
-      hpxml.elements["XMLTransactionHeaderInformation/CreatedDateAndTime"].text = Time.new(2000, 1, 1).strftime("%Y-%m-%dT%H:%M:%S%:z") # Hard-code to prevent diffs
-      HPXML.add_site(hpxml: hpxml, **site_values) unless site_values.nil?
-      site_neighbors_values.each do |site_neighbor_values|
-        HPXML.add_site_neighbor(hpxml: hpxml, **site_neighbor_values)
-      end
-      HPXML.add_building_occupancy(hpxml: hpxml, **building_occupancy_values) unless building_occupancy_values.empty?
-      HPXML.add_building_construction(hpxml: hpxml, **building_construction_values)
-      HPXML.add_climate_and_risk_zones(hpxml: hpxml, **climate_and_risk_zones_values)
-      HPXML.add_air_infiltration_measurement(hpxml: hpxml, **air_infiltration_measurement_values)
-      HPXML.add_attic(hpxml: hpxml, **attic_values) unless attic_values.empty?
-      HPXML.add_foundation(hpxml: hpxml, **foundation_values) unless foundation_values.empty?
-      roofs_values.each do |roof_values|
-        HPXML.add_roof(hpxml: hpxml, **roof_values)
-      end
-      rim_joists_values.each do |rim_joist_values|
-        HPXML.add_rim_joist(hpxml: hpxml, **rim_joist_values)
-      end
-      walls_values.each do |wall_values|
-        HPXML.add_wall(hpxml: hpxml, **wall_values)
-      end
-      foundation_walls_values.each do |foundation_wall_values|
-        HPXML.add_foundation_wall(hpxml: hpxml, **foundation_wall_values)
-      end
-      framefloors_values.each do |framefloor_values|
-        HPXML.add_framefloor(hpxml: hpxml, **framefloor_values)
-      end
-      slabs_values.each do |slab_values|
-        HPXML.add_slab(hpxml: hpxml, **slab_values)
-      end
-      windows_values.each do |window_values|
-        HPXML.add_window(hpxml: hpxml, **window_values)
-      end
-      skylights_values.each do |skylight_values|
-        HPXML.add_skylight(hpxml: hpxml, **skylight_values)
-      end
-      doors_values.each do |door_values|
-        HPXML.add_door(hpxml: hpxml, **door_values)
-      end
-      heating_systems_values.each do |heating_system_values|
-        HPXML.add_heating_system(hpxml: hpxml, **heating_system_values)
-      end
-      cooling_systems_values.each do |cooling_system_values|
-        HPXML.add_cooling_system(hpxml: hpxml, **cooling_system_values)
-      end
-      heat_pumps_values.each do |heat_pump_values|
-        HPXML.add_heat_pump(hpxml: hpxml, **heat_pump_values)
-      end
-      HPXML.add_hvac_control(hpxml: hpxml, **hvac_control_values) unless hvac_control_values.empty?
-      hvac_distributions_values.each_with_index do |hvac_distribution_values, i|
-        hvac_distribution = HPXML.add_hvac_distribution(hpxml: hpxml, **hvac_distribution_values)
-        air_distribution = hvac_distribution.elements["DistributionSystemType/AirDistribution"]
-        next if air_distribution.nil?
-
-        duct_leakage_measurements_values[i].each do |duct_leakage_measurement_values|
-          HPXML.add_duct_leakage_measurement(air_distribution: air_distribution, **duct_leakage_measurement_values)
-        end
-        ducts_values[i].each do |duct_values|
-          HPXML.add_ducts(air_distribution: air_distribution, **duct_values)
-        end
-      end
-      ventilation_fans_values.each do |ventilation_fan_values|
-        HPXML.add_ventilation_fan(hpxml: hpxml, **ventilation_fan_values)
-      end
-      water_heating_systems_values.each do |water_heating_system_values|
-        HPXML.add_water_heating_system(hpxml: hpxml, **water_heating_system_values)
-      end
-      HPXML.add_hot_water_distribution(hpxml: hpxml, **hot_water_distribution_values) unless hot_water_distribution_values.empty?
-      water_fixtures_values.each do |water_fixture_values|
-        HPXML.add_water_fixture(hpxml: hpxml, **water_fixture_values)
-      end
-      HPXML.add_solar_thermal_system(hpxml: hpxml, **solar_thermal_system_values) unless solar_thermal_system_values.empty?
-      pv_systems_values.each do |pv_system_values|
-        HPXML.add_pv_system(hpxml: hpxml, **pv_system_values)
-      end
-      HPXML.add_clothes_washer(hpxml: hpxml, **clothes_washer_values) unless clothes_washer_values.empty?
-      HPXML.add_clothes_dryer(hpxml: hpxml, **clothes_dryer_values) unless clothes_dryer_values.empty?
-      HPXML.add_dishwasher(hpxml: hpxml, **dishwasher_values) unless dishwasher_values.empty?
-      HPXML.add_refrigerator(hpxml: hpxml, **refrigerator_values) unless refrigerator_values.empty?
-      HPXML.add_cooking_range(hpxml: hpxml, **cooking_range_values) unless cooking_range_values.empty?
-      HPXML.add_oven(hpxml: hpxml, **oven_values) unless oven_values.empty?
-      HPXML.add_lighting(hpxml: hpxml, **lighting_values) unless lighting_values.empty?
-      ceiling_fans_values.each do |ceiling_fan_values|
-        HPXML.add_ceiling_fan(hpxml: hpxml, **ceiling_fan_values)
-      end
-      plug_loads_values.each do |plug_load_values|
-        HPXML.add_plug_load(hpxml: hpxml, **plug_load_values)
-      end
-      HPXML.add_misc_loads_schedule(hpxml: hpxml, **misc_load_schedule_values) unless misc_load_schedule_values.empty?
+      hpxml = HPXML.new(hpxml_data: hpxml_data)
+      hpxml_doc = hpxml.to_object()
 
       if ['invalid_files/missing-elements.xml'].include? derivative
-        hpxml.elements["Building/BuildingDetails/BuildingSummary/BuildingConstruction"].elements.delete("NumberofConditionedFloors")
-        hpxml.elements["Building/BuildingDetails/BuildingSummary/BuildingConstruction"].elements.delete("ConditionedFloorArea")
+        hpxml_doc.elements["/HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction"].elements.delete("NumberofConditionedFloors")
+        hpxml_doc.elements["/HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction"].elements.delete("ConditionedFloorArea")
       end
 
       hpxml_path = File.join(sample_files_dir, derivative)
@@ -593,1137 +463,1124 @@ def create_hpxmls
   end
 end
 
-def get_hpxml_file_hpxml_values(hpxml_file, hpxml_values)
+def set_hpxml_data_header_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    hpxml_values = { :xml_type => "HPXML",
-                     :xml_generated_by => "Rakefile",
-                     :transaction => "create",
-                     :software_program_used => nil,
-                     :software_program_version => nil,
-                     :eri_calculation_version => nil,
-                     :building_id => "MyBuilding",
-                     :event_type => "proposed workscope" }
+    hpxml_data[:header] = { :xml_type => "HPXML",
+                            :xml_generated_by => "Rakefile",
+                            :transaction => "create",
+                            :software_program_used => nil,
+                            :software_program_version => nil,
+                            :eri_calculation_version => nil,
+                            :building_id => "MyBuilding",
+                            :event_type => "proposed workscope",
+                            :created_date_and_time => Time.new(2000, 1, 1).strftime("%Y-%m-%dT%H:%M:%S%:z") } # Hard-code to prevent diffs
   elsif ['base-version-2014.xml'].include? hpxml_file
-    hpxml_values[:eri_calculation_version] = "2014"
+    hpxml_data[:header][:eri_calculation_version] = "2014"
   elsif ['base-version-2014A.xml'].include? hpxml_file
-    hpxml_values[:eri_calculation_version] = "2014A"
+    hpxml_data[:header][:eri_calculation_version] = "2014A"
   elsif ['base-version-2014AE.xml'].include? hpxml_file
-    hpxml_values[:eri_calculation_version] = "2014AE"
+    hpxml_data[:header][:eri_calculation_version] = "2014AE"
   elsif ['base-version-2014AEG.xml'].include? hpxml_file
-    hpxml_values[:eri_calculation_version] = "2014AEG"
+    hpxml_data[:header][:eri_calculation_version] = "2014AEG"
   elsif ['base-version-latest.xml'].include? hpxml_file
-    hpxml_values[:eri_calculation_version] = 'latest'
+    hpxml_data[:header][:eri_calculation_version] = 'latest'
   elsif ['base-misc-timestep-10-mins.xml'].include? hpxml_file
-    hpxml_values[:timestep] = 10
+    hpxml_data[:header][:timestep] = 10
   elsif ['base-misc-timestep-60-mins.xml'].include? hpxml_file
-    hpxml_values[:timestep] = 60
+    hpxml_data[:header][:timestep] = 60
   elsif ['invalid_files/invalid-timestep.xml'].include? hpxml_file
-    hpxml_values[:timestep] = 45
+    hpxml_data[:header][:timestep] = 45
   end
-  return hpxml_values
 end
 
-def get_hpxml_file_site_values(hpxml_file, site_values)
+def set_hpxml_data_site_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    site_values = { :fuels => ["electricity", "natural gas"] }
+    hpxml_data[:site] = { :fuels => ["electricity", "natural gas"] }
   elsif ['base-hvac-none-no-fuel-access.xml'].include? hpxml_file
-    site_values[:fuels] = ["electricity"]
+    hpxml_data[:site][:fuels] = ["electricity"]
   end
-  return site_values
 end
 
-def get_hpxml_file_site_neighbor_values(hpxml_file, site_neighbors_values)
-  if ['base-site-neighbors.xml'].include? hpxml_file
-    site_neighbors_values << { :azimuth => 0,
-                               :distance => 10 }
-    site_neighbors_values << { :azimuth => 180,
-                               :distance => 15,
-                               :height => 12 }
-  elsif ['invalid_files/bad-site-neighbor-azimuth.xml'].include? hpxml_file
-    site_neighbors_values[0][:azimuth] = 145
-  end
-  return site_neighbors_values
-end
-
-def get_hpxml_file_building_occupancy_values(hpxml_file, building_occupancy_values)
-  if ['base-misc-number-of-occupants.xml'].include? hpxml_file
-    building_occupancy_values = { :number_of_residents => 5 }
-  end
-  return building_occupancy_values
-end
-
-def get_hpxml_file_building_construction_values(hpxml_file, building_construction_values)
+def set_hpxml_data_neighbor_buildings_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    building_construction_values = { :number_of_conditioned_floors => 2,
-                                     :number_of_conditioned_floors_above_grade => 1,
-                                     :number_of_bedrooms => 3,
-                                     :conditioned_floor_area => 2700,
-                                     :conditioned_building_volume => 2700 * 8,
-                                     :fraction_of_operable_window_area => 0.33 }
+    hpxml_data[:neighbor_buildings] = []
+  elsif ['base-site-neighbors.xml'].include? hpxml_file
+    hpxml_data[:neighbor_buildings] << { :azimuth => 0,
+                                         :distance => 10 }
+    hpxml_data[:neighbor_buildings] << { :azimuth => 180,
+                                         :distance => 15,
+                                         :height => 12 }
+  elsif ['invalid_files/bad-site-neighbor-azimuth.xml'].include? hpxml_file
+    hpxml_data[:neighbor_buildings][0][:azimuth] = 145
+  end
+end
+
+def set_hpxml_data_building_occupancy_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:building_occupants] = {}
+  elsif ['base-misc-number-of-occupants.xml'].include? hpxml_file
+    hpxml_data[:building_occupants] = { :number_of_residents => 5 }
+  end
+end
+
+def set_hpxml_data_building_construction_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:building_construction] = { :number_of_conditioned_floors => 2,
+                                           :number_of_conditioned_floors_above_grade => 1,
+                                           :number_of_bedrooms => 3,
+                                           :conditioned_floor_area => 2700,
+                                           :conditioned_building_volume => 2700 * 8,
+                                           :fraction_of_operable_window_area => 0.33 }
   elsif ['base-enclosure-beds-1.xml'].include? hpxml_file
-    building_construction_values[:number_of_bedrooms] = 1
+    hpxml_data[:building_construction][:number_of_bedrooms] = 1
   elsif ['base-enclosure-beds-2.xml'].include? hpxml_file
-    building_construction_values[:number_of_bedrooms] = 2
+    hpxml_data[:building_construction][:number_of_bedrooms] = 2
   elsif ['base-enclosure-beds-4.xml'].include? hpxml_file
-    building_construction_values[:number_of_bedrooms] = 4
+    hpxml_data[:building_construction][:number_of_bedrooms] = 4
   elsif ['base-enclosure-beds-5.xml'].include? hpxml_file
-    building_construction_values[:number_of_bedrooms] = 5
+    hpxml_data[:building_construction][:number_of_bedrooms] = 5
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml',
          'base-foundation-unconditioned-basement.xml',
          'base-foundation-unvented-crawlspace.xml',
          'base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    building_construction_values[:number_of_conditioned_floors] -= 1
-    building_construction_values[:conditioned_floor_area] -= 1350
-    building_construction_values[:conditioned_building_volume] -= 1350 * 8
+    hpxml_data[:building_construction][:number_of_conditioned_floors] -= 1
+    hpxml_data[:building_construction][:conditioned_floor_area] -= 1350
+    hpxml_data[:building_construction][:conditioned_building_volume] -= 1350 * 8
   elsif ['base-hvac-ideal-air.xml'].include? hpxml_file
-    building_construction_values[:use_only_ideal_air_system] = true
+    hpxml_data[:building_construction][:use_only_ideal_air_system] = true
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    building_construction_values[:number_of_conditioned_floors] += 1
-    building_construction_values[:number_of_conditioned_floors_above_grade] += 1
-    building_construction_values[:conditioned_floor_area] += 900
-    building_construction_values[:conditioned_building_volume] += 2250
+    hpxml_data[:building_construction][:number_of_conditioned_floors] += 1
+    hpxml_data[:building_construction][:number_of_conditioned_floors_above_grade] += 1
+    hpxml_data[:building_construction][:conditioned_floor_area] += 900
+    hpxml_data[:building_construction][:conditioned_building_volume] += 2250
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    building_construction_values[:conditioned_building_volume] += 10800
+    hpxml_data[:building_construction][:conditioned_building_volume] += 10800
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    building_construction_values[:number_of_conditioned_floors] += 1
-    building_construction_values[:number_of_conditioned_floors_above_grade] += 1
-    building_construction_values[:conditioned_floor_area] += 1350
-    building_construction_values[:conditioned_building_volume] += 1350 * 8
+    hpxml_data[:building_construction][:number_of_conditioned_floors] += 1
+    hpxml_data[:building_construction][:number_of_conditioned_floors_above_grade] += 1
+    hpxml_data[:building_construction][:conditioned_floor_area] += 1350
+    hpxml_data[:building_construction][:conditioned_building_volume] += 1350 * 8
   elsif ['base-enclosure-windows-inoperable.xml'].include? hpxml_file
-    building_construction_values[:fraction_of_operable_window_area] = 0.0
+    hpxml_data[:building_construction][:fraction_of_operable_window_area] = 0.0
   end
-  return building_construction_values
 end
 
-def get_hpxml_file_climate_and_risk_zones_values(hpxml_file, climate_and_risk_zones_values)
+def set_hpxml_data_climate_and_risk_zones_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    climate_and_risk_zones_values = { :iecc2006 => "5B",
-                                      :weather_station_id => "WeatherStation",
-                                      :weather_station_name => "Denver, CO",
-                                      :weather_station_wmo => "725650" }
+    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "5B",
+                                            :weather_station_id => "WeatherStation",
+                                            :weather_station_name => "Denver, CO",
+                                            :weather_station_wmo => "725650" }
   elsif ['base-location-baltimore-md.xml'].include? hpxml_file
-    climate_and_risk_zones_values = { :iecc2006 => "4A",
-                                      :weather_station_id => "WeatherStation",
-                                      :weather_station_name => "Baltimore, MD",
-                                      :weather_station_wmo => "724060" }
+    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "4A",
+                                            :weather_station_id => "WeatherStation",
+                                            :weather_station_name => "Baltimore, MD",
+                                            :weather_station_wmo => "724060" }
   elsif ['base-location-dallas-tx.xml'].include? hpxml_file
-    climate_and_risk_zones_values = { :iecc2006 => "3A",
-                                      :weather_station_id => "WeatherStation",
-                                      :weather_station_name => "Dallas, TX",
-                                      :weather_station_wmo => "722590" }
+    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "3A",
+                                            :weather_station_id => "WeatherStation",
+                                            :weather_station_name => "Dallas, TX",
+                                            :weather_station_wmo => "722590" }
   elsif ['base-location-duluth-mn.xml'].include? hpxml_file
-    climate_and_risk_zones_values = { :iecc2006 => "7",
-                                      :weather_station_id => "WeatherStation",
-                                      :weather_station_name => "Duluth, MN",
-                                      :weather_station_wmo => "727450" }
+    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "7",
+                                            :weather_station_id => "WeatherStation",
+                                            :weather_station_name => "Duluth, MN",
+                                            :weather_station_wmo => "727450" }
   elsif ['base-location-miami-fl.xml'].include? hpxml_file
-    climate_and_risk_zones_values = { :iecc2006 => "1A",
-                                      :weather_station_id => "WeatherStation",
-                                      :weather_station_name => "Miami, FL",
-                                      :weather_station_wmo => "722020" }
+    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "1A",
+                                            :weather_station_id => "WeatherStation",
+                                            :weather_station_name => "Miami, FL",
+                                            :weather_station_wmo => "722020" }
   elsif ['base-location-epw-filename.xml'].include? hpxml_file
-    climate_and_risk_zones_values[:weather_station_wmo] = nil
-    climate_and_risk_zones_values[:weather_station_epw_filename] = "USA_CO_Denver.Intl.AP.725650_TMY3.epw"
+    hpxml_data[:climate_and_risk_zones][:weather_station_wmo] = nil
+    hpxml_data[:climate_and_risk_zones][:weather_station_epw_filename] = "USA_CO_Denver.Intl.AP.725650_TMY3.epw"
   elsif ['invalid_files/bad-wmo.xml'].include? hpxml_file
-    climate_and_risk_zones_values[:weather_station_wmo] = "999999"
+    hpxml_data[:climate_and_risk_zones][:weather_station_wmo] = "999999"
   end
-  return climate_and_risk_zones_values
 end
 
-def get_hpxml_file_air_infiltration_measurement_values(hpxml_file, air_infiltration_measurement_values, building_construction_values)
-  infil_volume = building_construction_values[:conditioned_building_volume]
+def set_hpxml_data_air_infiltration_measurements_values(hpxml_file, hpxml_data)
+  infil_volume = hpxml_data[:building_construction][:conditioned_building_volume]
   if ['base.xml'].include? hpxml_file
-    air_infiltration_measurement_values = { :id => "InfiltrationMeasurement",
-                                            :house_pressure => 50,
-                                            :unit_of_measure => "ACH",
-                                            :air_leakage => 3.0 }
+    hpxml_data[:air_infiltration_measurements] = [{ :id => "InfiltrationMeasurement",
+                                                    :house_pressure => 50,
+                                                    :unit_of_measure => "ACH",
+                                                    :air_leakage => 3.0 }]
   elsif ['base-infiltration-ach-natural.xml'].include? hpxml_file
-    air_infiltration_measurement_values = { :id => "InfiltrationMeasurement",
-                                            :constant_ach_natural => 0.67 }
+    hpxml_data[:air_infiltration_measurements] = [{ :id => "InfiltrationMeasurement",
+                                                    :constant_ach_natural => 0.67 }]
   elsif ['base-enclosure-infil-cfm50.xml'].include? hpxml_file
-    air_infiltration_measurement_values = { :id => "InfiltrationMeasurement",
-                                            :house_pressure => 50,
-                                            :unit_of_measure => "CFM",
-                                            :air_leakage => 3.0 / 60.0 * infil_volume }
+    hpxml_data[:air_infiltration_measurements] = [{ :id => "InfiltrationMeasurement",
+                                                    :house_pressure => 50,
+                                                    :unit_of_measure => "CFM",
+                                                    :air_leakage => 3.0 / 60.0 * infil_volume }]
   end
-  air_infiltration_measurement_values[:infiltration_volume] = infil_volume
-  return air_infiltration_measurement_values
+  hpxml_data[:air_infiltration_measurements][0][:infiltration_volume] = infil_volume
 end
 
-def get_hpxml_file_attic_values(hpxml_file, attic_values)
+def set_hpxml_data_attics_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    attic_values = {}
+    hpxml_data[:attics] = []
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    attic_values = { :id => "VentedAttic",
-                     :attic_type => "VentedAttic",
-                     :vented_attic_sla => 0.003 }
+    hpxml_data[:attics] << { :id => "VentedAttic",
+                             :attic_type => "VentedAttic",
+                             :vented_attic_sla => 0.003 }
   end
-  return attic_values
 end
 
-def get_hpxml_file_foundation_values(hpxml_file, foundation_values)
+def set_hpxml_data_foundations_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    foundation_values = {}
+    hpxml_data[:foundations] = []
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    foundation_values = { :id => "VentedCrawlspace",
-                          :foundation_type => "VentedCrawlspace",
-                          :vented_crawlspace_sla => 0.00667 }
+    hpxml_data[:foundations] << { :id => "VentedCrawlspace",
+                                  :foundation_type => "VentedCrawlspace",
+                                  :vented_crawlspace_sla => 0.00667 }
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    foundation_values = { :id => "UnconditionedBasement",
-                          :foundation_type => "UnconditionedBasement",
-                          :unconditioned_basement_thermal_boundary => "frame floor" }
+    hpxml_data[:foundations] << { :id => "UnconditionedBasement",
+                                  :foundation_type => "UnconditionedBasement",
+                                  :unconditioned_basement_thermal_boundary => "frame floor" }
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    foundation_values = { :id => "UnconditionedBasement",
-                          :foundation_type => "UnconditionedBasement",
-                          :unconditioned_basement_thermal_boundary => "foundation wall" }
+    hpxml_data[:foundations][0][:unconditioned_basement_thermal_boundary] = "foundation wall"
   end
-  return foundation_values
 end
 
-def get_hpxml_file_roofs_values(hpxml_file, roofs_values)
+def set_hpxml_data_roofs_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    roofs_values = [{ :id => "Roof",
-                      :interior_adjacent_to => "attic - unvented",
-                      :area => 1510,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 6,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 2.3 }]
+    hpxml_data[:roofs] = [{ :id => "Roof",
+                            :interior_adjacent_to => "attic - unvented",
+                            :area => 1510,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :pitch => 6,
+                            :radiant_barrier => false,
+                            :insulation_assembly_r_value => 2.3 }]
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
-    roofs_values = [{ :id => "Roof",
-                      :interior_adjacent_to => "living space",
-                      :area => 1350,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 0,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 25.8 }]
+    hpxml_data[:roofs] = [{ :id => "Roof",
+                            :interior_adjacent_to => "living space",
+                            :area => 1350,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :pitch => 0,
+                            :radiant_barrier => false,
+                            :insulation_assembly_r_value => 25.8 }]
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    roofs_values = [{ :id => "RoofCond",
-                      :interior_adjacent_to => "living space",
-                      :area => 1006,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 6,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 25.8 },
-                    { :id => "RoofUncond",
-                      :interior_adjacent_to => "attic - unvented",
-                      :area => 504,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 6,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 2.3 }]
+    hpxml_data[:roofs] = [{ :id => "RoofCond",
+                            :interior_adjacent_to => "living space",
+                            :area => 1006,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :pitch => 6,
+                            :radiant_barrier => false,
+                            :insulation_assembly_r_value => 25.8 },
+                          { :id => "RoofUncond",
+                            :interior_adjacent_to => "attic - unvented",
+                            :area => 504,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :pitch => 6,
+                            :radiant_barrier => false,
+                            :insulation_assembly_r_value => 2.3 }]
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    roofs_values[0][:interior_adjacent_to] = "attic - vented"
+    hpxml_data[:roofs][0][:interior_adjacent_to] = "attic - vented"
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    roofs_values[0][:interior_adjacent_to] = "living space"
-    roofs_values[0][:insulation_assembly_r_value] = 25.8
+    hpxml_data[:roofs][0][:interior_adjacent_to] = "living space"
+    hpxml_data[:roofs][0][:insulation_assembly_r_value] = 25.8
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    roofs_values << { :id => "RoofGarage",
-                      :interior_adjacent_to => "garage",
-                      :area => 670,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 6,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 2.3 }
+    hpxml_data[:roofs] << { :id => "RoofGarage",
+                            :interior_adjacent_to => "garage",
+                            :area => 670,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :pitch => 6,
+                            :radiant_barrier => false,
+                            :insulation_assembly_r_value => 2.3 }
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
-    roofs_values[0][:insulation_assembly_r_value] = 25.8
+    hpxml_data[:roofs][0][:insulation_assembly_r_value] = 25.8
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    roofs_values = []
+    hpxml_data[:roofs] = []
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..roofs_values.size
-      roofs_values[n - 1][:area] /= 10.0
+    for n in 1..hpxml_data[:roofs].size
+      hpxml_data[:roofs][n - 1][:area] /= 10.0
       for i in 2..10
-        roofs_values << roofs_values[n - 1].dup
-        roofs_values[-1][:id] += i.to_s
+        hpxml_data[:roofs] << hpxml_data[:roofs][n - 1].dup
+        hpxml_data[:roofs][-1][:id] += i.to_s
       end
     end
   elsif ['base-atticroof-radiant-barrier.xml'].include? hpxml_file
-    roofs_values[0][:radiant_barrier] = true
+    hpxml_data[:roofs][0][:radiant_barrier] = true
   end
-  return roofs_values
 end
 
-def get_hpxml_file_rim_joists_values(hpxml_file, rim_joists_values)
+def set_hpxml_data_rim_joists_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
     # TODO: Other geometry values (e.g., building volume) assume
     # no rim joists.
-    rim_joists_values = [{ :id => "RimJoistFoundation",
-                           :exterior_adjacent_to => "outside",
-                           :interior_adjacent_to => "basement - conditioned",
-                           :area => 116,
-                           :solar_absorptance => 0.7,
-                           :emittance => 0.92,
-                           :insulation_assembly_r_value => 23.0 }]
+    hpxml_data[:rim_joists] = [{ :id => "RimJoistFoundation",
+                                 :exterior_adjacent_to => "outside",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :area => 116,
+                                 :solar_absorptance => 0.7,
+                                 :emittance => 0.92,
+                                 :insulation_assembly_r_value => 23.0 }]
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml'].include? hpxml_file
-    rim_joists_values = []
+    hpxml_data[:rim_joists] = []
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    for i in 0..rim_joists_values.size - 1
-      rim_joists_values[i][:interior_adjacent_to] = "basement - unconditioned"
-      rim_joists_values[i][:insulation_assembly_r_value] = 2.3
+    for i in 0..hpxml_data[:rim_joists].size - 1
+      hpxml_data[:rim_joists][i][:interior_adjacent_to] = "basement - unconditioned"
+      hpxml_data[:rim_joists][i][:insulation_assembly_r_value] = 2.3
     end
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    for i in 0..rim_joists_values.size - 1
-      rim_joists_values[i][:insulation_assembly_r_value] = 23.0
+    for i in 0..hpxml_data[:rim_joists].size - 1
+      hpxml_data[:rim_joists][i][:insulation_assembly_r_value] = 23.0
     end
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    for i in 0..rim_joists_values.size - 1
-      rim_joists_values[i][:interior_adjacent_to] = "crawlspace - unvented"
+    for i in 0..hpxml_data[:rim_joists].size - 1
+      hpxml_data[:rim_joists][i][:interior_adjacent_to] = "crawlspace - unvented"
     end
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    for i in 0..rim_joists_values.size - 1
-      rim_joists_values[i][:interior_adjacent_to] = "crawlspace - vented"
+    for i in 0..hpxml_data[:rim_joists].size - 1
+      hpxml_data[:rim_joists][i][:interior_adjacent_to] = "crawlspace - vented"
     end
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
-    rim_joists_values[0][:exterior_adjacent_to] = "crawlspace - unvented"
-    rim_joists_values << { :id => "RimJoistCrawlspace",
-                           :exterior_adjacent_to => "outside",
-                           :interior_adjacent_to => "crawlspace - unvented",
-                           :area => 81,
-                           :solar_absorptance => 0.7,
-                           :emittance => 0.92,
-                           :insulation_assembly_r_value => 2.3 }
-  elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    rim_joists_values << { :id => "RimJoist2ndStory",
-                           :exterior_adjacent_to => "outside",
-                           :interior_adjacent_to => "living space",
-                           :area => 116,
-                           :solar_absorptance => 0.7,
-                           :emittance => 0.92,
-                           :insulation_assembly_r_value => 23.0 }
-  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..rim_joists_values.size
-      rim_joists_values[n - 1][:area] /= 10.0
-      for i in 2..10
-        rim_joists_values << rim_joists_values[n - 1].dup
-        rim_joists_values[-1][:id] += i.to_s
-      end
-    end
-  end
-  return rim_joists_values
-end
-
-def get_hpxml_file_walls_values(hpxml_file, walls_values)
-  if ['base.xml'].include? hpxml_file
-    walls_values = [{ :id => "Wall",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 1200,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 },
-                    { :id => "WallAtticGable",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "attic - unvented",
-                      :wall_type => "WoodStud",
-                      :area => 290,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4.0 }]
-  elsif ['base-atticroof-flat.xml'].include? hpxml_file
-    walls_values.delete_at(1)
-  elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    walls_values[1][:interior_adjacent_to] = "attic - vented"
-  elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    walls_values[1][:interior_adjacent_to] = "living space"
-    walls_values[1][:insulation_assembly_r_value] = 23.0
-  elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    walls_values.delete_at(1)
-    walls_values << { :id => "WallAtticKneeWall",
-                      :exterior_adjacent_to => "attic - unvented",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 316,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23.0 }
-    walls_values << { :id => "WallAtticGableCond",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 240,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 22.3 }
-    walls_values << { :id => "WallAtticGableUncond",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "attic - unvented",
-                      :wall_type => "WoodStud",
-                      :area => 50,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4.0 }
-  elsif ['base-enclosure-walltype-cmu.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "ConcreteMasonryUnit"
-    walls_values[0][:insulation_assembly_r_value] = 12
-  elsif ['base-enclosure-walltype-doublestud.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "DoubleWoodStud"
-    walls_values[0][:insulation_assembly_r_value] = 28.7
-  elsif ['base-enclosure-walltype-icf.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "InsulatedConcreteForms"
-    walls_values[0][:insulation_assembly_r_value] = 21
-  elsif ['base-enclosure-walltype-log.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "LogWall"
-    walls_values[0][:insulation_assembly_r_value] = 7.1
-  elsif ['base-enclosure-walltype-sip.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "StructurallyInsulatedPanel"
-    walls_values[0][:insulation_assembly_r_value] = 16.1
-  elsif ['base-enclosure-walltype-solidconcrete.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "SolidConcrete"
-    walls_values[0][:insulation_assembly_r_value] = 1.35
-  elsif ['base-enclosure-walltype-steelstud.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "SteelFrame"
-    walls_values[0][:insulation_assembly_r_value] = 8.1
-  elsif ['base-enclosure-walltype-stone.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "Stone"
-    walls_values[0][:insulation_assembly_r_value] = 5.4
-  elsif ['base-enclosure-walltype-strawbale.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "StrawBale"
-    walls_values[0][:insulation_assembly_r_value] = 58.8
-  elsif ['base-enclosure-walltype-structuralbrick.xml'].include? hpxml_file
-    walls_values[0][:wall_type] = "StructuralBrick"
-    walls_values[0][:insulation_assembly_r_value] = 7.9
-  elsif ['invalid_files/missing-surfaces.xml'].include? hpxml_file
-    walls_values << { :id => "WallGarage",
-                      :exterior_adjacent_to => "garage",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 100,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4 }
-  elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    walls_values[0][:area] *= 2.0
-  elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    walls_values = [{ :id => "Wall",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 880,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 },
-                    { :id => "WallGarageInterior",
-                      :exterior_adjacent_to => "garage",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 320,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 },
-                    { :id => "WallGarageExterior",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "garage",
-                      :wall_type => "WoodStud",
-                      :area => 800,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4 }]
-  elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    walls_values = [{ :id => "Wall",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 960,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 },
-                    { :id => "WallGarageInterior",
-                      :exterior_adjacent_to => "garage",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 240,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 },
-                    { :id => "WallGarageExterior",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "garage",
-                      :wall_type => "WoodStud",
-                      :area => 560,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4 }]
-  elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
-    walls_values[1][:insulation_assembly_r_value] = 23
-  elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    walls_values.delete_at(1)
-    walls_values << walls_values[0].dup
-    walls_values[0][:area] *= 0.35
-    walls_values[-1][:area] *= 0.65
-    walls_values[-1][:id] += "Adiabatic"
-    walls_values[-1][:exterior_adjacent_to] = "other housing unit"
-    walls_values[-1][:insulation_assembly_r_value] = 4
-  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..walls_values.size
-      walls_values[n - 1][:area] /= 10.0
-      for i in 2..10
-        walls_values << walls_values[n - 1].dup
-        walls_values[-1][:id] += i.to_s
-      end
-    end
-  end
-  return walls_values
-end
-
-def get_hpxml_file_foundation_walls_values(hpxml_file, foundation_walls_values)
-  if ['base.xml'].include? hpxml_file
-    foundation_walls_values = [{ :id => "FoundationWall",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 8,
-                                 :area => 1200,
-                                 :thickness => 8,
-                                 :depth_below_grade => 7,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 8,
-                                 :insulation_exterior_r_value => 8.9 }]
-  elsif ['base-foundation-conditioned-basement-wall-interior-insulation.xml'].include? hpxml_file
-    foundation_walls_values[0][:insulation_interior_distance_to_top] = 0
-    foundation_walls_values[0][:insulation_interior_distance_to_bottom] = 8
-    foundation_walls_values[0][:insulation_interior_r_value] = 10
-    foundation_walls_values[0][:insulation_exterior_distance_to_top] = 1
-    foundation_walls_values[0][:insulation_exterior_distance_to_bottom] = 8
-  elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    foundation_walls_values[0][:interior_adjacent_to] = "basement - unconditioned"
-    foundation_walls_values[0][:insulation_exterior_distance_to_bottom] = 0
-    foundation_walls_values[0][:insulation_exterior_r_value] = 0
-  elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    foundation_walls_values[0][:insulation_exterior_distance_to_bottom] = 4
-    foundation_walls_values[0][:insulation_exterior_r_value] = 8.9
-  elsif ['base-foundation-unconditioned-basement-assembly-r.xml'].include? hpxml_file
-    foundation_walls_values[0][:insulation_exterior_distance_to_top] = nil
-    foundation_walls_values[0][:insulation_exterior_distance_to_bottom] = nil
-    foundation_walls_values[0][:insulation_exterior_r_value] = nil
-    foundation_walls_values[0][:insulation_interior_distance_to_top] = nil
-    foundation_walls_values[0][:insulation_interior_distance_to_bottom] = nil
-    foundation_walls_values[0][:insulation_interior_r_value] = nil
-    foundation_walls_values[0][:insulation_assembly_r_value] = 10.69
-  elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
-    foundation_walls_values[0][:depth_below_grade] = 4
-  elsif ['base-foundation-unvented-crawlspace.xml',
-         'base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    if ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-      foundation_walls_values[0][:interior_adjacent_to] = "crawlspace - unvented"
-    else
-      foundation_walls_values[0][:interior_adjacent_to] = "crawlspace - vented"
-    end
-    foundation_walls_values[0][:height] -= 4
-    foundation_walls_values[0][:area] /= 2.0
-    foundation_walls_values[0][:depth_below_grade] -= 4
-    foundation_walls_values[0][:insulation_exterior_distance_to_bottom] -= 4
-  elsif ['base-foundation-multiple.xml'].include? hpxml_file
-    foundation_walls_values[0][:area] = 600
-    foundation_walls_values << { :id => "FoundationWallInterior",
-                                 :exterior_adjacent_to => "crawlspace - unvented",
-                                 :interior_adjacent_to => "basement - unconditioned",
-                                 :height => 8,
-                                 :area => 360,
-                                 :thickness => 8,
-                                 :depth_below_grade => 4,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 0,
-                                 :insulation_exterior_r_value => 0 }
-    foundation_walls_values << { :id => "FoundationWallCrawlspace",
-                                 :exterior_adjacent_to => "ground",
+    hpxml_data[:rim_joists][0][:exterior_adjacent_to] = "crawlspace - unvented"
+    hpxml_data[:rim_joists] << { :id => "RimJoistCrawlspace",
+                                 :exterior_adjacent_to => "outside",
                                  :interior_adjacent_to => "crawlspace - unvented",
-                                 :height => 4,
-                                 :area => 600,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 0,
-                                 :insulation_exterior_r_value => 0 }
-  elsif ['base-foundation-ambient.xml',
-         'base-foundation-slab.xml'].include? hpxml_file
-    foundation_walls_values = []
-  elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
-    foundation_walls_values = [{ :id => "FoundationWall1",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 8,
-                                 :area => 480,
-                                 :thickness => 8,
-                                 :depth_below_grade => 7,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 8,
-                                 :insulation_exterior_r_value => 8.9 },
-                               { :id => "FoundationWall2",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 4,
-                                 :area => 120,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 4,
-                                 :insulation_exterior_r_value => 8.9 },
-                               { :id => "FoundationWall3",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 2,
-                                 :area => 60,
-                                 :thickness => 8,
-                                 :depth_below_grade => 1,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 2,
-                                 :insulation_exterior_r_value => 8.9 }]
-  elsif ['base-foundation-complex.xml'].include? hpxml_file
-    foundation_walls_values = [{ :id => "FoundationWall1",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 8,
-                                 :area => 160,
-                                 :thickness => 8,
-                                 :depth_below_grade => 7,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 0,
-                                 :insulation_exterior_r_value => 0.0 },
-                               { :id => "FoundationWall2",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 8,
-                                 :area => 240,
-                                 :thickness => 8,
-                                 :depth_below_grade => 7,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 8,
-                                 :insulation_exterior_r_value => 8.9 },
-                               { :id => "FoundationWall3",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 4,
-                                 :area => 160,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 0,
-                                 :insulation_exterior_r_value => 0.0 },
-                               { :id => "FoundationWall4",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 4,
-                                 :area => 120,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 4,
-                                 :insulation_exterior_r_value => 8.9 },
-                               { :id => "FoundationWall5",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 4,
-                                 :area => 80,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 4,
-                                 :insulation_exterior_r_value => 8.9 }]
+                                 :area => 81,
+                                 :solar_absorptance => 0.7,
+                                 :emittance => 0.92,
+                                 :insulation_assembly_r_value => 2.3 }
+  elsif ['base-enclosure-2stories.xml'].include? hpxml_file
+    hpxml_data[:rim_joists] << { :id => "RimJoist2ndStory",
+                                 :exterior_adjacent_to => "outside",
+                                 :interior_adjacent_to => "living space",
+                                 :area => 116,
+                                 :solar_absorptance => 0.7,
+                                 :emittance => 0.92,
+                                 :insulation_assembly_r_value => 23.0 }
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..foundation_walls_values.size
-      foundation_walls_values[n - 1][:area] /= 10.0
+    for n in 1..hpxml_data[:rim_joists].size
+      hpxml_data[:rim_joists][n - 1][:area] /= 10.0
       for i in 2..10
-        foundation_walls_values << foundation_walls_values[n - 1].dup
-        foundation_walls_values[-1][:id] += i.to_s
+        hpxml_data[:rim_joists] << hpxml_data[:rim_joists][n - 1].dup
+        hpxml_data[:rim_joists][-1][:id] += i.to_s
       end
     end
-  elsif ['invalid_files/mismatched-slab-and-foundation-wall.xml'].include? hpxml_file
-    foundation_walls_values << foundation_walls_values[0].dup
-    foundation_walls_values[1][:id] = "FoundationWall2"
-    foundation_walls_values[1][:interior_adjacent_to] = "garage"
   end
-  return foundation_walls_values
 end
 
-def get_hpxml_file_framefloors_values(hpxml_file, framefloors_values)
+def set_hpxml_data_walls_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    framefloors_values = [{ :id => "FloorBelowAttic",
-                            :exterior_adjacent_to => "attic - unvented",
-                            :interior_adjacent_to => "living space",
-                            :area => 1350,
-                            :insulation_assembly_r_value => 39.3 }]
-  elsif ['base-atticroof-flat.xml',
-         'base-atticroof-cathedral.xml'].include? hpxml_file
-    framefloors_values.delete_at(0)
-  elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    framefloors_values[0][:exterior_adjacent_to] = "attic - vented"
-  elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    framefloors_values[0][:area] = 450
-  elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    framefloors_values << { :id => "FloorBetweenAtticGarage",
-                            :exterior_adjacent_to => "attic - unvented",
-                            :interior_adjacent_to => "garage",
-                            :area => 600,
-                            :insulation_assembly_r_value => 2.1 }
-  elsif ['base-foundation-ambient.xml'].include? hpxml_file
-    framefloors_values << { :id => "FloorAboveAmbient",
+    hpxml_data[:walls] = [{ :id => "Wall",
                             :exterior_adjacent_to => "outside",
                             :interior_adjacent_to => "living space",
-                            :area => 1350,
-                            :insulation_assembly_r_value => 18.7 }
-  elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    framefloors_values << { :id => "FloorAboveUncondBasement",
-                            :exterior_adjacent_to => "basement - unconditioned",
+                            :wall_type => "WoodStud",
+                            :area => 1200,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 23 },
+                          { :id => "WallAtticGable",
+                            :exterior_adjacent_to => "outside",
+                            :interior_adjacent_to => "attic - unvented",
+                            :wall_type => "WoodStud",
+                            :area => 290,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 4.0 }]
+  elsif ['base-atticroof-flat.xml'].include? hpxml_file
+    hpxml_data[:walls].delete_at(1)
+  elsif ['base-atticroof-vented.xml'].include? hpxml_file
+    hpxml_data[:walls][1][:interior_adjacent_to] = "attic - vented"
+  elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
+    hpxml_data[:walls][1][:interior_adjacent_to] = "living space"
+    hpxml_data[:walls][1][:insulation_assembly_r_value] = 23.0
+  elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
+    hpxml_data[:walls].delete_at(1)
+    hpxml_data[:walls] << { :id => "WallAtticKneeWall",
+                            :exterior_adjacent_to => "attic - unvented",
                             :interior_adjacent_to => "living space",
-                            :area => 1350,
-                            :insulation_assembly_r_value => 18.7 }
-  elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    framefloors_values[1][:insulation_assembly_r_value] = 2.1
-  elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    framefloors_values << { :id => "FloorAboveUnventedCrawl",
-                            :exterior_adjacent_to => "crawlspace - unvented",
+                            :wall_type => "WoodStud",
+                            :area => 316,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 23.0 }
+    hpxml_data[:walls] << { :id => "WallAtticGableCond",
+                            :exterior_adjacent_to => "outside",
                             :interior_adjacent_to => "living space",
-                            :area => 1350,
-                            :insulation_assembly_r_value => 18.7 }
-  elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    framefloors_values << { :id => "FloorAboveVentedCrawl",
-                            :exterior_adjacent_to => "crawlspace - vented",
-                            :interior_adjacent_to => "living space",
-                            :area => 1350,
-                            :insulation_assembly_r_value => 18.7 }
-  elsif ['base-foundation-multiple.xml'].include? hpxml_file
-    framefloors_values[1][:area] = 675
-    framefloors_values << { :id => "FloorAboveUnventedCrawlspace",
-                            :exterior_adjacent_to => "crawlspace - unvented",
-                            :interior_adjacent_to => "living space",
-                            :area => 675,
-                            :insulation_assembly_r_value => 18.7 }
-  elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    framefloors_values << { :id => "FloorAboveGarage",
+                            :wall_type => "WoodStud",
+                            :area => 240,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 22.3 }
+    hpxml_data[:walls] << { :id => "WallAtticGableUncond",
+                            :exterior_adjacent_to => "outside",
+                            :interior_adjacent_to => "attic - unvented",
+                            :wall_type => "WoodStud",
+                            :area => 50,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 4.0 }
+  elsif ['base-enclosure-walltype-cmu.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "ConcreteMasonryUnit"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 12
+  elsif ['base-enclosure-walltype-doublestud.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "DoubleWoodStud"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 28.7
+  elsif ['base-enclosure-walltype-icf.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "InsulatedConcreteForms"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 21
+  elsif ['base-enclosure-walltype-log.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "LogWall"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 7.1
+  elsif ['base-enclosure-walltype-sip.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "StructurallyInsulatedPanel"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 16.1
+  elsif ['base-enclosure-walltype-solidconcrete.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "SolidConcrete"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 1.35
+  elsif ['base-enclosure-walltype-steelstud.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "SteelFrame"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 8.1
+  elsif ['base-enclosure-walltype-stone.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "Stone"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 5.4
+  elsif ['base-enclosure-walltype-strawbale.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "StrawBale"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 58.8
+  elsif ['base-enclosure-walltype-structuralbrick.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:wall_type] = "StructuralBrick"
+    hpxml_data[:walls][0][:insulation_assembly_r_value] = 7.9
+  elsif ['invalid_files/missing-surfaces.xml'].include? hpxml_file
+    hpxml_data[:walls] << { :id => "WallGarage",
                             :exterior_adjacent_to => "garage",
                             :interior_adjacent_to => "living space",
-                            :area => 400,
-                            :insulation_assembly_r_value => 18.7 }
+                            :wall_type => "WoodStud",
+                            :area => 100,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 4 }
+  elsif ['base-enclosure-2stories.xml'].include? hpxml_file
+    hpxml_data[:walls][0][:area] *= 2.0
+  elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
+    hpxml_data[:walls] = [{ :id => "Wall",
+                            :exterior_adjacent_to => "outside",
+                            :interior_adjacent_to => "living space",
+                            :wall_type => "WoodStud",
+                            :area => 880,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 23 },
+                          { :id => "WallGarageInterior",
+                            :exterior_adjacent_to => "garage",
+                            :interior_adjacent_to => "living space",
+                            :wall_type => "WoodStud",
+                            :area => 320,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 23 },
+                          { :id => "WallGarageExterior",
+                            :exterior_adjacent_to => "outside",
+                            :interior_adjacent_to => "garage",
+                            :wall_type => "WoodStud",
+                            :area => 800,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 4 }]
+  elsif ['base-enclosure-garage.xml'].include? hpxml_file
+    hpxml_data[:walls] = [{ :id => "Wall",
+                            :exterior_adjacent_to => "outside",
+                            :interior_adjacent_to => "living space",
+                            :wall_type => "WoodStud",
+                            :area => 960,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 23 },
+                          { :id => "WallGarageInterior",
+                            :exterior_adjacent_to => "garage",
+                            :interior_adjacent_to => "living space",
+                            :wall_type => "WoodStud",
+                            :area => 240,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 23 },
+                          { :id => "WallGarageExterior",
+                            :exterior_adjacent_to => "outside",
+                            :interior_adjacent_to => "garage",
+                            :wall_type => "WoodStud",
+                            :area => 560,
+                            :solar_absorptance => 0.7,
+                            :emittance => 0.92,
+                            :insulation_assembly_r_value => 4 }]
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
-    framefloors_values[0][:insulation_assembly_r_value] = 2.1
+    hpxml_data[:walls][1][:insulation_assembly_r_value] = 23
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    framefloors_values = [{ :id => "FloorAboveAdiabatic",
-                            :exterior_adjacent_to => "other housing unit below",
-                            :interior_adjacent_to => "living space",
-                            :area => 1350,
-                            :insulation_assembly_r_value => 2.1 },
-                          { :id => "FloorBelowAdiabatic",
-                            :exterior_adjacent_to => "other housing unit above",
-                            :interior_adjacent_to => "living space",
-                            :area => 1350,
-                            :insulation_assembly_r_value => 2.1 }]
+    hpxml_data[:walls].delete_at(1)
+    hpxml_data[:walls] << hpxml_data[:walls][0].dup
+    hpxml_data[:walls][0][:area] *= 0.35
+    hpxml_data[:walls][-1][:area] *= 0.65
+    hpxml_data[:walls][-1][:id] += "Adiabatic"
+    hpxml_data[:walls][-1][:exterior_adjacent_to] = "other housing unit"
+    hpxml_data[:walls][-1][:insulation_assembly_r_value] = 4
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..framefloors_values.size
-      framefloors_values[n - 1][:area] /= 10.0
+    for n in 1..hpxml_data[:walls].size
+      hpxml_data[:walls][n - 1][:area] /= 10.0
       for i in 2..10
-        framefloors_values << framefloors_values[n - 1].dup
-        framefloors_values[-1][:id] += i.to_s
+        hpxml_data[:walls] << hpxml_data[:walls][n - 1].dup
+        hpxml_data[:walls][-1][:id] += i.to_s
       end
     end
   end
-  return framefloors_values
 end
 
-def get_hpxml_file_slabs_values(hpxml_file, slabs_values)
+def set_hpxml_data_foundation_walls_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    slabs_values = [{ :id => "Slab",
-                      :interior_adjacent_to => "basement - conditioned",
-                      :area => 1350,
-                      :thickness => 4,
-                      :exposed_perimeter => 150,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 }]
+    hpxml_data[:foundation_walls] = [{ :id => "FoundationWall",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 8,
+                                       :area => 1200,
+                                       :thickness => 8,
+                                       :depth_below_grade => 7,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 8,
+                                       :insulation_exterior_r_value => 8.9 }]
+  elsif ['base-foundation-conditioned-basement-wall-interior-insulation.xml'].include? hpxml_file
+    hpxml_data[:foundation_walls][0][:insulation_interior_distance_to_top] = 0
+    hpxml_data[:foundation_walls][0][:insulation_interior_distance_to_bottom] = 8
+    hpxml_data[:foundation_walls][0][:insulation_interior_r_value] = 10
+    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_top] = 1
+    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] = 8
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    slabs_values[0][:interior_adjacent_to] = "basement - unconditioned"
-  elsif ['base-foundation-conditioned-basement-slab-insulation.xml'].include? hpxml_file
-    slabs_values[0][:under_slab_insulation_width] = 4
-    slabs_values[0][:under_slab_insulation_r_value] = 10
-  elsif ['base-foundation-slab.xml'].include? hpxml_file
-    slabs_values[0][:interior_adjacent_to] = "living space"
-    slabs_values[0][:under_slab_insulation_width] = nil
-    slabs_values[0][:under_slab_insulation_spans_entire_slab] = true
-    slabs_values[0][:depth_below_grade] = 0
-    slabs_values[0][:under_slab_insulation_r_value] = 5
-    slabs_values[0][:carpet_fraction] = 1
-    slabs_values[0][:carpet_r_value] = 2.5
+    hpxml_data[:foundation_walls][0][:interior_adjacent_to] = "basement - unconditioned"
+    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] = 0
+    hpxml_data[:foundation_walls][0][:insulation_exterior_r_value] = 0
+  elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
+    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] = 4
+    hpxml_data[:foundation_walls][0][:insulation_exterior_r_value] = 8.9
+  elsif ['base-foundation-unconditioned-basement-assembly-r.xml'].include? hpxml_file
+    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_top] = nil
+    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] = nil
+    hpxml_data[:foundation_walls][0][:insulation_exterior_r_value] = nil
+    hpxml_data[:foundation_walls][0][:insulation_interior_distance_to_top] = nil
+    hpxml_data[:foundation_walls][0][:insulation_interior_distance_to_bottom] = nil
+    hpxml_data[:foundation_walls][0][:insulation_interior_r_value] = nil
+    hpxml_data[:foundation_walls][0][:insulation_assembly_r_value] = 10.69
+  elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
+    hpxml_data[:foundation_walls][0][:depth_below_grade] = 4
   elsif ['base-foundation-unvented-crawlspace.xml',
          'base-foundation-vented-crawlspace.xml'].include? hpxml_file
     if ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-      slabs_values[0][:interior_adjacent_to] = "crawlspace - unvented"
+      hpxml_data[:foundation_walls][0][:interior_adjacent_to] = "crawlspace - unvented"
     else
-      slabs_values[0][:interior_adjacent_to] = "crawlspace - vented"
+      hpxml_data[:foundation_walls][0][:interior_adjacent_to] = "crawlspace - vented"
     end
-    slabs_values[0][:thickness] = 0
-    slabs_values[0][:carpet_r_value] = 2.5
+    hpxml_data[:foundation_walls][0][:height] -= 4
+    hpxml_data[:foundation_walls][0][:area] /= 2.0
+    hpxml_data[:foundation_walls][0][:depth_below_grade] -= 4
+    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] -= 4
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
-    slabs_values[0][:area] = 675
-    slabs_values[0][:exposed_perimeter] = 75
-    slabs_values << { :id => "SlabUnderCrawlspace",
-                      :interior_adjacent_to => "crawlspace - unvented",
-                      :area => 675,
-                      :thickness => 0,
-                      :exposed_perimeter => 75,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 }
-  elsif ['base-foundation-ambient.xml'].include? hpxml_file
-    slabs_values = []
-  elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    slabs_values[0][:area] -= 400
-    slabs_values[0][:exposed_perimeter] -= 40
-    slabs_values << { :id => "SlabUnderGarage",
-                      :interior_adjacent_to => "garage",
-                      :area => 400,
-                      :thickness => 4,
-                      :exposed_perimeter => 40,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :depth_below_grade => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 }
-  elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    slabs_values[0][:exposed_perimeter] -= 30
-    slabs_values << { :id => "SlabUnderGarage",
-                      :interior_adjacent_to => "garage",
-                      :area => 600,
-                      :thickness => 4,
-                      :exposed_perimeter => 70,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :depth_below_grade => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 }
+    hpxml_data[:foundation_walls][0][:area] = 600
+    hpxml_data[:foundation_walls] << { :id => "FoundationWallInterior",
+                                       :exterior_adjacent_to => "crawlspace - unvented",
+                                       :interior_adjacent_to => "basement - unconditioned",
+                                       :height => 8,
+                                       :area => 360,
+                                       :thickness => 8,
+                                       :depth_below_grade => 4,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 0,
+                                       :insulation_exterior_r_value => 0 }
+    hpxml_data[:foundation_walls] << { :id => "FoundationWallCrawlspace",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "crawlspace - unvented",
+                                       :height => 4,
+                                       :area => 600,
+                                       :thickness => 8,
+                                       :depth_below_grade => 3,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 0,
+                                       :insulation_exterior_r_value => 0 }
+  elsif ['base-foundation-ambient.xml',
+         'base-foundation-slab.xml'].include? hpxml_file
+    hpxml_data[:foundation_walls] = []
+  elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
+    hpxml_data[:foundation_walls] = [{ :id => "FoundationWall1",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 8,
+                                       :area => 480,
+                                       :thickness => 8,
+                                       :depth_below_grade => 7,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 8,
+                                       :insulation_exterior_r_value => 8.9 },
+                                     { :id => "FoundationWall2",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 4,
+                                       :area => 120,
+                                       :thickness => 8,
+                                       :depth_below_grade => 3,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 4,
+                                       :insulation_exterior_r_value => 8.9 },
+                                     { :id => "FoundationWall3",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 2,
+                                       :area => 60,
+                                       :thickness => 8,
+                                       :depth_below_grade => 1,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 2,
+                                       :insulation_exterior_r_value => 8.9 }]
   elsif ['base-foundation-complex.xml'].include? hpxml_file
-    slabs_values = [{ :id => "Slab1",
-                      :interior_adjacent_to => "basement - conditioned",
-                      :area => 675,
-                      :thickness => 4,
-                      :exposed_perimeter => 75,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 },
-                    { :id => "Slab2",
-                      :interior_adjacent_to => "basement - conditioned",
-                      :area => 405,
-                      :thickness => 4,
-                      :exposed_perimeter => 45,
-                      :perimeter_insulation_depth => 1,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 5,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 },
-                    { :id => "Slab3",
-                      :interior_adjacent_to => "basement - conditioned",
-                      :area => 270,
-                      :thickness => 4,
-                      :exposed_perimeter => 30,
-                      :perimeter_insulation_depth => 1,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 5,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 }]
+    hpxml_data[:foundation_walls] = [{ :id => "FoundationWall1",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 8,
+                                       :area => 160,
+                                       :thickness => 8,
+                                       :depth_below_grade => 7,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 0,
+                                       :insulation_exterior_r_value => 0.0 },
+                                     { :id => "FoundationWall2",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 8,
+                                       :area => 240,
+                                       :thickness => 8,
+                                       :depth_below_grade => 7,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 8,
+                                       :insulation_exterior_r_value => 8.9 },
+                                     { :id => "FoundationWall3",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 4,
+                                       :area => 160,
+                                       :thickness => 8,
+                                       :depth_below_grade => 3,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 0,
+                                       :insulation_exterior_r_value => 0.0 },
+                                     { :id => "FoundationWall4",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 4,
+                                       :area => 120,
+                                       :thickness => 8,
+                                       :depth_below_grade => 3,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 4,
+                                       :insulation_exterior_r_value => 8.9 },
+                                     { :id => "FoundationWall5",
+                                       :exterior_adjacent_to => "ground",
+                                       :interior_adjacent_to => "basement - conditioned",
+                                       :height => 4,
+                                       :area => 80,
+                                       :thickness => 8,
+                                       :depth_below_grade => 3,
+                                       :insulation_interior_r_value => 0,
+                                       :insulation_interior_distance_to_top => 0,
+                                       :insulation_interior_distance_to_bottom => 0,
+                                       :insulation_exterior_distance_to_top => 0,
+                                       :insulation_exterior_distance_to_bottom => 4,
+                                       :insulation_exterior_r_value => 8.9 }]
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..slabs_values.size
-      slabs_values[n - 1][:area] /= 10.0
-      slabs_values[n - 1][:exposed_perimeter] /= 10.0
+    for n in 1..hpxml_data[:foundation_walls].size
+      hpxml_data[:foundation_walls][n - 1][:area] /= 10.0
       for i in 2..10
-        slabs_values << slabs_values[n - 1].dup
-        slabs_values[-1][:id] += i.to_s
+        hpxml_data[:foundation_walls] << hpxml_data[:foundation_walls][n - 1].dup
+        hpxml_data[:foundation_walls][-1][:id] += i.to_s
       end
     end
   elsif ['invalid_files/mismatched-slab-and-foundation-wall.xml'].include? hpxml_file
-    slabs_values[0][:interior_adjacent_to] = "basement - unconditioned"
-    slabs_values[0][:depth_below_grade] = 7.0
-  elsif ['invalid_files/slab-zero-exposed-perimeter.xml'].include? hpxml_file
-    slabs_values[0][:exposed_perimeter] = 0
+    hpxml_data[:foundation_walls] << hpxml_data[:foundation_walls][0].dup
+    hpxml_data[:foundation_walls][1][:id] = "FoundationWall2"
+    hpxml_data[:foundation_walls][1][:interior_adjacent_to] = "garage"
   end
-  return slabs_values
 end
 
-def get_hpxml_file_windows_values(hpxml_file, windows_values)
+def set_hpxml_data_frame_floors_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    windows_values = [{ :id => "WindowNorth",
-                        :area => 108,
-                        :azimuth => 0,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "Wall" },
-                      { :id => "WindowSouth",
-                        :area => 108,
-                        :azimuth => 180,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "Wall" },
-                      { :id => "WindowEast",
-                        :area => 72,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "Wall" },
-                      { :id => "WindowWest",
-                        :area => 72,
-                        :azimuth => 270,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "Wall" }]
-  elsif ['base-enclosure-overhangs.xml'].include? hpxml_file
-    windows_values[0][:overhangs_depth] = 2.5
-    windows_values[0][:overhangs_distance_to_top_of_window] = 0
-    windows_values[0][:overhangs_distance_to_bottom_of_window] = 4
-    windows_values[2][:overhangs_depth] = 1.5
-    windows_values[2][:overhangs_distance_to_top_of_window] = 2
-    windows_values[2][:overhangs_distance_to_bottom_of_window] = 6
-    windows_values[3][:overhangs_depth] = 1.5
-    windows_values[3][:overhangs_distance_to_top_of_window] = 2
-    windows_values[3][:overhangs_distance_to_bottom_of_window] = 7
-  elsif ['base-enclosure-windows-interior-shading.xml'].include? hpxml_file
-    windows_values[0][:interior_shading_factor_summer] = 0.7
-    windows_values[0][:interior_shading_factor_winter] = 0.85
-    windows_values[1][:interior_shading_factor_summer] = 0.01
-    windows_values[1][:interior_shading_factor_winter] = 0.99
-    windows_values[2][:interior_shading_factor_summer] = 0.0
-    windows_values[2][:interior_shading_factor_winter] = 0.5
-    windows_values[3][:interior_shading_factor_summer] = 1.0
-    windows_values[3][:interior_shading_factor_winter] = 1.0
-  elsif ['invalid_files/invalid-window-interior-shading.xml'].include? hpxml_file
-    windows_values[0][:interior_shading_factor_summer] = 0.85
-    windows_values[0][:interior_shading_factor_winter] = 0.7
-  elsif ['base-enclosure-windows-none.xml'].include? hpxml_file
-    windows_values = []
-  elsif ['invalid_files/net-area-negative-wall.xml'].include? hpxml_file
-    windows_values[0][:area] = 1000
+    hpxml_data[:frame_floors] = [{ :id => "FloorBelowAttic",
+                                   :exterior_adjacent_to => "attic - unvented",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 1350,
+                                   :insulation_assembly_r_value => 39.3 }]
+  elsif ['base-atticroof-flat.xml',
+         'base-atticroof-cathedral.xml'].include? hpxml_file
+    hpxml_data[:frame_floors].delete_at(0)
+  elsif ['base-atticroof-vented.xml'].include? hpxml_file
+    hpxml_data[:frame_floors][0][:exterior_adjacent_to] = "attic - vented"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    windows_values[0][:area] = 108
-    windows_values[1][:area] = 108
-    windows_values[2][:area] = 108
-    windows_values[3][:area] = 108
-    windows_values << { :id => "AtticGableWindowEast",
-                        :area => 12,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "WallAtticGableCond" }
-    windows_values << { :id => "AtticGableWindowWest",
-                        :area => 62,
-                        :azimuth => 270,
-                        :ufactor => 0.3,
-                        :shgc => 0.45,
-                        :wall_idref => "WallAtticGableCond" }
-  elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    windows_values[0][:area] = 108
-    windows_values[1][:area] = 108
-    windows_values[2][:area] = 108
-    windows_values[3][:area] = 108
-    windows_values << { :id => "AtticGableWindowEast",
-                        :area => 12,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "WallAtticGable" }
-    windows_values << { :id => "AtticGableWindowWest",
-                        :area => 12,
-                        :azimuth => 270,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "WallAtticGable" }
+    hpxml_data[:frame_floors][0][:area] = 450
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    windows_values.delete_at(2)
-    windows_values << { :id => "GarageWindowEast",
-                        :area => 12,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "WallGarageExterior" }
-  elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    windows_values[0][:area] = 216
-    windows_values[1][:area] = 216
-    windows_values[2][:area] = 144
-    windows_values[3][:area] = 144
-  elsif ['base-enclosure-2stories-garage'].include? hpxml_file
-    windows_values[0][:area] = 168
-    windows_values[1][:area] = 216
-    windows_values[2][:area] = 144
-    windows_values[3][:area] = 96
-  elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
-    windows_values << { :id => "FoundationWindowNorth",
-                        :area => 20,
-                        :azimuth => 0,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall" }
-    windows_values << { :id => "FoundationWindowSouth",
-                        :area => 20,
-                        :azimuth => 180,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall" }
-    windows_values << { :id => "FoundationWindowEast",
-                        :area => 10,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall" }
-    windows_values << { :id => "FoundationWindowWest",
-                        :area => 10,
-                        :azimuth => 270,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall" }
+    hpxml_data[:frame_floors] << { :id => "FloorBetweenAtticGarage",
+                                   :exterior_adjacent_to => "attic - unvented",
+                                   :interior_adjacent_to => "garage",
+                                   :area => 600,
+                                   :insulation_assembly_r_value => 2.1 }
+  elsif ['base-foundation-ambient.xml'].include? hpxml_file
+    hpxml_data[:frame_floors] << { :id => "FloorAboveAmbient",
+                                   :exterior_adjacent_to => "outside",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 1350,
+                                   :insulation_assembly_r_value => 18.7 }
+  elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
+    hpxml_data[:frame_floors] << { :id => "FloorAboveUncondBasement",
+                                   :exterior_adjacent_to => "basement - unconditioned",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 1350,
+                                   :insulation_assembly_r_value => 18.7 }
+  elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
+    hpxml_data[:frame_floors][1][:insulation_assembly_r_value] = 2.1
+  elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
+    hpxml_data[:frame_floors] << { :id => "FloorAboveUnventedCrawl",
+                                   :exterior_adjacent_to => "crawlspace - unvented",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 1350,
+                                   :insulation_assembly_r_value => 18.7 }
+  elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
+    hpxml_data[:frame_floors] << { :id => "FloorAboveVentedCrawl",
+                                   :exterior_adjacent_to => "crawlspace - vented",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 1350,
+                                   :insulation_assembly_r_value => 18.7 }
+  elsif ['base-foundation-multiple.xml'].include? hpxml_file
+    hpxml_data[:frame_floors][1][:area] = 675
+    hpxml_data[:frame_floors] << { :id => "FloorAboveUnventedCrawlspace",
+                                   :exterior_adjacent_to => "crawlspace - unvented",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 675,
+                                   :insulation_assembly_r_value => 18.7 }
+  elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
+    hpxml_data[:frame_floors] << { :id => "FloorAboveGarage",
+                                   :exterior_adjacent_to => "garage",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 400,
+                                   :insulation_assembly_r_value => 18.7 }
+  elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
+    hpxml_data[:frame_floors][0][:insulation_assembly_r_value] = 2.1
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    for n in 1..windows_values.size
-      windows_values[n - 1][:area] *= 0.35
+    hpxml_data[:frame_floors] = [{ :id => "FloorAboveAdiabatic",
+                                   :exterior_adjacent_to => "other housing unit below",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 1350,
+                                   :insulation_assembly_r_value => 2.1 },
+                                 { :id => "FloorBelowAdiabatic",
+                                   :exterior_adjacent_to => "other housing unit above",
+                                   :interior_adjacent_to => "living space",
+                                   :area => 1350,
+                                   :insulation_assembly_r_value => 2.1 }]
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..hpxml_data[:frame_floors].size
+      hpxml_data[:frame_floors][n - 1][:area] /= 10.0
+      for i in 2..10
+        hpxml_data[:frame_floors] << hpxml_data[:frame_floors][n - 1].dup
+        hpxml_data[:frame_floors][-1][:id] += i.to_s
+      end
+    end
+  end
+end
+
+def set_hpxml_data_slabs_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:slabs] = [{ :id => "Slab",
+                            :interior_adjacent_to => "basement - conditioned",
+                            :area => 1350,
+                            :thickness => 4,
+                            :exposed_perimeter => 150,
+                            :perimeter_insulation_depth => 0,
+                            :under_slab_insulation_width => 0,
+                            :perimeter_insulation_r_value => 0,
+                            :under_slab_insulation_r_value => 0,
+                            :carpet_fraction => 0,
+                            :carpet_r_value => 0 }]
+  elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
+    hpxml_data[:slabs][0][:interior_adjacent_to] = "basement - unconditioned"
+  elsif ['base-foundation-conditioned-basement-slab-insulation.xml'].include? hpxml_file
+    hpxml_data[:slabs][0][:under_slab_insulation_width] = 4
+    hpxml_data[:slabs][0][:under_slab_insulation_r_value] = 10
+  elsif ['base-foundation-slab.xml'].include? hpxml_file
+    hpxml_data[:slabs][0][:interior_adjacent_to] = "living space"
+    hpxml_data[:slabs][0][:under_slab_insulation_width] = nil
+    hpxml_data[:slabs][0][:under_slab_insulation_spans_entire_slab] = true
+    hpxml_data[:slabs][0][:depth_below_grade] = 0
+    hpxml_data[:slabs][0][:under_slab_insulation_r_value] = 5
+    hpxml_data[:slabs][0][:carpet_fraction] = 1
+    hpxml_data[:slabs][0][:carpet_r_value] = 2.5
+  elsif ['base-foundation-unvented-crawlspace.xml',
+         'base-foundation-vented-crawlspace.xml'].include? hpxml_file
+    if ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
+      hpxml_data[:slabs][0][:interior_adjacent_to] = "crawlspace - unvented"
+    else
+      hpxml_data[:slabs][0][:interior_adjacent_to] = "crawlspace - vented"
+    end
+    hpxml_data[:slabs][0][:thickness] = 0
+    hpxml_data[:slabs][0][:carpet_r_value] = 2.5
+  elsif ['base-foundation-multiple.xml'].include? hpxml_file
+    hpxml_data[:slabs][0][:area] = 675
+    hpxml_data[:slabs][0][:exposed_perimeter] = 75
+    hpxml_data[:slabs] << { :id => "SlabUnderCrawlspace",
+                            :interior_adjacent_to => "crawlspace - unvented",
+                            :area => 675,
+                            :thickness => 0,
+                            :exposed_perimeter => 75,
+                            :perimeter_insulation_depth => 0,
+                            :under_slab_insulation_width => 0,
+                            :perimeter_insulation_r_value => 0,
+                            :under_slab_insulation_r_value => 0,
+                            :carpet_fraction => 0,
+                            :carpet_r_value => 0 }
+  elsif ['base-foundation-ambient.xml'].include? hpxml_file
+    hpxml_data[:slabs] = []
+  elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
+    hpxml_data[:slabs][0][:area] -= 400
+    hpxml_data[:slabs][0][:exposed_perimeter] -= 40
+    hpxml_data[:slabs] << { :id => "SlabUnderGarage",
+                            :interior_adjacent_to => "garage",
+                            :area => 400,
+                            :thickness => 4,
+                            :exposed_perimeter => 40,
+                            :perimeter_insulation_depth => 0,
+                            :under_slab_insulation_width => 0,
+                            :depth_below_grade => 0,
+                            :perimeter_insulation_r_value => 0,
+                            :under_slab_insulation_r_value => 0,
+                            :carpet_fraction => 0,
+                            :carpet_r_value => 0 }
+  elsif ['base-enclosure-garage.xml'].include? hpxml_file
+    hpxml_data[:slabs][0][:exposed_perimeter] -= 30
+    hpxml_data[:slabs] << { :id => "SlabUnderGarage",
+                            :interior_adjacent_to => "garage",
+                            :area => 600,
+                            :thickness => 4,
+                            :exposed_perimeter => 70,
+                            :perimeter_insulation_depth => 0,
+                            :under_slab_insulation_width => 0,
+                            :depth_below_grade => 0,
+                            :perimeter_insulation_r_value => 0,
+                            :under_slab_insulation_r_value => 0,
+                            :carpet_fraction => 0,
+                            :carpet_r_value => 0 }
+  elsif ['base-foundation-complex.xml'].include? hpxml_file
+    hpxml_data[:slabs] = [{ :id => "Slab1",
+                            :interior_adjacent_to => "basement - conditioned",
+                            :area => 675,
+                            :thickness => 4,
+                            :exposed_perimeter => 75,
+                            :perimeter_insulation_depth => 0,
+                            :under_slab_insulation_width => 0,
+                            :perimeter_insulation_r_value => 0,
+                            :under_slab_insulation_r_value => 0,
+                            :carpet_fraction => 0,
+                            :carpet_r_value => 0 },
+                          { :id => "Slab2",
+                            :interior_adjacent_to => "basement - conditioned",
+                            :area => 405,
+                            :thickness => 4,
+                            :exposed_perimeter => 45,
+                            :perimeter_insulation_depth => 1,
+                            :under_slab_insulation_width => 0,
+                            :perimeter_insulation_r_value => 5,
+                            :under_slab_insulation_r_value => 0,
+                            :carpet_fraction => 0,
+                            :carpet_r_value => 0 },
+                          { :id => "Slab3",
+                            :interior_adjacent_to => "basement - conditioned",
+                            :area => 270,
+                            :thickness => 4,
+                            :exposed_perimeter => 30,
+                            :perimeter_insulation_depth => 1,
+                            :under_slab_insulation_width => 0,
+                            :perimeter_insulation_r_value => 5,
+                            :under_slab_insulation_r_value => 0,
+                            :carpet_fraction => 0,
+                            :carpet_r_value => 0 }]
+  elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
+    for n in 1..hpxml_data[:slabs].size
+      hpxml_data[:slabs][n - 1][:area] /= 10.0
+      hpxml_data[:slabs][n - 1][:exposed_perimeter] /= 10.0
+      for i in 2..10
+        hpxml_data[:slabs] << hpxml_data[:slabs][n - 1].dup
+        hpxml_data[:slabs][-1][:id] += i.to_s
+      end
+    end
+  elsif ['invalid_files/mismatched-slab-and-foundation-wall.xml'].include? hpxml_file
+    hpxml_data[:slabs][0][:interior_adjacent_to] = "basement - unconditioned"
+    hpxml_data[:slabs][0][:depth_below_grade] = 7.0
+  elsif ['invalid_files/slab-zero-exposed-perimeter.xml'].include? hpxml_file
+    hpxml_data[:slabs][0][:exposed_perimeter] = 0
+  end
+end
+
+def set_hpxml_data_windows_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:windows] = [{ :id => "WindowNorth",
+                              :area => 108,
+                              :azimuth => 0,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "Wall" },
+                            { :id => "WindowSouth",
+                              :area => 108,
+                              :azimuth => 180,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "Wall" },
+                            { :id => "WindowEast",
+                              :area => 72,
+                              :azimuth => 90,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "Wall" },
+                            { :id => "WindowWest",
+                              :area => 72,
+                              :azimuth => 270,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "Wall" }]
+  elsif ['base-enclosure-overhangs.xml'].include? hpxml_file
+    hpxml_data[:windows][0][:overhangs_depth] = 2.5
+    hpxml_data[:windows][0][:overhangs_distance_to_top_of_window] = 0
+    hpxml_data[:windows][0][:overhangs_distance_to_bottom_of_window] = 4
+    hpxml_data[:windows][2][:overhangs_depth] = 1.5
+    hpxml_data[:windows][2][:overhangs_distance_to_top_of_window] = 2
+    hpxml_data[:windows][2][:overhangs_distance_to_bottom_of_window] = 6
+    hpxml_data[:windows][3][:overhangs_depth] = 1.5
+    hpxml_data[:windows][3][:overhangs_distance_to_top_of_window] = 2
+    hpxml_data[:windows][3][:overhangs_distance_to_bottom_of_window] = 7
+  elsif ['base-enclosure-windows-interior-shading.xml'].include? hpxml_file
+    hpxml_data[:windows][0][:interior_shading_factor_summer] = 0.7
+    hpxml_data[:windows][0][:interior_shading_factor_winter] = 0.85
+    hpxml_data[:windows][1][:interior_shading_factor_summer] = 0.01
+    hpxml_data[:windows][1][:interior_shading_factor_winter] = 0.99
+    hpxml_data[:windows][2][:interior_shading_factor_summer] = 0.0
+    hpxml_data[:windows][2][:interior_shading_factor_winter] = 0.5
+    hpxml_data[:windows][3][:interior_shading_factor_summer] = 1.0
+    hpxml_data[:windows][3][:interior_shading_factor_winter] = 1.0
+  elsif ['invalid_files/invalid-window-interior-shading.xml'].include? hpxml_file
+    hpxml_data[:windows][0][:interior_shading_factor_summer] = 0.85
+    hpxml_data[:windows][0][:interior_shading_factor_winter] = 0.7
+  elsif ['base-enclosure-windows-none.xml'].include? hpxml_file
+    hpxml_data[:windows] = []
+  elsif ['invalid_files/net-area-negative-wall.xml'].include? hpxml_file
+    hpxml_data[:windows][0][:area] = 1000
+  elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
+    hpxml_data[:windows][0][:area] = 108
+    hpxml_data[:windows][1][:area] = 108
+    hpxml_data[:windows][2][:area] = 108
+    hpxml_data[:windows][3][:area] = 108
+    hpxml_data[:windows] << { :id => "AtticGableWindowEast",
+                              :area => 12,
+                              :azimuth => 90,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "WallAtticGableCond" }
+    hpxml_data[:windows] << { :id => "AtticGableWindowWest",
+                              :area => 62,
+                              :azimuth => 270,
+                              :ufactor => 0.3,
+                              :shgc => 0.45,
+                              :wall_idref => "WallAtticGableCond" }
+  elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
+    hpxml_data[:windows][0][:area] = 108
+    hpxml_data[:windows][1][:area] = 108
+    hpxml_data[:windows][2][:area] = 108
+    hpxml_data[:windows][3][:area] = 108
+    hpxml_data[:windows] << { :id => "AtticGableWindowEast",
+                              :area => 12,
+                              :azimuth => 90,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "WallAtticGable" }
+    hpxml_data[:windows] << { :id => "AtticGableWindowWest",
+                              :area => 12,
+                              :azimuth => 270,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "WallAtticGable" }
+  elsif ['base-enclosure-garage.xml'].include? hpxml_file
+    hpxml_data[:windows].delete_at(2)
+    hpxml_data[:windows] << { :id => "GarageWindowEast",
+                              :area => 12,
+                              :azimuth => 90,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "WallGarageExterior" }
+  elsif ['base-enclosure-2stories.xml'].include? hpxml_file
+    hpxml_data[:windows][0][:area] = 216
+    hpxml_data[:windows][1][:area] = 216
+    hpxml_data[:windows][2][:area] = 144
+    hpxml_data[:windows][3][:area] = 144
+  elsif ['base-enclosure-2stories-garage'].include? hpxml_file
+    hpxml_data[:windows][0][:area] = 168
+    hpxml_data[:windows][1][:area] = 216
+    hpxml_data[:windows][2][:area] = 144
+    hpxml_data[:windows][3][:area] = 96
+  elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
+    hpxml_data[:windows] << { :id => "FoundationWindowNorth",
+                              :area => 20,
+                              :azimuth => 0,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "FoundationWall" }
+    hpxml_data[:windows] << { :id => "FoundationWindowSouth",
+                              :area => 20,
+                              :azimuth => 180,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "FoundationWall" }
+    hpxml_data[:windows] << { :id => "FoundationWindowEast",
+                              :area => 10,
+                              :azimuth => 90,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "FoundationWall" }
+    hpxml_data[:windows] << { :id => "FoundationWindowWest",
+                              :area => 10,
+                              :azimuth => 270,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "FoundationWall" }
+  elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
+    for n in 1..hpxml_data[:windows].size
+      hpxml_data[:windows][n - 1][:area] *= 0.35
     end
   elsif ['invalid_files/unattached-window.xml'].include? hpxml_file
-    windows_values[0][:wall_idref] = "foobar"
+    hpxml_data[:windows][0][:wall_idref] = "foobar"
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     area_adjustments = []
-    for n in 1..windows_values.size
-      windows_values[n - 1][:area] /= 10.0
+    for n in 1..hpxml_data[:windows].size
+      hpxml_data[:windows][n - 1][:area] /= 10.0
       for i in 2..10
-        windows_values << windows_values[n - 1].dup
-        windows_values[-1][:id] += i.to_s
-        windows_values[-1][:wall_idref] += i.to_s
+        hpxml_data[:windows] << hpxml_data[:windows][n - 1].dup
+        hpxml_data[:windows][-1][:id] += i.to_s
+        hpxml_data[:windows][-1][:wall_idref] += i.to_s
       end
     end
   elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
-    windows_values << { :id => "FoundationWindow",
-                        :area => 20,
-                        :azimuth => 0,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall3" }
+    hpxml_data[:windows] << { :id => "FoundationWindow",
+                              :area => 20,
+                              :azimuth => 0,
+                              :ufactor => 0.33,
+                              :shgc => 0.45,
+                              :wall_idref => "FoundationWall3" }
   elsif ['invalid_files/invalid-window-height.xml'].include? hpxml_file
-    windows_values[2][:overhangs_distance_to_bottom_of_window] = windows_values[2][:overhangs_distance_to_top_of_window]
+    hpxml_data[:windows][2][:overhangs_distance_to_bottom_of_window] = hpxml_data[:windows][2][:overhangs_distance_to_top_of_window]
   end
-  return windows_values
 end
 
-def get_hpxml_file_skylights_values(hpxml_file, skylights_values)
-  if ['base-enclosure-skylights.xml'].include? hpxml_file
-    skylights_values << { :id => "SkylightNorth",
-                          :area => 45,
-                          :azimuth => 0,
-                          :ufactor => 0.33,
-                          :shgc => 0.45,
-                          :roof_idref => "Roof" }
-    skylights_values << { :id => "SkylightSouth",
-                          :area => 45,
-                          :azimuth => 180,
-                          :ufactor => 0.35,
-                          :shgc => 0.47,
-                          :roof_idref => "Roof" }
+def set_hpxml_data_skylights_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:skylights] = []
+  elsif ['base-enclosure-skylights.xml'].include? hpxml_file
+    hpxml_data[:skylights] << { :id => "SkylightNorth",
+                                :area => 45,
+                                :azimuth => 0,
+                                :ufactor => 0.33,
+                                :shgc => 0.45,
+                                :roof_idref => "Roof" }
+    hpxml_data[:skylights] << { :id => "SkylightSouth",
+                                :area => 45,
+                                :azimuth => 180,
+                                :ufactor => 0.35,
+                                :shgc => 0.47,
+                                :roof_idref => "Roof" }
   elsif ['invalid_files/net-area-negative-roof.xml'].include? hpxml_file
-    skylights_values[0][:area] = 4000
+    hpxml_data[:skylights][0][:area] = 4000
   elsif ['invalid_files/unattached-skylight.xml'].include? hpxml_file
-    skylights_values[0][:roof_idref] = "foobar"
+    hpxml_data[:skylights][0][:roof_idref] = "foobar"
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..skylights_values.size
-      skylights_values[n - 1][:area] /= 10.0
+    for n in 1..hpxml_data[:skylights].size
+      hpxml_data[:skylights][n - 1][:area] /= 10.0
       for i in 2..10
-        skylights_values << skylights_values[n - 1].dup
-        skylights_values[-1][:id] += i.to_s
-        skylights_values[-1][:roof_idref] += i.to_s if i % 2 == 0
+        hpxml_data[:skylights] << hpxml_data[:skylights][n - 1].dup
+        hpxml_data[:skylights][-1][:id] += i.to_s
+        hpxml_data[:skylights][-1][:roof_idref] += i.to_s if i % 2 == 0
       end
     end
   end
-  return skylights_values
 end
 
-def get_hpxml_file_doors_values(hpxml_file, doors_values)
+def set_hpxml_data_doors_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    doors_values = [{ :id => "DoorNorth",
-                      :wall_idref => "Wall",
-                      :area => 40,
-                      :azimuth => 0,
-                      :r_value => 4.4 },
-                    { :id => "DoorSouth",
-                      :wall_idref => "Wall",
-                      :area => 40,
-                      :azimuth => 180,
-                      :r_value => 4.4 }]
+    hpxml_data[:doors] = [{ :id => "DoorNorth",
+                            :wall_idref => "Wall",
+                            :area => 40,
+                            :azimuth => 0,
+                            :r_value => 4.4 },
+                          { :id => "DoorSouth",
+                            :wall_idref => "Wall",
+                            :area => 40,
+                            :azimuth => 180,
+                            :r_value => 4.4 }]
   elsif ['base-enclosure-garage.xml',
          'base-enclosure-2stories-garage.xml'].include? hpxml_file
-    doors_values << { :id => "GarageDoorSouth",
-                      :wall_idref => "WallGarageExterior",
-                      :area => 70,
-                      :azimuth => 180,
-                      :r_value => 4.4 }
+    hpxml_data[:doors] << { :id => "GarageDoorSouth",
+                            :wall_idref => "WallGarageExterior",
+                            :area => 70,
+                            :azimuth => 180,
+                            :r_value => 4.4 }
   elsif ['invalid_files/unattached-door.xml'].include? hpxml_file
-    doors_values[0][:wall_idref] = "foobar"
+    hpxml_data[:doors][0][:wall_idref] = "foobar"
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     area_adjustments = []
-    for n in 1..doors_values.size
-      doors_values[n - 1][:area] /= 10.0
+    for n in 1..hpxml_data[:doors].size
+      hpxml_data[:doors][n - 1][:area] /= 10.0
       for i in 2..10
-        doors_values << doors_values[n - 1].dup
-        doors_values[-1][:id] += i.to_s
-        doors_values[-1][:wall_idref] += i.to_s
+        hpxml_data[:doors] << hpxml_data[:doors][n - 1].dup
+        hpxml_data[:doors][-1][:id] += i.to_s
+        hpxml_data[:doors][-1][:wall_idref] += i.to_s
       end
     end
   end
-  return doors_values
 end
 
-def get_hpxml_file_heating_systems_values(hpxml_file, heating_systems_values)
+def set_hpxml_data_heating_systems_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    heating_systems_values = [{ :id => "HeatingSystem",
-                                :distribution_system_idref => "HVACDistribution",
-                                :heating_system_type => "Furnace",
-                                :heating_system_fuel => "natural gas",
-                                :heating_capacity => 64000,
-                                :heating_efficiency_afue => 0.92,
-                                :fraction_heat_load_served => 1 }]
+    hpxml_data[:heating_systems] = [{ :id => "HeatingSystem",
+                                      :distribution_system_idref => "HVACDistribution",
+                                      :heating_system_type => "Furnace",
+                                      :heating_system_fuel => "natural gas",
+                                      :heating_capacity => 64000,
+                                      :heating_efficiency_afue => 0.92,
+                                      :fraction_heat_load_served => 1 }]
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-air-to-air-heat-pump-var-speed.xml',
@@ -1739,196 +1596,195 @@ def get_hpxml_file_heating_systems_values(hpxml_file, heating_systems_values)
          'base-hvac-none.xml',
          'base-hvac-room-ac-only.xml',
          'invalid_files/orphaned-hvac-distribution.xml'].include? hpxml_file
-    heating_systems_values = []
+    hpxml_data[:heating_systems] = []
   elsif ['base-hvac-boiler-elec-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_type] = "Boiler"
-    heating_systems_values[0][:heating_system_fuel] = "electricity"
-    heating_systems_values[0][:heating_efficiency_afue] = 1
+    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 1
   elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml',
          'base-hvac-boiler-gas-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_type] = "Boiler"
-    heating_systems_values[0][:electric_auxiliary_energy] = 200
+    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
   elsif ['base-hvac-boiler-oil-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_type] = "Boiler"
-    heating_systems_values[0][:heating_system_fuel] = "fuel oil"
+    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "fuel oil"
   elsif ['base-hvac-boiler-propane-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_type] = "Boiler"
-    heating_systems_values[0][:heating_system_fuel] = "propane"
+    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "propane"
   elsif ['base-hvac-boiler-wood-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_type] = "Boiler"
-    heating_systems_values[0][:heating_system_fuel] = "wood"
+    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "wood"
   elsif ['base-hvac-elec-resistance-only.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = nil
-    heating_systems_values[0][:heating_system_type] = "ElectricResistance"
-    heating_systems_values[0][:heating_system_fuel] = "electricity"
-    heating_systems_values[0][:heating_efficiency_afue] = nil
-    heating_systems_values[0][:heating_efficiency_percent] = 1
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
+    hpxml_data[:heating_systems][0][:heating_system_type] = "ElectricResistance"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = nil
+    hpxml_data[:heating_systems][0][:heating_efficiency_percent] = 1
   elsif ['base-hvac-furnace-elec-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_fuel] = "electricity"
-    heating_systems_values[0][:heating_efficiency_afue] = 1
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 1
   elsif ['base-hvac-furnace-gas-only.xml'].include? hpxml_file
-    heating_systems_values[0][:electric_auxiliary_energy] = 700
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 700
   elsif ['base-hvac-furnace-gas-only-no-eae.xml',
          'base-hvac-boiler-gas-only-no-eae.xml',
          'base-hvac-stove-oil-only-no-eae.xml',
          'base-hvac-wall-furnace-propane-only-no-eae.xml'].include? hpxml_file
-    heating_systems_values[0][:electric_auxiliary_energy] = nil
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = nil
   elsif ['base-hvac-furnace-oil-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_fuel] = "fuel oil"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "fuel oil"
   elsif ['base-hvac-furnace-propane-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_fuel] = "propane"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "propane"
   elsif ['base-hvac-furnace-wood-only.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_fuel] = "wood"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "wood"
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_system_type] = "Boiler"
-    heating_systems_values[0][:heating_system_fuel] = "electricity"
-    heating_systems_values[0][:heating_efficiency_afue] = 1
-    heating_systems_values[0][:fraction_heat_load_served] = 0.1
-    heating_systems_values[0][:heating_capacity] *= 0.1
-    heating_systems_values << { :id => "HeatingSystem2",
-                                :distribution_system_idref => "HVACDistribution2",
-                                :heating_system_type => "Boiler",
-                                :heating_system_fuel => "natural gas",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_afue => 0.92,
-                                :fraction_heat_load_served => 0.1,
-                                :electric_auxiliary_energy => 200 }
-    heating_systems_values << { :id => "HeatingSystem3",
-                                :heating_system_type => "ElectricResistance",
-                                :heating_system_fuel => "electricity",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_percent => 1,
-                                :fraction_heat_load_served => 0.1 }
-    heating_systems_values << { :id => "HeatingSystem4",
-                                :distribution_system_idref => "HVACDistribution3",
-                                :heating_system_type => "Furnace",
-                                :heating_system_fuel => "electricity",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_afue => 1,
-                                :fraction_heat_load_served => 0.1 }
-    heating_systems_values << { :id => "HeatingSystem5",
-                                :distribution_system_idref => "HVACDistribution4",
-                                :heating_system_type => "Furnace",
-                                :heating_system_fuel => "natural gas",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_afue => 0.92,
-                                :fraction_heat_load_served => 0.1,
-                                :electric_auxiliary_energy => 700 }
-    heating_systems_values << { :id => "HeatingSystem6",
-                                :heating_system_type => "Stove",
-                                :heating_system_fuel => "fuel oil",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_percent => 0.8,
-                                :fraction_heat_load_served => 0.1,
-                                :electric_auxiliary_energy => 200 }
-    heating_systems_values << { :id => "HeatingSystem7",
-                                :heating_system_type => "WallFurnace",
-                                :heating_system_fuel => "propane",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_afue => 0.8,
-                                :fraction_heat_load_served => 0.1,
-                                :electric_auxiliary_energy => 200 }
+    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 1
+    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.1
+    hpxml_data[:heating_systems][0][:heating_capacity] *= 0.1
+    hpxml_data[:heating_systems] << { :id => "HeatingSystem2",
+                                      :distribution_system_idref => "HVACDistribution2",
+                                      :heating_system_type => "Boiler",
+                                      :heating_system_fuel => "natural gas",
+                                      :heating_capacity => 6400,
+                                      :heating_efficiency_afue => 0.92,
+                                      :fraction_heat_load_served => 0.1,
+                                      :electric_auxiliary_energy => 200 }
+    hpxml_data[:heating_systems] << { :id => "HeatingSystem3",
+                                      :heating_system_type => "ElectricResistance",
+                                      :heating_system_fuel => "electricity",
+                                      :heating_capacity => 6400,
+                                      :heating_efficiency_percent => 1,
+                                      :fraction_heat_load_served => 0.1 }
+    hpxml_data[:heating_systems] << { :id => "HeatingSystem4",
+                                      :distribution_system_idref => "HVACDistribution3",
+                                      :heating_system_type => "Furnace",
+                                      :heating_system_fuel => "electricity",
+                                      :heating_capacity => 6400,
+                                      :heating_efficiency_afue => 1,
+                                      :fraction_heat_load_served => 0.1 }
+    hpxml_data[:heating_systems] << { :id => "HeatingSystem5",
+                                      :distribution_system_idref => "HVACDistribution4",
+                                      :heating_system_type => "Furnace",
+                                      :heating_system_fuel => "natural gas",
+                                      :heating_capacity => 6400,
+                                      :heating_efficiency_afue => 0.92,
+                                      :fraction_heat_load_served => 0.1,
+                                      :electric_auxiliary_energy => 700 }
+    hpxml_data[:heating_systems] << { :id => "HeatingSystem6",
+                                      :heating_system_type => "Stove",
+                                      :heating_system_fuel => "fuel oil",
+                                      :heating_capacity => 6400,
+                                      :heating_efficiency_percent => 0.8,
+                                      :fraction_heat_load_served => 0.1,
+                                      :electric_auxiliary_energy => 200 }
+    hpxml_data[:heating_systems] << { :id => "HeatingSystem7",
+                                      :heating_system_type => "WallFurnace",
+                                      :heating_system_fuel => "propane",
+                                      :heating_capacity => 6400,
+                                      :heating_efficiency_afue => 0.8,
+                                      :fraction_heat_load_served => 0.1,
+                                      :electric_auxiliary_energy => 200 }
   elsif ['invalid_files/hvac-frac-load-served.xml'].include? hpxml_file
-    heating_systems_values[0][:fraction_heat_load_served] += 0.1
+    hpxml_data[:heating_systems][0][:fraction_heat_load_served] += 0.1
   elsif ['base-hvac-portable-heater-electric-only.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = nil
-    heating_systems_values[0][:heating_system_type] = "PortableHeater"
-    heating_systems_values[0][:heating_system_fuel] = "electricity"
-    heating_systems_values[0][:heating_efficiency_afue] = nil
-    heating_systems_values[0][:heating_efficiency_percent] = 1.0
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
+    hpxml_data[:heating_systems][0][:heating_system_type] = "PortableHeater"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = nil
+    hpxml_data[:heating_systems][0][:heating_efficiency_percent] = 1.0
   elsif ['base-hvac-stove-oil-only.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = nil
-    heating_systems_values[0][:heating_system_type] = "Stove"
-    heating_systems_values[0][:heating_system_fuel] = "fuel oil"
-    heating_systems_values[0][:heating_efficiency_afue] = nil
-    heating_systems_values[0][:heating_efficiency_percent] = 0.8
-    heating_systems_values[0][:electric_auxiliary_energy] = 200
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
+    hpxml_data[:heating_systems][0][:heating_system_type] = "Stove"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "fuel oil"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = nil
+    hpxml_data[:heating_systems][0][:heating_efficiency_percent] = 0.8
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
   elsif ['base-hvac-stove-wood-only.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = nil
-    heating_systems_values[0][:heating_system_type] = "Stove"
-    heating_systems_values[0][:heating_system_fuel] = "wood"
-    heating_systems_values[0][:heating_efficiency_afue] = nil
-    heating_systems_values[0][:heating_efficiency_percent] = 0.8
-    heating_systems_values[0][:electric_auxiliary_energy] = 200
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
+    hpxml_data[:heating_systems][0][:heating_system_type] = "Stove"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "wood"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = nil
+    hpxml_data[:heating_systems][0][:heating_efficiency_percent] = 0.8
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
   elsif ['base-hvac-wall-furnace-elec-only.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = nil
-    heating_systems_values[0][:heating_system_type] = "WallFurnace"
-    heating_systems_values[0][:heating_system_fuel] = "electricity"
-    heating_systems_values[0][:heating_efficiency_afue] = 1.0
-    heating_systems_values[0][:electric_auxiliary_energy] = 200
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
+    hpxml_data[:heating_systems][0][:heating_system_type] = "WallFurnace"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 1.0
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
   elsif ['base-hvac-wall-furnace-propane-only.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = nil
-    heating_systems_values[0][:heating_system_type] = "WallFurnace"
-    heating_systems_values[0][:heating_system_fuel] = "propane"
-    heating_systems_values[0][:heating_efficiency_afue] = 0.8
-    heating_systems_values[0][:electric_auxiliary_energy] = 200
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
+    hpxml_data[:heating_systems][0][:heating_system_type] = "WallFurnace"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "propane"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 0.8
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
   elsif ['base-hvac-wall-furnace-wood-only.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = nil
-    heating_systems_values[0][:heating_system_type] = "WallFurnace"
-    heating_systems_values[0][:heating_system_fuel] = "wood"
-    heating_systems_values[0][:heating_efficiency_afue] = 0.8
-    heating_systems_values[0][:electric_auxiliary_energy] = 200
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
+    hpxml_data[:heating_systems][0][:heating_system_type] = "WallFurnace"
+    hpxml_data[:heating_systems][0][:heating_system_fuel] = "wood"
+    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 0.8
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
   elsif ['base-hvac-furnace-x3-dse.xml'].include? hpxml_file
-    heating_systems_values << heating_systems_values[0].dup
-    heating_systems_values << heating_systems_values[1].dup
-    heating_systems_values[1][:id] = "HeatingSystem2"
-    heating_systems_values[1][:distribution_system_idref] = "HVACDistribution2"
-    heating_systems_values[2][:id] = "HeatingSystem3"
-    heating_systems_values[2][:distribution_system_idref] = "HVACDistribution3"
+    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][0].dup
+    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][1].dup
+    hpxml_data[:heating_systems][1][:id] = "HeatingSystem2"
+    hpxml_data[:heating_systems][1][:distribution_system_idref] = "HVACDistribution2"
+    hpxml_data[:heating_systems][2][:id] = "HeatingSystem3"
+    hpxml_data[:heating_systems][2][:distribution_system_idref] = "HVACDistribution3"
     for i in 0..2
-      heating_systems_values[i][:heating_capacity] /= 3.0
-      heating_systems_values[i][:fraction_heat_load_served] = 0.333
+      hpxml_data[:heating_systems][i][:heating_capacity] /= 3.0
+      hpxml_data[:heating_systems][i][:fraction_heat_load_served] = 0.333
     end
   elsif ['invalid_files/unattached-hvac-distribution.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = "foobar"
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = "foobar"
   elsif ['invalid_files/hvac-invalid-distribution-system-type.xml'].include? hpxml_file
-    heating_systems_values[0][:distribution_system_idref] = "HVACDistribution2"
+    hpxml_data[:heating_systems][0][:distribution_system_idref] = "HVACDistribution2"
   elsif ['invalid_files/hvac-dse-multiple-attached-heating.xml'].include? hpxml_file
-    heating_systems_values[0][:fraction_heat_load_served] = 0.5
-    heating_systems_values << heating_systems_values[0].dup
-    heating_systems_values[1][:id] += "2"
+    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.5
+    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][0].dup
+    hpxml_data[:heating_systems][1][:id] += "2"
   elsif ['base-hvac-undersized.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_capacity] /= 10.0
+    hpxml_data[:heating_systems][0][:heating_capacity] /= 10.0
   elsif ['base-hvac-flowrate.xml'].include? hpxml_file
-    heating_systems_values[0][:heating_cfm] = heating_systems_values[0][:heating_capacity] * 360.0 / 12000.0
-  elsif hpxml_file.include? 'hvac_autosizing' and not heating_systems_values.nil? and heating_systems_values.size > 0
-    heating_systems_values[0][:heating_capacity] = -1
-  elsif hpxml_file.include? '-zero-heat.xml' and not heating_systems_values.nil? and heating_systems_values.size > 0
-    heating_systems_values[0][:fraction_heat_load_served] = 0
-    heating_systems_values[0][:heating_capacity] = 0
-  elsif hpxml_file.include? 'hvac_multiple' and not heating_systems_values.nil? and heating_systems_values.size > 0
-    heating_systems_values[0][:heating_capacity] /= 3.0
-    heating_systems_values[0][:fraction_heat_load_served] = 0.333
-    heating_systems_values[0][:electric_auxiliary_energy] /= 3.0 unless heating_systems_values[0][:electric_auxiliary_energy].nil?
-    heating_systems_values << heating_systems_values[0].dup
-    heating_systems_values[1][:id] = "HeatingSystem2"
-    heating_systems_values[1][:distribution_system_idref] = "HVACDistribution2" unless heating_systems_values[1][:distribution_system_idref].nil?
-    heating_systems_values << heating_systems_values[0].dup
-    heating_systems_values[2][:id] = "HeatingSystem3"
-    heating_systems_values[2][:distribution_system_idref] = "HVACDistribution3" unless heating_systems_values[2][:distribution_system_idref].nil?
+    hpxml_data[:heating_systems][0][:heating_cfm] = hpxml_data[:heating_systems][0][:heating_capacity] * 360.0 / 12000.0
+  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml_data[:heating_systems].nil? and hpxml_data[:heating_systems].size > 0
+    hpxml_data[:heating_systems][0][:heating_capacity] = -1
+  elsif hpxml_file.include? '-zero-heat.xml' and not hpxml_data[:heating_systems].nil? and hpxml_data[:heating_systems].size > 0
+    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0
+    hpxml_data[:heating_systems][0][:heating_capacity] = 0
+  elsif hpxml_file.include? 'hvac_multiple' and not hpxml_data[:heating_systems].nil? and hpxml_data[:heating_systems].size > 0
+    hpxml_data[:heating_systems][0][:heating_capacity] /= 3.0
+    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.333
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] /= 3.0 unless hpxml_data[:heating_systems][0][:electric_auxiliary_energy].nil?
+    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][0].dup
+    hpxml_data[:heating_systems][1][:id] = "HeatingSystem2"
+    hpxml_data[:heating_systems][1][:distribution_system_idref] = "HVACDistribution2" unless hpxml_data[:heating_systems][1][:distribution_system_idref].nil?
+    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][0].dup
+    hpxml_data[:heating_systems][2][:id] = "HeatingSystem3"
+    hpxml_data[:heating_systems][2][:distribution_system_idref] = "HVACDistribution3" unless hpxml_data[:heating_systems][2][:distribution_system_idref].nil?
     if ['hvac_multiple/base-hvac-boiler-gas-only-x3.xml'].include? hpxml_file
       # Test a file where sum is slightly greater than 1
-      heating_systems_values[0][:fraction_heat_load_served] = 0.33
-      heating_systems_values[1][:fraction_heat_load_served] = 0.33
-      heating_systems_values[2][:fraction_heat_load_served] = 0.35
+      hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.33
+      hpxml_data[:heating_systems][1][:fraction_heat_load_served] = 0.33
+      hpxml_data[:heating_systems][2][:fraction_heat_load_served] = 0.35
     end
-  elsif hpxml_file.include? 'hvac_partial' and not heating_systems_values.nil? and heating_systems_values.size > 0
-    heating_systems_values[0][:heating_capacity] /= 3.0
-    heating_systems_values[0][:fraction_heat_load_served] = 0.333
-    heating_systems_values[0][:electric_auxiliary_energy] /= 3.0 unless heating_systems_values[0][:electric_auxiliary_energy].nil?
+  elsif hpxml_file.include? 'hvac_partial' and not hpxml_data[:heating_systems].nil? and hpxml_data[:heating_systems].size > 0
+    hpxml_data[:heating_systems][0][:heating_capacity] /= 3.0
+    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.333
+    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] /= 3.0 unless hpxml_data[:heating_systems][0][:electric_auxiliary_energy].nil?
   end
-  return heating_systems_values
 end
 
-def get_hpxml_file_cooling_systems_values(hpxml_file, cooling_systems_values)
+def set_hpxml_data_cooling_systems_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    cooling_systems_values = [{ :id => "CoolingSystem",
-                                :distribution_system_idref => "HVACDistribution",
-                                :cooling_system_type => "central air conditioner",
-                                :cooling_system_fuel => "electricity",
-                                :cooling_capacity => 48000,
-                                :fraction_cool_load_served => 1,
-                                :cooling_efficiency_seer => 13 }]
+    hpxml_data[:cooling_systems] = [{ :id => "CoolingSystem",
+                                      :distribution_system_idref => "HVACDistribution",
+                                      :cooling_system_type => "central air conditioner",
+                                      :cooling_system_fuel => "electricity",
+                                      :cooling_capacity => 48000,
+                                      :fraction_cool_load_served => 1,
+                                      :cooling_efficiency_seer => 13 }]
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-air-to-air-heat-pump-var-speed.xml',
@@ -1953,324 +1809,351 @@ def get_hpxml_file_cooling_systems_values(hpxml_file, cooling_systems_values)
          'base-hvac-wall-furnace-elec-only.xml',
          'base-hvac-wall-furnace-propane-only.xml',
          'base-hvac-wall-furnace-wood-only.xml'].include? hpxml_file
-    cooling_systems_values = []
+    hpxml_data[:cooling_systems] = []
   elsif ['base-hvac-central-ac-only-1-speed-detailed.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_shr] = 0.7
-    cooling_systems_values[0][:compressor_type] = "single stage"
+    hpxml_data[:cooling_systems][0][:cooling_shr] = 0.7
+    hpxml_data[:cooling_systems][0][:compressor_type] = "single stage"
   elsif ['base-hvac-central-ac-only-2-speed-detailed.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_shr] = 0.7
-    cooling_systems_values[0][:compressor_type] = "two stage"
+    hpxml_data[:cooling_systems][0][:cooling_shr] = 0.7
+    hpxml_data[:cooling_systems][0][:compressor_type] = "two stage"
   elsif ['base-hvac-central-ac-only-var-speed-detailed.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_shr] = 0.7
-    cooling_systems_values[0][:compressor_type] = "variable speed"
+    hpxml_data[:cooling_systems][0][:cooling_shr] = 0.7
+    hpxml_data[:cooling_systems][0][:compressor_type] = "variable speed"
   elsif ['base-hvac-room-ac-only-detailed.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_shr] = 0.7
+    hpxml_data[:cooling_systems][0][:cooling_shr] = 0.7
   elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml'].include? hpxml_file
-    cooling_systems_values[0][:distribution_system_idref] = "HVACDistribution2"
+    hpxml_data[:cooling_systems][0][:distribution_system_idref] = "HVACDistribution2"
   elsif ['base-hvac-furnace-gas-central-ac-2-speed.xml',
          'base-hvac-central-ac-only-2-speed.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_efficiency_seer] = 18
+    hpxml_data[:cooling_systems][0][:cooling_efficiency_seer] = 18
   elsif ['base-hvac-furnace-gas-central-ac-var-speed.xml',
          'base-hvac-central-ac-only-var-speed.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_efficiency_seer] = 24
+    hpxml_data[:cooling_systems][0][:cooling_efficiency_seer] = 24
   elsif ['base-hvac-furnace-gas-room-ac.xml',
          'base-hvac-room-ac-only.xml'].include? hpxml_file
-    cooling_systems_values[0][:distribution_system_idref] = nil
-    cooling_systems_values[0][:cooling_system_type] = "room air conditioner"
-    cooling_systems_values[0][:cooling_efficiency_seer] = nil
-    cooling_systems_values[0][:cooling_efficiency_eer] = 8.5
+    hpxml_data[:cooling_systems][0][:distribution_system_idref] = nil
+    hpxml_data[:cooling_systems][0][:cooling_system_type] = "room air conditioner"
+    hpxml_data[:cooling_systems][0][:cooling_efficiency_seer] = nil
+    hpxml_data[:cooling_systems][0][:cooling_efficiency_eer] = 8.5
   elsif ['base-hvac-evap-cooler-only-ducted.xml',
          'base-hvac-evap-cooler-furnace-gas.xml',
          'base-hvac-evap-cooler-only.xml',
          'hvac_autosizing/base-hvac-evap-cooler-furnace-gas-autosize.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_system_type] = "evaporative cooler"
-    cooling_systems_values[0][:cooling_efficiency_seer] = nil
-    cooling_systems_values[0][:cooling_efficiency_eer] = nil
-    cooling_systems_values[0][:cooling_capacity] = nil
+    hpxml_data[:cooling_systems][0][:cooling_system_type] = "evaporative cooler"
+    hpxml_data[:cooling_systems][0][:cooling_efficiency_seer] = nil
+    hpxml_data[:cooling_systems][0][:cooling_efficiency_eer] = nil
+    hpxml_data[:cooling_systems][0][:cooling_capacity] = nil
     if ['base-hvac-evap-cooler-furnace-gas.xml',
         'hvac_autosizing/base-hvac-evap-cooler-furnace-gas-autosize.xml',
         'base-hvac-evap-cooler-only.xml'].include? hpxml_file
-      cooling_systems_values[0][:distribution_system_idref] = nil
+      hpxml_data[:cooling_systems][0][:distribution_system_idref] = nil
     end
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    cooling_systems_values[0][:distribution_system_idref] = "HVACDistribution4"
-    cooling_systems_values[0][:fraction_cool_load_served] = 0.2
-    cooling_systems_values[0][:cooling_capacity] *= 0.2
-    cooling_systems_values << { :id => "CoolingSystem2",
-                                :cooling_system_type => "room air conditioner",
-                                :cooling_system_fuel => "electricity",
-                                :cooling_capacity => 9600,
-                                :fraction_cool_load_served => 0.2,
-                                :cooling_efficiency_eer => 8.5 }
+    hpxml_data[:cooling_systems][0][:distribution_system_idref] = "HVACDistribution4"
+    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0.2
+    hpxml_data[:cooling_systems][0][:cooling_capacity] *= 0.2
+    hpxml_data[:cooling_systems] << { :id => "CoolingSystem2",
+                                      :cooling_system_type => "room air conditioner",
+                                      :cooling_system_fuel => "electricity",
+                                      :cooling_capacity => 9600,
+                                      :fraction_cool_load_served => 0.2,
+                                      :cooling_efficiency_eer => 8.5 }
   elsif ['invalid_files/hvac-frac-load-served.xml'].include? hpxml_file
-    cooling_systems_values[0][:fraction_cool_load_served] += 0.2
+    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] += 0.2
   elsif ['invalid_files/hvac-dse-multiple-attached-cooling.xml'].include? hpxml_file
-    cooling_systems_values[0][:fraction_cool_load_served] = 0.5
-    cooling_systems_values << cooling_systems_values[0].dup
-    cooling_systems_values[1][:id] += "2"
+    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0.5
+    hpxml_data[:cooling_systems] << hpxml_data[:cooling_systems][0].dup
+    hpxml_data[:cooling_systems][1][:id] += "2"
   elsif ['base-hvac-undersized.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_capacity] /= 10.0
+    hpxml_data[:cooling_systems][0][:cooling_capacity] /= 10.0
   elsif ['base-hvac-flowrate.xml'].include? hpxml_file
-    cooling_systems_values[0][:cooling_cfm] = cooling_systems_values[0][:cooling_capacity] * 360.0 / 12000.0
-  elsif hpxml_file.include? 'hvac_autosizing' and not cooling_systems_values.nil? and cooling_systems_values.size > 0
-    cooling_systems_values[0][:cooling_capacity] = -1
-  elsif hpxml_file.include? '-zero-cool.xml' and not cooling_systems_values.nil? and cooling_systems_values.size > 0
-    cooling_systems_values[0][:fraction_cool_load_served] = 0
-    cooling_systems_values[0][:cooling_capacity] = 0
-  elsif hpxml_file.include? 'hvac_multiple' and not cooling_systems_values.nil? and cooling_systems_values.size > 0
-    cooling_systems_values[0][:cooling_capacity] /= 3.0 unless cooling_systems_values[0][:cooling_capacity].nil?
-    cooling_systems_values[0][:fraction_cool_load_served] = 0.333
-    cooling_systems_values << cooling_systems_values[0].dup
-    cooling_systems_values[1][:id] = "CoolingSystem2"
-    cooling_systems_values[1][:distribution_system_idref] = "HVACDistribution2" unless cooling_systems_values[1][:distribution_system_idref].nil?
-    cooling_systems_values << cooling_systems_values[0].dup
-    cooling_systems_values[2][:id] = "CoolingSystem3"
-    cooling_systems_values[2][:distribution_system_idref] = "HVACDistribution3" unless cooling_systems_values[2][:distribution_system_idref].nil?
-  elsif hpxml_file.include? 'hvac_partial' and not cooling_systems_values.nil? and cooling_systems_values.size > 0
-    cooling_systems_values[0][:cooling_capacity] /= 3.0 unless cooling_systems_values[0][:cooling_capacity].nil?
-    cooling_systems_values[0][:fraction_cool_load_served] = 0.333
+    hpxml_data[:cooling_systems][0][:cooling_cfm] = hpxml_data[:cooling_systems][0][:cooling_capacity] * 360.0 / 12000.0
+  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml_data[:cooling_systems].nil? and hpxml_data[:cooling_systems].size > 0
+    hpxml_data[:cooling_systems][0][:cooling_capacity] = -1
+  elsif hpxml_file.include? '-zero-cool.xml' and not hpxml_data[:cooling_systems].nil? and hpxml_data[:cooling_systems].size > 0
+    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0
+    hpxml_data[:cooling_systems][0][:cooling_capacity] = 0
+  elsif hpxml_file.include? 'hvac_multiple' and not hpxml_data[:cooling_systems].nil? and hpxml_data[:cooling_systems].size > 0
+    hpxml_data[:cooling_systems][0][:cooling_capacity] /= 3.0 unless hpxml_data[:cooling_systems][0][:cooling_capacity].nil?
+    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0.333
+    hpxml_data[:cooling_systems] << hpxml_data[:cooling_systems][0].dup
+    hpxml_data[:cooling_systems][1][:id] = "CoolingSystem2"
+    hpxml_data[:cooling_systems][1][:distribution_system_idref] = "HVACDistribution2" unless hpxml_data[:cooling_systems][1][:distribution_system_idref].nil?
+    hpxml_data[:cooling_systems] << hpxml_data[:cooling_systems][0].dup
+    hpxml_data[:cooling_systems][2][:id] = "CoolingSystem3"
+    hpxml_data[:cooling_systems][2][:distribution_system_idref] = "HVACDistribution3" unless hpxml_data[:cooling_systems][2][:distribution_system_idref].nil?
+  elsif hpxml_file.include? 'hvac_partial' and not hpxml_data[:cooling_systems].nil? and hpxml_data[:cooling_systems].size > 0
+    hpxml_data[:cooling_systems][0][:cooling_capacity] /= 3.0 unless hpxml_data[:cooling_systems][0][:cooling_capacity].nil?
+    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0.333
   end
-  return cooling_systems_values
 end
 
-def get_hpxml_file_heat_pumps_values(hpxml_file, heat_pumps_values)
-  if ['base-hvac-air-to-air-heat-pump-1-speed.xml',
-      'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'].include? hpxml_file
-    heat_pumps_values << { :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "air-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 42000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_hspf => 7.7,
-                           :cooling_efficiency_seer => 13 }
+def set_hpxml_data_heat_pumps_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:heat_pumps] = []
+  elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
+         'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'].include? hpxml_file
+    hpxml_data[:heat_pumps] << { :id => "HeatPump",
+                                 :distribution_system_idref => "HVACDistribution",
+                                 :heat_pump_type => "air-to-air",
+                                 :heat_pump_fuel => "electricity",
+                                 :heating_capacity => 42000,
+                                 :cooling_capacity => 48000,
+                                 :backup_heating_fuel => "electricity",
+                                 :backup_heating_capacity => 34121,
+                                 :backup_heating_efficiency_percent => 1.0,
+                                 :fraction_heat_load_served => 1,
+                                 :fraction_cool_load_served => 1,
+                                 :heating_efficiency_hspf => 7.7,
+                                 :cooling_efficiency_seer => 13 }
     if hpxml_file == 'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'
-      heat_pumps_values[0][:fraction_cool_load_served] = 0
+      hpxml_data[:heat_pumps][0][:fraction_cool_load_served] = 0
     end
   elsif ['base-hvac-air-to-air-heat-pump-2-speed.xml'].include? hpxml_file
-    heat_pumps_values << { :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "air-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 42000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_hspf => 9.3,
-                           :cooling_efficiency_seer => 18 }
+    hpxml_data[:heat_pumps] << { :id => "HeatPump",
+                                 :distribution_system_idref => "HVACDistribution",
+                                 :heat_pump_type => "air-to-air",
+                                 :heat_pump_fuel => "electricity",
+                                 :heating_capacity => 42000,
+                                 :cooling_capacity => 48000,
+                                 :backup_heating_fuel => "electricity",
+                                 :backup_heating_capacity => 34121,
+                                 :backup_heating_efficiency_percent => 1.0,
+                                 :fraction_heat_load_served => 1,
+                                 :fraction_cool_load_served => 1,
+                                 :heating_efficiency_hspf => 9.3,
+                                 :cooling_efficiency_seer => 18 }
   elsif ['base-hvac-air-to-air-heat-pump-var-speed.xml'].include? hpxml_file
-    heat_pumps_values << { :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "air-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 42000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_hspf => 10,
-                           :cooling_efficiency_seer => 22 }
+    hpxml_data[:heat_pumps] << { :id => "HeatPump",
+                                 :distribution_system_idref => "HVACDistribution",
+                                 :heat_pump_type => "air-to-air",
+                                 :heat_pump_fuel => "electricity",
+                                 :heating_capacity => 42000,
+                                 :cooling_capacity => 48000,
+                                 :backup_heating_fuel => "electricity",
+                                 :backup_heating_capacity => 34121,
+                                 :backup_heating_efficiency_percent => 1.0,
+                                 :fraction_heat_load_served => 1,
+                                 :fraction_cool_load_served => 1,
+                                 :heating_efficiency_hspf => 10,
+                                 :cooling_efficiency_seer => 22 }
   elsif ['base-hvac-ground-to-air-heat-pump.xml'].include? hpxml_file
-    heat_pumps_values << { :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "ground-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 42000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_cop => 3.6,
-                           :cooling_efficiency_eer => 16.6 }
+    hpxml_data[:heat_pumps] << { :id => "HeatPump",
+                                 :distribution_system_idref => "HVACDistribution",
+                                 :heat_pump_type => "ground-to-air",
+                                 :heat_pump_fuel => "electricity",
+                                 :heating_capacity => 42000,
+                                 :cooling_capacity => 48000,
+                                 :backup_heating_fuel => "electricity",
+                                 :backup_heating_capacity => 34121,
+                                 :backup_heating_efficiency_percent => 1.0,
+                                 :fraction_heat_load_served => 1,
+                                 :fraction_cool_load_served => 1,
+                                 :heating_efficiency_cop => 3.6,
+                                 :cooling_efficiency_eer => 16.6 }
   elsif ['base-hvac-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    heat_pumps_values << { :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "mini-split",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 52000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_hspf => 10,
-                           :cooling_efficiency_seer => 19 }
+    hpxml_data[:heat_pumps] << { :id => "HeatPump",
+                                 :distribution_system_idref => "HVACDistribution",
+                                 :heat_pump_type => "mini-split",
+                                 :heat_pump_fuel => "electricity",
+                                 :heating_capacity => 52000,
+                                 :cooling_capacity => 48000,
+                                 :backup_heating_fuel => "electricity",
+                                 :backup_heating_capacity => 34121,
+                                 :backup_heating_efficiency_percent => 1.0,
+                                 :fraction_heat_load_served => 1,
+                                 :fraction_cool_load_served => 1,
+                                 :heating_efficiency_hspf => 10,
+                                 :cooling_efficiency_seer => 19 }
   elsif ['base-hvac-mini-split-heat-pump-ductless.xml'].include? hpxml_file
-    heat_pumps_values[0][:distribution_system_idref] = nil
+    hpxml_data[:heat_pumps][0][:distribution_system_idref] = nil
   elsif ['base-hvac-mini-split-heat-pump-ductless-no-backup.xml'].include? hpxml_file
-    heat_pumps_values[0][:backup_heating_fuel] = nil
+    hpxml_data[:heat_pumps][0][:backup_heating_fuel] = nil
   elsif ['invalid_files/heat-pump-mixed-fixed-and-autosize-capacities.xml'].include? hpxml_file
-    heat_pumps_values[0][:heating_capacity] = -1
+    hpxml_data[:heat_pumps][0][:heating_capacity] = -1
   elsif ['invalid_files/heat-pump-mixed-fixed-and-autosize-capacities2.xml'].include? hpxml_file
-    heat_pumps_values[0][:cooling_capacity] = -1
+    hpxml_data[:heat_pumps][0][:cooling_capacity] = -1
   elsif ['invalid_files/heat-pump-mixed-fixed-and-autosize-capacities3.xml'].include? hpxml_file
-    heat_pumps_values[0][:cooling_capacity] = -1
-    heat_pumps_values[0][:heating_capacity] = -1
-    heat_pumps_values[0][:heating_capacity_17F] = 25000
+    hpxml_data[:heat_pumps][0][:cooling_capacity] = -1
+    hpxml_data[:heat_pumps][0][:heating_capacity] = -1
+    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = 25000
   elsif ['invalid_files/heat-pump-mixed-fixed-and-autosize-capacities4.xml'].include? hpxml_file
-    heat_pumps_values[0][:backup_heating_capacity] = -1
+    hpxml_data[:heat_pumps][0][:backup_heating_capacity] = -1
   elsif ['base-hvac-air-to-air-heat-pump-1-speed-detailed.xml'].include? hpxml_file
-    heat_pumps_values[0][:heating_capacity_17F] = heat_pumps_values[0][:heating_capacity] * 0.630 # Based on OAT slope of default curves
-    heat_pumps_values[0][:cooling_shr] = 0.7
-    heat_pumps_values[0][:compressor_type] = "single stage"
+    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = hpxml_data[:heat_pumps][0][:heating_capacity] * 0.630 # Based on OAT slope of default curves
+    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
+    hpxml_data[:heat_pumps][0][:compressor_type] = "single stage"
   elsif ['base-hvac-air-to-air-heat-pump-2-speed-detailed.xml'].include? hpxml_file
-    heat_pumps_values[0][:heating_capacity_17F] = heat_pumps_values[0][:heating_capacity] * 0.590 # Based on OAT slope of default curves
-    heat_pumps_values[0][:cooling_shr] = 0.7
-    heat_pumps_values[0][:compressor_type] = "two stage"
+    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = hpxml_data[:heat_pumps][0][:heating_capacity] * 0.590 # Based on OAT slope of default curves
+    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
+    hpxml_data[:heat_pumps][0][:compressor_type] = "two stage"
   elsif ['base-hvac-air-to-air-heat-pump-var-speed-detailed.xml'].include? hpxml_file
-    heat_pumps_values[0][:heating_capacity_17F] = heat_pumps_values[0][:heating_capacity] * 0.640 # Based on OAT slope of default curves
-    heat_pumps_values[0][:cooling_shr] = 0.7
-    heat_pumps_values[0][:compressor_type] = "variable speed"
+    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = hpxml_data[:heat_pumps][0][:heating_capacity] * 0.640 # Based on OAT slope of default curves
+    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
+    hpxml_data[:heat_pumps][0][:compressor_type] = "variable speed"
   elsif ['base-hvac-mini-split-heat-pump-ducted-detailed.xml'].include? hpxml_file
     f = 1.0 - (1.0 - 0.25) / (47.0 + 5.0) * (47.0 - 17.0)
-    heat_pumps_values[0][:heating_capacity_17F] = heat_pumps_values[0][:heating_capacity] * f
-    heat_pumps_values[0][:cooling_shr] = 0.7
+    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = hpxml_data[:heat_pumps][0][:heating_capacity] * f
+    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
   elsif ['base-hvac-ground-to-air-heat-pump-detailed.xml'].include? hpxml_file
-    heat_pumps_values[0][:cooling_shr] = 0.7
+    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    heat_pumps_values << { :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution5",
-                           :heat_pump_type => "air-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 4800,
-                           :cooling_capacity => 4800,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 3412,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 0.1,
-                           :fraction_cool_load_served => 0.2,
-                           :heating_efficiency_hspf => 7.7,
-                           :cooling_efficiency_seer => 13 }
-    heat_pumps_values << { :id => "HeatPump2",
-                           :distribution_system_idref => "HVACDistribution6",
-                           :heat_pump_type => "ground-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 4800,
-                           :cooling_capacity => 4800,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 3412,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 0.1,
-                           :fraction_cool_load_served => 0.2,
-                           :heating_efficiency_cop => 3.6,
-                           :cooling_efficiency_eer => 16.6 }
-    heat_pumps_values << { :id => "HeatPump3",
-                           :heat_pump_type => "mini-split",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 4800,
-                           :cooling_capacity => 4800,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 3412,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 0.1,
-                           :fraction_cool_load_served => 0.2,
-                           :heating_efficiency_hspf => 10,
-                           :cooling_efficiency_seer => 19 }
+    hpxml_data[:heat_pumps] << { :id => "HeatPump",
+                                 :distribution_system_idref => "HVACDistribution5",
+                                 :heat_pump_type => "air-to-air",
+                                 :heat_pump_fuel => "electricity",
+                                 :heating_capacity => 4800,
+                                 :cooling_capacity => 4800,
+                                 :backup_heating_fuel => "electricity",
+                                 :backup_heating_capacity => 3412,
+                                 :backup_heating_efficiency_percent => 1.0,
+                                 :fraction_heat_load_served => 0.1,
+                                 :fraction_cool_load_served => 0.2,
+                                 :heating_efficiency_hspf => 7.7,
+                                 :cooling_efficiency_seer => 13 }
+    hpxml_data[:heat_pumps] << { :id => "HeatPump2",
+                                 :distribution_system_idref => "HVACDistribution6",
+                                 :heat_pump_type => "ground-to-air",
+                                 :heat_pump_fuel => "electricity",
+                                 :heating_capacity => 4800,
+                                 :cooling_capacity => 4800,
+                                 :backup_heating_fuel => "electricity",
+                                 :backup_heating_capacity => 3412,
+                                 :backup_heating_efficiency_percent => 1.0,
+                                 :fraction_heat_load_served => 0.1,
+                                 :fraction_cool_load_served => 0.2,
+                                 :heating_efficiency_cop => 3.6,
+                                 :cooling_efficiency_eer => 16.6 }
+    hpxml_data[:heat_pumps] << { :id => "HeatPump3",
+                                 :heat_pump_type => "mini-split",
+                                 :heat_pump_fuel => "electricity",
+                                 :heating_capacity => 4800,
+                                 :cooling_capacity => 4800,
+                                 :backup_heating_fuel => "electricity",
+                                 :backup_heating_capacity => 3412,
+                                 :backup_heating_efficiency_percent => 1.0,
+                                 :fraction_heat_load_served => 0.1,
+                                 :fraction_cool_load_served => 0.2,
+                                 :heating_efficiency_hspf => 10,
+                                 :cooling_efficiency_seer => 19 }
   elsif ['invalid_files/hvac-distribution-multiple-attached-heating.xml'].include? hpxml_file
-    heat_pumps_values[0][:distribution_system_idref] = "HVACDistribution3"
+    hpxml_data[:heat_pumps][0][:distribution_system_idref] = "HVACDistribution3"
   elsif ['invalid_files/hvac-distribution-multiple-attached-cooling.xml'].include? hpxml_file
-    heat_pumps_values[0][:distribution_system_idref] = "HVACDistribution4"
+    hpxml_data[:heat_pumps][0][:distribution_system_idref] = "HVACDistribution4"
   elsif ['base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.xml',
          'base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    heat_pumps_values[0][:backup_heating_fuel] = "natural gas"
-    heat_pumps_values[0][:backup_heating_capacity] = 36000
-    heat_pumps_values[0][:backup_heating_efficiency_percent] = nil
-    heat_pumps_values[0][:backup_heating_efficiency_afue] = 0.95
-    heat_pumps_values[0][:backup_heating_switchover_temp] = 25
+    hpxml_data[:heat_pumps][0][:backup_heating_fuel] = "natural gas"
+    hpxml_data[:heat_pumps][0][:backup_heating_capacity] = 36000
+    hpxml_data[:heat_pumps][0][:backup_heating_efficiency_percent] = nil
+    hpxml_data[:heat_pumps][0][:backup_heating_efficiency_afue] = 0.95
+    hpxml_data[:heat_pumps][0][:backup_heating_switchover_temp] = 25
   elsif ['base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml'].include? hpxml_file
-    heat_pumps_values[0][:backup_heating_fuel] = "electricity"
-    heat_pumps_values[0][:backup_heating_efficiency_afue] = 1.0
-  elsif hpxml_file.include? 'hvac_autosizing' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
-    heat_pumps_values[0][:cooling_capacity] = -1
-    heat_pumps_values[0][:heating_capacity] = -1
-    heat_pumps_values[0][:backup_heating_capacity] = -1
-  elsif hpxml_file.include? '-zero-heat.xml' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
-    heat_pumps_values[0][:fraction_heat_load_served] = 0
-    heat_pumps_values[0][:heating_capacity] = 0
-    heat_pumps_values[0][:backup_heating_capacity] = 0
-  elsif hpxml_file.include? '-zero-cool.xml' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
-    heat_pumps_values[0][:fraction_cool_load_served] = 0
-    heat_pumps_values[0][:cooling_capacity] = 0
-  elsif hpxml_file.include? 'hvac_multiple' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
-    heat_pumps_values[0][:cooling_capacity] /= 3.0
-    heat_pumps_values[0][:heating_capacity] /= 3.0
-    heat_pumps_values[0][:backup_heating_capacity] /= 3.0
-    heat_pumps_values[0][:fraction_heat_load_served] = 0.333
-    heat_pumps_values[0][:fraction_cool_load_served] = 0.333
-    heat_pumps_values << heat_pumps_values[0].dup
-    heat_pumps_values[1][:id] = "HeatPump2"
-    heat_pumps_values[1][:distribution_system_idref] = "HVACDistribution2" unless heat_pumps_values[1][:distribution_system_idref].nil?
-    heat_pumps_values << heat_pumps_values[0].dup
-    heat_pumps_values[2][:id] = "HeatPump3"
-    heat_pumps_values[2][:distribution_system_idref] = "HVACDistribution3" unless heat_pumps_values[2][:distribution_system_idref].nil?
-  elsif hpxml_file.include? 'hvac_partial' and not heat_pumps_values.nil? and heat_pumps_values.size > 0
-    heat_pumps_values[0][:cooling_capacity] /= 3.0
-    heat_pumps_values[0][:heating_capacity] /= 3.0
-    heat_pumps_values[0][:backup_heating_capacity] /= 3.0
-    heat_pumps_values[0][:fraction_heat_load_served] = 0.333
-    heat_pumps_values[0][:fraction_cool_load_served] = 0.333
+    hpxml_data[:heat_pumps][0][:backup_heating_fuel] = "electricity"
+    hpxml_data[:heat_pumps][0][:backup_heating_efficiency_afue] = 1.0
+  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
+    hpxml_data[:heat_pumps][0][:cooling_capacity] = -1
+    hpxml_data[:heat_pumps][0][:heating_capacity] = -1
+    hpxml_data[:heat_pumps][0][:backup_heating_capacity] = -1
+  elsif hpxml_file.include? '-zero-heat.xml' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
+    hpxml_data[:heat_pumps][0][:fraction_heat_load_served] = 0
+    hpxml_data[:heat_pumps][0][:heating_capacity] = 0
+    hpxml_data[:heat_pumps][0][:backup_heating_capacity] = 0
+  elsif hpxml_file.include? '-zero-cool.xml' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
+    hpxml_data[:heat_pumps][0][:fraction_cool_load_served] = 0
+    hpxml_data[:heat_pumps][0][:cooling_capacity] = 0
+  elsif hpxml_file.include? 'hvac_multiple' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
+    hpxml_data[:heat_pumps][0][:cooling_capacity] /= 3.0
+    hpxml_data[:heat_pumps][0][:heating_capacity] /= 3.0
+    hpxml_data[:heat_pumps][0][:backup_heating_capacity] /= 3.0
+    hpxml_data[:heat_pumps][0][:fraction_heat_load_served] = 0.333
+    hpxml_data[:heat_pumps][0][:fraction_cool_load_served] = 0.333
+    hpxml_data[:heat_pumps] << hpxml_data[:heat_pumps][0].dup
+    hpxml_data[:heat_pumps][1][:id] = "HeatPump2"
+    hpxml_data[:heat_pumps][1][:distribution_system_idref] = "HVACDistribution2" unless hpxml_data[:heat_pumps][1][:distribution_system_idref].nil?
+    hpxml_data[:heat_pumps] << hpxml_data[:heat_pumps][0].dup
+    hpxml_data[:heat_pumps][2][:id] = "HeatPump3"
+    hpxml_data[:heat_pumps][2][:distribution_system_idref] = "HVACDistribution3" unless hpxml_data[:heat_pumps][2][:distribution_system_idref].nil?
+  elsif hpxml_file.include? 'hvac_partial' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
+    hpxml_data[:heat_pumps][0][:cooling_capacity] /= 3.0
+    hpxml_data[:heat_pumps][0][:heating_capacity] /= 3.0
+    hpxml_data[:heat_pumps][0][:backup_heating_capacity] /= 3.0
+    hpxml_data[:heat_pumps][0][:fraction_heat_load_served] = 0.333
+    hpxml_data[:heat_pumps][0][:fraction_cool_load_served] = 0.333
   end
-
-  return heat_pumps_values
 end
 
-def get_hpxml_file_hvac_control_values(hpxml_file, hvac_control_values)
+def set_hpxml_data_hvac_control_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    hvac_control_values = { :id => "HVACControl",
-                            :control_type => "manual thermostat",
-                            :heating_setpoint_temp => 68,
-                            :cooling_setpoint_temp => 78 }
+    hpxml_data[:hvac_control] = { :id => "HVACControl",
+                                  :control_type => "manual thermostat",
+                                  :heating_setpoint_temp => 68,
+                                  :cooling_setpoint_temp => 78 }
   elsif ['base-hvac-none.xml'].include? hpxml_file
-    hvac_control_values = {}
+    hpxml_data[:hvac_control] = {}
   elsif ['base-hvac-programmable-thermostat.xml'].include? hpxml_file
-    hvac_control_values[:control_type] = "programmable thermostat"
-    hvac_control_values[:heating_setback_temp] = 66
-    hvac_control_values[:heating_setback_hours_per_week] = 7 * 7
-    hvac_control_values[:heating_setback_start_hour] = 23 # 11pm
-    hvac_control_values[:cooling_setup_temp] = 80
-    hvac_control_values[:cooling_setup_hours_per_week] = 6 * 7
-    hvac_control_values[:cooling_setup_start_hour] = 9 # 9am
+    hpxml_data[:hvac_control][:control_type] = "programmable thermostat"
+    hpxml_data[:hvac_control][:heating_setback_temp] = 66
+    hpxml_data[:hvac_control][:heating_setback_hours_per_week] = 7 * 7
+    hpxml_data[:hvac_control][:heating_setback_start_hour] = 23 # 11pm
+    hpxml_data[:hvac_control][:cooling_setup_temp] = 80
+    hpxml_data[:hvac_control][:cooling_setup_hours_per_week] = 6 * 7
+    hpxml_data[:hvac_control][:cooling_setup_start_hour] = 9 # 9am
   elsif ['base-hvac-setpoints.xml'].include? hpxml_file
-    hvac_control_values[:heating_setpoint_temp] = 60
-    hvac_control_values[:cooling_setpoint_temp] = 80
+    hpxml_data[:hvac_control][:heating_setpoint_temp] = 60
+    hpxml_data[:hvac_control][:cooling_setpoint_temp] = 80
   elsif ['base-misc-ceiling-fans.xml'].include? hpxml_file
-    hvac_control_values[:ceiling_fan_cooling_setpoint_temp_offset] = 0.5
+    hpxml_data[:hvac_control][:ceiling_fan_cooling_setpoint_temp_offset] = 0.5
   end
-  return hvac_control_values
 end
 
-def get_hpxml_file_hvac_distributions_values(hpxml_file, hvac_distributions_values)
+def set_hpxml_data_hvac_distributions_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    hvac_distributions_values = [{ :id => "HVACDistribution",
-                                   :distribution_system_type => "AirDistribution" }]
+    hpxml_data[:hvac_distributions] = [{ :id => "HVACDistribution",
+                                         :distribution_system_type => "AirDistribution",
+                                         :duct_leakage_measurements => [{ :duct_type => "supply",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 75 },
+                                                                        { :duct_type => "return",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 25 }],
+                                         :ducts => [{ :duct_type => "supply",
+                                                      :duct_insulation_r_value => 4,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 150 },
+                                                    { :duct_type => "return",
+                                                      :duct_insulation_r_value => 0,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 50 }] }]
   elsif ['base-hvac-boiler-elec-only.xml',
          'base-hvac-boiler-gas-only.xml',
          'base-hvac-boiler-oil-only.xml',
          'base-hvac-boiler-propane-only.xml',
          'base-hvac-boiler-wood-only.xml'].include? hpxml_file
-    hvac_distributions_values[0][:distribution_system_type] = "HydronicDistribution"
+    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "HydronicDistribution"
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements] = []
+    hpxml_data[:hvac_distributions][0][:ducts] = []
   elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml'].include? hpxml_file
-    hvac_distributions_values[0][:distribution_system_type] = "HydronicDistribution"
-    hvac_distributions_values << { :id => "HVACDistribution2",
-                                   :distribution_system_type => "AirDistribution" }
-  elsif ['invalid_files/hvac-invalid-distribution-system-type.xml'].include? hpxml_file
-    hvac_distributions_values << { :id => "HVACDistribution2",
-                                   :distribution_system_type => "HydronicDistribution" }
+    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "HydronicDistribution"
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements] = []
+    hpxml_data[:hvac_distributions][0][:ducts] = []
+    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution2",
+                                         :distribution_system_type => "AirDistribution",
+                                         :duct_leakage_measurements => [{ :duct_type => "supply",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 75 },
+                                                                        { :duct_type => "return",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 25 }],
+                                         :ducts => [{ :duct_type => "supply",
+                                                      :duct_insulation_r_value => 4,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 150 },
+                                                    { :duct_type => "return",
+                                                      :duct_insulation_r_value => 0,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 50 }] }
   elsif ['base-hvac-none.xml',
          'base-hvac-elec-resistance-only.xml',
          'base-hvac-evap-cooler-only.xml',
@@ -2282,920 +2165,849 @@ def get_hpxml_file_hvac_distributions_values(hpxml_file, hvac_distributions_valu
          'base-hvac-wall-furnace-elec-only.xml',
          'base-hvac-wall-furnace-propane-only.xml',
          'base-hvac-wall-furnace-wood-only.xml'].include? hpxml_file
-    hvac_distributions_values = []
+    hpxml_data[:hvac_distributions] = []
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    hvac_distributions_values[0][:distribution_system_type] = "HydronicDistribution"
-    hvac_distributions_values << { :id => "HVACDistribution2",
-                                   :distribution_system_type => "HydronicDistribution" }
-    hvac_distributions_values << { :id => "HVACDistribution3",
-                                   :distribution_system_type => "AirDistribution" }
-    hvac_distributions_values << { :id => "HVACDistribution4",
-                                   :distribution_system_type => "AirDistribution" }
-    hvac_distributions_values << { :id => "HVACDistribution5",
-                                   :distribution_system_type => "AirDistribution" }
-    hvac_distributions_values << { :id => "HVACDistribution6",
-                                   :distribution_system_type => "AirDistribution" }
+    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "HydronicDistribution"
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements] = []
+    hpxml_data[:hvac_distributions][0][:ducts] = []
+    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution2",
+                                         :distribution_system_type => "HydronicDistribution",
+                                         :duct_leakage_measurements => [],
+                                         :ducts => [] }
+    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution3",
+                                         :distribution_system_type => "AirDistribution",
+                                         :duct_leakage_measurements => [{ :duct_type => "supply",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 75 },
+                                                                        { :duct_type => "return",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 25 }],
+                                         :ducts => [{ :duct_type => "supply",
+                                                      :duct_insulation_r_value => 4,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 150 },
+                                                    { :duct_type => "return",
+                                                      :duct_insulation_r_value => 0,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 50 }] }
+    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution4",
+                                         :distribution_system_type => "AirDistribution",
+                                         :duct_leakage_measurements => [{ :duct_type => "supply",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 75 },
+                                                                        { :duct_type => "return",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 25 }],
+                                         :ducts => [{ :duct_type => "supply",
+                                                      :duct_insulation_r_value => 4,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 150 },
+                                                    { :duct_type => "return",
+                                                      :duct_insulation_r_value => 0,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 50 }] }
+    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution5",
+                                         :distribution_system_type => "AirDistribution",
+                                         :duct_leakage_measurements => [{ :duct_type => "supply",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 75 },
+                                                                        { :duct_type => "return",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 25 }],
+                                         :ducts => [{ :duct_type => "supply",
+                                                      :duct_insulation_r_value => 4,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 150 },
+                                                    { :duct_type => "return",
+                                                      :duct_insulation_r_value => 0,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 50 }] }
+    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution6",
+                                         :distribution_system_type => "AirDistribution",
+                                         :duct_leakage_measurements => [{ :duct_type => "supply",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 75 },
+                                                                        { :duct_type => "return",
+                                                                          :duct_leakage_units => "CFM25",
+                                                                          :duct_leakage_value => 25 }],
+                                         :ducts => [{ :duct_type => "supply",
+                                                      :duct_insulation_r_value => 4,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 150 },
+                                                    { :duct_type => "return",
+                                                      :duct_insulation_r_value => 0,
+                                                      :duct_location => "attic - unvented",
+                                                      :duct_surface_area => 50 }] }
   elsif ['base-hvac-dse.xml',
          'base-dhw-indirect-dse.xml'].include? hpxml_file
-    hvac_distributions_values[0][:distribution_system_type] = "DSE"
-    hvac_distributions_values[0][:annual_heating_dse] = 0.8
-    hvac_distributions_values[0][:annual_cooling_dse] = 0.7
+    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "DSE"
+    hpxml_data[:hvac_distributions][0][:annual_heating_dse] = 0.8
+    hpxml_data[:hvac_distributions][0][:annual_cooling_dse] = 0.7
   elsif ['base-hvac-furnace-x3-dse.xml'].include? hpxml_file
-    hvac_distributions_values[0][:distribution_system_type] = "DSE"
-    hvac_distributions_values[0][:annual_heating_dse] = 0.8
-    hvac_distributions_values[0][:annual_cooling_dse] = 0.7
-    hvac_distributions_values << hvac_distributions_values[0].dup
-    hvac_distributions_values[1][:id] = "HVACDistribution2"
-    hvac_distributions_values[1][:annual_cooling_dse] = nil
-    hvac_distributions_values << hvac_distributions_values[0].dup
-    hvac_distributions_values[2][:id] = "HVACDistribution3"
-    hvac_distributions_values[2][:annual_cooling_dse] = nil
-  elsif hpxml_file.include? 'hvac_multiple' and not hvac_distributions_values.empty?
-    hvac_distributions_values << hvac_distributions_values[0].dup
-    hvac_distributions_values[1][:id] = "HVACDistribution2"
-    hvac_distributions_values << hvac_distributions_values[0].dup
-    hvac_distributions_values[2][:id] = "HVACDistribution3"
-  end
-  return hvac_distributions_values
-end
-
-def get_hpxml_file_duct_leakage_measurements_values(hpxml_file, duct_leakage_measurements_values)
-  if ['base.xml'].include? hpxml_file
-    duct_leakage_measurements_values = [[{ :duct_type => "supply",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 75 },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 25 }]]
-  elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml'].include? hpxml_file
-    duct_leakage_measurements_values[0] = []
-    duct_leakage_measurements_values << [{ :duct_type => "supply",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 75 },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 25 }]
+    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "DSE"
+    hpxml_data[:hvac_distributions][0][:annual_heating_dse] = 0.8
+    hpxml_data[:hvac_distributions][0][:annual_cooling_dse] = 0.7
+    hpxml_data[:hvac_distributions] << hpxml_data[:hvac_distributions][0].dup
+    hpxml_data[:hvac_distributions][1][:id] = "HVACDistribution2"
+    hpxml_data[:hvac_distributions][1][:annual_cooling_dse] = nil
+    hpxml_data[:hvac_distributions] << hpxml_data[:hvac_distributions][0].dup
+    hpxml_data[:hvac_distributions][2][:id] = "HVACDistribution3"
+    hpxml_data[:hvac_distributions][2][:annual_cooling_dse] = nil
   elsif ['base-hvac-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    duct_leakage_measurements_values[0][0][:duct_leakage_value] = 15
-    duct_leakage_measurements_values[0][1][:duct_leakage_value] = 5
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 15
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 5
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_insulation_r_value] = 0
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_surface_area] = 30
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_surface_area] = 10
   elsif ['base-hvac-evap-cooler-only-ducted.xml'].include? hpxml_file
-    duct_leakage_measurements_values[0].pop
-  elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    duct_leakage_measurements_values[0] = []
-    duct_leakage_measurements_values[1] = []
-    duct_leakage_measurements_values << [{ :duct_type => "supply",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 75 },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 25 }]
-    duct_leakage_measurements_values << [{ :duct_type => "supply",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 75 },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 25 }]
-    duct_leakage_measurements_values << [{ :duct_type => "supply",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 75 },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 25 }]
-    duct_leakage_measurements_values << [{ :duct_type => "supply",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 75 },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => 25 }]
-  elsif ['hvac_multiple/base-hvac-air-to-air-heat-pump-1-speed-x3.xml',
-         'hvac_multiple/base-hvac-air-to-air-heat-pump-2-speed-x3.xml',
-         'hvac_multiple/base-hvac-air-to-air-heat-pump-var-speed-x3.xml',
-         'hvac_multiple/base-hvac-central-ac-only-1-speed-x3.xml',
-         'hvac_multiple/base-hvac-central-ac-only-2-speed-x3.xml',
-         'hvac_multiple/base-hvac-central-ac-only-var-speed-x3.xml',
-         'hvac_multiple/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-x3.xml',
-         'hvac_multiple/base-hvac-furnace-gas-only-x3.xml',
-         'hvac_multiple/base-hvac-ground-to-air-heat-pump-x3.xml',
-         'hvac_multiple/base-hvac-mini-split-heat-pump-ducted-x3.xml'].include? hpxml_file
-    duct_leakage_measurements_values[0][0][:duct_leakage_value] = 0.0
-    duct_leakage_measurements_values[0][1][:duct_leakage_value] = 0.0
-    duct_leakage_measurements_values << [{ :duct_type => "supply",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => duct_leakage_measurements_values[0][0][:duct_leakage_value] },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => duct_leakage_measurements_values[0][1][:duct_leakage_value] }]
-    duct_leakage_measurements_values << [{ :duct_type => "supply",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => duct_leakage_measurements_values[0][0][:duct_leakage_value] },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "CFM25",
-                                           :duct_leakage_value => duct_leakage_measurements_values[0][1][:duct_leakage_value] }]
-  elsif (hpxml_file.include? 'hvac_partial' and not duct_leakage_measurements_values.empty?) or
-        (hpxml_file.include? 'hvac_base' and not duct_leakage_measurements_values.empty?) or
-        ['base-atticroof-conditioned.xml',
-         'base-enclosure-adiabatic-surfaces.xml',
-         'base-atticroof-cathedral.xml',
-         'base-atticroof-conditioned.xml',
-         'base-atticroof-flat.xml'].include? hpxml_file
-    duct_leakage_measurements_values[0][0][:duct_leakage_value] = 0.0
-    duct_leakage_measurements_values[0][1][:duct_leakage_value] = 0.0
-  elsif ['base-hvac-ducts-in-conditioned-space.xml'].include? hpxml_file
-    # Test leakage to outside when all ducts in conditioned space
-    # (e.g., ducts may be in floor cavities which have leaky rims)
-    duct_leakage_measurements_values[0][0][:duct_leakage_value] = 1.5
-    duct_leakage_measurements_values[0][1][:duct_leakage_value] = 1.5
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements].pop
+    hpxml_data[:hvac_distributions][0][:ducts].pop
   elsif ['base-hvac-ducts-leakage-percent.xml'].include? hpxml_file
-    duct_leakage_measurements_values = [[{ :duct_type => "supply",
-                                           :duct_leakage_units => "Percent",
-                                           :duct_leakage_value => 0.1 },
-                                         { :duct_type => "return",
-                                           :duct_leakage_units => "Percent",
-                                           :duct_leakage_value => 0.05 }]]
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements] = [{ :duct_type => "supply",
+                                                                        :duct_leakage_units => "Percent",
+                                                                        :duct_leakage_value => 0.1 },
+                                                                      { :duct_type => "return",
+                                                                        :duct_leakage_units => "Percent",
+                                                                        :duct_leakage_value => 0.05 }]
   elsif ['base-hvac-undersized.xml'].include? hpxml_file
-    duct_leakage_measurements_values[0][0][:duct_leakage_value] /= 10.0
-    duct_leakage_measurements_values[0][1][:duct_leakage_value] /= 10.0
-  end
-  return duct_leakage_measurements_values
-end
-
-def get_hpxml_file_ducts_values(hpxml_file, ducts_values)
-  if ['base.xml'].include? hpxml_file
-    ducts_values = [[{ :duct_type => "supply",
-                       :duct_insulation_r_value => 4,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 150 },
-                     { :duct_type => "return",
-                       :duct_insulation_r_value => 0,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 50 }]]
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] /= 10.0
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] /= 10.0
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "basement - unconditioned"
-    ducts_values[0][1][:duct_location] = "basement - unconditioned"
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "basement - unconditioned"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "basement - unconditioned"
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "crawlspace - unvented"
-    ducts_values[0][1][:duct_location] = "crawlspace - unvented"
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "crawlspace - unvented"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "crawlspace - unvented"
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "crawlspace - vented"
-    ducts_values[0][1][:duct_location] = "crawlspace - vented"
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "crawlspace - vented"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "crawlspace - vented"
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "basement - conditioned"
-    ducts_values[0][1][:duct_location] = "basement - conditioned"
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 0.0
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 0.0
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "basement - conditioned"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "basement - conditioned"
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "attic - vented"
-    ducts_values[0][1][:duct_location] = "attic - vented"
-  elsif ['base-atticroof-conditioned.xml',
-         'base-enclosure-adiabatic-surfaces.xml',
-         'base-hvac-ducts-in-conditioned-space.xml',
-         'base-atticroof-cathedral.xml',
-         'base-atticroof-conditioned.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "living space"
-    ducts_values[0][1][:duct_location] = "living space"
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "attic - vented"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "attic - vented"
   elsif ['base-enclosure-garage.xml',
          'invalid_files/duct-location.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "garage"
-    ducts_values[0][1][:duct_location] = "garage"
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "garage"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "garage"
   elsif ['invalid_files/duct-location-other.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "unconditioned space"
-    ducts_values[0][1][:duct_location] = "unconditioned space"
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "unconditioned space"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "unconditioned space"
   elsif ['base-hvac-ducts-outside.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_location] = "outside"
-    ducts_values[0][1][:duct_location] = "outside"
-  elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml'].include? hpxml_file
-    ducts_values[0] = []
-    ducts_values << [{ :duct_type => "supply",
-                       :duct_insulation_r_value => 4,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 150 },
-                     { :duct_type => "return",
-                       :duct_insulation_r_value => 0,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 50 }]
-  elsif ['base-hvac-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    ducts_values[0][0][:duct_insulation_r_value] = 0
-    ducts_values[0][0][:duct_surface_area] = 30
-    ducts_values[0][1][:duct_surface_area] = 10
-  elsif ['base-hvac-evap-cooler-only-ducted.xml'].include? hpxml_file
-    ducts_values[0].pop
-  elsif ['invalid_files/hvac-distribution-return-duct-leakage-missing.xml'].include? hpxml_file
-    ducts_values[0] << { :duct_type => "return",
-                         :duct_insulation_r_value => 0,
-                         :duct_location => "attic - unvented",
-                         :duct_surface_area => 50 }
-  elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    ducts_values[0] = []
-    ducts_values[1] = []
-    ducts_values << [{ :duct_type => "supply",
-                       :duct_insulation_r_value => 4,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 150 },
-                     { :duct_type => "return",
-                       :duct_insulation_r_value => 0,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 50 }]
-    ducts_values << [{ :duct_type => "supply",
-                       :duct_insulation_r_value => 4,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 150 },
-                     { :duct_type => "return",
-                       :duct_insulation_r_value => 0,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 50 }]
-    ducts_values << [{ :duct_type => "supply",
-                       :duct_insulation_r_value => 4,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 150 },
-                     { :duct_type => "return",
-                       :duct_insulation_r_value => 0,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 50 }]
-    ducts_values << [{ :duct_type => "supply",
-                       :duct_insulation_r_value => 4,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 150 },
-                     { :duct_type => "return",
-                       :duct_insulation_r_value => 0,
-                       :duct_location => "attic - unvented",
-                       :duct_surface_area => 50 }]
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "outside"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "outside"
   elsif ['base-hvac-ducts-locations.xml'].include? hpxml_file
-    ducts_values[0][1][:duct_location] = "attic - unvented"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "attic - unvented"
   elsif ['base-hvac-ducts-multiple.xml'].include? hpxml_file
-    ducts_values[0] << { :duct_type => "supply",
-                         :duct_insulation_r_value => 8,
-                         :duct_location => "attic - unvented",
-                         :duct_surface_area => 300 }
-    ducts_values[0] << { :duct_type => "supply",
-                         :duct_insulation_r_value => 8,
-                         :duct_location => "outside",
-                         :duct_surface_area => 300 }
-    ducts_values[0] << { :duct_type => "return",
-                         :duct_insulation_r_value => 4,
-                         :duct_location => "attic - unvented",
-                         :duct_surface_area => 100 }
-    ducts_values[0] << { :duct_type => "return",
-                         :duct_insulation_r_value => 4,
-                         :duct_location => "outside",
-                         :duct_surface_area => 100 }
-  elsif (hpxml_file.include? 'hvac_multiple' and not ducts_values.empty?)
-    ducts_values = [[], [], []]
-  elsif (hpxml_file.include? 'hvac_partial' and not ducts_values.empty?) or
-        (hpxml_file.include? 'hvac_base' and not ducts_values.empty?)
-    ducts_values = [[]]
+    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "supply",
+                                                    :duct_insulation_r_value => 8,
+                                                    :duct_location => "attic - unvented",
+                                                    :duct_surface_area => 300 }
+    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "supply",
+                                                    :duct_insulation_r_value => 8,
+                                                    :duct_location => "outside",
+                                                    :duct_surface_area => 300 }
+    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "return",
+                                                    :duct_insulation_r_value => 4,
+                                                    :duct_location => "attic - unvented",
+                                                    :duct_surface_area => 100 }
+    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "return",
+                                                    :duct_insulation_r_value => 4,
+                                                    :duct_location => "outside",
+                                                    :duct_surface_area => 100 }
+  elsif ['base-atticroof-conditioned.xml',
+         'base-enclosure-adiabatic-surfaces.xml',
+         'base-atticroof-cathedral.xml',
+         'base-atticroof-conditioned.xml'].include? hpxml_file
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "living space"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "living space"
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 0.0
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 0.0
+
+  elsif ['base-hvac-ducts-in-conditioned-space.xml'].include? hpxml_file
+    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "living space"
+    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "living space"
+    # Test leakage to outside when all ducts in conditioned space
+    # (e.g., ducts may be in floor cavities which have leaky rims)
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 1.5
+    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 1.5
+  elsif (hpxml_file.include? 'hvac_partial' or hpxml_file.include? 'hvac_base') and not hpxml_data[:hvac_distributions].empty?
+    if not hpxml_data[:hvac_distributions][0][:duct_leakage_measurements].empty?
+      hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 0.0
+      hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 0.0
+    end
+    hpxml_data[:hvac_distributions][0][:ducts] = []
+  elsif hpxml_file.include? 'hvac_multiple' and not hpxml_data[:hvac_distributions].empty?
+    hpxml_data[:hvac_distributions][0][:ducts] = []
+    if not hpxml_data[:hvac_distributions][0][:duct_leakage_measurements].empty?
+      hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 0.0
+      hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 0.0
+    end
+    hpxml_data[:hvac_distributions] << hpxml_data[:hvac_distributions][0].dup
+    hpxml_data[:hvac_distributions][1][:id] = "HVACDistribution2"
+    hpxml_data[:hvac_distributions] << hpxml_data[:hvac_distributions][0].dup
+    hpxml_data[:hvac_distributions][2][:id] = "HVACDistribution3"
+  elsif ['invalid_files/hvac-invalid-distribution-system-type.xml'].include? hpxml_file
+    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution2",
+                                         :distribution_system_type => "HydronicDistribution",
+                                         :duct_leakage_measurements => [],
+                                         :ducts => [] }
+  elsif ['invalid_files/hvac-distribution-return-duct-leakage-missing.xml'].include? hpxml_file
+    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "return",
+                                                    :duct_insulation_r_value => 0,
+                                                    :duct_location => "attic - unvented",
+                                                    :duct_surface_area => 50 }
   end
-  return ducts_values
 end
 
-def get_hpxml_file_ventilation_fan_values(hpxml_file, ventilation_fans_values)
-  if ['base-mechvent-balanced.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "balanced",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true }
+def set_hpxml_data_ventilation_fans_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:ventilation_fans] = []
+  elsif ['base-mechvent-balanced.xml'].include? hpxml_file
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "balanced",
+                                       :tested_flow_rate => 110,
+                                       :hours_in_operation => 24,
+                                       :fan_power => 60,
+                                       :used_for_whole_building_ventilation => true }
   elsif ['invalid_files/unattached-cfis.xml',
          'invalid_files/cfis-with-hydronic-distribution.xml',
          'base-mechvent-cfis.xml',
          'base-mechvent-cfis-evap-cooler-only-ducted.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "central fan integrated supply",
-                                 :tested_flow_rate => 330,
-                                 :hours_in_operation => 8,
-                                 :fan_power => 300,
-                                 :used_for_whole_building_ventilation => true,
-                                 :distribution_system_idref => "HVACDistribution" }
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "central fan integrated supply",
+                                       :tested_flow_rate => 330,
+                                       :hours_in_operation => 8,
+                                       :fan_power => 300,
+                                       :used_for_whole_building_ventilation => true,
+                                       :distribution_system_idref => "HVACDistribution" }
     if ['invalid_files/unattached-cfis.xml'].include? hpxml_file
-      ventilation_fans_values[0][:distribution_system_idref] = "foobar"
+      hpxml_data[:ventilation_fans][0][:distribution_system_idref] = "foobar"
     end
   elsif ['base-mechvent-erv.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "energy recovery ventilator",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :total_recovery_efficiency => 0.48,
-                                 :sensible_recovery_efficiency => 0.72,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true }
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "energy recovery ventilator",
+                                       :tested_flow_rate => 110,
+                                       :hours_in_operation => 24,
+                                       :total_recovery_efficiency => 0.48,
+                                       :sensible_recovery_efficiency => 0.72,
+                                       :fan_power => 60,
+                                       :used_for_whole_building_ventilation => true }
   elsif ['base-mechvent-erv-atre-asre.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "energy recovery ventilator",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :total_recovery_efficiency_adjusted => 0.526,
-                                 :sensible_recovery_efficiency_adjusted => 0.79,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true }
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "energy recovery ventilator",
+                                       :tested_flow_rate => 110,
+                                       :hours_in_operation => 24,
+                                       :total_recovery_efficiency_adjusted => 0.526,
+                                       :sensible_recovery_efficiency_adjusted => 0.79,
+                                       :fan_power => 60,
+                                       :used_for_whole_building_ventilation => true }
   elsif ['base-mechvent-exhaust.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "exhaust only",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :fan_power => 30,
-                                 :used_for_whole_building_ventilation => true }
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "exhaust only",
+                                       :tested_flow_rate => 110,
+                                       :hours_in_operation => 24,
+                                       :fan_power => 30,
+                                       :used_for_whole_building_ventilation => true }
   elsif ['base-mechvent-exhaust-rated-flow-rate.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "exhaust only",
-                                 :rated_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :fan_power => 30,
-                                 :used_for_whole_building_ventilation => true }
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "exhaust only",
+                                       :rated_flow_rate => 110,
+                                       :hours_in_operation => 24,
+                                       :fan_power => 30,
+                                       :used_for_whole_building_ventilation => true }
   elsif ['base-mechvent-hrv.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "heat recovery ventilator",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :sensible_recovery_efficiency => 0.72,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true }
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "heat recovery ventilator",
+                                       :tested_flow_rate => 110,
+                                       :hours_in_operation => 24,
+                                       :sensible_recovery_efficiency => 0.72,
+                                       :fan_power => 60,
+                                       :used_for_whole_building_ventilation => true }
   elsif ['base-mechvent-hrv-asre.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "heat recovery ventilator",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :sensible_recovery_efficiency_adjusted => 0.790,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true }
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "heat recovery ventilator",
+                                       :tested_flow_rate => 110,
+                                       :hours_in_operation => 24,
+                                       :sensible_recovery_efficiency_adjusted => 0.790,
+                                       :fan_power => 60,
+                                       :used_for_whole_building_ventilation => true }
   elsif ['base-mechvent-supply.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "MechanicalVentilation",
-                                 :fan_type => "supply only",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :fan_power => 30,
-                                 :used_for_whole_building_ventilation => true }
+    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
+                                       :fan_type => "supply only",
+                                       :tested_flow_rate => 110,
+                                       :hours_in_operation => 24,
+                                       :fan_power => 30,
+                                       :used_for_whole_building_ventilation => true }
   elsif ['base-misc-whole-house-fan.xml'].include? hpxml_file
-    ventilation_fans_values << { :id => "WholeHouseFan",
-                                 :rated_flow_rate => 4500,
-                                 :fan_power => 300,
-                                 :used_for_seasonal_cooling_load_reduction => true }
+    hpxml_data[:ventilation_fans] << { :id => "WholeHouseFan",
+                                       :rated_flow_rate => 4500,
+                                       :fan_power => 300,
+                                       :used_for_seasonal_cooling_load_reduction => true }
   end
-  return ventilation_fans_values
 end
 
-def get_hpxml_file_water_heating_system_values(hpxml_file, water_heating_systems_values)
+def set_hpxml_data_water_heating_systems_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    water_heating_systems_values = [{ :id => "WaterHeater",
-                                      :fuel_type => "electricity",
-                                      :water_heater_type => "storage water heater",
-                                      :location => "living space",
-                                      :tank_volume => 40,
-                                      :fraction_dhw_load_served => 1,
-                                      :heating_capacity => 18767,
-                                      :energy_factor => 0.95 }]
+    hpxml_data[:water_heating_systems] = [{ :id => "WaterHeater",
+                                            :fuel_type => "electricity",
+                                            :water_heater_type => "storage water heater",
+                                            :location => "living space",
+                                            :tank_volume => 40,
+                                            :fraction_dhw_load_served => 1,
+                                            :heating_capacity => 18767,
+                                            :energy_factor => 0.95 }]
   elsif ['base-dhw-multiple.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fraction_dhw_load_served] = 0.2
-    water_heating_systems_values << { :id => "WaterHeater2",
-                                      :fuel_type => "natural gas",
-                                      :water_heater_type => "storage water heater",
-                                      :location => "living space",
-                                      :tank_volume => 50,
-                                      :fraction_dhw_load_served => 0.2,
-                                      :heating_capacity => 40000,
-                                      :energy_factor => 0.59,
-                                      :recovery_efficiency => 0.76 }
-    water_heating_systems_values << { :id => "WaterHeater3",
-                                      :fuel_type => "electricity",
-                                      :water_heater_type => "heat pump water heater",
-                                      :location => "living space",
-                                      :tank_volume => 80,
-                                      :fraction_dhw_load_served => 0.2,
-                                      :energy_factor => 2.3 }
-    water_heating_systems_values << { :id => "WaterHeater4",
-                                      :fuel_type => "electricity",
-                                      :water_heater_type => "instantaneous water heater",
-                                      :location => "living space",
-                                      :fraction_dhw_load_served => 0.2,
-                                      :energy_factor => 0.99 }
-    water_heating_systems_values << { :id => "WaterHeater5",
-                                      :fuel_type => "natural gas",
-                                      :water_heater_type => "instantaneous water heater",
-                                      :location => "living space",
-                                      :fraction_dhw_load_served => 0.1,
-                                      :energy_factor => 0.82 }
-    water_heating_systems_values << { :id => "WaterHeater6",
-                                      :water_heater_type => "space-heating boiler with storage tank",
-                                      :location => "living space",
-                                      :tank_volume => 50,
-                                      :fraction_dhw_load_served => 0.1,
-                                      :related_hvac => "HeatingSystem" }
+    hpxml_data[:water_heating_systems][0][:fraction_dhw_load_served] = 0.2
+    hpxml_data[:water_heating_systems] << { :id => "WaterHeater2",
+                                            :fuel_type => "natural gas",
+                                            :water_heater_type => "storage water heater",
+                                            :location => "living space",
+                                            :tank_volume => 50,
+                                            :fraction_dhw_load_served => 0.2,
+                                            :heating_capacity => 40000,
+                                            :energy_factor => 0.59,
+                                            :recovery_efficiency => 0.76 }
+    hpxml_data[:water_heating_systems] << { :id => "WaterHeater3",
+                                            :fuel_type => "electricity",
+                                            :water_heater_type => "heat pump water heater",
+                                            :location => "living space",
+                                            :tank_volume => 80,
+                                            :fraction_dhw_load_served => 0.2,
+                                            :energy_factor => 2.3 }
+    hpxml_data[:water_heating_systems] << { :id => "WaterHeater4",
+                                            :fuel_type => "electricity",
+                                            :water_heater_type => "instantaneous water heater",
+                                            :location => "living space",
+                                            :fraction_dhw_load_served => 0.2,
+                                            :energy_factor => 0.99 }
+    hpxml_data[:water_heating_systems] << { :id => "WaterHeater5",
+                                            :fuel_type => "natural gas",
+                                            :water_heater_type => "instantaneous water heater",
+                                            :location => "living space",
+                                            :fraction_dhw_load_served => 0.1,
+                                            :energy_factor => 0.82 }
+    hpxml_data[:water_heating_systems] << { :id => "WaterHeater6",
+                                            :water_heater_type => "space-heating boiler with storage tank",
+                                            :location => "living space",
+                                            :tank_volume => 50,
+                                            :fraction_dhw_load_served => 0.1,
+                                            :related_hvac => "HeatingSystem" }
   elsif ['invalid_files/dhw-frac-load-served.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fraction_dhw_load_served] += 0.15
+    hpxml_data[:water_heating_systems][0][:fraction_dhw_load_served] += 0.15
   elsif ['base-dhw-tank-gas.xml',
          'base-dhw-tank-gas-outside.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fuel_type] = "natural gas"
-    water_heating_systems_values[0][:tank_volume] = 50
-    water_heating_systems_values[0][:heating_capacity] = 40000
-    water_heating_systems_values[0][:energy_factor] = 0.59
-    water_heating_systems_values[0][:recovery_efficiency] = 0.76
+    hpxml_data[:water_heating_systems][0][:fuel_type] = "natural gas"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = 40000
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.59
+    hpxml_data[:water_heating_systems][0][:recovery_efficiency] = 0.76
     if hpxml_file == 'base-dhw-tank-gas-outside.xml'
-      water_heating_systems_values[0][:location] = "other exterior"
+      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
     end
   elsif ['base-dhw-tank-wood.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fuel_type] = "wood"
-    water_heating_systems_values[0][:tank_volume] = 50
-    water_heating_systems_values[0][:heating_capacity] = 40000
-    water_heating_systems_values[0][:energy_factor] = 0.59
-    water_heating_systems_values[0][:recovery_efficiency] = 0.76
+    hpxml_data[:water_heating_systems][0][:fuel_type] = "wood"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = 40000
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.59
+    hpxml_data[:water_heating_systems][0][:recovery_efficiency] = 0.76
   elsif ['base-dhw-tank-heat-pump.xml',
          'base-dhw-tank-heat-pump-outside.xml'].include? hpxml_file
-    water_heating_systems_values[0][:water_heater_type] = "heat pump water heater"
-    water_heating_systems_values[0][:tank_volume] = 80
-    water_heating_systems_values[0][:heating_capacity] = nil
-    water_heating_systems_values[0][:energy_factor] = 2.3
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "heat pump water heater"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = 80
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 2.3
     if hpxml_file == 'base-dhw-tank-heat-pump-outside.xml'
-      water_heating_systems_values[0][:location] = "other exterior"
+      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
     end
   elsif ['base-dhw-tankless-electric.xml',
          'base-dhw-tankless-electric-outside.xml'].include? hpxml_file
-    water_heating_systems_values[0][:water_heater_type] = "instantaneous water heater"
-    water_heating_systems_values[0][:tank_volume] = nil
-    water_heating_systems_values[0][:heating_capacity] = nil
-    water_heating_systems_values[0][:energy_factor] = 0.99
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.99
     if hpxml_file == 'base-dhw-tankless-electric-outside.xml'
-      water_heating_systems_values[0][:location] = "other exterior"
+      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
     end
   elsif ['base-dhw-tankless-gas.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fuel_type] = "natural gas"
-    water_heating_systems_values[0][:water_heater_type] = "instantaneous water heater"
-    water_heating_systems_values[0][:tank_volume] = nil
-    water_heating_systems_values[0][:heating_capacity] = nil
-    water_heating_systems_values[0][:energy_factor] = 0.82
+    hpxml_data[:water_heating_systems][0][:fuel_type] = "natural gas"
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.82
   elsif ['base-dhw-tankless-oil.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fuel_type] = "fuel oil"
-    water_heating_systems_values[0][:water_heater_type] = "instantaneous water heater"
-    water_heating_systems_values[0][:tank_volume] = nil
-    water_heating_systems_values[0][:heating_capacity] = nil
-    water_heating_systems_values[0][:energy_factor] = 0.82
+    hpxml_data[:water_heating_systems][0][:fuel_type] = "fuel oil"
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.82
   elsif ['base-dhw-tankless-propane.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fuel_type] = "propane"
-    water_heating_systems_values[0][:water_heater_type] = "instantaneous water heater"
-    water_heating_systems_values[0][:tank_volume] = nil
-    water_heating_systems_values[0][:heating_capacity] = nil
-    water_heating_systems_values[0][:energy_factor] = 0.82
+    hpxml_data[:water_heating_systems][0][:fuel_type] = "propane"
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.82
   elsif ['base-dhw-tankless-wood.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fuel_type] = "wood"
-    water_heating_systems_values[0][:water_heater_type] = "instantaneous water heater"
-    water_heating_systems_values[0][:tank_volume] = nil
-    water_heating_systems_values[0][:heating_capacity] = nil
-    water_heating_systems_values[0][:energy_factor] = 0.82
+    hpxml_data[:water_heating_systems][0][:fuel_type] = "wood"
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.82
   elsif ['base-dhw-tank-oil.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fuel_type] = "fuel oil"
-    water_heating_systems_values[0][:tank_volume] = 50
-    water_heating_systems_values[0][:heating_capacity] = 40000
-    water_heating_systems_values[0][:energy_factor] = 0.59
-    water_heating_systems_values[0][:recovery_efficiency] = 0.76
+    hpxml_data[:water_heating_systems][0][:fuel_type] = "fuel oil"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = 40000
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.59
+    hpxml_data[:water_heating_systems][0][:recovery_efficiency] = 0.76
   elsif ['base-dhw-tank-propane.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fuel_type] = "propane"
-    water_heating_systems_values[0][:tank_volume] = 50
-    water_heating_systems_values[0][:heating_capacity] = 40000
-    water_heating_systems_values[0][:energy_factor] = 0.59
-    water_heating_systems_values[0][:recovery_efficiency] = 0.76
+    hpxml_data[:water_heating_systems][0][:fuel_type] = "propane"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = 40000
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.59
+    hpxml_data[:water_heating_systems][0][:recovery_efficiency] = 0.76
   elsif ['base-dhw-uef.xml'].include? hpxml_file
-    water_heating_systems_values[0][:energy_factor] = nil
-    water_heating_systems_values[0][:uniform_energy_factor] = 0.93
+    hpxml_data[:water_heating_systems][0][:energy_factor] = nil
+    hpxml_data[:water_heating_systems][0][:uniform_energy_factor] = 0.93
   elsif ['base-dhw-desuperheater.xml'].include? hpxml_file
-    water_heating_systems_values[0][:uses_desuperheater] = true
-    water_heating_systems_values[0][:related_hvac] = "CoolingSystem"
+    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
   elsif ['base-dhw-desuperheater-tankless.xml'].include? hpxml_file
-    water_heating_systems_values[0][:water_heater_type] = "instantaneous water heater"
-    water_heating_systems_values[0][:tank_volume] = nil
-    water_heating_systems_values[0][:heating_capacity] = nil
-    water_heating_systems_values[0][:energy_factor] = 0.99
-    water_heating_systems_values[0][:uses_desuperheater] = true
-    water_heating_systems_values[0][:related_hvac] = "CoolingSystem"
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
+    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.99
+    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
   elsif ['base-dhw-desuperheater-2-speed.xml'].include? hpxml_file
-    water_heating_systems_values[0][:uses_desuperheater] = true
-    water_heating_systems_values[0][:related_hvac] = "CoolingSystem"
+    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
   elsif ['base-dhw-desuperheater-var-speed.xml'].include? hpxml_file
-    water_heating_systems_values[0][:uses_desuperheater] = true
-    water_heating_systems_values[0][:related_hvac] = "CoolingSystem"
+    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
   elsif ['base-dhw-desuperheater-gshp.xml'].include? hpxml_file
-    water_heating_systems_values[0][:uses_desuperheater] = true
-    water_heating_systems_values[0][:related_hvac] = "HeatPump"
+    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "HeatPump"
   elsif ['base-dhw-jacket-electric.xml',
          'base-dhw-jacket-indirect.xml',
          'base-dhw-jacket-gas.xml',
          'base-dhw-jacket-hpwh.xml'].include? hpxml_file
-    water_heating_systems_values[0][:jacket_r_value] = 10.0
+    hpxml_data[:water_heating_systems][0][:jacket_r_value] = 10.0
   elsif ['base-dhw-indirect.xml',
          'base-dhw-indirect-outside.xml'].include? hpxml_file
-    water_heating_systems_values[0][:water_heater_type] = "space-heating boiler with storage tank"
-    water_heating_systems_values[0][:tank_volume] = 50
-    water_heating_systems_values[0][:heating_capacity] = nil
-    water_heating_systems_values[0][:energy_factor] = nil
-    water_heating_systems_values[0][:fuel_type] = nil
-    water_heating_systems_values[0][:related_hvac] = "HeatingSystem"
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "space-heating boiler with storage tank"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
+    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
+    hpxml_data[:water_heating_systems][0][:energy_factor] = nil
+    hpxml_data[:water_heating_systems][0][:fuel_type] = nil
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "HeatingSystem"
     if hpxml_file == 'base-dhw-indirect-outside.xml'
-      water_heating_systems_values[0][:location] = "other exterior"
+      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
     end
   elsif ['base-dhw-indirect-standbyloss.xml'].include? hpxml_file
-    water_heating_systems_values[0][:standby_loss] = 1.0
+    hpxml_data[:water_heating_systems][0][:standby_loss] = 1.0
   elsif ['base-dhw-combi-tankless.xml',
          'base-dhw-combi-tankless-outside.xml'].include? hpxml_file
-    water_heating_systems_values[0][:water_heater_type] = "space-heating boiler with tankless coil"
-    water_heating_systems_values[0][:tank_volume] = nil
+    hpxml_data[:water_heating_systems][0][:water_heater_type] = "space-heating boiler with tankless coil"
+    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
     if hpxml_file == 'base-dhw-combi-tankless-outside.xml'
-      water_heating_systems_values[0][:location] = "other exterior"
+      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
     end
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "basement - unconditioned"
+    hpxml_data[:water_heating_systems][0][:location] = "basement - unconditioned"
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "crawlspace - unvented"
+    hpxml_data[:water_heating_systems][0][:location] = "crawlspace - unvented"
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "crawlspace - vented"
+    hpxml_data[:water_heating_systems][0][:location] = "crawlspace - vented"
   elsif ['base-foundation-slab.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "living space"
+    hpxml_data[:water_heating_systems][0][:location] = "living space"
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "attic - vented"
+    hpxml_data[:water_heating_systems][0][:location] = "attic - vented"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "basement - conditioned"
+    hpxml_data[:water_heating_systems][0][:location] = "basement - conditioned"
   elsif ['invalid_files/water-heater-location.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "crawlspace - vented"
+    hpxml_data[:water_heating_systems][0][:location] = "crawlspace - vented"
   elsif ['invalid_files/water-heater-location-other.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "unconditioned space"
+    hpxml_data[:water_heating_systems][0][:location] = "unconditioned space"
   elsif ['invalid_files/invalid-relatedhvac-desuperheater.xml'].include? hpxml_file
-    water_heating_systems_values[0][:uses_desuperheater] = true
-    water_heating_systems_values[0][:related_hvac] = "CoolingSystem_bad"
+    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem_bad"
   elsif ['invalid_files/repeated-relatedhvac-desuperheater.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fraction_dhw_load_served] = 0.5
-    water_heating_systems_values[0][:uses_desuperheater] = true
-    water_heating_systems_values[0][:related_hvac] = "CoolingSystem"
-    water_heating_systems_values << water_heating_systems_values[0].dup
-    water_heating_systems_values[1][:id] = "WaterHeater2"
+    hpxml_data[:water_heating_systems][0][:fraction_dhw_load_served] = 0.5
+    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
+    hpxml_data[:water_heating_systems] << hpxml_data[:water_heating_systems][0].dup
+    hpxml_data[:water_heating_systems][1][:id] = "WaterHeater2"
   elsif ['invalid_files/invalid-relatedhvac-dhw-indirect.xml'].include? hpxml_file
-    water_heating_systems_values[0][:related_hvac] = "HeatingSystem_bad"
+    hpxml_data[:water_heating_systems][0][:related_hvac] = "HeatingSystem_bad"
   elsif ['invalid_files/repeated-relatedhvac-dhw-indirect.xml'].include? hpxml_file
-    water_heating_systems_values[0][:fraction_dhw_load_served] = 0.5
-    water_heating_systems_values << water_heating_systems_values[0].dup
-    water_heating_systems_values[1][:id] = "WaterHeater2"
+    hpxml_data[:water_heating_systems][0][:fraction_dhw_load_served] = 0.5
+    hpxml_data[:water_heating_systems] << hpxml_data[:water_heating_systems][0].dup
+    hpxml_data[:water_heating_systems][1][:id] = "WaterHeater2"
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    water_heating_systems_values[0][:location] = "garage"
+    hpxml_data[:water_heating_systems][0][:location] = "garage"
   elsif ['base-dhw-temperature.xml'].include? hpxml_file
-    water_heating_systems_values[0][:temperature] = 130.0
+    hpxml_data[:water_heating_systems][0][:temperature] = 130.0
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    water_heating_systems_values = []
+    hpxml_data[:water_heating_systems] = []
   end
-  return water_heating_systems_values
 end
 
-def get_hpxml_file_hot_water_distribution_values(hpxml_file, hot_water_distribution_values)
+def set_hpxml_data_hot_water_distribution_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    hot_water_distribution_values = { :id => "HotWaterDstribution",
-                                      :system_type => "Standard",
-                                      :standard_piping_length => 50, # Chosen to test a negative EC_adj
-                                      :pipe_r_value => 0.0 }
+    hpxml_data[:hot_water_distribution] = { :id => "HotWaterDstribution",
+                                            :system_type => "Standard",
+                                            :standard_piping_length => 50, # Chosen to test a negative EC_adj
+                                            :pipe_r_value => 0.0 }
   elsif ['base-dhw-dwhr.xml'].include? hpxml_file
-    hot_water_distribution_values[:dwhr_facilities_connected] = "all"
-    hot_water_distribution_values[:dwhr_equal_flow] = true
-    hot_water_distribution_values[:dwhr_efficiency] = 0.55
+    hpxml_data[:hot_water_distribution][:dwhr_facilities_connected] = "all"
+    hpxml_data[:hot_water_distribution][:dwhr_equal_flow] = true
+    hpxml_data[:hot_water_distribution][:dwhr_efficiency] = 0.55
   elsif ['base-dhw-recirc-demand.xml'].include? hpxml_file
-    hot_water_distribution_values[:system_type] = "Recirculation"
-    hot_water_distribution_values[:recirculation_control_type] = "presence sensor demand control"
-    hot_water_distribution_values[:recirculation_piping_length] = 50
-    hot_water_distribution_values[:recirculation_branch_piping_length] = 50
-    hot_water_distribution_values[:recirculation_pump_power] = 50
-    hot_water_distribution_values[:pipe_r_value] = 3
+    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
+    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "presence sensor demand control"
+    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
+    hpxml_data[:hot_water_distribution][:pipe_r_value] = 3
   elsif ['base-dhw-recirc-manual.xml'].include? hpxml_file
-    hot_water_distribution_values[:system_type] = "Recirculation"
-    hot_water_distribution_values[:recirculation_control_type] = "manual demand control"
-    hot_water_distribution_values[:recirculation_piping_length] = 50
-    hot_water_distribution_values[:recirculation_branch_piping_length] = 50
-    hot_water_distribution_values[:recirculation_pump_power] = 50
-    hot_water_distribution_values[:pipe_r_value] = 3
+    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
+    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "manual demand control"
+    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
+    hpxml_data[:hot_water_distribution][:pipe_r_value] = 3
   elsif ['base-dhw-recirc-nocontrol.xml'].include? hpxml_file
-    hot_water_distribution_values[:system_type] = "Recirculation"
-    hot_water_distribution_values[:recirculation_control_type] = "no control"
-    hot_water_distribution_values[:recirculation_piping_length] = 50
-    hot_water_distribution_values[:recirculation_branch_piping_length] = 50
-    hot_water_distribution_values[:recirculation_pump_power] = 50
+    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
+    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "no control"
+    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
   elsif ['base-dhw-recirc-temperature.xml'].include? hpxml_file
-    hot_water_distribution_values[:system_type] = "Recirculation"
-    hot_water_distribution_values[:recirculation_control_type] = "temperature"
-    hot_water_distribution_values[:recirculation_piping_length] = 50
-    hot_water_distribution_values[:recirculation_branch_piping_length] = 50
-    hot_water_distribution_values[:recirculation_pump_power] = 50
+    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
+    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "temperature"
+    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
   elsif ['base-dhw-recirc-timer.xml'].include? hpxml_file
-    hot_water_distribution_values[:system_type] = "Recirculation"
-    hot_water_distribution_values[:recirculation_control_type] = "timer"
-    hot_water_distribution_values[:recirculation_piping_length] = 50
-    hot_water_distribution_values[:recirculation_branch_piping_length] = 50
-    hot_water_distribution_values[:recirculation_pump_power] = 50
+    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
+    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "timer"
+    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
+    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hot_water_distribution_values = {}
+    hpxml_data[:hot_water_distribution] = {}
   end
-  return hot_water_distribution_values
 end
 
-def get_hpxml_file_water_fixtures_values(hpxml_file, water_fixtures_values)
+def set_hpxml_data_water_fixtures_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    water_fixtures_values = [{ :id => "WaterFixture",
-                               :water_fixture_type => "shower head",
-                               :low_flow => true },
-                             { :id => "WaterFixture2",
-                               :water_fixture_type => "faucet",
-                               :low_flow => false }]
+    hpxml_data[:water_fixtures] = [{ :id => "WaterFixture",
+                                     :water_fixture_type => "shower head",
+                                     :low_flow => true },
+                                   { :id => "WaterFixture2",
+                                     :water_fixture_type => "faucet",
+                                     :low_flow => false }]
   elsif ['base-dhw-low-flow-fixtures.xml'].include? hpxml_file
-    water_fixtures_values[1][:low_flow] = true
+    hpxml_data[:water_fixtures][1][:low_flow] = true
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    water_fixtures_values = []
+    hpxml_data[:water_fixtures] = []
   end
-  return water_fixtures_values
 end
 
-def get_hpxml_file_solar_thermal_system_values(hpxml_file, solar_thermal_system_values)
-  if ['base-dhw-solar-fraction.xml',
-      'base-dhw-multiple.xml',
-      'base-dhw-tank-heat-pump-with-solar-fraction.xml',
-      'base-dhw-tankless-gas-with-solar-fraction.xml',
-      'invalid_files/solar-thermal-system-with-combi-tankless.xml',
-      'invalid_files/solar-thermal-system-with-desuperheater.xml',
-      'invalid_files/solar-thermal-system-with-dhw-indirect.xml'].include? hpxml_file
-    solar_thermal_system_values = { :id => "SolarThermalSystem",
-                                    :system_type => "hot water",
-                                    :water_heating_system_idref => "WaterHeater",
-                                    :solar_fraction => 0.65 }
+def set_hpxml_data_solar_thermal_system_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:solar_thermal_system] = {}
+  elsif ['base-dhw-solar-fraction.xml',
+         'base-dhw-multiple.xml',
+         'base-dhw-tank-heat-pump-with-solar-fraction.xml',
+         'base-dhw-tankless-gas-with-solar-fraction.xml',
+         'invalid_files/solar-thermal-system-with-combi-tankless.xml',
+         'invalid_files/solar-thermal-system-with-desuperheater.xml',
+         'invalid_files/solar-thermal-system-with-dhw-indirect.xml'].include? hpxml_file
+    hpxml_data[:solar_thermal_system] = { :id => "SolarThermalSystem",
+                                          :system_type => "hot water",
+                                          :water_heating_system_idref => "WaterHeater",
+                                          :solar_fraction => 0.65 }
   elsif ['base-dhw-solar-direct-flat-plate.xml',
          'base-dhw-solar-indirect-flat-plate.xml',
          'base-dhw-solar-thermosyphon-flat-plate.xml',
          'base-dhw-tank-heat-pump-with-solar.xml',
          'base-dhw-tankless-gas-with-solar.xml'].include? hpxml_file
-    solar_thermal_system_values = { :id => "SolarThermalSystem",
-                                    :system_type => "hot water",
-                                    :collector_area => 40,
-                                    :collector_type => "single glazing black",
-                                    :collector_azimuth => 180,
-                                    :collector_tilt => 20,
-                                    :collector_frta => 0.77,
-                                    :collector_frul => 0.793,
-                                    :storage_volume => 60,
-                                    :water_heating_system_idref => "WaterHeater" }
+    hpxml_data[:solar_thermal_system] = { :id => "SolarThermalSystem",
+                                          :system_type => "hot water",
+                                          :collector_area => 40,
+                                          :collector_type => "single glazing black",
+                                          :collector_azimuth => 180,
+                                          :collector_tilt => 20,
+                                          :collector_frta => 0.77,
+                                          :collector_frul => 0.793,
+                                          :storage_volume => 60,
+                                          :water_heating_system_idref => "WaterHeater" }
     if hpxml_file == 'base-dhw-solar-direct-flat-plate.xml'
-      solar_thermal_system_values[:collector_loop_type] = "liquid direct"
+      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-flat-plate.xml'
-      solar_thermal_system_values[:collector_loop_type] = "passive thermosyphon"
+      hpxml_data[:solar_thermal_system][:collector_loop_type] = "passive thermosyphon"
     else
-      solar_thermal_system_values[:collector_loop_type] = "liquid indirect"
+      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid indirect"
     end
   elsif ['base-dhw-solar-indirect-evacuated-tube.xml',
          'base-dhw-solar-direct-evacuated-tube.xml',
          'base-dhw-solar-thermosyphon-evacuated-tube.xml'].include? hpxml_file
-    solar_thermal_system_values = { :id => "SolarThermalSystem",
-                                    :system_type => "hot water",
-                                    :collector_area => 40,
-                                    :collector_type => "evacuated tube",
-                                    :collector_azimuth => 180,
-                                    :collector_tilt => 20,
-                                    :collector_frta => 0.50,
-                                    :collector_frul => 0.2799,
-                                    :storage_volume => 60,
-                                    :water_heating_system_idref => "WaterHeater" }
+    hpxml_data[:solar_thermal_system] = { :id => "SolarThermalSystem",
+                                          :system_type => "hot water",
+                                          :collector_area => 40,
+                                          :collector_type => "evacuated tube",
+                                          :collector_azimuth => 180,
+                                          :collector_tilt => 20,
+                                          :collector_frta => 0.50,
+                                          :collector_frul => 0.2799,
+                                          :storage_volume => 60,
+                                          :water_heating_system_idref => "WaterHeater" }
     if hpxml_file == 'base-dhw-solar-direct-evacuated-tube.xml'
-      solar_thermal_system_values[:collector_loop_type] = "liquid direct"
+      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-evacuated-tube.xml'
-      solar_thermal_system_values[:collector_loop_type] = "passive thermosyphon"
+      hpxml_data[:solar_thermal_system][:collector_loop_type] = "passive thermosyphon"
     else
-      solar_thermal_system_values[:collector_loop_type] = "liquid indirect"
+      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid indirect"
     end
   elsif ['base-dhw-solar-direct-ics.xml',
          'base-dhw-solar-thermosyphon-ics.xml'].include? hpxml_file
-    solar_thermal_system_values = { :id => "SolarThermalSystem",
-                                    :system_type => "hot water",
-                                    :collector_area => 40,
-                                    :collector_type => "integrated collector storage",
-                                    :collector_azimuth => 180,
-                                    :collector_tilt => 20,
-                                    :collector_frta => 0.77,
-                                    :collector_frul => 0.793,
-                                    :storage_volume => 60,
-                                    :water_heating_system_idref => "WaterHeater" }
+    hpxml_data[:solar_thermal_system] = { :id => "SolarThermalSystem",
+                                          :system_type => "hot water",
+                                          :collector_area => 40,
+                                          :collector_type => "integrated collector storage",
+                                          :collector_azimuth => 180,
+                                          :collector_tilt => 20,
+                                          :collector_frta => 0.77,
+                                          :collector_frul => 0.793,
+                                          :storage_volume => 60,
+                                          :water_heating_system_idref => "WaterHeater" }
     if hpxml_file == 'base-dhw-solar-direct-ics.xml'
-      solar_thermal_system_values[:collector_loop_type] = "liquid direct"
+      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-ics.xml'
-      solar_thermal_system_values[:collector_loop_type] = "passive thermosyphon"
+      hpxml_data[:solar_thermal_system][:collector_loop_type] = "passive thermosyphon"
     end
   elsif ['invalid_files/unattached-solar-thermal-system.xml'].include? hpxml_file
-    solar_thermal_system_values[:water_heating_system_idref] = "foobar"
+    hpxml_data[:solar_thermal_system][:water_heating_system_idref] = "foobar"
   end
-  return solar_thermal_system_values
 end
 
-def get_hpxml_file_pv_system_values(hpxml_file, pv_systems_values)
-  if ['base-pv.xml'].include? hpxml_file
-    pv_systems_values << { :id => "PVSystem",
-                           :module_type => "standard",
-                           :location => "roof",
-                           :tracking => "fixed",
-                           :array_azimuth => 180,
-                           :array_tilt => 20,
-                           :max_power_output => 4000,
-                           :inverter_efficiency => 0.96,
-                           :system_losses_fraction => 0.14 }
-    pv_systems_values << { :id => "PVSystem2",
-                           :module_type => "premium",
-                           :location => "roof",
-                           :tracking => "fixed",
-                           :array_azimuth => 90,
-                           :array_tilt => 20,
-                           :max_power_output => 1500,
-                           :inverter_efficiency => 0.96,
-                           :system_losses_fraction => 0.14 }
-  end
-  return pv_systems_values
-end
-
-def get_hpxml_file_clothes_washer_values(hpxml_file, clothes_washer_values)
+def set_hpxml_data_pv_systems_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    clothes_washer_values = { :id => "ClothesWasher",
-                              :location => "living space",
-                              :modified_energy_factor => 0.8,
-                              :rated_annual_kwh => 700.0,
-                              :label_electric_rate => 0.10,
-                              :label_gas_rate => 0.60,
-                              :label_annual_gas_cost => 25.0,
-                              :capacity => 3.0 }
+    hpxml_data[:pv_systems] = []
+  elsif ['base-pv.xml'].include? hpxml_file
+    hpxml_data[:pv_systems] << { :id => "PVSystem",
+                                 :module_type => "standard",
+                                 :location => "roof",
+                                 :tracking => "fixed",
+                                 :array_azimuth => 180,
+                                 :array_tilt => 20,
+                                 :max_power_output => 4000,
+                                 :inverter_efficiency => 0.96,
+                                 :system_losses_fraction => 0.14 }
+    hpxml_data[:pv_systems] << { :id => "PVSystem2",
+                                 :module_type => "premium",
+                                 :location => "roof",
+                                 :tracking => "fixed",
+                                 :array_azimuth => 90,
+                                 :array_tilt => 20,
+                                 :max_power_output => 1500,
+                                 :inverter_efficiency => 0.96,
+                                 :system_losses_fraction => 0.14 }
+  end
+end
+
+def set_hpxml_data_clothes_washer_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:clothes_washer] = { :id => "ClothesWasher",
+                                    :location => "living space",
+                                    :modified_energy_factor => 0.8,
+                                    :rated_annual_kwh => 700.0,
+                                    :label_electric_rate => 0.10,
+                                    :label_gas_rate => 0.60,
+                                    :label_annual_gas_cost => 25.0,
+                                    :capacity => 3.0 }
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    clothes_washer_values = {}
+    hpxml_data[:clothes_washer] = {}
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    clothes_washer_values[:modified_energy_factor] = nil
-    clothes_washer_values[:integrated_modified_energy_factor] = 0.73
+    hpxml_data[:clothes_washer][:modified_energy_factor] = nil
+    hpxml_data[:clothes_washer][:integrated_modified_energy_factor] = 0.73
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    clothes_washer_values[:location] = "basement - unconditioned"
+    hpxml_data[:clothes_washer][:location] = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    clothes_washer_values[:location] = "basement - conditioned"
+    hpxml_data[:clothes_washer][:location] = "basement - conditioned"
   elsif ['base-enclosure-garage.xml',
          'invalid_files/clothes-washer-location.xml'].include? hpxml_file
-    clothes_washer_values[:location] = "garage"
+    hpxml_data[:clothes_washer][:location] = "garage"
   elsif ['invalid_files/clothes-washer-location-other.xml'].include? hpxml_file
-    clothes_washer_values[:location] = "other"
+    hpxml_data[:clothes_washer][:location] = "other"
   end
-  return clothes_washer_values
 end
 
-def get_hpxml_file_clothes_dryer_values(hpxml_file, clothes_dryer_values)
+def set_hpxml_data_clothes_dryer_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    clothes_dryer_values = { :id => "ClothesDryer",
-                             :location => "living space",
-                             :fuel_type => "electricity",
-                             :energy_factor => 2.95,
-                             :control_type => "timer" }
+    hpxml_data[:clothes_dryer] = { :id => "ClothesDryer",
+                                   :location => "living space",
+                                   :fuel_type => "electricity",
+                                   :energy_factor => 2.95,
+                                   :control_type => "timer" }
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    clothes_dryer_values = {}
+    hpxml_data[:clothes_dryer] = {}
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    clothes_dryer_values = { :id => "ClothesDryer",
-                             :location => "living space",
-                             :fuel_type => "electricity",
-                             :combined_energy_factor => 2.62,
-                             :control_type => "moisture" }
+    hpxml_data[:clothes_dryer] = { :id => "ClothesDryer",
+                                   :location => "living space",
+                                   :fuel_type => "electricity",
+                                   :combined_energy_factor => 2.62,
+                                   :control_type => "moisture" }
   elsif ['base-appliances-gas.xml',
          'base-appliances-propane.xml',
          'base-appliances-oil.xml'].include? hpxml_file
-    clothes_dryer_values = { :id => "ClothesDryer",
-                             :location => "living space",
-                             :energy_factor => 2.67,
-                             :control_type => "moisture" }
+    hpxml_data[:clothes_dryer] = { :id => "ClothesDryer",
+                                   :location => "living space",
+                                   :energy_factor => 2.67,
+                                   :control_type => "moisture" }
     if hpxml_file == 'base-appliances-gas.xml'
-      clothes_dryer_values[:fuel_type] = "natural gas"
+      hpxml_data[:clothes_dryer][:fuel_type] = "natural gas"
     elsif hpxml_file == 'base-appliances-propane.xml'
-      clothes_dryer_values[:fuel_type] = "propane"
+      hpxml_data[:clothes_dryer][:fuel_type] = "propane"
     elsif hpxml_file == 'base-appliances-oil.xml'
-      clothes_dryer_values[:fuel_type] = "fuel oil"
+      hpxml_data[:clothes_dryer][:fuel_type] = "fuel oil"
     end
   elsif ['base-appliances-wood.xml'].include? hpxml_file
-    clothes_dryer_values = { :id => "ClothesDryer",
-                             :location => "living space",
-                             :fuel_type => "wood",
-                             :energy_factor => 2.67,
-                             :control_type => "moisture" }
+    hpxml_data[:clothes_dryer] = { :id => "ClothesDryer",
+                                   :location => "living space",
+                                   :fuel_type => "wood",
+                                   :energy_factor => 2.67,
+                                   :control_type => "moisture" }
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    clothes_dryer_values[:location] = "basement - unconditioned"
+    hpxml_data[:clothes_dryer][:location] = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    clothes_dryer_values[:location] = "basement - conditioned"
+    hpxml_data[:clothes_dryer][:location] = "basement - conditioned"
   elsif ['base-enclosure-garage.xml',
          'invalid_files/clothes-dryer-location.xml'].include? hpxml_file
-    clothes_dryer_values[:location] = "garage"
+    hpxml_data[:clothes_dryer][:location] = "garage"
   elsif ['invalid_files/clothes-dryer-location-other.xml'].include? hpxml_file
-    clothes_dryer_values[:location] = "other"
+    hpxml_data[:clothes_dryer][:location] = "other"
   end
-  return clothes_dryer_values
 end
 
-def get_hpxml_file_dishwasher_values(hpxml_file, dishwasher_values)
+def set_hpxml_data_dishwasher_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    dishwasher_values = { :id => "Dishwasher",
-                          :rated_annual_kwh => 450,
-                          :place_setting_capacity => 12 }
+    hpxml_data[:dishwasher] = { :id => "Dishwasher",
+                                :rated_annual_kwh => 450,
+                                :place_setting_capacity => 12 }
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    dishwasher_values = {}
+    hpxml_data[:dishwasher] = {}
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    dishwasher_values = { :id => "Dishwasher",
-                          :energy_factor => 0.5,
-                          :place_setting_capacity => 12 }
+    hpxml_data[:dishwasher] = { :id => "Dishwasher",
+                                :energy_factor => 0.5,
+                                :place_setting_capacity => 12 }
   end
-  return dishwasher_values
 end
 
-def get_hpxml_file_refrigerator_values(hpxml_file, refrigerator_values)
+def set_hpxml_data_refrigerator_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    refrigerator_values = { :id => "Refrigerator",
-                            :location => "living space",
-                            :rated_annual_kwh => 650 }
+    hpxml_data[:refrigerator] = { :id => "Refrigerator",
+                                  :location => "living space",
+                                  :rated_annual_kwh => 650 }
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    refrigerator_values[:adjusted_annual_kwh] = 600
+    hpxml_data[:refrigerator][:adjusted_annual_kwh] = 600
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    refrigerator_values = {}
+    hpxml_data[:refrigerator] = {}
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    refrigerator_values[:location] = "basement - unconditioned"
+    hpxml_data[:refrigerator][:location] = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    refrigerator_values[:location] = "basement - conditioned"
+    hpxml_data[:refrigerator][:location] = "basement - conditioned"
   elsif ['base-enclosure-garage.xml',
          'invalid_files/refrigerator-location.xml'].include? hpxml_file
-    refrigerator_values[:location] = "garage"
+    hpxml_data[:refrigerator][:location] = "garage"
   elsif ['invalid_files/refrigerator-location-other.xml'].include? hpxml_file
-    refrigerator_values[:location] = "other"
+    hpxml_data[:refrigerator][:location] = "other"
   end
-  return refrigerator_values
 end
 
-def get_hpxml_file_cooking_range_values(hpxml_file, cooking_range_values)
+def set_hpxml_data_cooking_range_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    cooking_range_values = { :id => "Range",
-                             :fuel_type => "electricity",
-                             :is_induction => false }
+    hpxml_data[:cooking_range] = { :id => "Range",
+                                   :fuel_type => "electricity",
+                                   :is_induction => false }
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    cooking_range_values = {}
+    hpxml_data[:cooking_range] = {}
   elsif ['base-appliances-gas.xml'].include? hpxml_file
-    cooking_range_values[:fuel_type] = "natural gas"
-    cooking_range_values[:is_induction] = false
+    hpxml_data[:cooking_range][:fuel_type] = "natural gas"
+    hpxml_data[:cooking_range][:is_induction] = false
   elsif ['base-appliances-propane.xml'].include? hpxml_file
-    cooking_range_values[:fuel_type] = "propane"
-    cooking_range_values[:is_induction] = false
+    hpxml_data[:cooking_range][:fuel_type] = "propane"
+    hpxml_data[:cooking_range][:is_induction] = false
   elsif ['base-appliances-oil.xml'].include? hpxml_file
-    cooking_range_values[:fuel_type] = "fuel oil"
+    hpxml_data[:cooking_range][:fuel_type] = "fuel oil"
   elsif ['base-appliances-wood.xml'].include? hpxml_file
-    cooking_range_values[:fuel_type] = "wood"
-    cooking_range_values[:is_induction] = false
+    hpxml_data[:cooking_range][:fuel_type] = "wood"
+    hpxml_data[:cooking_range][:is_induction] = false
   end
-  return cooking_range_values
 end
 
-def get_hpxml_file_oven_values(hpxml_file, oven_values)
+def set_hpxml_data_oven_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    oven_values = { :id => "Oven",
-                    :is_convection => false }
+    hpxml_data[:oven] = { :id => "Oven",
+                          :is_convection => false }
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    oven_values = {}
+    hpxml_data[:oven] = {}
   end
-  return oven_values
 end
 
-def get_hpxml_file_lighting_values(hpxml_file, lighting_values)
+def set_hpxml_data_lighting_values(hpxml_file, hpxml_data)
   if ['base.xml'].include? hpxml_file
-    lighting_values = { :fraction_tier_i_interior => 0.5,
-                        :fraction_tier_i_exterior => 0.5,
-                        :fraction_tier_i_garage => 0.5,
-                        :fraction_tier_ii_interior => 0.25,
-                        :fraction_tier_ii_exterior => 0.25,
-                        :fraction_tier_ii_garage => 0.25 }
+    hpxml_data[:lighting] = { :fraction_tier_i_interior => 0.5,
+                              :fraction_tier_i_exterior => 0.5,
+                              :fraction_tier_i_garage => 0.5,
+                              :fraction_tier_ii_interior => 0.25,
+                              :fraction_tier_ii_exterior => 0.25,
+                              :fraction_tier_ii_garage => 0.25 }
   elsif ['base-misc-lighting-none.xml'].include? hpxml_file
-    lighting_values = {}
+    hpxml_data[:lighting] = {}
   end
-  return lighting_values
 end
 
-def get_hpxml_file_ceiling_fan_values(hpxml_file, ceiling_fans_values)
-  if ['base-misc-ceiling-fans.xml'].include? hpxml_file
-    ceiling_fans_values << { :id => "CeilingFan",
-                             :efficiency => 100,
-                             :quantity => 2 }
+def set_hpxml_data_ceiling_fans_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:ceiling_fans] = []
+  elsif ['base-misc-ceiling-fans.xml'].include? hpxml_file
+    hpxml_data[:ceiling_fans] << { :id => "CeilingFan",
+                                   :efficiency => 100,
+                                   :quantity => 2 }
   end
-  return ceiling_fans_values
 end
 
-def get_hpxml_file_plug_loads_values(hpxml_file, plug_loads_values)
+def set_hpxml_data_plug_loads_values(hpxml_file, hpxml_data)
   if ['base-misc-loads-detailed.xml'].include? hpxml_file
-    plug_loads_values = [{ :id => "PlugLoadMisc",
-                           :plug_load_type => "other",
-                           :kWh_per_year => 7302,
-                           :frac_sensible => 0.82,
-                           :frac_latent => 0.18 },
-                         { :id => "PlugLoadMisc2",
-                           :plug_load_type => "TV other",
-                           :kWh_per_year => 400 }]
+    hpxml_data[:plug_loads] = [{ :id => "PlugLoadMisc",
+                                 :plug_load_type => "other",
+                                 :kWh_per_year => 7302,
+                                 :frac_sensible => 0.82,
+                                 :frac_latent => 0.18 },
+                               { :id => "PlugLoadMisc2",
+                                 :plug_load_type => "TV other",
+                                 :kWh_per_year => 400 }]
   else
-    plug_loads_values = [{ :id => "PlugLoadMisc",
-                           :plug_load_type => "other" },
-                         { :id => "PlugLoadMisc2",
-                           :plug_load_type => "TV other" }]
+    hpxml_data[:plug_loads] = [{ :id => "PlugLoadMisc",
+                                 :plug_load_type => "other" },
+                               { :id => "PlugLoadMisc2",
+                                 :plug_load_type => "TV other" }]
   end
-  return plug_loads_values
 end
 
-def get_hpxml_file_misc_load_schedule_values(hpxml_file, misc_load_schedule_values)
-  if ['base-misc-loads-detailed.xml'].include? hpxml_file
-    misc_load_schedule_values = { :weekday_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
-                                  :weekend_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
-                                  :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0" }
+def set_hpxml_data_misc_load_schedule_values(hpxml_file, hpxml_data)
+  if ['base.xml'].include? hpxml_file
+    hpxml_data[:misc_load_schedule] = {}
+  elsif ['base-misc-loads-detailed.xml'].include? hpxml_file
+    hpxml_data[:misc_load_schedule] = { :weekday_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
+                                        :weekend_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
+                                        :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0" }
   end
-  return misc_load_schedule_values
 end
 
 def download_epws

--- a/tasks.rb
+++ b/tasks.rb
@@ -464,12 +464,12 @@ end
 
 def set_hpxml_header(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_header({ :xml_type => "HPXML",
-                       :xml_generated_by => "Rakefile",
-                       :transaction => "create",
-                       :building_id => "MyBuilding",
-                       :event_type => "proposed workscope",
-                       :created_date_and_time => Time.new(2000, 1, 1).strftime("%Y-%m-%dT%H:%M:%S%:z") }) # Hard-code to prevent diffs
+    hpxml.set_header(:xml_type => "HPXML",
+                     :xml_generated_by => "Rakefile",
+                     :transaction => "create",
+                     :building_id => "MyBuilding",
+                     :event_type => "proposed workscope",
+                     :created_date_and_time => Time.new(2000, 1, 1).strftime("%Y-%m-%dT%H:%M:%S%:z")) # Hard-code to prevent diffs
   elsif ['base-version-2014.xml'].include? hpxml_file
     hpxml.header.eri_calculation_version = "2014"
   elsif ['base-version-2014A.xml'].include? hpxml_file
@@ -491,7 +491,7 @@ end
 
 def set_hpxml_site(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_site({ :fuels => ["electricity", "natural gas"] })
+    hpxml.set_site(:fuels => ["electricity", "natural gas"])
   elsif ['base-hvac-none-no-fuel-access.xml'].include? hpxml_file
     hpxml.site.fuels = ["electricity"]
   end
@@ -499,11 +499,11 @@ end
 
 def set_hpxml_neighbor_buildings(hpxml_file, hpxml)
   if ['base-site-neighbors.xml'].include? hpxml_file
-    hpxml.neighbor_buildings.add({ :azimuth => 0,
-                                   :distance => 10 })
-    hpxml.neighbor_buildings.add({ :azimuth => 180,
-                                   :distance => 15,
-                                   :height => 12 })
+    hpxml.neighbor_buildings.add(:azimuth => 0,
+                                 :distance => 10)
+    hpxml.neighbor_buildings.add(:azimuth => 180,
+                                 :distance => 15,
+                                 :height => 12)
   elsif ['invalid_files/bad-site-neighbor-azimuth.xml'].include? hpxml_file
     hpxml.neighbor_buildings[0].azimuth = 145
   end
@@ -511,18 +511,18 @@ end
 
 def set_hpxml_building_occupancy(hpxml_file, hpxml)
   if ['base-misc-number-of-occupants.xml'].include? hpxml_file
-    hpxml.set_building_occupancy({ :number_of_residents => 5 })
+    hpxml.set_building_occupancy(:number_of_residents => 5)
   end
 end
 
 def set_hpxml_building_construction(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_building_construction({ :number_of_conditioned_floors => 2,
-                                      :number_of_conditioned_floors_above_grade => 1,
-                                      :number_of_bedrooms => 3,
-                                      :conditioned_floor_area => 2700,
-                                      :conditioned_building_volume => 2700 * 8,
-                                      :fraction_of_operable_window_area => 0.33 })
+    hpxml.set_building_construction(:number_of_conditioned_floors => 2,
+                                    :number_of_conditioned_floors_above_grade => 1,
+                                    :number_of_bedrooms => 3,
+                                    :conditioned_floor_area => 2700,
+                                    :conditioned_building_volume => 2700 * 8,
+                                    :fraction_of_operable_window_area => 0.33)
   elsif ['base-enclosure-beds-1.xml'].include? hpxml_file
     hpxml.building_construction.number_of_bedrooms = 1
   elsif ['base-enclosure-beds-2.xml'].include? hpxml_file
@@ -560,30 +560,30 @@ end
 
 def set_hpxml_climate_and_risk_zones(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_climate_and_risk_zones({ :iecc2006 => "5B",
-                                       :weather_station_id => "WeatherStation",
-                                       :weather_station_name => "Denver, CO",
-                                       :weather_station_wmo => "725650" })
+    hpxml.set_climate_and_risk_zones(:iecc2006 => "5B",
+                                     :weather_station_id => "WeatherStation",
+                                     :weather_station_name => "Denver, CO",
+                                     :weather_station_wmo => "725650")
   elsif ['base-location-baltimore-md.xml'].include? hpxml_file
-    hpxml.set_climate_and_risk_zones({ :iecc2006 => "4A",
-                                       :weather_station_id => "WeatherStation",
-                                       :weather_station_name => "Baltimore, MD",
-                                       :weather_station_wmo => "724060" })
+    hpxml.set_climate_and_risk_zones(:iecc2006 => "4A",
+                                     :weather_station_id => "WeatherStation",
+                                     :weather_station_name => "Baltimore, MD",
+                                     :weather_station_wmo => "724060")
   elsif ['base-location-dallas-tx.xml'].include? hpxml_file
-    hpxml.set_climate_and_risk_zones({ :iecc2006 => "3A",
-                                       :weather_station_id => "WeatherStation",
-                                       :weather_station_name => "Dallas, TX",
-                                       :weather_station_wmo => "722590" })
+    hpxml.set_climate_and_risk_zones(:iecc2006 => "3A",
+                                     :weather_station_id => "WeatherStation",
+                                     :weather_station_name => "Dallas, TX",
+                                     :weather_station_wmo => "722590")
   elsif ['base-location-duluth-mn.xml'].include? hpxml_file
-    hpxml.set_climate_and_risk_zones({ :iecc2006 => "7",
-                                       :weather_station_id => "WeatherStation",
-                                       :weather_station_name => "Duluth, MN",
-                                       :weather_station_wmo => "727450" })
+    hpxml.set_climate_and_risk_zones(:iecc2006 => "7",
+                                     :weather_station_id => "WeatherStation",
+                                     :weather_station_name => "Duluth, MN",
+                                     :weather_station_wmo => "727450")
   elsif ['base-location-miami-fl.xml'].include? hpxml_file
-    hpxml.set_climate_and_risk_zones({ :iecc2006 => "1A",
-                                       :weather_station_id => "WeatherStation",
-                                       :weather_station_name => "Miami, FL",
-                                       :weather_station_wmo => "722020" })
+    hpxml.set_climate_and_risk_zones(:iecc2006 => "1A",
+                                     :weather_station_id => "WeatherStation",
+                                     :weather_station_name => "Miami, FL",
+                                     :weather_station_wmo => "722020")
   elsif ['base-location-epw-filename.xml'].include? hpxml_file
     hpxml.climate_and_risk_zones.weather_station_wmo = nil
     hpxml.climate_and_risk_zones.weather_station_epw_filename = "USA_CO_Denver.Intl.AP.725650_TMY3.epw"
@@ -595,41 +595,41 @@ end
 def set_hpxml_air_infiltration_measurements(hpxml_file, hpxml)
   infil_volume = hpxml.building_construction.conditioned_building_volume
   if ['base.xml'].include? hpxml_file
-    hpxml.air_infiltration_measurements.add({ :id => "InfiltrationMeasurement",
-                                              :house_pressure => 50,
-                                              :unit_of_measure => "ACH",
-                                              :air_leakage => 3.0 })
+    hpxml.air_infiltration_measurements.add(:id => "InfiltrationMeasurement",
+                                            :house_pressure => 50,
+                                            :unit_of_measure => "ACH",
+                                            :air_leakage => 3.0)
   elsif ['base-infiltration-ach-natural.xml'].include? hpxml_file
     hpxml.air_infiltration_measurements.clear
-    hpxml.air_infiltration_measurements.add({ :id => "InfiltrationMeasurement",
-                                              :constant_ach_natural => 0.67 })
+    hpxml.air_infiltration_measurements.add(:id => "InfiltrationMeasurement",
+                                            :constant_ach_natural => 0.67)
   elsif ['base-enclosure-infil-cfm50.xml'].include? hpxml_file
     hpxml.air_infiltration_measurements.clear
-    hpxml.air_infiltration_measurements.add({ :id => "InfiltrationMeasurement",
-                                              :house_pressure => 50,
-                                              :unit_of_measure => "CFM",
-                                              :air_leakage => 3.0 / 60.0 * infil_volume })
+    hpxml.air_infiltration_measurements.add(:id => "InfiltrationMeasurement",
+                                            :house_pressure => 50,
+                                            :unit_of_measure => "CFM",
+                                            :air_leakage => 3.0 / 60.0 * infil_volume)
   end
   hpxml.air_infiltration_measurements[0].infiltration_volume = infil_volume
 end
 
 def set_hpxml_attics(hpxml_file, hpxml)
   if ['base-atticroof-vented.xml'].include? hpxml_file
-    hpxml.attics.add({ :id => "VentedAttic",
-                       :attic_type => "VentedAttic",
-                       :vented_attic_sla => 0.003 })
+    hpxml.attics.add(:id => "VentedAttic",
+                     :attic_type => "VentedAttic",
+                     :vented_attic_sla => 0.003)
   end
 end
 
 def set_hpxml_foundations(hpxml_file, hpxml)
   if ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml.foundations.add({ :id => "VentedCrawlspace",
-                            :foundation_type => "VentedCrawlspace",
-                            :vented_crawlspace_sla => 0.00667 })
+    hpxml.foundations.add(:id => "VentedCrawlspace",
+                          :foundation_type => "VentedCrawlspace",
+                          :vented_crawlspace_sla => 0.00667)
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml.foundations.add({ :id => "UnconditionedBasement",
-                            :foundation_type => "UnconditionedBasement",
-                            :unconditioned_basement_thermal_boundary => "frame floor" })
+    hpxml.foundations.add(:id => "UnconditionedBasement",
+                          :foundation_type => "UnconditionedBasement",
+                          :unconditioned_basement_thermal_boundary => "frame floor")
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
     hpxml.foundations[0].unconditioned_basement_thermal_boundary = "foundation wall"
   end
@@ -637,56 +637,56 @@ end
 
 def set_hpxml_roofs(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.roofs.add({ :id => "Roof",
-                      :interior_adjacent_to => "attic - unvented",
-                      :area => 1510,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 6,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 2.3 })
+    hpxml.roofs.add(:id => "Roof",
+                    :interior_adjacent_to => "attic - unvented",
+                    :area => 1510,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :pitch => 6,
+                    :radiant_barrier => false,
+                    :insulation_assembly_r_value => 2.3)
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
     hpxml.roofs.clear
-    hpxml.roofs.add({ :id => "Roof",
-                      :interior_adjacent_to => "living space",
-                      :area => 1350,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 0,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 25.8 })
+    hpxml.roofs.add(:id => "Roof",
+                    :interior_adjacent_to => "living space",
+                    :area => 1350,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :pitch => 0,
+                    :radiant_barrier => false,
+                    :insulation_assembly_r_value => 25.8)
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
     hpxml.roofs.clear
-    hpxml.roofs.add({ :id => "RoofCond",
-                      :interior_adjacent_to => "living space",
-                      :area => 1006,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 6,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 25.8 })
-    hpxml.roofs.add({ :id => "RoofUncond",
-                      :interior_adjacent_to => "attic - unvented",
-                      :area => 504,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 6,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 2.3 })
+    hpxml.roofs.add(:id => "RoofCond",
+                    :interior_adjacent_to => "living space",
+                    :area => 1006,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :pitch => 6,
+                    :radiant_barrier => false,
+                    :insulation_assembly_r_value => 25.8)
+    hpxml.roofs.add(:id => "RoofUncond",
+                    :interior_adjacent_to => "attic - unvented",
+                    :area => 504,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :pitch => 6,
+                    :radiant_barrier => false,
+                    :insulation_assembly_r_value => 2.3)
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
     hpxml.roofs[0].interior_adjacent_to = "attic - vented"
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
     hpxml.roofs[0].interior_adjacent_to = "living space"
     hpxml.roofs[0].insulation_assembly_r_value = 25.8
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml.roofs.add({ :id => "RoofGarage",
-                      :interior_adjacent_to => "garage",
-                      :area => 670,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :pitch => 6,
-                      :radiant_barrier => false,
-                      :insulation_assembly_r_value => 2.3 })
+    hpxml.roofs.add(:id => "RoofGarage",
+                    :interior_adjacent_to => "garage",
+                    :area => 670,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :pitch => 6,
+                    :radiant_barrier => false,
+                    :insulation_assembly_r_value => 2.3)
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
     hpxml.roofs[0].insulation_assembly_r_value = 25.8
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
@@ -708,13 +708,13 @@ def set_hpxml_rim_joists(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
     # TODO: Other geometry values (e.g., building volume) assume
     # no rim joists.
-    hpxml.rim_joists.add({ :id => "RimJoistFoundation",
-                           :exterior_adjacent_to => "outside",
-                           :interior_adjacent_to => "basement - conditioned",
-                           :area => 116,
-                           :solar_absorptance => 0.7,
-                           :emittance => 0.92,
-                           :insulation_assembly_r_value => 23.0 })
+    hpxml.rim_joists.add(:id => "RimJoistFoundation",
+                         :exterior_adjacent_to => "outside",
+                         :interior_adjacent_to => "basement - conditioned",
+                         :area => 116,
+                         :solar_absorptance => 0.7,
+                         :emittance => 0.92,
+                         :insulation_assembly_r_value => 23.0)
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml'].include? hpxml_file
     hpxml.rim_joists.clear
@@ -737,21 +737,21 @@ def set_hpxml_rim_joists(hpxml_file, hpxml)
     end
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     hpxml.rim_joists[0].exterior_adjacent_to = "crawlspace - unvented"
-    hpxml.rim_joists.add({ :id => "RimJoistCrawlspace",
-                           :exterior_adjacent_to => "outside",
-                           :interior_adjacent_to => "crawlspace - unvented",
-                           :area => 81,
-                           :solar_absorptance => 0.7,
-                           :emittance => 0.92,
-                           :insulation_assembly_r_value => 2.3 })
+    hpxml.rim_joists.add(:id => "RimJoistCrawlspace",
+                         :exterior_adjacent_to => "outside",
+                         :interior_adjacent_to => "crawlspace - unvented",
+                         :area => 81,
+                         :solar_absorptance => 0.7,
+                         :emittance => 0.92,
+                         :insulation_assembly_r_value => 2.3)
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    hpxml.rim_joists.add({ :id => "RimJoist2ndStory",
-                           :exterior_adjacent_to => "outside",
-                           :interior_adjacent_to => "living space",
-                           :area => 116,
-                           :solar_absorptance => 0.7,
-                           :emittance => 0.92,
-                           :insulation_assembly_r_value => 23.0 })
+    hpxml.rim_joists.add(:id => "RimJoist2ndStory",
+                         :exterior_adjacent_to => "outside",
+                         :interior_adjacent_to => "living space",
+                         :area => 116,
+                         :solar_absorptance => 0.7,
+                         :emittance => 0.92,
+                         :insulation_assembly_r_value => 23.0)
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.rim_joists.size
       hpxml.rim_joists[n - 1].area /= 10.0
@@ -765,22 +765,22 @@ end
 
 def set_hpxml_walls(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.walls.add({ :id => "Wall",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 1200,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 })
-    hpxml.walls.add({ :id => "WallAtticGable",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "attic - unvented",
-                      :wall_type => "WoodStud",
-                      :area => 290,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4.0 })
+    hpxml.walls.add(:id => "Wall",
+                    :exterior_adjacent_to => "outside",
+                    :interior_adjacent_to => "living space",
+                    :wall_type => "WoodStud",
+                    :area => 1200,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 23)
+    hpxml.walls.add(:id => "WallAtticGable",
+                    :exterior_adjacent_to => "outside",
+                    :interior_adjacent_to => "attic - unvented",
+                    :wall_type => "WoodStud",
+                    :area => 290,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 4.0)
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
     hpxml.walls.delete_at(1)
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
@@ -790,30 +790,30 @@ def set_hpxml_walls(hpxml_file, hpxml)
     hpxml.walls[1].insulation_assembly_r_value = 23.0
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
     hpxml.walls.delete_at(1)
-    hpxml.walls.add({ :id => "WallAtticKneeWall",
-                      :exterior_adjacent_to => "attic - unvented",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 316,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23.0 })
-    hpxml.walls.add({ :id => "WallAtticGableCond",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 240,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 22.3 })
-    hpxml.walls.add({ :id => "WallAtticGableUncond",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "attic - unvented",
-                      :wall_type => "WoodStud",
-                      :area => 50,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4.0 })
+    hpxml.walls.add(:id => "WallAtticKneeWall",
+                    :exterior_adjacent_to => "attic - unvented",
+                    :interior_adjacent_to => "living space",
+                    :wall_type => "WoodStud",
+                    :area => 316,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 23.0)
+    hpxml.walls.add(:id => "WallAtticGableCond",
+                    :exterior_adjacent_to => "outside",
+                    :interior_adjacent_to => "living space",
+                    :wall_type => "WoodStud",
+                    :area => 240,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 22.3)
+    hpxml.walls.add(:id => "WallAtticGableUncond",
+                    :exterior_adjacent_to => "outside",
+                    :interior_adjacent_to => "attic - unvented",
+                    :wall_type => "WoodStud",
+                    :area => 50,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 4.0)
   elsif ['base-enclosure-walltype-cmu.xml'].include? hpxml_file
     hpxml.walls[0].wall_type = "ConcreteMasonryUnit"
     hpxml.walls[0].insulation_assembly_r_value = 12
@@ -845,68 +845,68 @@ def set_hpxml_walls(hpxml_file, hpxml)
     hpxml.walls[0].wall_type = "StructuralBrick"
     hpxml.walls[0].insulation_assembly_r_value = 7.9
   elsif ['invalid_files/missing-surfaces.xml'].include? hpxml_file
-    hpxml.walls.add({ :id => "WallGarage",
-                      :exterior_adjacent_to => "garage",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 100,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4 })
+    hpxml.walls.add(:id => "WallGarage",
+                    :exterior_adjacent_to => "garage",
+                    :interior_adjacent_to => "living space",
+                    :wall_type => "WoodStud",
+                    :area => 100,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 4)
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
     hpxml.walls[0].area *= 2.0
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
     hpxml.walls.clear
-    hpxml.walls.add({ :id => "Wall",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 880,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 })
-    hpxml.walls.add({ :id => "WallGarageInterior",
-                      :exterior_adjacent_to => "garage",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 320,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 })
-    hpxml.walls.add({ :id => "WallGarageExterior",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "garage",
-                      :wall_type => "WoodStud",
-                      :area => 800,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4 })
+    hpxml.walls.add(:id => "Wall",
+                    :exterior_adjacent_to => "outside",
+                    :interior_adjacent_to => "living space",
+                    :wall_type => "WoodStud",
+                    :area => 880,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 23)
+    hpxml.walls.add(:id => "WallGarageInterior",
+                    :exterior_adjacent_to => "garage",
+                    :interior_adjacent_to => "living space",
+                    :wall_type => "WoodStud",
+                    :area => 320,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 23)
+    hpxml.walls.add(:id => "WallGarageExterior",
+                    :exterior_adjacent_to => "outside",
+                    :interior_adjacent_to => "garage",
+                    :wall_type => "WoodStud",
+                    :area => 800,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 4)
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
     hpxml.walls.clear
-    hpxml.walls.add({ :id => "Wall",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 960,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 })
-    hpxml.walls.add({ :id => "WallGarageInterior",
-                      :exterior_adjacent_to => "garage",
-                      :interior_adjacent_to => "living space",
-                      :wall_type => "WoodStud",
-                      :area => 240,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 23 })
-    hpxml.walls.add({ :id => "WallGarageExterior",
-                      :exterior_adjacent_to => "outside",
-                      :interior_adjacent_to => "garage",
-                      :wall_type => "WoodStud",
-                      :area => 560,
-                      :solar_absorptance => 0.7,
-                      :emittance => 0.92,
-                      :insulation_assembly_r_value => 4 })
+    hpxml.walls.add(:id => "Wall",
+                    :exterior_adjacent_to => "outside",
+                    :interior_adjacent_to => "living space",
+                    :wall_type => "WoodStud",
+                    :area => 960,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 23)
+    hpxml.walls.add(:id => "WallGarageInterior",
+                    :exterior_adjacent_to => "garage",
+                    :interior_adjacent_to => "living space",
+                    :wall_type => "WoodStud",
+                    :area => 240,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 23)
+    hpxml.walls.add(:id => "WallGarageExterior",
+                    :exterior_adjacent_to => "outside",
+                    :interior_adjacent_to => "garage",
+                    :wall_type => "WoodStud",
+                    :area => 560,
+                    :solar_absorptance => 0.7,
+                    :emittance => 0.92,
+                    :insulation_assembly_r_value => 4)
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
     hpxml.walls[1].insulation_assembly_r_value = 23
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
@@ -930,19 +930,19 @@ end
 
 def set_hpxml_foundation_walls(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml. foundation_walls.add({ :id => "FoundationWall",
-                                  :exterior_adjacent_to => "ground",
-                                  :interior_adjacent_to => "basement - conditioned",
-                                  :height => 8,
-                                  :area => 1200,
-                                  :thickness => 8,
-                                  :depth_below_grade => 7,
-                                  :insulation_interior_r_value => 0,
-                                  :insulation_interior_distance_to_top => 0,
-                                  :insulation_interior_distance_to_bottom => 0,
-                                  :insulation_exterior_distance_to_top => 0,
-                                  :insulation_exterior_distance_to_bottom => 8,
-                                  :insulation_exterior_r_value => 8.9 })
+    hpxml. foundation_walls.add(:id => "FoundationWall",
+                                :exterior_adjacent_to => "ground",
+                                :interior_adjacent_to => "basement - conditioned",
+                                :height => 8,
+                                :area => 1200,
+                                :thickness => 8,
+                                :depth_below_grade => 7,
+                                :insulation_interior_r_value => 0,
+                                :insulation_interior_distance_to_top => 0,
+                                :insulation_interior_distance_to_bottom => 0,
+                                :insulation_exterior_distance_to_top => 0,
+                                :insulation_exterior_distance_to_bottom => 8,
+                                :insulation_exterior_r_value => 8.9)
   elsif ['base-foundation-conditioned-basement-wall-interior-insulation.xml'].include? hpxml_file
     hpxml.foundation_walls[0].insulation_interior_distance_to_top = 0
     hpxml.foundation_walls[0].insulation_interior_distance_to_bottom = 8
@@ -979,143 +979,143 @@ def set_hpxml_foundation_walls(hpxml_file, hpxml)
     hpxml.foundation_walls[0].insulation_exterior_distance_to_bottom -= 4
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     hpxml.foundation_walls[0].area = 600
-    hpxml.foundation_walls.add({ :id => "FoundationWallInterior",
-                                 :exterior_adjacent_to => "crawlspace - unvented",
-                                 :interior_adjacent_to => "basement - unconditioned",
-                                 :height => 8,
-                                 :area => 360,
-                                 :thickness => 8,
-                                 :depth_below_grade => 4,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 0,
-                                 :insulation_exterior_r_value => 0 })
-    hpxml.foundation_walls.add({ :id => "FoundationWallCrawlspace",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "crawlspace - unvented",
-                                 :height => 4,
-                                 :area => 600,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 0,
-                                 :insulation_exterior_r_value => 0 })
+    hpxml.foundation_walls.add(:id => "FoundationWallInterior",
+                               :exterior_adjacent_to => "crawlspace - unvented",
+                               :interior_adjacent_to => "basement - unconditioned",
+                               :height => 8,
+                               :area => 360,
+                               :thickness => 8,
+                               :depth_below_grade => 4,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 0,
+                               :insulation_exterior_r_value => 0)
+    hpxml.foundation_walls.add(:id => "FoundationWallCrawlspace",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "crawlspace - unvented",
+                               :height => 4,
+                               :area => 600,
+                               :thickness => 8,
+                               :depth_below_grade => 3,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 0,
+                               :insulation_exterior_r_value => 0)
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml'].include? hpxml_file
     hpxml.foundation_walls.clear
   elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
     hpxml.foundation_walls.clear
-    hpxml.foundation_walls.add({ :id => "FoundationWall1",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 8,
-                                 :area => 480,
-                                 :thickness => 8,
-                                 :depth_below_grade => 7,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 8,
-                                 :insulation_exterior_r_value => 8.9 })
-    hpxml.foundation_walls.add({ :id => "FoundationWall2",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 4,
-                                 :area => 120,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 4,
-                                 :insulation_exterior_r_value => 8.9 })
-    hpxml.foundation_walls.add({ :id => "FoundationWall3",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 2,
-                                 :area => 60,
-                                 :thickness => 8,
-                                 :depth_below_grade => 1,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 2,
-                                 :insulation_exterior_r_value => 8.9 })
+    hpxml.foundation_walls.add(:id => "FoundationWall1",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "basement - conditioned",
+                               :height => 8,
+                               :area => 480,
+                               :thickness => 8,
+                               :depth_below_grade => 7,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 8,
+                               :insulation_exterior_r_value => 8.9)
+    hpxml.foundation_walls.add(:id => "FoundationWall2",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "basement - conditioned",
+                               :height => 4,
+                               :area => 120,
+                               :thickness => 8,
+                               :depth_below_grade => 3,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 4,
+                               :insulation_exterior_r_value => 8.9)
+    hpxml.foundation_walls.add(:id => "FoundationWall3",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "basement - conditioned",
+                               :height => 2,
+                               :area => 60,
+                               :thickness => 8,
+                               :depth_below_grade => 1,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 2,
+                               :insulation_exterior_r_value => 8.9)
   elsif ['base-foundation-complex.xml'].include? hpxml_file
     hpxml.foundation_walls.clear
-    hpxml.foundation_walls.add({ :id => "FoundationWall1",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 8,
-                                 :area => 160,
-                                 :thickness => 8,
-                                 :depth_below_grade => 7,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 0,
-                                 :insulation_exterior_r_value => 0.0 })
-    hpxml.foundation_walls.add({ :id => "FoundationWall2",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 8,
-                                 :area => 240,
-                                 :thickness => 8,
-                                 :depth_below_grade => 7,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 8,
-                                 :insulation_exterior_r_value => 8.9 })
-    hpxml.foundation_walls.add({ :id => "FoundationWall3",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 4,
-                                 :area => 160,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 0,
-                                 :insulation_exterior_r_value => 0.0 })
-    hpxml.foundation_walls.add({ :id => "FoundationWall4",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 4,
-                                 :area => 120,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 4,
-                                 :insulation_exterior_r_value => 8.9 })
-    hpxml.foundation_walls.add({ :id => "FoundationWall5",
-                                 :exterior_adjacent_to => "ground",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :height => 4,
-                                 :area => 80,
-                                 :thickness => 8,
-                                 :depth_below_grade => 3,
-                                 :insulation_interior_r_value => 0,
-                                 :insulation_interior_distance_to_top => 0,
-                                 :insulation_interior_distance_to_bottom => 0,
-                                 :insulation_exterior_distance_to_top => 0,
-                                 :insulation_exterior_distance_to_bottom => 4,
-                                 :insulation_exterior_r_value => 8.9 })
+    hpxml.foundation_walls.add(:id => "FoundationWall1",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "basement - conditioned",
+                               :height => 8,
+                               :area => 160,
+                               :thickness => 8,
+                               :depth_below_grade => 7,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 0,
+                               :insulation_exterior_r_value => 0.0)
+    hpxml.foundation_walls.add(:id => "FoundationWall2",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "basement - conditioned",
+                               :height => 8,
+                               :area => 240,
+                               :thickness => 8,
+                               :depth_below_grade => 7,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 8,
+                               :insulation_exterior_r_value => 8.9)
+    hpxml.foundation_walls.add(:id => "FoundationWall3",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "basement - conditioned",
+                               :height => 4,
+                               :area => 160,
+                               :thickness => 8,
+                               :depth_below_grade => 3,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 0,
+                               :insulation_exterior_r_value => 0.0)
+    hpxml.foundation_walls.add(:id => "FoundationWall4",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "basement - conditioned",
+                               :height => 4,
+                               :area => 120,
+                               :thickness => 8,
+                               :depth_below_grade => 3,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 4,
+                               :insulation_exterior_r_value => 8.9)
+    hpxml.foundation_walls.add(:id => "FoundationWall5",
+                               :exterior_adjacent_to => "ground",
+                               :interior_adjacent_to => "basement - conditioned",
+                               :height => 4,
+                               :area => 80,
+                               :thickness => 8,
+                               :depth_below_grade => 3,
+                               :insulation_interior_r_value => 0,
+                               :insulation_interior_distance_to_top => 0,
+                               :insulation_interior_distance_to_bottom => 0,
+                               :insulation_exterior_distance_to_top => 0,
+                               :insulation_exterior_distance_to_bottom => 4,
+                               :insulation_exterior_r_value => 8.9)
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.foundation_walls.size
       hpxml.foundation_walls[n - 1].area /= 10.0
@@ -1133,11 +1133,11 @@ end
 
 def set_hpxml_frame_floors(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.frame_floors.add({ :id => "FloorBelowAttic",
-                             :exterior_adjacent_to => "attic - unvented",
-                             :interior_adjacent_to => "living space",
-                             :area => 1350,
-                             :insulation_assembly_r_value => 39.3 })
+    hpxml.frame_floors.add(:id => "FloorBelowAttic",
+                           :exterior_adjacent_to => "attic - unvented",
+                           :interior_adjacent_to => "living space",
+                           :area => 1350,
+                           :insulation_assembly_r_value => 39.3)
   elsif ['base-atticroof-flat.xml',
          'base-atticroof-cathedral.xml'].include? hpxml_file
     hpxml.frame_floors.delete_at(0)
@@ -1146,64 +1146,64 @@ def set_hpxml_frame_floors(hpxml_file, hpxml)
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
     hpxml.frame_floors[0].area = 450
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml.frame_floors.add({ :id => "FloorBetweenAtticGarage",
-                             :exterior_adjacent_to => "attic - unvented",
-                             :interior_adjacent_to => "garage",
-                             :area => 600,
-                             :insulation_assembly_r_value => 2.1 })
+    hpxml.frame_floors.add(:id => "FloorBetweenAtticGarage",
+                           :exterior_adjacent_to => "attic - unvented",
+                           :interior_adjacent_to => "garage",
+                           :area => 600,
+                           :insulation_assembly_r_value => 2.1)
   elsif ['base-foundation-ambient.xml'].include? hpxml_file
-    hpxml.frame_floors.add({ :id => "FloorAboveAmbient",
-                             :exterior_adjacent_to => "outside",
-                             :interior_adjacent_to => "living space",
-                             :area => 1350,
-                             :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add(:id => "FloorAboveAmbient",
+                           :exterior_adjacent_to => "outside",
+                           :interior_adjacent_to => "living space",
+                           :area => 1350,
+                           :insulation_assembly_r_value => 18.7)
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml.frame_floors.add({ :id => "FloorAboveUncondBasement",
-                             :exterior_adjacent_to => "basement - unconditioned",
-                             :interior_adjacent_to => "living space",
-                             :area => 1350,
-                             :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add(:id => "FloorAboveUncondBasement",
+                           :exterior_adjacent_to => "basement - unconditioned",
+                           :interior_adjacent_to => "living space",
+                           :area => 1350,
+                           :insulation_assembly_r_value => 18.7)
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
     hpxml.frame_floors[1].insulation_assembly_r_value = 2.1
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    hpxml.frame_floors.add({ :id => "FloorAboveUnventedCrawl",
-                             :exterior_adjacent_to => "crawlspace - unvented",
-                             :interior_adjacent_to => "living space",
-                             :area => 1350,
-                             :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add(:id => "FloorAboveUnventedCrawl",
+                           :exterior_adjacent_to => "crawlspace - unvented",
+                           :interior_adjacent_to => "living space",
+                           :area => 1350,
+                           :insulation_assembly_r_value => 18.7)
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml.frame_floors.add({ :id => "FloorAboveVentedCrawl",
-                             :exterior_adjacent_to => "crawlspace - vented",
-                             :interior_adjacent_to => "living space",
-                             :area => 1350,
-                             :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add(:id => "FloorAboveVentedCrawl",
+                           :exterior_adjacent_to => "crawlspace - vented",
+                           :interior_adjacent_to => "living space",
+                           :area => 1350,
+                           :insulation_assembly_r_value => 18.7)
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     hpxml.frame_floors[1].area = 675
-    hpxml.frame_floors.add({ :id => "FloorAboveUnventedCrawlspace",
-                             :exterior_adjacent_to => "crawlspace - unvented",
-                             :interior_adjacent_to => "living space",
-                             :area => 675,
-                             :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add(:id => "FloorAboveUnventedCrawlspace",
+                           :exterior_adjacent_to => "crawlspace - unvented",
+                           :interior_adjacent_to => "living space",
+                           :area => 675,
+                           :insulation_assembly_r_value => 18.7)
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    hpxml.frame_floors.add({ :id => "FloorAboveGarage",
-                             :exterior_adjacent_to => "garage",
-                             :interior_adjacent_to => "living space",
-                             :area => 400,
-                             :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add(:id => "FloorAboveGarage",
+                           :exterior_adjacent_to => "garage",
+                           :interior_adjacent_to => "living space",
+                           :area => 400,
+                           :insulation_assembly_r_value => 18.7)
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
     hpxml.frame_floors[0].insulation_assembly_r_value = 2.1
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
     hpxml.frame_floors.clear
-    hpxml.frame_floors.add({ :id => "FloorAboveAdiabatic",
-                             :exterior_adjacent_to => "other housing unit below",
-                             :interior_adjacent_to => "living space",
-                             :area => 1350,
-                             :insulation_assembly_r_value => 2.1 })
-    hpxml.frame_floors.add({ :id => "FloorBelowAdiabatic",
-                             :exterior_adjacent_to => "other housing unit above",
-                             :interior_adjacent_to => "living space",
-                             :area => 1350,
-                             :insulation_assembly_r_value => 2.1 })
+    hpxml.frame_floors.add(:id => "FloorAboveAdiabatic",
+                           :exterior_adjacent_to => "other housing unit below",
+                           :interior_adjacent_to => "living space",
+                           :area => 1350,
+                           :insulation_assembly_r_value => 2.1)
+    hpxml.frame_floors.add(:id => "FloorBelowAdiabatic",
+                           :exterior_adjacent_to => "other housing unit above",
+                           :interior_adjacent_to => "living space",
+                           :area => 1350,
+                           :insulation_assembly_r_value => 2.1)
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.frame_floors.size
       hpxml.frame_floors[n - 1].area /= 10.0
@@ -1217,17 +1217,17 @@ end
 
 def set_hpxml_slabs(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.slabs.add({ :id => "Slab",
-                      :interior_adjacent_to => "basement - conditioned",
-                      :area => 1350,
-                      :thickness => 4,
-                      :exposed_perimeter => 150,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 })
+    hpxml.slabs.add(:id => "Slab",
+                    :interior_adjacent_to => "basement - conditioned",
+                    :area => 1350,
+                    :thickness => 4,
+                    :exposed_perimeter => 150,
+                    :perimeter_insulation_depth => 0,
+                    :under_slab_insulation_width => 0,
+                    :perimeter_insulation_r_value => 0,
+                    :under_slab_insulation_r_value => 0,
+                    :carpet_fraction => 0,
+                    :carpet_r_value => 0)
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     hpxml.slabs[0].interior_adjacent_to = "basement - unconditioned"
   elsif ['base-foundation-conditioned-basement-slab-insulation.xml'].include? hpxml_file
@@ -1253,83 +1253,83 @@ def set_hpxml_slabs(hpxml_file, hpxml)
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     hpxml.slabs[0].area = 675
     hpxml.slabs[0].exposed_perimeter = 75
-    hpxml.slabs.add({ :id => "SlabUnderCrawlspace",
-                      :interior_adjacent_to => "crawlspace - unvented",
-                      :area => 675,
-                      :thickness => 0,
-                      :exposed_perimeter => 75,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 })
+    hpxml.slabs.add(:id => "SlabUnderCrawlspace",
+                    :interior_adjacent_to => "crawlspace - unvented",
+                    :area => 675,
+                    :thickness => 0,
+                    :exposed_perimeter => 75,
+                    :perimeter_insulation_depth => 0,
+                    :under_slab_insulation_width => 0,
+                    :perimeter_insulation_r_value => 0,
+                    :under_slab_insulation_r_value => 0,
+                    :carpet_fraction => 0,
+                    :carpet_r_value => 0)
   elsif ['base-foundation-ambient.xml'].include? hpxml_file
     hpxml.slabs.clear
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
     hpxml.slabs[0].area -= 400
     hpxml.slabs[0].exposed_perimeter -= 40
-    hpxml.slabs.add({ :id => "SlabUnderGarage",
-                      :interior_adjacent_to => "garage",
-                      :area => 400,
-                      :thickness => 4,
-                      :exposed_perimeter => 40,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :depth_below_grade => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 })
+    hpxml.slabs.add(:id => "SlabUnderGarage",
+                    :interior_adjacent_to => "garage",
+                    :area => 400,
+                    :thickness => 4,
+                    :exposed_perimeter => 40,
+                    :perimeter_insulation_depth => 0,
+                    :under_slab_insulation_width => 0,
+                    :depth_below_grade => 0,
+                    :perimeter_insulation_r_value => 0,
+                    :under_slab_insulation_r_value => 0,
+                    :carpet_fraction => 0,
+                    :carpet_r_value => 0)
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
     hpxml.slabs[0].exposed_perimeter -= 30
-    hpxml.slabs.add({ :id => "SlabUnderGarage",
-                      :interior_adjacent_to => "garage",
-                      :area => 600,
-                      :thickness => 4,
-                      :exposed_perimeter => 70,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :depth_below_grade => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 })
+    hpxml.slabs.add(:id => "SlabUnderGarage",
+                    :interior_adjacent_to => "garage",
+                    :area => 600,
+                    :thickness => 4,
+                    :exposed_perimeter => 70,
+                    :perimeter_insulation_depth => 0,
+                    :under_slab_insulation_width => 0,
+                    :depth_below_grade => 0,
+                    :perimeter_insulation_r_value => 0,
+                    :under_slab_insulation_r_value => 0,
+                    :carpet_fraction => 0,
+                    :carpet_r_value => 0)
   elsif ['base-foundation-complex.xml'].include? hpxml_file
     hpxml.slabs.clear
-    hpxml.slabs.add({ :id => "Slab1",
-                      :interior_adjacent_to => "basement - conditioned",
-                      :area => 675,
-                      :thickness => 4,
-                      :exposed_perimeter => 75,
-                      :perimeter_insulation_depth => 0,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 0,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 })
-    hpxml.slabs.add({ :id => "Slab2",
-                      :interior_adjacent_to => "basement - conditioned",
-                      :area => 405,
-                      :thickness => 4,
-                      :exposed_perimeter => 45,
-                      :perimeter_insulation_depth => 1,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 5,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 })
-    hpxml.slabs.add({ :id => "Slab3",
-                      :interior_adjacent_to => "basement - conditioned",
-                      :area => 270,
-                      :thickness => 4,
-                      :exposed_perimeter => 30,
-                      :perimeter_insulation_depth => 1,
-                      :under_slab_insulation_width => 0,
-                      :perimeter_insulation_r_value => 5,
-                      :under_slab_insulation_r_value => 0,
-                      :carpet_fraction => 0,
-                      :carpet_r_value => 0 })
+    hpxml.slabs.add(:id => "Slab1",
+                    :interior_adjacent_to => "basement - conditioned",
+                    :area => 675,
+                    :thickness => 4,
+                    :exposed_perimeter => 75,
+                    :perimeter_insulation_depth => 0,
+                    :under_slab_insulation_width => 0,
+                    :perimeter_insulation_r_value => 0,
+                    :under_slab_insulation_r_value => 0,
+                    :carpet_fraction => 0,
+                    :carpet_r_value => 0)
+    hpxml.slabs.add(:id => "Slab2",
+                    :interior_adjacent_to => "basement - conditioned",
+                    :area => 405,
+                    :thickness => 4,
+                    :exposed_perimeter => 45,
+                    :perimeter_insulation_depth => 1,
+                    :under_slab_insulation_width => 0,
+                    :perimeter_insulation_r_value => 5,
+                    :under_slab_insulation_r_value => 0,
+                    :carpet_fraction => 0,
+                    :carpet_r_value => 0)
+    hpxml.slabs.add(:id => "Slab3",
+                    :interior_adjacent_to => "basement - conditioned",
+                    :area => 270,
+                    :thickness => 4,
+                    :exposed_perimeter => 30,
+                    :perimeter_insulation_depth => 1,
+                    :under_slab_insulation_width => 0,
+                    :perimeter_insulation_r_value => 5,
+                    :under_slab_insulation_r_value => 0,
+                    :carpet_fraction => 0,
+                    :carpet_r_value => 0)
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.slabs.size
       hpxml.slabs[n - 1].area /= 10.0
@@ -1349,30 +1349,30 @@ end
 
 def set_hpxml_windows(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.windows.add({ :id => "WindowNorth",
-                        :area => 108,
-                        :azimuth => 0,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "Wall" })
-    hpxml.windows.add({ :id => "WindowSouth",
-                        :area => 108,
-                        :azimuth => 180,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "Wall" })
-    hpxml.windows.add({ :id => "WindowEast",
-                        :area => 72,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "Wall" })
-    hpxml.windows.add({ :id => "WindowWest",
-                        :area => 72,
-                        :azimuth => 270,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "Wall" })
+    hpxml.windows.add(:id => "WindowNorth",
+                      :area => 108,
+                      :azimuth => 0,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "Wall")
+    hpxml.windows.add(:id => "WindowSouth",
+                      :area => 108,
+                      :azimuth => 180,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "Wall")
+    hpxml.windows.add(:id => "WindowEast",
+                      :area => 72,
+                      :azimuth => 90,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "Wall")
+    hpxml.windows.add(:id => "WindowWest",
+                      :area => 72,
+                      :azimuth => 270,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "Wall")
   elsif ['base-enclosure-overhangs.xml'].include? hpxml_file
     hpxml.windows[0].overhangs_depth = 2.5
     hpxml.windows[0].overhangs_distance_to_top_of_window = 0
@@ -1404,43 +1404,43 @@ def set_hpxml_windows(hpxml_file, hpxml)
     hpxml.windows[1].area = 108
     hpxml.windows[2].area = 108
     hpxml.windows[3].area = 108
-    hpxml.windows.add({ :id => "AtticGableWindowEast",
-                        :area => 12,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "WallAtticGableCond" })
-    hpxml.windows.add({ :id => "AtticGableWindowWest",
-                        :area => 62,
-                        :azimuth => 270,
-                        :ufactor => 0.3,
-                        :shgc => 0.45,
-                        :wall_idref => "WallAtticGableCond" })
+    hpxml.windows.add(:id => "AtticGableWindowEast",
+                      :area => 12,
+                      :azimuth => 90,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "WallAtticGableCond")
+    hpxml.windows.add(:id => "AtticGableWindowWest",
+                      :area => 62,
+                      :azimuth => 270,
+                      :ufactor => 0.3,
+                      :shgc => 0.45,
+                      :wall_idref => "WallAtticGableCond")
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
     hpxml.windows[0].area = 108
     hpxml.windows[1].area = 108
     hpxml.windows[2].area = 108
     hpxml.windows[3].area = 108
-    hpxml.windows.add({ :id => "AtticGableWindowEast",
-                        :area => 12,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "WallAtticGable" })
-    hpxml.windows.add({ :id => "AtticGableWindowWest",
-                        :area => 12,
-                        :azimuth => 270,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "WallAtticGable" })
+    hpxml.windows.add(:id => "AtticGableWindowEast",
+                      :area => 12,
+                      :azimuth => 90,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "WallAtticGable")
+    hpxml.windows.add(:id => "AtticGableWindowWest",
+                      :area => 12,
+                      :azimuth => 270,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "WallAtticGable")
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
     hpxml.windows.delete_at(2)
-    hpxml.windows.add({ :id => "GarageWindowEast",
-                        :area => 12,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "WallGarageExterior" })
+    hpxml.windows.add(:id => "GarageWindowEast",
+                      :area => 12,
+                      :azimuth => 90,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "WallGarageExterior")
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
     hpxml.windows[0].area = 216
     hpxml.windows[1].area = 216
@@ -1452,30 +1452,30 @@ def set_hpxml_windows(hpxml_file, hpxml)
     hpxml.windows[2].area = 144
     hpxml.windows[3].area = 96
   elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
-    hpxml.windows.add({ :id => "FoundationWindowNorth",
-                        :area => 20,
-                        :azimuth => 0,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall" })
-    hpxml.windows.add({ :id => "FoundationWindowSouth",
-                        :area => 20,
-                        :azimuth => 180,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall" })
-    hpxml.windows.add({ :id => "FoundationWindowEast",
-                        :area => 10,
-                        :azimuth => 90,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall" })
-    hpxml.windows.add({ :id => "FoundationWindowWest",
-                        :area => 10,
-                        :azimuth => 270,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall" })
+    hpxml.windows.add(:id => "FoundationWindowNorth",
+                      :area => 20,
+                      :azimuth => 0,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "FoundationWall")
+    hpxml.windows.add(:id => "FoundationWindowSouth",
+                      :area => 20,
+                      :azimuth => 180,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "FoundationWall")
+    hpxml.windows.add(:id => "FoundationWindowEast",
+                      :area => 10,
+                      :azimuth => 90,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "FoundationWall")
+    hpxml.windows.add(:id => "FoundationWindowWest",
+                      :area => 10,
+                      :azimuth => 270,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "FoundationWall")
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.windows.size
       hpxml.windows[n - 1].area *= 0.35
@@ -1493,12 +1493,12 @@ def set_hpxml_windows(hpxml_file, hpxml)
       end
     end
   elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
-    hpxml.windows.add({ :id => "FoundationWindow",
-                        :area => 20,
-                        :azimuth => 0,
-                        :ufactor => 0.33,
-                        :shgc => 0.45,
-                        :wall_idref => "FoundationWall3" })
+    hpxml.windows.add(:id => "FoundationWindow",
+                      :area => 20,
+                      :azimuth => 0,
+                      :ufactor => 0.33,
+                      :shgc => 0.45,
+                      :wall_idref => "FoundationWall3")
   elsif ['invalid_files/invalid-window-height.xml'].include? hpxml_file
     hpxml.windows[2].overhangs_distance_to_bottom_of_window = hpxml.windows[2].overhangs_distance_to_top_of_window
   end
@@ -1506,18 +1506,18 @@ end
 
 def set_hpxml_skylights(hpxml_file, hpxml)
   if ['base-enclosure-skylights.xml'].include? hpxml_file
-    hpxml.skylights.add({ :id => "SkylightNorth",
-                          :area => 45,
-                          :azimuth => 0,
-                          :ufactor => 0.33,
-                          :shgc => 0.45,
-                          :roof_idref => "Roof" })
-    hpxml.skylights.add({ :id => "SkylightSouth",
-                          :area => 45,
-                          :azimuth => 180,
-                          :ufactor => 0.35,
-                          :shgc => 0.47,
-                          :roof_idref => "Roof" })
+    hpxml.skylights.add(:id => "SkylightNorth",
+                        :area => 45,
+                        :azimuth => 0,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :roof_idref => "Roof")
+    hpxml.skylights.add(:id => "SkylightSouth",
+                        :area => 45,
+                        :azimuth => 180,
+                        :ufactor => 0.35,
+                        :shgc => 0.47,
+                        :roof_idref => "Roof")
   elsif ['invalid_files/net-area-negative-roof.xml'].include? hpxml_file
     hpxml.skylights[0].area = 4000
   elsif ['invalid_files/unattached-skylight.xml'].include? hpxml_file
@@ -1536,23 +1536,23 @@ end
 
 def set_hpxml_doors(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.doors.add({ :id => "DoorNorth",
-                      :wall_idref => "Wall",
-                      :area => 40,
-                      :azimuth => 0,
-                      :r_value => 4.4 })
-    hpxml.doors.add({ :id => "DoorSouth",
-                      :wall_idref => "Wall",
-                      :area => 40,
-                      :azimuth => 180,
-                      :r_value => 4.4 })
+    hpxml.doors.add(:id => "DoorNorth",
+                    :wall_idref => "Wall",
+                    :area => 40,
+                    :azimuth => 0,
+                    :r_value => 4.4)
+    hpxml.doors.add(:id => "DoorSouth",
+                    :wall_idref => "Wall",
+                    :area => 40,
+                    :azimuth => 180,
+                    :r_value => 4.4)
   elsif ['base-enclosure-garage.xml',
          'base-enclosure-2stories-garage.xml'].include? hpxml_file
-    hpxml.doors << HPXML::Door.new({ :id => "GarageDoorSouth",
-                                     :wall_idref => "WallGarageExterior",
-                                     :area => 70,
-                                     :azimuth => 180,
-                                     :r_value => 4.4 })
+    hpxml.doors << HPXML::Door.new(:id => "GarageDoorSouth",
+                                   :wall_idref => "WallGarageExterior",
+                                   :area => 70,
+                                   :azimuth => 180,
+                                   :r_value => 4.4)
   elsif ['invalid_files/unattached-door.xml'].include? hpxml_file
     hpxml.doors[0].wall_idref = "foobar"
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
@@ -1570,13 +1570,13 @@ end
 
 def set_hpxml_heating_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.heating_systems.add({ :id => "HeatingSystem",
-                                :distribution_system_idref => "HVACDistribution",
-                                :heating_system_type => "Furnace",
-                                :heating_system_fuel => "natural gas",
-                                :heating_capacity => 64000,
-                                :heating_efficiency_afue => 0.92,
-                                :fraction_heat_load_served => 1 })
+    hpxml.heating_systems.add(:id => "HeatingSystem",
+                              :distribution_system_idref => "HVACDistribution",
+                              :heating_system_type => "Furnace",
+                              :heating_system_fuel => "natural gas",
+                              :heating_capacity => 64000,
+                              :heating_efficiency_afue => 0.92,
+                              :fraction_heat_load_served => 1)
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-air-to-air-heat-pump-var-speed.xml',
@@ -1638,49 +1638,49 @@ def set_hpxml_heating_systems(hpxml_file, hpxml)
     hpxml.heating_systems[0].heating_efficiency_afue = 1
     hpxml.heating_systems[0].fraction_heat_load_served = 0.1
     hpxml.heating_systems[0].heating_capacity *= 0.1
-    hpxml.heating_systems.add({ :id => "HeatingSystem2",
-                                :distribution_system_idref => "HVACDistribution2",
-                                :heating_system_type => "Boiler",
-                                :heating_system_fuel => "natural gas",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_afue => 0.92,
-                                :fraction_heat_load_served => 0.1,
-                                :electric_auxiliary_energy => 200 })
-    hpxml.heating_systems.add({ :id => "HeatingSystem3",
-                                :heating_system_type => "ElectricResistance",
-                                :heating_system_fuel => "electricity",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_percent => 1,
-                                :fraction_heat_load_served => 0.1 })
-    hpxml.heating_systems.add({ :id => "HeatingSystem4",
-                                :distribution_system_idref => "HVACDistribution3",
-                                :heating_system_type => "Furnace",
-                                :heating_system_fuel => "electricity",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_afue => 1,
-                                :fraction_heat_load_served => 0.1 })
-    hpxml.heating_systems.add({ :id => "HeatingSystem5",
-                                :distribution_system_idref => "HVACDistribution4",
-                                :heating_system_type => "Furnace",
-                                :heating_system_fuel => "natural gas",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_afue => 0.92,
-                                :fraction_heat_load_served => 0.1,
-                                :electric_auxiliary_energy => 700 })
-    hpxml.heating_systems.add({ :id => "HeatingSystem6",
-                                :heating_system_type => "Stove",
-                                :heating_system_fuel => "fuel oil",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_percent => 0.8,
-                                :fraction_heat_load_served => 0.1,
-                                :electric_auxiliary_energy => 200 })
-    hpxml.heating_systems.add({ :id => "HeatingSystem7",
-                                :heating_system_type => "WallFurnace",
-                                :heating_system_fuel => "propane",
-                                :heating_capacity => 6400,
-                                :heating_efficiency_afue => 0.8,
-                                :fraction_heat_load_served => 0.1,
-                                :electric_auxiliary_energy => 200 })
+    hpxml.heating_systems.add(:id => "HeatingSystem2",
+                              :distribution_system_idref => "HVACDistribution2",
+                              :heating_system_type => "Boiler",
+                              :heating_system_fuel => "natural gas",
+                              :heating_capacity => 6400,
+                              :heating_efficiency_afue => 0.92,
+                              :fraction_heat_load_served => 0.1,
+                              :electric_auxiliary_energy => 200)
+    hpxml.heating_systems.add(:id => "HeatingSystem3",
+                              :heating_system_type => "ElectricResistance",
+                              :heating_system_fuel => "electricity",
+                              :heating_capacity => 6400,
+                              :heating_efficiency_percent => 1,
+                              :fraction_heat_load_served => 0.1)
+    hpxml.heating_systems.add(:id => "HeatingSystem4",
+                              :distribution_system_idref => "HVACDistribution3",
+                              :heating_system_type => "Furnace",
+                              :heating_system_fuel => "electricity",
+                              :heating_capacity => 6400,
+                              :heating_efficiency_afue => 1,
+                              :fraction_heat_load_served => 0.1)
+    hpxml.heating_systems.add(:id => "HeatingSystem5",
+                              :distribution_system_idref => "HVACDistribution4",
+                              :heating_system_type => "Furnace",
+                              :heating_system_fuel => "natural gas",
+                              :heating_capacity => 6400,
+                              :heating_efficiency_afue => 0.92,
+                              :fraction_heat_load_served => 0.1,
+                              :electric_auxiliary_energy => 700)
+    hpxml.heating_systems.add(:id => "HeatingSystem6",
+                              :heating_system_type => "Stove",
+                              :heating_system_fuel => "fuel oil",
+                              :heating_capacity => 6400,
+                              :heating_efficiency_percent => 0.8,
+                              :fraction_heat_load_served => 0.1,
+                              :electric_auxiliary_energy => 200)
+    hpxml.heating_systems.add(:id => "HeatingSystem7",
+                              :heating_system_type => "WallFurnace",
+                              :heating_system_fuel => "propane",
+                              :heating_capacity => 6400,
+                              :heating_efficiency_afue => 0.8,
+                              :fraction_heat_load_served => 0.1,
+                              :electric_auxiliary_energy => 200)
   elsif ['invalid_files/hvac-frac-load-served.xml'].include? hpxml_file
     hpxml.heating_systems[0].fraction_heat_load_served += 0.1
   elsif ['base-hvac-portable-heater-electric-only.xml'].include? hpxml_file
@@ -1774,13 +1774,13 @@ end
 
 def set_hpxml_cooling_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.cooling_systems.add({ :id => "CoolingSystem",
-                                :distribution_system_idref => "HVACDistribution",
-                                :cooling_system_type => "central air conditioner",
-                                :cooling_system_fuel => "electricity",
-                                :cooling_capacity => 48000,
-                                :fraction_cool_load_served => 1,
-                                :cooling_efficiency_seer => 13 })
+    hpxml.cooling_systems.add(:id => "CoolingSystem",
+                              :distribution_system_idref => "HVACDistribution",
+                              :cooling_system_type => "central air conditioner",
+                              :cooling_system_fuel => "electricity",
+                              :cooling_capacity => 48000,
+                              :fraction_cool_load_served => 1,
+                              :cooling_efficiency_seer => 13)
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-air-to-air-heat-pump-var-speed.xml',
@@ -1848,12 +1848,12 @@ def set_hpxml_cooling_systems(hpxml_file, hpxml)
     hpxml.cooling_systems[0].distribution_system_idref = "HVACDistribution4"
     hpxml.cooling_systems[0].fraction_cool_load_served = 0.2
     hpxml.cooling_systems[0].cooling_capacity *= 0.2
-    hpxml.cooling_systems.add({ :id => "CoolingSystem2",
-                                :cooling_system_type => "room air conditioner",
-                                :cooling_system_fuel => "electricity",
-                                :cooling_capacity => 9600,
-                                :fraction_cool_load_served => 0.2,
-                                :cooling_efficiency_eer => 8.5 })
+    hpxml.cooling_systems.add(:id => "CoolingSystem2",
+                              :cooling_system_type => "room air conditioner",
+                              :cooling_system_fuel => "electricity",
+                              :cooling_capacity => 9600,
+                              :fraction_cool_load_served => 0.2,
+                              :cooling_efficiency_eer => 8.5)
   elsif ['invalid_files/hvac-frac-load-served.xml'].include? hpxml_file
     hpxml.cooling_systems[0].fraction_cool_load_served += 0.2
   elsif ['invalid_files/hvac-dse-multiple-attached-cooling.xml'].include? hpxml_file
@@ -1887,78 +1887,78 @@ end
 def set_hpxml_heat_pumps(hpxml_file, hpxml)
   if ['base-hvac-air-to-air-heat-pump-1-speed.xml',
       'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'].include? hpxml_file
-    hpxml.heat_pumps.add({ :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "air-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 42000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_hspf => 7.7,
-                           :cooling_efficiency_seer => 13 })
+    hpxml.heat_pumps.add(:id => "HeatPump",
+                         :distribution_system_idref => "HVACDistribution",
+                         :heat_pump_type => "air-to-air",
+                         :heat_pump_fuel => "electricity",
+                         :heating_capacity => 42000,
+                         :cooling_capacity => 48000,
+                         :backup_heating_fuel => "electricity",
+                         :backup_heating_capacity => 34121,
+                         :backup_heating_efficiency_percent => 1.0,
+                         :fraction_heat_load_served => 1,
+                         :fraction_cool_load_served => 1,
+                         :heating_efficiency_hspf => 7.7,
+                         :cooling_efficiency_seer => 13)
     if hpxml_file == 'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'
       hpxml.heat_pumps[0].fraction_cool_load_served = 0
     end
   elsif ['base-hvac-air-to-air-heat-pump-2-speed.xml'].include? hpxml_file
-    hpxml.heat_pumps.add({ :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "air-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 42000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_hspf => 9.3,
-                           :cooling_efficiency_seer => 18 })
+    hpxml.heat_pumps.add(:id => "HeatPump",
+                         :distribution_system_idref => "HVACDistribution",
+                         :heat_pump_type => "air-to-air",
+                         :heat_pump_fuel => "electricity",
+                         :heating_capacity => 42000,
+                         :cooling_capacity => 48000,
+                         :backup_heating_fuel => "electricity",
+                         :backup_heating_capacity => 34121,
+                         :backup_heating_efficiency_percent => 1.0,
+                         :fraction_heat_load_served => 1,
+                         :fraction_cool_load_served => 1,
+                         :heating_efficiency_hspf => 9.3,
+                         :cooling_efficiency_seer => 18)
   elsif ['base-hvac-air-to-air-heat-pump-var-speed.xml'].include? hpxml_file
-    hpxml.heat_pumps.add({ :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "air-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 42000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_hspf => 10,
-                           :cooling_efficiency_seer => 22 })
+    hpxml.heat_pumps.add(:id => "HeatPump",
+                         :distribution_system_idref => "HVACDistribution",
+                         :heat_pump_type => "air-to-air",
+                         :heat_pump_fuel => "electricity",
+                         :heating_capacity => 42000,
+                         :cooling_capacity => 48000,
+                         :backup_heating_fuel => "electricity",
+                         :backup_heating_capacity => 34121,
+                         :backup_heating_efficiency_percent => 1.0,
+                         :fraction_heat_load_served => 1,
+                         :fraction_cool_load_served => 1,
+                         :heating_efficiency_hspf => 10,
+                         :cooling_efficiency_seer => 22)
   elsif ['base-hvac-ground-to-air-heat-pump.xml'].include? hpxml_file
-    hpxml.heat_pumps.add({ :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "ground-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 42000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_cop => 3.6,
-                           :cooling_efficiency_eer => 16.6 })
+    hpxml.heat_pumps.add(:id => "HeatPump",
+                         :distribution_system_idref => "HVACDistribution",
+                         :heat_pump_type => "ground-to-air",
+                         :heat_pump_fuel => "electricity",
+                         :heating_capacity => 42000,
+                         :cooling_capacity => 48000,
+                         :backup_heating_fuel => "electricity",
+                         :backup_heating_capacity => 34121,
+                         :backup_heating_efficiency_percent => 1.0,
+                         :fraction_heat_load_served => 1,
+                         :fraction_cool_load_served => 1,
+                         :heating_efficiency_cop => 3.6,
+                         :cooling_efficiency_eer => 16.6)
   elsif ['base-hvac-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    hpxml.heat_pumps.add({ :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution",
-                           :heat_pump_type => "mini-split",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 52000,
-                           :cooling_capacity => 48000,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 34121,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 1,
-                           :fraction_cool_load_served => 1,
-                           :heating_efficiency_hspf => 10,
-                           :cooling_efficiency_seer => 19 })
+    hpxml.heat_pumps.add(:id => "HeatPump",
+                         :distribution_system_idref => "HVACDistribution",
+                         :heat_pump_type => "mini-split",
+                         :heat_pump_fuel => "electricity",
+                         :heating_capacity => 52000,
+                         :cooling_capacity => 48000,
+                         :backup_heating_fuel => "electricity",
+                         :backup_heating_capacity => 34121,
+                         :backup_heating_efficiency_percent => 1.0,
+                         :fraction_heat_load_served => 1,
+                         :fraction_cool_load_served => 1,
+                         :heating_efficiency_hspf => 10,
+                         :cooling_efficiency_seer => 19)
   elsif ['base-hvac-mini-split-heat-pump-ductless.xml'].include? hpxml_file
     hpxml.heat_pumps[0].distribution_system_idref = nil
   elsif ['base-hvac-mini-split-heat-pump-ductless-no-backup.xml'].include? hpxml_file
@@ -1992,44 +1992,44 @@ def set_hpxml_heat_pumps(hpxml_file, hpxml)
   elsif ['base-hvac-ground-to-air-heat-pump-detailed.xml'].include? hpxml_file
     hpxml.heat_pumps[0].cooling_shr = 0.7
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    hpxml.heat_pumps.add({ :id => "HeatPump",
-                           :distribution_system_idref => "HVACDistribution5",
-                           :heat_pump_type => "air-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 4800,
-                           :cooling_capacity => 4800,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 3412,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 0.1,
-                           :fraction_cool_load_served => 0.2,
-                           :heating_efficiency_hspf => 7.7,
-                           :cooling_efficiency_seer => 13 })
-    hpxml.heat_pumps.add({ :id => "HeatPump2",
-                           :distribution_system_idref => "HVACDistribution6",
-                           :heat_pump_type => "ground-to-air",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 4800,
-                           :cooling_capacity => 4800,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 3412,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 0.1,
-                           :fraction_cool_load_served => 0.2,
-                           :heating_efficiency_cop => 3.6,
-                           :cooling_efficiency_eer => 16.6 })
-    hpxml.heat_pumps.add({ :id => "HeatPump3",
-                           :heat_pump_type => "mini-split",
-                           :heat_pump_fuel => "electricity",
-                           :heating_capacity => 4800,
-                           :cooling_capacity => 4800,
-                           :backup_heating_fuel => "electricity",
-                           :backup_heating_capacity => 3412,
-                           :backup_heating_efficiency_percent => 1.0,
-                           :fraction_heat_load_served => 0.1,
-                           :fraction_cool_load_served => 0.2,
-                           :heating_efficiency_hspf => 10,
-                           :cooling_efficiency_seer => 19 })
+    hpxml.heat_pumps.add(:id => "HeatPump",
+                         :distribution_system_idref => "HVACDistribution5",
+                         :heat_pump_type => "air-to-air",
+                         :heat_pump_fuel => "electricity",
+                         :heating_capacity => 4800,
+                         :cooling_capacity => 4800,
+                         :backup_heating_fuel => "electricity",
+                         :backup_heating_capacity => 3412,
+                         :backup_heating_efficiency_percent => 1.0,
+                         :fraction_heat_load_served => 0.1,
+                         :fraction_cool_load_served => 0.2,
+                         :heating_efficiency_hspf => 7.7,
+                         :cooling_efficiency_seer => 13)
+    hpxml.heat_pumps.add(:id => "HeatPump2",
+                         :distribution_system_idref => "HVACDistribution6",
+                         :heat_pump_type => "ground-to-air",
+                         :heat_pump_fuel => "electricity",
+                         :heating_capacity => 4800,
+                         :cooling_capacity => 4800,
+                         :backup_heating_fuel => "electricity",
+                         :backup_heating_capacity => 3412,
+                         :backup_heating_efficiency_percent => 1.0,
+                         :fraction_heat_load_served => 0.1,
+                         :fraction_cool_load_served => 0.2,
+                         :heating_efficiency_cop => 3.6,
+                         :cooling_efficiency_eer => 16.6)
+    hpxml.heat_pumps.add(:id => "HeatPump3",
+                         :heat_pump_type => "mini-split",
+                         :heat_pump_fuel => "electricity",
+                         :heating_capacity => 4800,
+                         :cooling_capacity => 4800,
+                         :backup_heating_fuel => "electricity",
+                         :backup_heating_capacity => 3412,
+                         :backup_heating_efficiency_percent => 1.0,
+                         :fraction_heat_load_served => 0.1,
+                         :fraction_cool_load_served => 0.2,
+                         :heating_efficiency_hspf => 10,
+                         :cooling_efficiency_seer => 19)
   elsif ['invalid_files/hvac-distribution-multiple-attached-heating.xml'].include? hpxml_file
     hpxml.heat_pumps[0].distribution_system_idref = "HVACDistribution3"
   elsif ['invalid_files/hvac-distribution-multiple-attached-cooling.xml'].include? hpxml_file
@@ -2080,12 +2080,12 @@ end
 
 def set_hpxml_hvac_control(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_hvac_control({ :id => "HVACControl",
-                             :control_type => "manual thermostat",
-                             :heating_setpoint_temp => 68,
-                             :cooling_setpoint_temp => 78 })
+    hpxml.set_hvac_control(:id => "HVACControl",
+                           :control_type => "manual thermostat",
+                           :heating_setpoint_temp => 68,
+                           :cooling_setpoint_temp => 78)
   elsif ['base-hvac-none.xml'].include? hpxml_file
-    hpxml.set_hvac_control(nil)
+    hpxml.set_hvac_control()
   elsif ['base-hvac-programmable-thermostat.xml'].include? hpxml_file
     hpxml.hvac_control.control_type = "programmable thermostat"
     hpxml.hvac_control.heating_setback_temp = 66
@@ -2104,22 +2104,22 @@ end
 
 def set_hpxml_hvac_distributions(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.hvac_distributions.add({ :id => "HVACDistribution",
-                                   :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[0].duct_leakage_measurements.add({ :duct_type => "supply",
-                                                                :duct_leakage_units => "CFM25",
-                                                                :duct_leakage_value => 75 })
-    hpxml.hvac_distributions[0].duct_leakage_measurements.add({ :duct_type => "return",
-                                                                :duct_leakage_units => "CFM25",
-                                                                :duct_leakage_value => 25 })
-    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "supply",
-                                            :duct_insulation_r_value => 4,
-                                            :duct_location => "attic - unvented",
-                                            :duct_surface_area => 150 })
-    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "return",
-                                            :duct_insulation_r_value => 0,
-                                            :duct_location => "attic - unvented",
-                                            :duct_surface_area => 50 })
+    hpxml.hvac_distributions.add(:id => "HVACDistribution",
+                                 :distribution_system_type => "AirDistribution")
+    hpxml.hvac_distributions[0].duct_leakage_measurements.add(:duct_type => "supply",
+                                                              :duct_leakage_units => "CFM25",
+                                                              :duct_leakage_value => 75)
+    hpxml.hvac_distributions[0].duct_leakage_measurements.add(:duct_type => "return",
+                                                              :duct_leakage_units => "CFM25",
+                                                              :duct_leakage_value => 25)
+    hpxml.hvac_distributions[0].ducts.add(:duct_type => "supply",
+                                          :duct_insulation_r_value => 4,
+                                          :duct_location => "attic - unvented",
+                                          :duct_surface_area => 150)
+    hpxml.hvac_distributions[0].ducts.add(:duct_type => "return",
+                                          :duct_insulation_r_value => 0,
+                                          :duct_location => "attic - unvented",
+                                          :duct_surface_area => 50)
   elsif ['base-hvac-boiler-elec-only.xml',
          'base-hvac-boiler-gas-only.xml',
          'base-hvac-boiler-oil-only.xml',
@@ -2132,22 +2132,22 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
     hpxml.hvac_distributions[0].distribution_system_type = "HydronicDistribution"
     hpxml.hvac_distributions[0].duct_leakage_measurements.clear
     hpxml.hvac_distributions[0].ducts.clear
-    hpxml.hvac_distributions.add({ :id => "HVACDistribution2",
-                                   :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 75 })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 25 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
-                                             :duct_insulation_r_value => 4,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 150 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
-                                             :duct_insulation_r_value => 0,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 50 })
+    hpxml.hvac_distributions.add(:id => "HVACDistribution2",
+                                 :distribution_system_type => "AirDistribution")
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "supply",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 75)
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "return",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 25)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "supply",
+                                           :duct_insulation_r_value => 4,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 150)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "return",
+                                           :duct_insulation_r_value => 0,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 50)
   elsif ['base-hvac-none.xml',
          'base-hvac-elec-resistance-only.xml',
          'base-hvac-evap-cooler-only.xml',
@@ -2164,72 +2164,72 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
     hpxml.hvac_distributions[0].distribution_system_type = "HydronicDistribution"
     hpxml.hvac_distributions[0].duct_leakage_measurements.clear
     hpxml.hvac_distributions[0].ducts.clear
-    hpxml.hvac_distributions.add({ :id => "HVACDistribution2",
-                                   :distribution_system_type => "HydronicDistribution" })
-    hpxml.hvac_distributions.add({ :id => "HVACDistribution3",
-                                   :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 75 })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 25 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
-                                             :duct_insulation_r_value => 4,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 150 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
-                                             :duct_insulation_r_value => 0,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 50 })
-    hpxml.hvac_distributions.add({ :id => "HVACDistribution4",
-                                   :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 75 })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 25 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
-                                             :duct_insulation_r_value => 4,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 150 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
-                                             :duct_insulation_r_value => 0,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 50 })
-    hpxml.hvac_distributions.add({ :id => "HVACDistribution5",
-                                   :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 75 })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 25 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
-                                             :duct_insulation_r_value => 4,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 150 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
-                                             :duct_insulation_r_value => 0,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 50 })
-    hpxml.hvac_distributions.add({ :id => "HVACDistribution6",
-                                   :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 75 })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
-                                                                 :duct_leakage_units => "CFM25",
-                                                                 :duct_leakage_value => 25 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
-                                             :duct_insulation_r_value => 4,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 150 })
-    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
-                                             :duct_insulation_r_value => 0,
-                                             :duct_location => "attic - unvented",
-                                             :duct_surface_area => 50 })
+    hpxml.hvac_distributions.add(:id => "HVACDistribution2",
+                                 :distribution_system_type => "HydronicDistribution")
+    hpxml.hvac_distributions.add(:id => "HVACDistribution3",
+                                 :distribution_system_type => "AirDistribution")
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "supply",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 75)
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "return",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 25)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "supply",
+                                           :duct_insulation_r_value => 4,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 150)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "return",
+                                           :duct_insulation_r_value => 0,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 50)
+    hpxml.hvac_distributions.add(:id => "HVACDistribution4",
+                                 :distribution_system_type => "AirDistribution")
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "supply",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 75)
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "return",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 25)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "supply",
+                                           :duct_insulation_r_value => 4,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 150)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "return",
+                                           :duct_insulation_r_value => 0,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 50)
+    hpxml.hvac_distributions.add(:id => "HVACDistribution5",
+                                 :distribution_system_type => "AirDistribution")
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "supply",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 75)
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "return",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 25)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "supply",
+                                           :duct_insulation_r_value => 4,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 150)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "return",
+                                           :duct_insulation_r_value => 0,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 50)
+    hpxml.hvac_distributions.add(:id => "HVACDistribution6",
+                                 :distribution_system_type => "AirDistribution")
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "supply",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 75)
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add(:duct_type => "return",
+                                                               :duct_leakage_units => "CFM25",
+                                                               :duct_leakage_value => 25)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "supply",
+                                           :duct_insulation_r_value => 4,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 150)
+    hpxml.hvac_distributions[-1].ducts.add(:duct_type => "return",
+                                           :duct_insulation_r_value => 0,
+                                           :duct_location => "attic - unvented",
+                                           :duct_surface_area => 50)
   elsif ['base-hvac-dse.xml',
          'base-dhw-indirect-dse.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].distribution_system_type = "DSE"
@@ -2256,12 +2256,12 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
     hpxml.hvac_distributions[0].ducts.pop
   elsif ['base-hvac-ducts-leakage-percent.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].duct_leakage_measurements.clear
-    hpxml.hvac_distributions[0].duct_leakage_measurements.add({ :duct_type => "supply",
-                                                                :duct_leakage_units => "Percent",
-                                                                :duct_leakage_value => 0.1 })
-    hpxml.hvac_distributions[0].duct_leakage_measurements.add({ :duct_type => "return",
-                                                                :duct_leakage_units => "Percent",
-                                                                :duct_leakage_value => 0.05 })
+    hpxml.hvac_distributions[0].duct_leakage_measurements.add(:duct_type => "supply",
+                                                              :duct_leakage_units => "Percent",
+                                                              :duct_leakage_value => 0.1)
+    hpxml.hvac_distributions[0].duct_leakage_measurements.add(:duct_type => "return",
+                                                              :duct_leakage_units => "Percent",
+                                                              :duct_leakage_value => 0.05)
   elsif ['base-hvac-undersized.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value /= 10.0
     hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value /= 10.0
@@ -2295,22 +2295,22 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
   elsif ['base-hvac-ducts-locations.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].ducts[1].duct_location = "attic - unvented"
   elsif ['base-hvac-ducts-multiple.xml'].include? hpxml_file
-    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "supply",
-                                            :duct_insulation_r_value => 8,
-                                            :duct_location => "attic - unvented",
-                                            :duct_surface_area => 300 })
-    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "supply",
-                                            :duct_insulation_r_value => 8,
-                                            :duct_location => "outside",
-                                            :duct_surface_area => 300 })
-    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "return",
-                                            :duct_insulation_r_value => 4,
-                                            :duct_location => "attic - unvented",
-                                            :duct_surface_area => 100 })
-    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "return",
-                                            :duct_insulation_r_value => 4,
-                                            :duct_location => "outside",
-                                            :duct_surface_area => 100 })
+    hpxml.hvac_distributions[0].ducts.add(:duct_type => "supply",
+                                          :duct_insulation_r_value => 8,
+                                          :duct_location => "attic - unvented",
+                                          :duct_surface_area => 300)
+    hpxml.hvac_distributions[0].ducts.add(:duct_type => "supply",
+                                          :duct_insulation_r_value => 8,
+                                          :duct_location => "outside",
+                                          :duct_surface_area => 300)
+    hpxml.hvac_distributions[0].ducts.add(:duct_type => "return",
+                                          :duct_insulation_r_value => 4,
+                                          :duct_location => "attic - unvented",
+                                          :duct_surface_area => 100)
+    hpxml.hvac_distributions[0].ducts.add(:duct_type => "return",
+                                          :duct_insulation_r_value => 4,
+                                          :duct_location => "outside",
+                                          :duct_surface_area => 100)
   elsif ['base-atticroof-conditioned.xml',
          'base-enclosure-adiabatic-surfaces.xml',
          'base-atticroof-cathedral.xml',
@@ -2344,147 +2344,147 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
     hpxml.hvac_distributions << hpxml.hvac_distributions[0].dup
     hpxml.hvac_distributions[2].id = "HVACDistribution3"
   elsif ['invalid_files/hvac-invalid-distribution-system-type.xml'].include? hpxml_file
-    hpxml.hvac_distributions.add({ :id => "HVACDistribution2",
-                                   :distribution_system_type => "HydronicDistribution" })
+    hpxml.hvac_distributions.add(:id => "HVACDistribution2",
+                                 :distribution_system_type => "HydronicDistribution")
   elsif ['invalid_files/hvac-distribution-return-duct-leakage-missing.xml'].include? hpxml_file
-    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "return",
-                                                           :duct_insulation_r_value => 0,
-                                                           :duct_location => "attic - unvented",
-                                                           :duct_surface_area => 50 })
+    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new(:duct_type => "return",
+                                                         :duct_insulation_r_value => 0,
+                                                         :duct_location => "attic - unvented",
+                                                         :duct_surface_area => 50)
   end
 end
 
 def set_hpxml_ventilation_fans(hpxml_file, hpxml)
   if ['base-mechvent-balanced.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "balanced",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "balanced",
+                               :tested_flow_rate => 110,
+                               :hours_in_operation => 24,
+                               :fan_power => 60,
+                               :used_for_whole_building_ventilation => true)
   elsif ['invalid_files/unattached-cfis.xml',
          'invalid_files/cfis-with-hydronic-distribution.xml',
          'base-mechvent-cfis.xml',
          'base-mechvent-cfis-evap-cooler-only-ducted.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "central fan integrated supply",
-                                 :tested_flow_rate => 330,
-                                 :hours_in_operation => 8,
-                                 :fan_power => 300,
-                                 :used_for_whole_building_ventilation => true,
-                                 :distribution_system_idref => "HVACDistribution" })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "central fan integrated supply",
+                               :tested_flow_rate => 330,
+                               :hours_in_operation => 8,
+                               :fan_power => 300,
+                               :used_for_whole_building_ventilation => true,
+                               :distribution_system_idref => "HVACDistribution")
     if ['invalid_files/unattached-cfis.xml'].include? hpxml_file
       hpxml.ventilation_fans[0].distribution_system_idref = "foobar"
     end
   elsif ['base-mechvent-erv.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "energy recovery ventilator",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :total_recovery_efficiency => 0.48,
-                                 :sensible_recovery_efficiency => 0.72,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "energy recovery ventilator",
+                               :tested_flow_rate => 110,
+                               :hours_in_operation => 24,
+                               :total_recovery_efficiency => 0.48,
+                               :sensible_recovery_efficiency => 0.72,
+                               :fan_power => 60,
+                               :used_for_whole_building_ventilation => true)
   elsif ['base-mechvent-erv-atre-asre.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "energy recovery ventilator",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :total_recovery_efficiency_adjusted => 0.526,
-                                 :sensible_recovery_efficiency_adjusted => 0.79,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "energy recovery ventilator",
+                               :tested_flow_rate => 110,
+                               :hours_in_operation => 24,
+                               :total_recovery_efficiency_adjusted => 0.526,
+                               :sensible_recovery_efficiency_adjusted => 0.79,
+                               :fan_power => 60,
+                               :used_for_whole_building_ventilation => true)
   elsif ['base-mechvent-exhaust.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "exhaust only",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :fan_power => 30,
-                                 :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "exhaust only",
+                               :tested_flow_rate => 110,
+                               :hours_in_operation => 24,
+                               :fan_power => 30,
+                               :used_for_whole_building_ventilation => true)
   elsif ['base-mechvent-exhaust-rated-flow-rate.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "exhaust only",
-                                 :rated_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :fan_power => 30,
-                                 :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "exhaust only",
+                               :rated_flow_rate => 110,
+                               :hours_in_operation => 24,
+                               :fan_power => 30,
+                               :used_for_whole_building_ventilation => true)
   elsif ['base-mechvent-hrv.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "heat recovery ventilator",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :sensible_recovery_efficiency => 0.72,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "heat recovery ventilator",
+                               :tested_flow_rate => 110,
+                               :hours_in_operation => 24,
+                               :sensible_recovery_efficiency => 0.72,
+                               :fan_power => 60,
+                               :used_for_whole_building_ventilation => true)
   elsif ['base-mechvent-hrv-asre.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "heat recovery ventilator",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :sensible_recovery_efficiency_adjusted => 0.790,
-                                 :fan_power => 60,
-                                 :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "heat recovery ventilator",
+                               :tested_flow_rate => 110,
+                               :hours_in_operation => 24,
+                               :sensible_recovery_efficiency_adjusted => 0.790,
+                               :fan_power => 60,
+                               :used_for_whole_building_ventilation => true)
   elsif ['base-mechvent-supply.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
-                                 :fan_type => "supply only",
-                                 :tested_flow_rate => 110,
-                                 :hours_in_operation => 24,
-                                 :fan_power => 30,
-                                 :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add(:id => "MechanicalVentilation",
+                               :fan_type => "supply only",
+                               :tested_flow_rate => 110,
+                               :hours_in_operation => 24,
+                               :fan_power => 30,
+                               :used_for_whole_building_ventilation => true)
   elsif ['base-misc-whole-house-fan.xml'].include? hpxml_file
-    hpxml.ventilation_fans.add({ :id => "WholeHouseFan",
-                                 :rated_flow_rate => 4500,
-                                 :fan_power => 300,
-                                 :used_for_seasonal_cooling_load_reduction => true })
+    hpxml.ventilation_fans.add(:id => "WholeHouseFan",
+                               :rated_flow_rate => 4500,
+                               :fan_power => 300,
+                               :used_for_seasonal_cooling_load_reduction => true)
   end
 end
 
 def set_hpxml_water_heating_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.water_heating_systems.add({ :id => "WaterHeater",
-                                      :fuel_type => "electricity",
-                                      :water_heater_type => "storage water heater",
-                                      :location => "living space",
-                                      :tank_volume => 40,
-                                      :fraction_dhw_load_served => 1,
-                                      :heating_capacity => 18767,
-                                      :energy_factor => 0.95 })
+    hpxml.water_heating_systems.add(:id => "WaterHeater",
+                                    :fuel_type => "electricity",
+                                    :water_heater_type => "storage water heater",
+                                    :location => "living space",
+                                    :tank_volume => 40,
+                                    :fraction_dhw_load_served => 1,
+                                    :heating_capacity => 18767,
+                                    :energy_factor => 0.95)
   elsif ['base-dhw-multiple.xml'].include? hpxml_file
     hpxml.water_heating_systems[0].fraction_dhw_load_served = 0.2
-    hpxml.water_heating_systems.add({ :id => "WaterHeater2",
-                                      :fuel_type => "natural gas",
-                                      :water_heater_type => "storage water heater",
-                                      :location => "living space",
-                                      :tank_volume => 50,
-                                      :fraction_dhw_load_served => 0.2,
-                                      :heating_capacity => 40000,
-                                      :energy_factor => 0.59,
-                                      :recovery_efficiency => 0.76 })
-    hpxml.water_heating_systems.add({ :id => "WaterHeater3",
-                                      :fuel_type => "electricity",
-                                      :water_heater_type => "heat pump water heater",
-                                      :location => "living space",
-                                      :tank_volume => 80,
-                                      :fraction_dhw_load_served => 0.2,
-                                      :energy_factor => 2.3 })
-    hpxml.water_heating_systems.add({ :id => "WaterHeater4",
-                                      :fuel_type => "electricity",
-                                      :water_heater_type => "instantaneous water heater",
-                                      :location => "living space",
-                                      :fraction_dhw_load_served => 0.2,
-                                      :energy_factor => 0.99 })
-    hpxml.water_heating_systems.add({ :id => "WaterHeater5",
-                                      :fuel_type => "natural gas",
-                                      :water_heater_type => "instantaneous water heater",
-                                      :location => "living space",
-                                      :fraction_dhw_load_served => 0.1,
-                                      :energy_factor => 0.82 })
-    hpxml.water_heating_systems.add({ :id => "WaterHeater6",
-                                      :water_heater_type => "space-heating boiler with storage tank",
-                                      :location => "living space",
-                                      :tank_volume => 50,
-                                      :fraction_dhw_load_served => 0.1,
-                                      :related_hvac => "HeatingSystem" })
+    hpxml.water_heating_systems.add(:id => "WaterHeater2",
+                                    :fuel_type => "natural gas",
+                                    :water_heater_type => "storage water heater",
+                                    :location => "living space",
+                                    :tank_volume => 50,
+                                    :fraction_dhw_load_served => 0.2,
+                                    :heating_capacity => 40000,
+                                    :energy_factor => 0.59,
+                                    :recovery_efficiency => 0.76)
+    hpxml.water_heating_systems.add(:id => "WaterHeater3",
+                                    :fuel_type => "electricity",
+                                    :water_heater_type => "heat pump water heater",
+                                    :location => "living space",
+                                    :tank_volume => 80,
+                                    :fraction_dhw_load_served => 0.2,
+                                    :energy_factor => 2.3)
+    hpxml.water_heating_systems.add(:id => "WaterHeater4",
+                                    :fuel_type => "electricity",
+                                    :water_heater_type => "instantaneous water heater",
+                                    :location => "living space",
+                                    :fraction_dhw_load_served => 0.2,
+                                    :energy_factor => 0.99)
+    hpxml.water_heating_systems.add(:id => "WaterHeater5",
+                                    :fuel_type => "natural gas",
+                                    :water_heater_type => "instantaneous water heater",
+                                    :location => "living space",
+                                    :fraction_dhw_load_served => 0.1,
+                                    :energy_factor => 0.82)
+    hpxml.water_heating_systems.add(:id => "WaterHeater6",
+                                    :water_heater_type => "space-heating boiler with storage tank",
+                                    :location => "living space",
+                                    :tank_volume => 50,
+                                    :fraction_dhw_load_served => 0.1,
+                                    :related_hvac => "HeatingSystem")
   elsif ['invalid_files/dhw-frac-load-served.xml'].include? hpxml_file
     hpxml.water_heating_systems[0].fraction_dhw_load_served += 0.15
   elsif ['base-dhw-tank-gas.xml',
@@ -2646,10 +2646,10 @@ end
 
 def set_hpxml_hot_water_distribution(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_hot_water_distribution({ :id => "HotWaterDstribution",
-                                       :system_type => "Standard",
-                                       :standard_piping_length => 50, # Chosen to test a negative EC_adj
-                                       :pipe_r_value => 0.0 })
+    hpxml.set_hot_water_distribution(:id => "HotWaterDstribution",
+                                     :system_type => "Standard",
+                                     :standard_piping_length => 50, # Chosen to test a negative EC_adj
+                                     :pipe_r_value => 0.0)
   elsif ['base-dhw-dwhr.xml'].include? hpxml_file
     hpxml.hot_water_distribution.dwhr_facilities_connected = "all"
     hpxml.hot_water_distribution.dwhr_equal_flow = true
@@ -2687,18 +2687,18 @@ def set_hpxml_hot_water_distribution(hpxml_file, hpxml)
     hpxml.hot_water_distribution.recirculation_branch_piping_length = 50
     hpxml.hot_water_distribution.recirculation_pump_power = 50
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hpxml.set_hot_water_distribution(nil)
+    hpxml.set_hot_water_distribution()
   end
 end
 
 def set_hpxml_water_fixtures(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.water_fixtures.add({ :id => "WaterFixture",
-                               :water_fixture_type => "shower head",
-                               :low_flow => true })
-    hpxml.water_fixtures.add({ :id => "WaterFixture2",
-                               :water_fixture_type => "faucet",
-                               :low_flow => false })
+    hpxml.water_fixtures.add(:id => "WaterFixture",
+                             :water_fixture_type => "shower head",
+                             :low_flow => true)
+    hpxml.water_fixtures.add(:id => "WaterFixture2",
+                             :water_fixture_type => "faucet",
+                             :low_flow => false)
   elsif ['base-dhw-low-flow-fixtures.xml'].include? hpxml_file
     hpxml.water_fixtures[1].low_flow = true
   elsif ['base-dhw-none.xml'].include? hpxml_file
@@ -2714,25 +2714,25 @@ def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
       'invalid_files/solar-thermal-system-with-combi-tankless.xml',
       'invalid_files/solar-thermal-system-with-desuperheater.xml',
       'invalid_files/solar-thermal-system-with-dhw-indirect.xml'].include? hpxml_file
-    hpxml.set_solar_thermal_system({ :id => "SolarThermalSystem",
-                                     :system_type => "hot water",
-                                     :water_heating_system_idref => "WaterHeater",
-                                     :solar_fraction => 0.65 })
+    hpxml.set_solar_thermal_system(:id => "SolarThermalSystem",
+                                   :system_type => "hot water",
+                                   :water_heating_system_idref => "WaterHeater",
+                                   :solar_fraction => 0.65)
   elsif ['base-dhw-solar-direct-flat-plate.xml',
          'base-dhw-solar-indirect-flat-plate.xml',
          'base-dhw-solar-thermosyphon-flat-plate.xml',
          'base-dhw-tank-heat-pump-with-solar.xml',
          'base-dhw-tankless-gas-with-solar.xml'].include? hpxml_file
-    hpxml.set_solar_thermal_system({ :id => "SolarThermalSystem",
-                                     :system_type => "hot water",
-                                     :collector_area => 40,
-                                     :collector_type => "single glazing black",
-                                     :collector_azimuth => 180,
-                                     :collector_tilt => 20,
-                                     :collector_frta => 0.77,
-                                     :collector_frul => 0.793,
-                                     :storage_volume => 60,
-                                     :water_heating_system_idref => "WaterHeater" })
+    hpxml.set_solar_thermal_system(:id => "SolarThermalSystem",
+                                   :system_type => "hot water",
+                                   :collector_area => 40,
+                                   :collector_type => "single glazing black",
+                                   :collector_azimuth => 180,
+                                   :collector_tilt => 20,
+                                   :collector_frta => 0.77,
+                                   :collector_frul => 0.793,
+                                   :storage_volume => 60,
+                                   :water_heating_system_idref => "WaterHeater")
     if hpxml_file == 'base-dhw-solar-direct-flat-plate.xml'
       hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-flat-plate.xml'
@@ -2743,16 +2743,16 @@ def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
   elsif ['base-dhw-solar-indirect-evacuated-tube.xml',
          'base-dhw-solar-direct-evacuated-tube.xml',
          'base-dhw-solar-thermosyphon-evacuated-tube.xml'].include? hpxml_file
-    hpxml.set_solar_thermal_system({ :id => "SolarThermalSystem",
-                                     :system_type => "hot water",
-                                     :collector_area => 40,
-                                     :collector_type => "evacuated tube",
-                                     :collector_azimuth => 180,
-                                     :collector_tilt => 20,
-                                     :collector_frta => 0.50,
-                                     :collector_frul => 0.2799,
-                                     :storage_volume => 60,
-                                     :water_heating_system_idref => "WaterHeater" })
+    hpxml.set_solar_thermal_system(:id => "SolarThermalSystem",
+                                   :system_type => "hot water",
+                                   :collector_area => 40,
+                                   :collector_type => "evacuated tube",
+                                   :collector_azimuth => 180,
+                                   :collector_tilt => 20,
+                                   :collector_frta => 0.50,
+                                   :collector_frul => 0.2799,
+                                   :storage_volume => 60,
+                                   :water_heating_system_idref => "WaterHeater")
     if hpxml_file == 'base-dhw-solar-direct-evacuated-tube.xml'
       hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-evacuated-tube.xml'
@@ -2762,16 +2762,16 @@ def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
     end
   elsif ['base-dhw-solar-direct-ics.xml',
          'base-dhw-solar-thermosyphon-ics.xml'].include? hpxml_file
-    hpxml.set_solar_thermal_system({ :id => "SolarThermalSystem",
-                                     :system_type => "hot water",
-                                     :collector_area => 40,
-                                     :collector_type => "integrated collector storage",
-                                     :collector_azimuth => 180,
-                                     :collector_tilt => 20,
-                                     :collector_frta => 0.77,
-                                     :collector_frul => 0.793,
-                                     :storage_volume => 60,
-                                     :water_heating_system_idref => "WaterHeater" })
+    hpxml.set_solar_thermal_system(:id => "SolarThermalSystem",
+                                   :system_type => "hot water",
+                                   :collector_area => 40,
+                                   :collector_type => "integrated collector storage",
+                                   :collector_azimuth => 180,
+                                   :collector_tilt => 20,
+                                   :collector_frta => 0.77,
+                                   :collector_frul => 0.793,
+                                   :storage_volume => 60,
+                                   :water_heating_system_idref => "WaterHeater")
     if hpxml_file == 'base-dhw-solar-direct-ics.xml'
       hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-ics.xml'
@@ -2784,39 +2784,39 @@ end
 
 def set_hpxml_pv_systems(hpxml_file, hpxml)
   if ['base-pv.xml'].include? hpxml_file
-    hpxml.pv_systems.add({ :id => "PVSystem",
-                           :module_type => "standard",
-                           :location => "roof",
-                           :tracking => "fixed",
-                           :array_azimuth => 180,
-                           :array_tilt => 20,
-                           :max_power_output => 4000,
-                           :inverter_efficiency => 0.96,
-                           :system_losses_fraction => 0.14 })
-    hpxml.pv_systems.add({ :id => "PVSystem2",
-                           :module_type => "premium",
-                           :location => "roof",
-                           :tracking => "fixed",
-                           :array_azimuth => 90,
-                           :array_tilt => 20,
-                           :max_power_output => 1500,
-                           :inverter_efficiency => 0.96,
-                           :system_losses_fraction => 0.14 })
+    hpxml.pv_systems.add(:id => "PVSystem",
+                         :module_type => "standard",
+                         :location => "roof",
+                         :tracking => "fixed",
+                         :array_azimuth => 180,
+                         :array_tilt => 20,
+                         :max_power_output => 4000,
+                         :inverter_efficiency => 0.96,
+                         :system_losses_fraction => 0.14)
+    hpxml.pv_systems.add(:id => "PVSystem2",
+                         :module_type => "premium",
+                         :location => "roof",
+                         :tracking => "fixed",
+                         :array_azimuth => 90,
+                         :array_tilt => 20,
+                         :max_power_output => 1500,
+                         :inverter_efficiency => 0.96,
+                         :system_losses_fraction => 0.14)
   end
 end
 
 def set_hpxml_clothes_washer(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_clothes_washer({ :id => "ClothesWasher",
-                               :location => "living space",
-                               :modified_energy_factor => 0.8,
-                               :rated_annual_kwh => 700.0,
-                               :label_electric_rate => 0.10,
-                               :label_gas_rate => 0.60,
-                               :label_annual_gas_cost => 25.0,
-                               :capacity => 3.0 })
+    hpxml.set_clothes_washer(:id => "ClothesWasher",
+                             :location => "living space",
+                             :modified_energy_factor => 0.8,
+                             :rated_annual_kwh => 700.0,
+                             :label_electric_rate => 0.10,
+                             :label_gas_rate => 0.60,
+                             :label_annual_gas_cost => 25.0,
+                             :capacity => 3.0)
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_clothes_washer(nil)
+    hpxml.set_clothes_washer()
   elsif ['base-appliances-modified.xml'].include? hpxml_file
     hpxml.clothes_washer.modified_energy_factor = nil
     hpxml.clothes_washer.integrated_modified_energy_factor = 0.73
@@ -2834,26 +2834,26 @@ end
 
 def set_hpxml_clothes_dryer(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_clothes_dryer({ :id => "ClothesDryer",
-                              :location => "living space",
-                              :fuel_type => "electricity",
-                              :energy_factor => 2.95,
-                              :control_type => "timer" })
+    hpxml.set_clothes_dryer(:id => "ClothesDryer",
+                            :location => "living space",
+                            :fuel_type => "electricity",
+                            :energy_factor => 2.95,
+                            :control_type => "timer")
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_clothes_dryer(nil)
+    hpxml.set_clothes_dryer()
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    hpxml.set_clothes_dryer({ :id => "ClothesDryer",
-                              :location => "living space",
-                              :fuel_type => "electricity",
-                              :combined_energy_factor => 2.62,
-                              :control_type => "moisture" })
+    hpxml.set_clothes_dryer(:id => "ClothesDryer",
+                            :location => "living space",
+                            :fuel_type => "electricity",
+                            :combined_energy_factor => 2.62,
+                            :control_type => "moisture")
   elsif ['base-appliances-gas.xml',
          'base-appliances-propane.xml',
          'base-appliances-oil.xml'].include? hpxml_file
-    hpxml.set_clothes_dryer({ :id => "ClothesDryer",
-                              :location => "living space",
-                              :energy_factor => 2.67,
-                              :control_type => "moisture" })
+    hpxml.set_clothes_dryer(:id => "ClothesDryer",
+                            :location => "living space",
+                            :energy_factor => 2.67,
+                            :control_type => "moisture")
     if hpxml_file == 'base-appliances-gas.xml'
       hpxml.clothes_dryer.fuel_type = "natural gas"
     elsif hpxml_file == 'base-appliances-propane.xml'
@@ -2862,11 +2862,11 @@ def set_hpxml_clothes_dryer(hpxml_file, hpxml)
       hpxml.clothes_dryer.fuel_type = "fuel oil"
     end
   elsif ['base-appliances-wood.xml'].include? hpxml_file
-    hpxml.set_clothes_dryer({ :id => "ClothesDryer",
-                              :location => "living space",
-                              :fuel_type => "wood",
-                              :energy_factor => 2.67,
-                              :control_type => "moisture" })
+    hpxml.set_clothes_dryer(:id => "ClothesDryer",
+                            :location => "living space",
+                            :fuel_type => "wood",
+                            :energy_factor => 2.67,
+                            :control_type => "moisture")
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     hpxml.clothes_dryer.location = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
@@ -2881,27 +2881,27 @@ end
 
 def set_hpxml_dishwasher(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_dishwasher({ :id => "Dishwasher",
-                           :rated_annual_kwh => 450,
-                           :place_setting_capacity => 12 })
+    hpxml.set_dishwasher(:id => "Dishwasher",
+                         :rated_annual_kwh => 450,
+                         :place_setting_capacity => 12)
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_dishwasher(nil)
+    hpxml.set_dishwasher()
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    hpxml.set_dishwasher({ :id => "Dishwasher",
-                           :energy_factor => 0.5,
-                           :place_setting_capacity => 12 })
+    hpxml.set_dishwasher(:id => "Dishwasher",
+                         :energy_factor => 0.5,
+                         :place_setting_capacity => 12)
   end
 end
 
 def set_hpxml_refrigerator(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_refrigerator({ :id => "Refrigerator",
-                             :location => "living space",
-                             :rated_annual_kwh => 650 })
+    hpxml.set_refrigerator(:id => "Refrigerator",
+                           :location => "living space",
+                           :rated_annual_kwh => 650)
   elsif ['base-appliances-modified.xml'].include? hpxml_file
     hpxml.refrigerator.adjusted_annual_kwh = 600
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_refrigerator(nil)
+    hpxml.set_refrigerator()
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     hpxml.refrigerator.location = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
@@ -2916,11 +2916,11 @@ end
 
 def set_hpxml_cooking_range(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_cooking_range({ :id => "Range",
-                              :fuel_type => "electricity",
-                              :is_induction => false })
+    hpxml.set_cooking_range(:id => "Range",
+                            :fuel_type => "electricity",
+                            :is_induction => false)
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_cooking_range(nil)
+    hpxml.set_cooking_range()
   elsif ['base-appliances-gas.xml'].include? hpxml_file
     hpxml.cooking_range.fuel_type = "natural gas"
     hpxml.cooking_range.is_induction = false
@@ -2937,58 +2937,58 @@ end
 
 def set_hpxml_oven(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_oven({ :id => "Oven",
-                     :is_convection => false })
+    hpxml.set_oven(:id => "Oven",
+                   :is_convection => false)
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_oven(nil)
+    hpxml.set_oven()
   end
 end
 
 def set_hpxml_lighting(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.set_lighting({ :fraction_tier_i_interior => 0.5,
-                         :fraction_tier_i_exterior => 0.5,
-                         :fraction_tier_i_garage => 0.5,
-                         :fraction_tier_ii_interior => 0.25,
-                         :fraction_tier_ii_exterior => 0.25,
-                         :fraction_tier_ii_garage => 0.25 })
+    hpxml.set_lighting(:fraction_tier_i_interior => 0.5,
+                       :fraction_tier_i_exterior => 0.5,
+                       :fraction_tier_i_garage => 0.5,
+                       :fraction_tier_ii_interior => 0.25,
+                       :fraction_tier_ii_exterior => 0.25,
+                       :fraction_tier_ii_garage => 0.25)
   elsif ['base-misc-lighting-none.xml'].include? hpxml_file
-    hpxml.set_lighting(nil)
+    hpxml.set_lighting()
   end
 end
 
 def set_hpxml_ceiling_fans(hpxml_file, hpxml)
   if ['base-misc-ceiling-fans.xml'].include? hpxml_file
-    hpxml.ceiling_fans.add({ :id => "CeilingFan",
-                             :efficiency => 100,
-                             :quantity => 2 })
+    hpxml.ceiling_fans.add(:id => "CeilingFan",
+                           :efficiency => 100,
+                           :quantity => 2)
   end
 end
 
 def set_hpxml_plug_loads(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.plug_loads.add({ :id => "PlugLoadMisc",
-                           :plug_load_type => "other" })
-    hpxml.plug_loads.add({ :id => "PlugLoadMisc2",
-                           :plug_load_type => "TV other" })
+    hpxml.plug_loads.add(:id => "PlugLoadMisc",
+                         :plug_load_type => "other")
+    hpxml.plug_loads.add(:id => "PlugLoadMisc2",
+                         :plug_load_type => "TV other")
   elsif ['base-misc-loads-detailed.xml'].include? hpxml_file
     hpxml.plug_loads.clear
-    hpxml.plug_loads.add({ :id => "PlugLoadMisc",
-                           :plug_load_type => "other",
-                           :kWh_per_year => 7302,
-                           :frac_sensible => 0.82,
-                           :frac_latent => 0.18 })
-    hpxml.plug_loads.add({ :id => "PlugLoadMisc2",
-                           :plug_load_type => "TV other",
-                           :kWh_per_year => 400 })
+    hpxml.plug_loads.add(:id => "PlugLoadMisc",
+                         :plug_load_type => "other",
+                         :kWh_per_year => 7302,
+                         :frac_sensible => 0.82,
+                         :frac_latent => 0.18)
+    hpxml.plug_loads.add(:id => "PlugLoadMisc2",
+                         :plug_load_type => "TV other",
+                         :kWh_per_year => 400)
   end
 end
 
 def set_hpxml_misc_load_schedule(hpxml_file, hpxml)
   if ['base-misc-loads-detailed.xml'].include? hpxml_file
-    hpxml.set_misc_loads_schedule({ :weekday_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
-                                    :weekend_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
-                                    :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0" })
+    hpxml.set_misc_loads_schedule(:weekday_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
+                                  :weekend_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
+                                  :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0")
   end
 end
 

--- a/tasks.rb
+++ b/tasks.rb
@@ -383,9 +383,9 @@ def create_hpxmls
         set_hpxml_building_occupancy(hpxml_file, hpxml)
         set_hpxml_building_construction(hpxml_file, hpxml)
         set_hpxml_climate_and_risk_zones(hpxml_file, hpxml)
+        set_hpxml_air_infiltration_measurements(hpxml_file, hpxml)
         set_hpxml_attics(hpxml_file, hpxml)
         set_hpxml_foundations(hpxml_file, hpxml)
-        set_hpxml_air_infiltration_measurements(hpxml_file, hpxml)
         set_hpxml_roofs(hpxml_file, hpxml)
         set_hpxml_rim_joists(hpxml_file, hpxml)
         set_hpxml_walls(hpxml_file, hpxml)
@@ -464,12 +464,12 @@ end
 
 def set_hpxml_header(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.header = HPXML::Header.new({ :xml_type => "HPXML",
-                                       :xml_generated_by => "Rakefile",
-                                       :transaction => "create",
-                                       :building_id => "MyBuilding",
-                                       :event_type => "proposed workscope",
-                                       :created_date_and_time => Time.new(2000, 1, 1).strftime("%Y-%m-%dT%H:%M:%S%:z") }) # Hard-code to prevent diffs
+    hpxml.set_header({ :xml_type => "HPXML",
+                       :xml_generated_by => "Rakefile",
+                       :transaction => "create",
+                       :building_id => "MyBuilding",
+                       :event_type => "proposed workscope",
+                       :created_date_and_time => Time.new(2000, 1, 1).strftime("%Y-%m-%dT%H:%M:%S%:z") }) # Hard-code to prevent diffs
   elsif ['base-version-2014.xml'].include? hpxml_file
     hpxml.header.eri_calculation_version = "2014"
   elsif ['base-version-2014A.xml'].include? hpxml_file
@@ -491,42 +491,38 @@ end
 
 def set_hpxml_site(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.site = HPXML::Site.new({ :fuels => ["electricity", "natural gas"] })
+    hpxml.set_site({ :fuels => ["electricity", "natural gas"] })
   elsif ['base-hvac-none-no-fuel-access.xml'].include? hpxml_file
     hpxml.site.fuels = ["electricity"]
   end
 end
 
 def set_hpxml_neighbor_buildings(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.neighbor_buildings = []
-  elsif ['base-site-neighbors.xml'].include? hpxml_file
-    hpxml.neighbor_buildings << HPXML::NeighborBuilding.new({ :azimuth => 0,
-                                                              :distance => 10 })
-    hpxml.neighbor_buildings << HPXML::NeighborBuilding.new({ :azimuth => 180,
-                                                              :distance => 15,
-                                                              :height => 12 })
+  if ['base-site-neighbors.xml'].include? hpxml_file
+    hpxml.neighbor_buildings.add({ :azimuth => 0,
+                                   :distance => 10 })
+    hpxml.neighbor_buildings.add({ :azimuth => 180,
+                                   :distance => 15,
+                                   :height => 12 })
   elsif ['invalid_files/bad-site-neighbor-azimuth.xml'].include? hpxml_file
     hpxml.neighbor_buildings[0].azimuth = 145
   end
 end
 
 def set_hpxml_building_occupancy(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.building_occupancy = nil
-  elsif ['base-misc-number-of-occupants.xml'].include? hpxml_file
-    hpxml.building_occupancy = HPXML::BuildingOccupancy.new({ :number_of_residents => 5 })
+  if ['base-misc-number-of-occupants.xml'].include? hpxml_file
+    hpxml.set_building_occupancy({ :number_of_residents => 5 })
   end
 end
 
 def set_hpxml_building_construction(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.building_construction = HPXML::BuildingConstruction.new({ :number_of_conditioned_floors => 2,
-                                                                    :number_of_conditioned_floors_above_grade => 1,
-                                                                    :number_of_bedrooms => 3,
-                                                                    :conditioned_floor_area => 2700,
-                                                                    :conditioned_building_volume => 2700 * 8,
-                                                                    :fraction_of_operable_window_area => 0.33 })
+    hpxml.set_building_construction({ :number_of_conditioned_floors => 2,
+                                      :number_of_conditioned_floors_above_grade => 1,
+                                      :number_of_bedrooms => 3,
+                                      :conditioned_floor_area => 2700,
+                                      :conditioned_building_volume => 2700 * 8,
+                                      :fraction_of_operable_window_area => 0.33 })
   elsif ['base-enclosure-beds-1.xml'].include? hpxml_file
     hpxml.building_construction.number_of_bedrooms = 1
   elsif ['base-enclosure-beds-2.xml'].include? hpxml_file
@@ -564,30 +560,30 @@ end
 
 def set_hpxml_climate_and_risk_zones(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "5B",
-                                                                    :weather_station_id => "WeatherStation",
-                                                                    :weather_station_name => "Denver, CO",
-                                                                    :weather_station_wmo => "725650" })
+    hpxml.set_climate_and_risk_zones({ :iecc2006 => "5B",
+                                       :weather_station_id => "WeatherStation",
+                                       :weather_station_name => "Denver, CO",
+                                       :weather_station_wmo => "725650" })
   elsif ['base-location-baltimore-md.xml'].include? hpxml_file
-    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "4A",
-                                                                    :weather_station_id => "WeatherStation",
-                                                                    :weather_station_name => "Baltimore, MD",
-                                                                    :weather_station_wmo => "724060" })
+    hpxml.set_climate_and_risk_zones({ :iecc2006 => "4A",
+                                       :weather_station_id => "WeatherStation",
+                                       :weather_station_name => "Baltimore, MD",
+                                       :weather_station_wmo => "724060" })
   elsif ['base-location-dallas-tx.xml'].include? hpxml_file
-    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "3A",
-                                                                    :weather_station_id => "WeatherStation",
-                                                                    :weather_station_name => "Dallas, TX",
-                                                                    :weather_station_wmo => "722590" })
+    hpxml.set_climate_and_risk_zones({ :iecc2006 => "3A",
+                                       :weather_station_id => "WeatherStation",
+                                       :weather_station_name => "Dallas, TX",
+                                       :weather_station_wmo => "722590" })
   elsif ['base-location-duluth-mn.xml'].include? hpxml_file
-    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "7",
-                                                                    :weather_station_id => "WeatherStation",
-                                                                    :weather_station_name => "Duluth, MN",
-                                                                    :weather_station_wmo => "727450" })
+    hpxml.set_climate_and_risk_zones({ :iecc2006 => "7",
+                                       :weather_station_id => "WeatherStation",
+                                       :weather_station_name => "Duluth, MN",
+                                       :weather_station_wmo => "727450" })
   elsif ['base-location-miami-fl.xml'].include? hpxml_file
-    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "1A",
-                                                                    :weather_station_id => "WeatherStation",
-                                                                    :weather_station_name => "Miami, FL",
-                                                                    :weather_station_wmo => "722020" })
+    hpxml.set_climate_and_risk_zones({ :iecc2006 => "1A",
+                                       :weather_station_id => "WeatherStation",
+                                       :weather_station_name => "Miami, FL",
+                                       :weather_station_wmo => "722020" })
   elsif ['base-location-epw-filename.xml'].include? hpxml_file
     hpxml.climate_and_risk_zones.weather_station_wmo = nil
     hpxml.climate_and_risk_zones.weather_station_epw_filename = "USA_CO_Denver.Intl.AP.725650_TMY3.epw"
@@ -599,43 +595,41 @@ end
 def set_hpxml_air_infiltration_measurements(hpxml_file, hpxml)
   infil_volume = hpxml.building_construction.conditioned_building_volume
   if ['base.xml'].include? hpxml_file
-    hpxml.air_infiltration_measurements = [HPXML::AirInfiltrationMeasurement.new({ :id => "InfiltrationMeasurement",
-                                                                                   :house_pressure => 50,
-                                                                                   :unit_of_measure => "ACH",
-                                                                                   :air_leakage => 3.0 })]
+    hpxml.air_infiltration_measurements.add({ :id => "InfiltrationMeasurement",
+                                              :house_pressure => 50,
+                                              :unit_of_measure => "ACH",
+                                              :air_leakage => 3.0 })
   elsif ['base-infiltration-ach-natural.xml'].include? hpxml_file
-    hpxml.air_infiltration_measurements = [HPXML::AirInfiltrationMeasurement.new({ :id => "InfiltrationMeasurement",
-                                                                                   :constant_ach_natural => 0.67 })]
+    hpxml.air_infiltration_measurements.clear
+    hpxml.air_infiltration_measurements.add({ :id => "InfiltrationMeasurement",
+                                              :constant_ach_natural => 0.67 })
   elsif ['base-enclosure-infil-cfm50.xml'].include? hpxml_file
-    hpxml.air_infiltration_measurements = [HPXML::AirInfiltrationMeasurement.new({ :id => "InfiltrationMeasurement",
-                                                                                   :house_pressure => 50,
-                                                                                   :unit_of_measure => "CFM",
-                                                                                   :air_leakage => 3.0 / 60.0 * infil_volume })]
+    hpxml.air_infiltration_measurements.clear
+    hpxml.air_infiltration_measurements.add({ :id => "InfiltrationMeasurement",
+                                              :house_pressure => 50,
+                                              :unit_of_measure => "CFM",
+                                              :air_leakage => 3.0 / 60.0 * infil_volume })
   end
   hpxml.air_infiltration_measurements[0].infiltration_volume = infil_volume
 end
 
 def set_hpxml_attics(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.attics = []
-  elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    hpxml.attics << HPXML::Attic.new({ :id => "VentedAttic",
-                                       :attic_type => "VentedAttic",
-                                       :vented_attic_sla => 0.003 })
+  if ['base-atticroof-vented.xml'].include? hpxml_file
+    hpxml.attics.add({ :id => "VentedAttic",
+                       :attic_type => "VentedAttic",
+                       :vented_attic_sla => 0.003 })
   end
 end
 
 def set_hpxml_foundations(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.foundations = []
-  elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml.foundations << HPXML::Foundation.new({ :id => "VentedCrawlspace",
-                                                 :foundation_type => "VentedCrawlspace",
-                                                 :vented_crawlspace_sla => 0.00667 })
+  if ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
+    hpxml.foundations.add({ :id => "VentedCrawlspace",
+                            :foundation_type => "VentedCrawlspace",
+                            :vented_crawlspace_sla => 0.00667 })
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml.foundations << HPXML::Foundation.new({ :id => "UnconditionedBasement",
-                                                 :foundation_type => "UnconditionedBasement",
-                                                 :unconditioned_basement_thermal_boundary => "frame floor" })
+    hpxml.foundations.add({ :id => "UnconditionedBasement",
+                            :foundation_type => "UnconditionedBasement",
+                            :unconditioned_basement_thermal_boundary => "frame floor" })
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
     hpxml.foundations[0].unconditioned_basement_thermal_boundary = "foundation wall"
   end
@@ -643,58 +637,60 @@ end
 
 def set_hpxml_roofs(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.roofs = [HPXML::Roof.new({ :id => "Roof",
-                                     :interior_adjacent_to => "attic - unvented",
-                                     :area => 1510,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :pitch => 6,
-                                     :radiant_barrier => false,
-                                     :insulation_assembly_r_value => 2.3 })]
+    hpxml.roofs.add({ :id => "Roof",
+                      :interior_adjacent_to => "attic - unvented",
+                      :area => 1510,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :pitch => 6,
+                      :radiant_barrier => false,
+                      :insulation_assembly_r_value => 2.3 })
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
-    hpxml.roofs = [HPXML::Roof.new({ :id => "Roof",
-                                     :interior_adjacent_to => "living space",
-                                     :area => 1350,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :pitch => 0,
-                                     :radiant_barrier => false,
-                                     :insulation_assembly_r_value => 25.8 })]
+    hpxml.roofs.clear
+    hpxml.roofs.add({ :id => "Roof",
+                      :interior_adjacent_to => "living space",
+                      :area => 1350,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :pitch => 0,
+                      :radiant_barrier => false,
+                      :insulation_assembly_r_value => 25.8 })
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml.roofs = [HPXML::Roof.new({ :id => "RoofCond",
-                                     :interior_adjacent_to => "living space",
-                                     :area => 1006,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :pitch => 6,
-                                     :radiant_barrier => false,
-                                     :insulation_assembly_r_value => 25.8 }),
-                   HPXML::Roof.new({ :id => "RoofUncond",
-                                     :interior_adjacent_to => "attic - unvented",
-                                     :area => 504,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :pitch => 6,
-                                     :radiant_barrier => false,
-                                     :insulation_assembly_r_value => 2.3 })]
+    hpxml.roofs.clear
+    hpxml.roofs.add({ :id => "RoofCond",
+                      :interior_adjacent_to => "living space",
+                      :area => 1006,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :pitch => 6,
+                      :radiant_barrier => false,
+                      :insulation_assembly_r_value => 25.8 })
+    hpxml.roofs.add({ :id => "RoofUncond",
+                      :interior_adjacent_to => "attic - unvented",
+                      :area => 504,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :pitch => 6,
+                      :radiant_barrier => false,
+                      :insulation_assembly_r_value => 2.3 })
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
     hpxml.roofs[0].interior_adjacent_to = "attic - vented"
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
     hpxml.roofs[0].interior_adjacent_to = "living space"
     hpxml.roofs[0].insulation_assembly_r_value = 25.8
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml.roofs << HPXML::Roof.new({ :id => "RoofGarage",
-                                     :interior_adjacent_to => "garage",
-                                     :area => 670,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :pitch => 6,
-                                     :radiant_barrier => false,
-                                     :insulation_assembly_r_value => 2.3 })
+    hpxml.roofs.add({ :id => "RoofGarage",
+                      :interior_adjacent_to => "garage",
+                      :area => 670,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :pitch => 6,
+                      :radiant_barrier => false,
+                      :insulation_assembly_r_value => 2.3 })
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
     hpxml.roofs[0].insulation_assembly_r_value = 25.8
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    hpxml.roofs = []
+    hpxml.roofs.clear
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.roofs.size
       hpxml.roofs[n - 1].area /= 10.0
@@ -712,16 +708,16 @@ def set_hpxml_rim_joists(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
     # TODO: Other geometry values (e.g., building volume) assume
     # no rim joists.
-    hpxml.rim_joists = [HPXML::RimJoist.new({ :id => "RimJoistFoundation",
-                                              :exterior_adjacent_to => "outside",
-                                              :interior_adjacent_to => "basement - conditioned",
-                                              :area => 116,
-                                              :solar_absorptance => 0.7,
-                                              :emittance => 0.92,
-                                              :insulation_assembly_r_value => 23.0 })]
+    hpxml.rim_joists.add({ :id => "RimJoistFoundation",
+                           :exterior_adjacent_to => "outside",
+                           :interior_adjacent_to => "basement - conditioned",
+                           :area => 116,
+                           :solar_absorptance => 0.7,
+                           :emittance => 0.92,
+                           :insulation_assembly_r_value => 23.0 })
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml'].include? hpxml_file
-    hpxml.rim_joists = []
+    hpxml.rim_joists.clear
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     for i in 0..hpxml.rim_joists.size - 1
       hpxml.rim_joists[i].interior_adjacent_to = "basement - unconditioned"
@@ -741,21 +737,21 @@ def set_hpxml_rim_joists(hpxml_file, hpxml)
     end
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     hpxml.rim_joists[0].exterior_adjacent_to = "crawlspace - unvented"
-    hpxml.rim_joists << HPXML::RimJoist.new({ :id => "RimJoistCrawlspace",
-                                              :exterior_adjacent_to => "outside",
-                                              :interior_adjacent_to => "crawlspace - unvented",
-                                              :area => 81,
-                                              :solar_absorptance => 0.7,
-                                              :emittance => 0.92,
-                                              :insulation_assembly_r_value => 2.3 })
+    hpxml.rim_joists.add({ :id => "RimJoistCrawlspace",
+                           :exterior_adjacent_to => "outside",
+                           :interior_adjacent_to => "crawlspace - unvented",
+                           :area => 81,
+                           :solar_absorptance => 0.7,
+                           :emittance => 0.92,
+                           :insulation_assembly_r_value => 2.3 })
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    hpxml.rim_joists << HPXML::RimJoist.new({ :id => "RimJoist2ndStory",
-                                              :exterior_adjacent_to => "outside",
-                                              :interior_adjacent_to => "living space",
-                                              :area => 116,
-                                              :solar_absorptance => 0.7,
-                                              :emittance => 0.92,
-                                              :insulation_assembly_r_value => 23.0 })
+    hpxml.rim_joists.add({ :id => "RimJoist2ndStory",
+                           :exterior_adjacent_to => "outside",
+                           :interior_adjacent_to => "living space",
+                           :area => 116,
+                           :solar_absorptance => 0.7,
+                           :emittance => 0.92,
+                           :insulation_assembly_r_value => 23.0 })
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.rim_joists.size
       hpxml.rim_joists[n - 1].area /= 10.0
@@ -769,22 +765,22 @@ end
 
 def set_hpxml_walls(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.walls = [HPXML::Wall.new({ :id => "Wall",
-                                     :exterior_adjacent_to => "outside",
-                                     :interior_adjacent_to => "living space",
-                                     :wall_type => "WoodStud",
-                                     :area => 1200,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 23 }),
-                   HPXML::Wall.new({ :id => "WallAtticGable",
-                                     :exterior_adjacent_to => "outside",
-                                     :interior_adjacent_to => "attic - unvented",
-                                     :wall_type => "WoodStud",
-                                     :area => 290,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 4.0 })]
+    hpxml.walls.add({ :id => "Wall",
+                      :exterior_adjacent_to => "outside",
+                      :interior_adjacent_to => "living space",
+                      :wall_type => "WoodStud",
+                      :area => 1200,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 23 })
+    hpxml.walls.add({ :id => "WallAtticGable",
+                      :exterior_adjacent_to => "outside",
+                      :interior_adjacent_to => "attic - unvented",
+                      :wall_type => "WoodStud",
+                      :area => 290,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 4.0 })
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
     hpxml.walls.delete_at(1)
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
@@ -794,30 +790,30 @@ def set_hpxml_walls(hpxml_file, hpxml)
     hpxml.walls[1].insulation_assembly_r_value = 23.0
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
     hpxml.walls.delete_at(1)
-    hpxml.walls << HPXML::Wall.new({ :id => "WallAtticKneeWall",
-                                     :exterior_adjacent_to => "attic - unvented",
-                                     :interior_adjacent_to => "living space",
-                                     :wall_type => "WoodStud",
-                                     :area => 316,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 23.0 })
-    hpxml.walls << HPXML::Wall.new({ :id => "WallAtticGableCond",
-                                     :exterior_adjacent_to => "outside",
-                                     :interior_adjacent_to => "living space",
-                                     :wall_type => "WoodStud",
-                                     :area => 240,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 22.3 })
-    hpxml.walls << HPXML::Wall.new({ :id => "WallAtticGableUncond",
-                                     :exterior_adjacent_to => "outside",
-                                     :interior_adjacent_to => "attic - unvented",
-                                     :wall_type => "WoodStud",
-                                     :area => 50,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 4.0 })
+    hpxml.walls.add({ :id => "WallAtticKneeWall",
+                      :exterior_adjacent_to => "attic - unvented",
+                      :interior_adjacent_to => "living space",
+                      :wall_type => "WoodStud",
+                      :area => 316,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 23.0 })
+    hpxml.walls.add({ :id => "WallAtticGableCond",
+                      :exterior_adjacent_to => "outside",
+                      :interior_adjacent_to => "living space",
+                      :wall_type => "WoodStud",
+                      :area => 240,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 22.3 })
+    hpxml.walls.add({ :id => "WallAtticGableUncond",
+                      :exterior_adjacent_to => "outside",
+                      :interior_adjacent_to => "attic - unvented",
+                      :wall_type => "WoodStud",
+                      :area => 50,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 4.0 })
   elsif ['base-enclosure-walltype-cmu.xml'].include? hpxml_file
     hpxml.walls[0].wall_type = "ConcreteMasonryUnit"
     hpxml.walls[0].insulation_assembly_r_value = 12
@@ -849,66 +845,68 @@ def set_hpxml_walls(hpxml_file, hpxml)
     hpxml.walls[0].wall_type = "StructuralBrick"
     hpxml.walls[0].insulation_assembly_r_value = 7.9
   elsif ['invalid_files/missing-surfaces.xml'].include? hpxml_file
-    hpxml.walls << HPXML::Wall.new({ :id => "WallGarage",
-                                     :exterior_adjacent_to => "garage",
-                                     :interior_adjacent_to => "living space",
-                                     :wall_type => "WoodStud",
-                                     :area => 100,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 4 })
+    hpxml.walls.add({ :id => "WallGarage",
+                      :exterior_adjacent_to => "garage",
+                      :interior_adjacent_to => "living space",
+                      :wall_type => "WoodStud",
+                      :area => 100,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 4 })
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
     hpxml.walls[0].area *= 2.0
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    hpxml.walls = [HPXML::Wall.new({ :id => "Wall",
-                                     :exterior_adjacent_to => "outside",
-                                     :interior_adjacent_to => "living space",
-                                     :wall_type => "WoodStud",
-                                     :area => 880,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 23 }),
-                   HPXML::Wall.new({ :id => "WallGarageInterior",
-                                     :exterior_adjacent_to => "garage",
-                                     :interior_adjacent_to => "living space",
-                                     :wall_type => "WoodStud",
-                                     :area => 320,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 23 }),
-                   HPXML::Wall.new({ :id => "WallGarageExterior",
-                                     :exterior_adjacent_to => "outside",
-                                     :interior_adjacent_to => "garage",
-                                     :wall_type => "WoodStud",
-                                     :area => 800,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 4 })]
+    hpxml.walls.clear
+    hpxml.walls.add({ :id => "Wall",
+                      :exterior_adjacent_to => "outside",
+                      :interior_adjacent_to => "living space",
+                      :wall_type => "WoodStud",
+                      :area => 880,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 23 })
+    hpxml.walls.add({ :id => "WallGarageInterior",
+                      :exterior_adjacent_to => "garage",
+                      :interior_adjacent_to => "living space",
+                      :wall_type => "WoodStud",
+                      :area => 320,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 23 })
+    hpxml.walls.add({ :id => "WallGarageExterior",
+                      :exterior_adjacent_to => "outside",
+                      :interior_adjacent_to => "garage",
+                      :wall_type => "WoodStud",
+                      :area => 800,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 4 })
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml.walls = [HPXML::Wall.new({ :id => "Wall",
-                                     :exterior_adjacent_to => "outside",
-                                     :interior_adjacent_to => "living space",
-                                     :wall_type => "WoodStud",
-                                     :area => 960,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 23 }),
-                   HPXML::Wall.new({ :id => "WallGarageInterior",
-                                     :exterior_adjacent_to => "garage",
-                                     :interior_adjacent_to => "living space",
-                                     :wall_type => "WoodStud",
-                                     :area => 240,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 23 }),
-                   HPXML::Wall.new({ :id => "WallGarageExterior",
-                                     :exterior_adjacent_to => "outside",
-                                     :interior_adjacent_to => "garage",
-                                     :wall_type => "WoodStud",
-                                     :area => 560,
-                                     :solar_absorptance => 0.7,
-                                     :emittance => 0.92,
-                                     :insulation_assembly_r_value => 4 })]
+    hpxml.walls.clear
+    hpxml.walls.add({ :id => "Wall",
+                      :exterior_adjacent_to => "outside",
+                      :interior_adjacent_to => "living space",
+                      :wall_type => "WoodStud",
+                      :area => 960,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 23 })
+    hpxml.walls.add({ :id => "WallGarageInterior",
+                      :exterior_adjacent_to => "garage",
+                      :interior_adjacent_to => "living space",
+                      :wall_type => "WoodStud",
+                      :area => 240,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 23 })
+    hpxml.walls.add({ :id => "WallGarageExterior",
+                      :exterior_adjacent_to => "outside",
+                      :interior_adjacent_to => "garage",
+                      :wall_type => "WoodStud",
+                      :area => 560,
+                      :solar_absorptance => 0.7,
+                      :emittance => 0.92,
+                      :insulation_assembly_r_value => 4 })
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
     hpxml.walls[1].insulation_assembly_r_value = 23
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
@@ -932,19 +930,19 @@ end
 
 def set_hpxml_foundation_walls(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.foundation_walls = [HPXML::FoundationWall.new({ :id => "FoundationWall",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 8,
-                                                          :area => 1200,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 7,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 8,
-                                                          :insulation_exterior_r_value => 8.9 })]
+    hpxml. foundation_walls.add({ :id => "FoundationWall",
+                                  :exterior_adjacent_to => "ground",
+                                  :interior_adjacent_to => "basement - conditioned",
+                                  :height => 8,
+                                  :area => 1200,
+                                  :thickness => 8,
+                                  :depth_below_grade => 7,
+                                  :insulation_interior_r_value => 0,
+                                  :insulation_interior_distance_to_top => 0,
+                                  :insulation_interior_distance_to_bottom => 0,
+                                  :insulation_exterior_distance_to_top => 0,
+                                  :insulation_exterior_distance_to_bottom => 8,
+                                  :insulation_exterior_r_value => 8.9 })
   elsif ['base-foundation-conditioned-basement-wall-interior-insulation.xml'].include? hpxml_file
     hpxml.foundation_walls[0].insulation_interior_distance_to_top = 0
     hpxml.foundation_walls[0].insulation_interior_distance_to_bottom = 8
@@ -981,141 +979,143 @@ def set_hpxml_foundation_walls(hpxml_file, hpxml)
     hpxml.foundation_walls[0].insulation_exterior_distance_to_bottom -= 4
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     hpxml.foundation_walls[0].area = 600
-    hpxml.foundation_walls << HPXML::FoundationWall.new({ :id => "FoundationWallInterior",
-                                                          :exterior_adjacent_to => "crawlspace - unvented",
-                                                          :interior_adjacent_to => "basement - unconditioned",
-                                                          :height => 8,
-                                                          :area => 360,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 4,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 0,
-                                                          :insulation_exterior_r_value => 0 })
-    hpxml.foundation_walls << HPXML::FoundationWall.new({ :id => "FoundationWallCrawlspace",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "crawlspace - unvented",
-                                                          :height => 4,
-                                                          :area => 600,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 3,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 0,
-                                                          :insulation_exterior_r_value => 0 })
+    hpxml.foundation_walls.add({ :id => "FoundationWallInterior",
+                                 :exterior_adjacent_to => "crawlspace - unvented",
+                                 :interior_adjacent_to => "basement - unconditioned",
+                                 :height => 8,
+                                 :area => 360,
+                                 :thickness => 8,
+                                 :depth_below_grade => 4,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 0,
+                                 :insulation_exterior_r_value => 0 })
+    hpxml.foundation_walls.add({ :id => "FoundationWallCrawlspace",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "crawlspace - unvented",
+                                 :height => 4,
+                                 :area => 600,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 0,
+                                 :insulation_exterior_r_value => 0 })
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml'].include? hpxml_file
-    hpxml.foundation_walls = []
+    hpxml.foundation_walls.clear
   elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
-    hpxml.foundation_walls = [HPXML::FoundationWall.new({ :id => "FoundationWall1",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 8,
-                                                          :area => 480,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 7,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 8,
-                                                          :insulation_exterior_r_value => 8.9 }),
-                              HPXML::FoundationWall.new({ :id => "FoundationWall2",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 4,
-                                                          :area => 120,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 3,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 4,
-                                                          :insulation_exterior_r_value => 8.9 }),
-                              HPXML::FoundationWall.new({ :id => "FoundationWall3",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 2,
-                                                          :area => 60,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 1,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 2,
-                                                          :insulation_exterior_r_value => 8.9 })]
+    hpxml.foundation_walls.clear
+    hpxml.foundation_walls.add({ :id => "FoundationWall1",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 8,
+                                 :area => 480,
+                                 :thickness => 8,
+                                 :depth_below_grade => 7,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 8,
+                                 :insulation_exterior_r_value => 8.9 })
+    hpxml.foundation_walls.add({ :id => "FoundationWall2",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 4,
+                                 :area => 120,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 4,
+                                 :insulation_exterior_r_value => 8.9 })
+    hpxml.foundation_walls.add({ :id => "FoundationWall3",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 2,
+                                 :area => 60,
+                                 :thickness => 8,
+                                 :depth_below_grade => 1,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 2,
+                                 :insulation_exterior_r_value => 8.9 })
   elsif ['base-foundation-complex.xml'].include? hpxml_file
-    hpxml.foundation_walls = [HPXML::FoundationWall.new({ :id => "FoundationWall1",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 8,
-                                                          :area => 160,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 7,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 0,
-                                                          :insulation_exterior_r_value => 0.0 }),
-                              HPXML::FoundationWall.new({ :id => "FoundationWall2",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 8,
-                                                          :area => 240,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 7,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 8,
-                                                          :insulation_exterior_r_value => 8.9 }),
-                              HPXML::FoundationWall.new({ :id => "FoundationWall3",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 4,
-                                                          :area => 160,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 3,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 0,
-                                                          :insulation_exterior_r_value => 0.0 }),
-                              HPXML::FoundationWall.new({ :id => "FoundationWall4",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 4,
-                                                          :area => 120,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 3,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 4,
-                                                          :insulation_exterior_r_value => 8.9 }),
-                              HPXML::FoundationWall.new({ :id => "FoundationWall5",
-                                                          :exterior_adjacent_to => "ground",
-                                                          :interior_adjacent_to => "basement - conditioned",
-                                                          :height => 4,
-                                                          :area => 80,
-                                                          :thickness => 8,
-                                                          :depth_below_grade => 3,
-                                                          :insulation_interior_r_value => 0,
-                                                          :insulation_interior_distance_to_top => 0,
-                                                          :insulation_interior_distance_to_bottom => 0,
-                                                          :insulation_exterior_distance_to_top => 0,
-                                                          :insulation_exterior_distance_to_bottom => 4,
-                                                          :insulation_exterior_r_value => 8.9 })]
+    hpxml.foundation_walls.clear
+    hpxml.foundation_walls.add({ :id => "FoundationWall1",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 8,
+                                 :area => 160,
+                                 :thickness => 8,
+                                 :depth_below_grade => 7,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 0,
+                                 :insulation_exterior_r_value => 0.0 })
+    hpxml.foundation_walls.add({ :id => "FoundationWall2",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 8,
+                                 :area => 240,
+                                 :thickness => 8,
+                                 :depth_below_grade => 7,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 8,
+                                 :insulation_exterior_r_value => 8.9 })
+    hpxml.foundation_walls.add({ :id => "FoundationWall3",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 4,
+                                 :area => 160,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 0,
+                                 :insulation_exterior_r_value => 0.0 })
+    hpxml.foundation_walls.add({ :id => "FoundationWall4",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 4,
+                                 :area => 120,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 4,
+                                 :insulation_exterior_r_value => 8.9 })
+    hpxml.foundation_walls.add({ :id => "FoundationWall5",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 4,
+                                 :area => 80,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_interior_r_value => 0,
+                                 :insulation_interior_distance_to_top => 0,
+                                 :insulation_interior_distance_to_bottom => 0,
+                                 :insulation_exterior_distance_to_top => 0,
+                                 :insulation_exterior_distance_to_bottom => 4,
+                                 :insulation_exterior_r_value => 8.9 })
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.foundation_walls.size
       hpxml.foundation_walls[n - 1].area /= 10.0
@@ -1133,11 +1133,11 @@ end
 
 def set_hpxml_frame_floors(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.frame_floors = [HPXML::FrameFloor.new({ :id => "FloorBelowAttic",
-                                                  :exterior_adjacent_to => "attic - unvented",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 1350,
-                                                  :insulation_assembly_r_value => 39.3 })]
+    hpxml.frame_floors.add({ :id => "FloorBelowAttic",
+                             :exterior_adjacent_to => "attic - unvented",
+                             :interior_adjacent_to => "living space",
+                             :area => 1350,
+                             :insulation_assembly_r_value => 39.3 })
   elsif ['base-atticroof-flat.xml',
          'base-atticroof-cathedral.xml'].include? hpxml_file
     hpxml.frame_floors.delete_at(0)
@@ -1146,63 +1146,64 @@ def set_hpxml_frame_floors(hpxml_file, hpxml)
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
     hpxml.frame_floors[0].area = 450
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorBetweenAtticGarage",
-                                                  :exterior_adjacent_to => "attic - unvented",
-                                                  :interior_adjacent_to => "garage",
-                                                  :area => 600,
-                                                  :insulation_assembly_r_value => 2.1 })
+    hpxml.frame_floors.add({ :id => "FloorBetweenAtticGarage",
+                             :exterior_adjacent_to => "attic - unvented",
+                             :interior_adjacent_to => "garage",
+                             :area => 600,
+                             :insulation_assembly_r_value => 2.1 })
   elsif ['base-foundation-ambient.xml'].include? hpxml_file
-    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveAmbient",
-                                                  :exterior_adjacent_to => "outside",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 1350,
-                                                  :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add({ :id => "FloorAboveAmbient",
+                             :exterior_adjacent_to => "outside",
+                             :interior_adjacent_to => "living space",
+                             :area => 1350,
+                             :insulation_assembly_r_value => 18.7 })
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveUncondBasement",
-                                                  :exterior_adjacent_to => "basement - unconditioned",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 1350,
-                                                  :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add({ :id => "FloorAboveUncondBasement",
+                             :exterior_adjacent_to => "basement - unconditioned",
+                             :interior_adjacent_to => "living space",
+                             :area => 1350,
+                             :insulation_assembly_r_value => 18.7 })
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
     hpxml.frame_floors[1].insulation_assembly_r_value = 2.1
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveUnventedCrawl",
-                                                  :exterior_adjacent_to => "crawlspace - unvented",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 1350,
-                                                  :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add({ :id => "FloorAboveUnventedCrawl",
+                             :exterior_adjacent_to => "crawlspace - unvented",
+                             :interior_adjacent_to => "living space",
+                             :area => 1350,
+                             :insulation_assembly_r_value => 18.7 })
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveVentedCrawl",
-                                                  :exterior_adjacent_to => "crawlspace - vented",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 1350,
-                                                  :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add({ :id => "FloorAboveVentedCrawl",
+                             :exterior_adjacent_to => "crawlspace - vented",
+                             :interior_adjacent_to => "living space",
+                             :area => 1350,
+                             :insulation_assembly_r_value => 18.7 })
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     hpxml.frame_floors[1].area = 675
-    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveUnventedCrawlspace",
-                                                  :exterior_adjacent_to => "crawlspace - unvented",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 675,
-                                                  :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add({ :id => "FloorAboveUnventedCrawlspace",
+                             :exterior_adjacent_to => "crawlspace - unvented",
+                             :interior_adjacent_to => "living space",
+                             :area => 675,
+                             :insulation_assembly_r_value => 18.7 })
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveGarage",
-                                                  :exterior_adjacent_to => "garage",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 400,
-                                                  :insulation_assembly_r_value => 18.7 })
+    hpxml.frame_floors.add({ :id => "FloorAboveGarage",
+                             :exterior_adjacent_to => "garage",
+                             :interior_adjacent_to => "living space",
+                             :area => 400,
+                             :insulation_assembly_r_value => 18.7 })
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
     hpxml.frame_floors[0].insulation_assembly_r_value = 2.1
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    hpxml.frame_floors = [HPXML::FrameFloor.new({ :id => "FloorAboveAdiabatic",
-                                                  :exterior_adjacent_to => "other housing unit below",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 1350,
-                                                  :insulation_assembly_r_value => 2.1 }),
-                          HPXML::FrameFloor.new({ :id => "FloorBelowAdiabatic",
-                                                  :exterior_adjacent_to => "other housing unit above",
-                                                  :interior_adjacent_to => "living space",
-                                                  :area => 1350,
-                                                  :insulation_assembly_r_value => 2.1 })]
+    hpxml.frame_floors.clear
+    hpxml.frame_floors.add({ :id => "FloorAboveAdiabatic",
+                             :exterior_adjacent_to => "other housing unit below",
+                             :interior_adjacent_to => "living space",
+                             :area => 1350,
+                             :insulation_assembly_r_value => 2.1 })
+    hpxml.frame_floors.add({ :id => "FloorBelowAdiabatic",
+                             :exterior_adjacent_to => "other housing unit above",
+                             :interior_adjacent_to => "living space",
+                             :area => 1350,
+                             :insulation_assembly_r_value => 2.1 })
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.frame_floors.size
       hpxml.frame_floors[n - 1].area /= 10.0
@@ -1216,17 +1217,17 @@ end
 
 def set_hpxml_slabs(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.slabs = [HPXML::Slab.new({ :id => "Slab",
-                                     :interior_adjacent_to => "basement - conditioned",
-                                     :area => 1350,
-                                     :thickness => 4,
-                                     :exposed_perimeter => 150,
-                                     :perimeter_insulation_depth => 0,
-                                     :under_slab_insulation_width => 0,
-                                     :perimeter_insulation_r_value => 0,
-                                     :under_slab_insulation_r_value => 0,
-                                     :carpet_fraction => 0,
-                                     :carpet_r_value => 0 })]
+    hpxml.slabs.add({ :id => "Slab",
+                      :interior_adjacent_to => "basement - conditioned",
+                      :area => 1350,
+                      :thickness => 4,
+                      :exposed_perimeter => 150,
+                      :perimeter_insulation_depth => 0,
+                      :under_slab_insulation_width => 0,
+                      :perimeter_insulation_r_value => 0,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 })
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     hpxml.slabs[0].interior_adjacent_to = "basement - unconditioned"
   elsif ['base-foundation-conditioned-basement-slab-insulation.xml'].include? hpxml_file
@@ -1252,82 +1253,83 @@ def set_hpxml_slabs(hpxml_file, hpxml)
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     hpxml.slabs[0].area = 675
     hpxml.slabs[0].exposed_perimeter = 75
-    hpxml.slabs << HPXML::Slab.new({ :id => "SlabUnderCrawlspace",
-                                     :interior_adjacent_to => "crawlspace - unvented",
-                                     :area => 675,
-                                     :thickness => 0,
-                                     :exposed_perimeter => 75,
-                                     :perimeter_insulation_depth => 0,
-                                     :under_slab_insulation_width => 0,
-                                     :perimeter_insulation_r_value => 0,
-                                     :under_slab_insulation_r_value => 0,
-                                     :carpet_fraction => 0,
-                                     :carpet_r_value => 0 })
+    hpxml.slabs.add({ :id => "SlabUnderCrawlspace",
+                      :interior_adjacent_to => "crawlspace - unvented",
+                      :area => 675,
+                      :thickness => 0,
+                      :exposed_perimeter => 75,
+                      :perimeter_insulation_depth => 0,
+                      :under_slab_insulation_width => 0,
+                      :perimeter_insulation_r_value => 0,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 })
   elsif ['base-foundation-ambient.xml'].include? hpxml_file
-    hpxml.slabs = []
+    hpxml.slabs.clear
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
     hpxml.slabs[0].area -= 400
     hpxml.slabs[0].exposed_perimeter -= 40
-    hpxml.slabs << HPXML::Slab.new({ :id => "SlabUnderGarage",
-                                     :interior_adjacent_to => "garage",
-                                     :area => 400,
-                                     :thickness => 4,
-                                     :exposed_perimeter => 40,
-                                     :perimeter_insulation_depth => 0,
-                                     :under_slab_insulation_width => 0,
-                                     :depth_below_grade => 0,
-                                     :perimeter_insulation_r_value => 0,
-                                     :under_slab_insulation_r_value => 0,
-                                     :carpet_fraction => 0,
-                                     :carpet_r_value => 0 })
+    hpxml.slabs.add({ :id => "SlabUnderGarage",
+                      :interior_adjacent_to => "garage",
+                      :area => 400,
+                      :thickness => 4,
+                      :exposed_perimeter => 40,
+                      :perimeter_insulation_depth => 0,
+                      :under_slab_insulation_width => 0,
+                      :depth_below_grade => 0,
+                      :perimeter_insulation_r_value => 0,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 })
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
     hpxml.slabs[0].exposed_perimeter -= 30
-    hpxml.slabs << HPXML::Slab.new({ :id => "SlabUnderGarage",
-                                     :interior_adjacent_to => "garage",
-                                     :area => 600,
-                                     :thickness => 4,
-                                     :exposed_perimeter => 70,
-                                     :perimeter_insulation_depth => 0,
-                                     :under_slab_insulation_width => 0,
-                                     :depth_below_grade => 0,
-                                     :perimeter_insulation_r_value => 0,
-                                     :under_slab_insulation_r_value => 0,
-                                     :carpet_fraction => 0,
-                                     :carpet_r_value => 0 })
+    hpxml.slabs.add({ :id => "SlabUnderGarage",
+                      :interior_adjacent_to => "garage",
+                      :area => 600,
+                      :thickness => 4,
+                      :exposed_perimeter => 70,
+                      :perimeter_insulation_depth => 0,
+                      :under_slab_insulation_width => 0,
+                      :depth_below_grade => 0,
+                      :perimeter_insulation_r_value => 0,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 })
   elsif ['base-foundation-complex.xml'].include? hpxml_file
-    hpxml.slabs = [HPXML::Slab.new({ :id => "Slab1",
-                                     :interior_adjacent_to => "basement - conditioned",
-                                     :area => 675,
-                                     :thickness => 4,
-                                     :exposed_perimeter => 75,
-                                     :perimeter_insulation_depth => 0,
-                                     :under_slab_insulation_width => 0,
-                                     :perimeter_insulation_r_value => 0,
-                                     :under_slab_insulation_r_value => 0,
-                                     :carpet_fraction => 0,
-                                     :carpet_r_value => 0 }),
-                   HPXML::Slab.new({ :id => "Slab2",
-                                     :interior_adjacent_to => "basement - conditioned",
-                                     :area => 405,
-                                     :thickness => 4,
-                                     :exposed_perimeter => 45,
-                                     :perimeter_insulation_depth => 1,
-                                     :under_slab_insulation_width => 0,
-                                     :perimeter_insulation_r_value => 5,
-                                     :under_slab_insulation_r_value => 0,
-                                     :carpet_fraction => 0,
-                                     :carpet_r_value => 0 }),
-                   HPXML::Slab.new({ :id => "Slab3",
-                                     :interior_adjacent_to => "basement - conditioned",
-                                     :area => 270,
-                                     :thickness => 4,
-                                     :exposed_perimeter => 30,
-                                     :perimeter_insulation_depth => 1,
-                                     :under_slab_insulation_width => 0,
-                                     :perimeter_insulation_r_value => 5,
-                                     :under_slab_insulation_r_value => 0,
-                                     :carpet_fraction => 0,
-                                     :carpet_r_value => 0 })]
+    hpxml.slabs.clear
+    hpxml.slabs.add({ :id => "Slab1",
+                      :interior_adjacent_to => "basement - conditioned",
+                      :area => 675,
+                      :thickness => 4,
+                      :exposed_perimeter => 75,
+                      :perimeter_insulation_depth => 0,
+                      :under_slab_insulation_width => 0,
+                      :perimeter_insulation_r_value => 0,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 })
+    hpxml.slabs.add({ :id => "Slab2",
+                      :interior_adjacent_to => "basement - conditioned",
+                      :area => 405,
+                      :thickness => 4,
+                      :exposed_perimeter => 45,
+                      :perimeter_insulation_depth => 1,
+                      :under_slab_insulation_width => 0,
+                      :perimeter_insulation_r_value => 5,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 })
+    hpxml.slabs.add({ :id => "Slab3",
+                      :interior_adjacent_to => "basement - conditioned",
+                      :area => 270,
+                      :thickness => 4,
+                      :exposed_perimeter => 30,
+                      :perimeter_insulation_depth => 1,
+                      :under_slab_insulation_width => 0,
+                      :perimeter_insulation_r_value => 5,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 })
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.slabs.size
       hpxml.slabs[n - 1].area /= 10.0
@@ -1347,30 +1349,30 @@ end
 
 def set_hpxml_windows(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.windows = [HPXML::Window.new({ :id => "WindowNorth",
-                                         :area => 108,
-                                         :azimuth => 0,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "Wall" }),
-                     HPXML::Window.new({ :id => "WindowSouth",
-                                         :area => 108,
-                                         :azimuth => 180,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "Wall" }),
-                     HPXML::Window.new({ :id => "WindowEast",
-                                         :area => 72,
-                                         :azimuth => 90,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "Wall" }),
-                     HPXML::Window.new({ :id => "WindowWest",
-                                         :area => 72,
-                                         :azimuth => 270,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "Wall" })]
+    hpxml.windows.add({ :id => "WindowNorth",
+                        :area => 108,
+                        :azimuth => 0,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "Wall" })
+    hpxml.windows.add({ :id => "WindowSouth",
+                        :area => 108,
+                        :azimuth => 180,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "Wall" })
+    hpxml.windows.add({ :id => "WindowEast",
+                        :area => 72,
+                        :azimuth => 90,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "Wall" })
+    hpxml.windows.add({ :id => "WindowWest",
+                        :area => 72,
+                        :azimuth => 270,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "Wall" })
   elsif ['base-enclosure-overhangs.xml'].include? hpxml_file
     hpxml.windows[0].overhangs_depth = 2.5
     hpxml.windows[0].overhangs_distance_to_top_of_window = 0
@@ -1394,7 +1396,7 @@ def set_hpxml_windows(hpxml_file, hpxml)
     hpxml.windows[0].interior_shading_factor_summer = 0.85
     hpxml.windows[0].interior_shading_factor_winter = 0.7
   elsif ['base-enclosure-windows-none.xml'].include? hpxml_file
-    hpxml.windows = []
+    hpxml.windows.clear
   elsif ['invalid_files/net-area-negative-wall.xml'].include? hpxml_file
     hpxml.windows[0].area = 1000
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
@@ -1402,43 +1404,43 @@ def set_hpxml_windows(hpxml_file, hpxml)
     hpxml.windows[1].area = 108
     hpxml.windows[2].area = 108
     hpxml.windows[3].area = 108
-    hpxml.windows << HPXML::Window.new({ :id => "AtticGableWindowEast",
-                                         :area => 12,
-                                         :azimuth => 90,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "WallAtticGableCond" })
-    hpxml.windows << HPXML::Window.new({ :id => "AtticGableWindowWest",
-                                         :area => 62,
-                                         :azimuth => 270,
-                                         :ufactor => 0.3,
-                                         :shgc => 0.45,
-                                         :wall_idref => "WallAtticGableCond" })
+    hpxml.windows.add({ :id => "AtticGableWindowEast",
+                        :area => 12,
+                        :azimuth => 90,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "WallAtticGableCond" })
+    hpxml.windows.add({ :id => "AtticGableWindowWest",
+                        :area => 62,
+                        :azimuth => 270,
+                        :ufactor => 0.3,
+                        :shgc => 0.45,
+                        :wall_idref => "WallAtticGableCond" })
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
     hpxml.windows[0].area = 108
     hpxml.windows[1].area = 108
     hpxml.windows[2].area = 108
     hpxml.windows[3].area = 108
-    hpxml.windows << HPXML::Window.new({ :id => "AtticGableWindowEast",
-                                         :area => 12,
-                                         :azimuth => 90,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "WallAtticGable" })
-    hpxml.windows << HPXML::Window.new({ :id => "AtticGableWindowWest",
-                                         :area => 12,
-                                         :azimuth => 270,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "WallAtticGable" })
+    hpxml.windows.add({ :id => "AtticGableWindowEast",
+                        :area => 12,
+                        :azimuth => 90,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "WallAtticGable" })
+    hpxml.windows.add({ :id => "AtticGableWindowWest",
+                        :area => 12,
+                        :azimuth => 270,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "WallAtticGable" })
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
     hpxml.windows.delete_at(2)
-    hpxml.windows << HPXML::Window.new({ :id => "GarageWindowEast",
-                                         :area => 12,
-                                         :azimuth => 90,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "WallGarageExterior" })
+    hpxml.windows.add({ :id => "GarageWindowEast",
+                        :area => 12,
+                        :azimuth => 90,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "WallGarageExterior" })
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
     hpxml.windows[0].area = 216
     hpxml.windows[1].area = 216
@@ -1450,30 +1452,30 @@ def set_hpxml_windows(hpxml_file, hpxml)
     hpxml.windows[2].area = 144
     hpxml.windows[3].area = 96
   elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
-    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindowNorth",
-                                         :area => 20,
-                                         :azimuth => 0,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "FoundationWall" })
-    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindowSouth",
-                                         :area => 20,
-                                         :azimuth => 180,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "FoundationWall" })
-    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindowEast",
-                                         :area => 10,
-                                         :azimuth => 90,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "FoundationWall" })
-    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindowWest",
-                                         :area => 10,
-                                         :azimuth => 270,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "FoundationWall" })
+    hpxml.windows.add({ :id => "FoundationWindowNorth",
+                        :area => 20,
+                        :azimuth => 0,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "FoundationWall" })
+    hpxml.windows.add({ :id => "FoundationWindowSouth",
+                        :area => 20,
+                        :azimuth => 180,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "FoundationWall" })
+    hpxml.windows.add({ :id => "FoundationWindowEast",
+                        :area => 10,
+                        :azimuth => 90,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "FoundationWall" })
+    hpxml.windows.add({ :id => "FoundationWindowWest",
+                        :area => 10,
+                        :azimuth => 270,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "FoundationWall" })
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.windows.size
       hpxml.windows[n - 1].area *= 0.35
@@ -1491,33 +1493,31 @@ def set_hpxml_windows(hpxml_file, hpxml)
       end
     end
   elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
-    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindow",
-                                         :area => 20,
-                                         :azimuth => 0,
-                                         :ufactor => 0.33,
-                                         :shgc => 0.45,
-                                         :wall_idref => "FoundationWall3" })
+    hpxml.windows.add({ :id => "FoundationWindow",
+                        :area => 20,
+                        :azimuth => 0,
+                        :ufactor => 0.33,
+                        :shgc => 0.45,
+                        :wall_idref => "FoundationWall3" })
   elsif ['invalid_files/invalid-window-height.xml'].include? hpxml_file
     hpxml.windows[2].overhangs_distance_to_bottom_of_window = hpxml.windows[2].overhangs_distance_to_top_of_window
   end
 end
 
 def set_hpxml_skylights(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.skylights = []
-  elsif ['base-enclosure-skylights.xml'].include? hpxml_file
-    hpxml.skylights << HPXML::Skylight.new({ :id => "SkylightNorth",
-                                             :area => 45,
-                                             :azimuth => 0,
-                                             :ufactor => 0.33,
-                                             :shgc => 0.45,
-                                             :roof_idref => "Roof" })
-    hpxml.skylights << HPXML::Skylight.new({ :id => "SkylightSouth",
-                                             :area => 45,
-                                             :azimuth => 180,
-                                             :ufactor => 0.35,
-                                             :shgc => 0.47,
-                                             :roof_idref => "Roof" })
+  if ['base-enclosure-skylights.xml'].include? hpxml_file
+    hpxml.skylights.add({ :id => "SkylightNorth",
+                          :area => 45,
+                          :azimuth => 0,
+                          :ufactor => 0.33,
+                          :shgc => 0.45,
+                          :roof_idref => "Roof" })
+    hpxml.skylights.add({ :id => "SkylightSouth",
+                          :area => 45,
+                          :azimuth => 180,
+                          :ufactor => 0.35,
+                          :shgc => 0.47,
+                          :roof_idref => "Roof" })
   elsif ['invalid_files/net-area-negative-roof.xml'].include? hpxml_file
     hpxml.skylights[0].area = 4000
   elsif ['invalid_files/unattached-skylight.xml'].include? hpxml_file
@@ -1536,16 +1536,16 @@ end
 
 def set_hpxml_doors(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.doors = [HPXML::Door.new({ :id => "DoorNorth",
-                                     :wall_idref => "Wall",
-                                     :area => 40,
-                                     :azimuth => 0,
-                                     :r_value => 4.4 }),
-                   HPXML::Door.new({ :id => "DoorSouth",
-                                     :wall_idref => "Wall",
-                                     :area => 40,
-                                     :azimuth => 180,
-                                     :r_value => 4.4 })]
+    hpxml.doors.add({ :id => "DoorNorth",
+                      :wall_idref => "Wall",
+                      :area => 40,
+                      :azimuth => 0,
+                      :r_value => 4.4 })
+    hpxml.doors.add({ :id => "DoorSouth",
+                      :wall_idref => "Wall",
+                      :area => 40,
+                      :azimuth => 180,
+                      :r_value => 4.4 })
   elsif ['base-enclosure-garage.xml',
          'base-enclosure-2stories-garage.xml'].include? hpxml_file
     hpxml.doors << HPXML::Door.new({ :id => "GarageDoorSouth",
@@ -1570,13 +1570,13 @@ end
 
 def set_hpxml_heating_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.heating_systems = [HPXML::HeatingSystem.new({ :id => "HeatingSystem",
-                                                        :distribution_system_idref => "HVACDistribution",
-                                                        :heating_system_type => "Furnace",
-                                                        :heating_system_fuel => "natural gas",
-                                                        :heating_capacity => 64000,
-                                                        :heating_efficiency_afue => 0.92,
-                                                        :fraction_heat_load_served => 1 })]
+    hpxml.heating_systems.add({ :id => "HeatingSystem",
+                                :distribution_system_idref => "HVACDistribution",
+                                :heating_system_type => "Furnace",
+                                :heating_system_fuel => "natural gas",
+                                :heating_capacity => 64000,
+                                :heating_efficiency_afue => 0.92,
+                                :fraction_heat_load_served => 1 })
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-air-to-air-heat-pump-var-speed.xml',
@@ -1592,7 +1592,7 @@ def set_hpxml_heating_systems(hpxml_file, hpxml)
          'base-hvac-none.xml',
          'base-hvac-room-ac-only.xml',
          'invalid_files/orphaned-hvac-distribution.xml'].include? hpxml_file
-    hpxml.heating_systems = []
+    hpxml.heating_systems.clear
   elsif ['base-hvac-boiler-elec-only.xml'].include? hpxml_file
     hpxml.heating_systems[0].heating_system_type = "Boiler"
     hpxml.heating_systems[0].heating_system_fuel = "electricity"
@@ -1638,49 +1638,49 @@ def set_hpxml_heating_systems(hpxml_file, hpxml)
     hpxml.heating_systems[0].heating_efficiency_afue = 1
     hpxml.heating_systems[0].fraction_heat_load_served = 0.1
     hpxml.heating_systems[0].heating_capacity *= 0.1
-    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem2",
-                                                        :distribution_system_idref => "HVACDistribution2",
-                                                        :heating_system_type => "Boiler",
-                                                        :heating_system_fuel => "natural gas",
-                                                        :heating_capacity => 6400,
-                                                        :heating_efficiency_afue => 0.92,
-                                                        :fraction_heat_load_served => 0.1,
-                                                        :electric_auxiliary_energy => 200 })
-    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem3",
-                                                        :heating_system_type => "ElectricResistance",
-                                                        :heating_system_fuel => "electricity",
-                                                        :heating_capacity => 6400,
-                                                        :heating_efficiency_percent => 1,
-                                                        :fraction_heat_load_served => 0.1 })
-    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem4",
-                                                        :distribution_system_idref => "HVACDistribution3",
-                                                        :heating_system_type => "Furnace",
-                                                        :heating_system_fuel => "electricity",
-                                                        :heating_capacity => 6400,
-                                                        :heating_efficiency_afue => 1,
-                                                        :fraction_heat_load_served => 0.1 })
-    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem5",
-                                                        :distribution_system_idref => "HVACDistribution4",
-                                                        :heating_system_type => "Furnace",
-                                                        :heating_system_fuel => "natural gas",
-                                                        :heating_capacity => 6400,
-                                                        :heating_efficiency_afue => 0.92,
-                                                        :fraction_heat_load_served => 0.1,
-                                                        :electric_auxiliary_energy => 700 })
-    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem6",
-                                                        :heating_system_type => "Stove",
-                                                        :heating_system_fuel => "fuel oil",
-                                                        :heating_capacity => 6400,
-                                                        :heating_efficiency_percent => 0.8,
-                                                        :fraction_heat_load_served => 0.1,
-                                                        :electric_auxiliary_energy => 200 })
-    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem7",
-                                                        :heating_system_type => "WallFurnace",
-                                                        :heating_system_fuel => "propane",
-                                                        :heating_capacity => 6400,
-                                                        :heating_efficiency_afue => 0.8,
-                                                        :fraction_heat_load_served => 0.1,
-                                                        :electric_auxiliary_energy => 200 })
+    hpxml.heating_systems.add({ :id => "HeatingSystem2",
+                                :distribution_system_idref => "HVACDistribution2",
+                                :heating_system_type => "Boiler",
+                                :heating_system_fuel => "natural gas",
+                                :heating_capacity => 6400,
+                                :heating_efficiency_afue => 0.92,
+                                :fraction_heat_load_served => 0.1,
+                                :electric_auxiliary_energy => 200 })
+    hpxml.heating_systems.add({ :id => "HeatingSystem3",
+                                :heating_system_type => "ElectricResistance",
+                                :heating_system_fuel => "electricity",
+                                :heating_capacity => 6400,
+                                :heating_efficiency_percent => 1,
+                                :fraction_heat_load_served => 0.1 })
+    hpxml.heating_systems.add({ :id => "HeatingSystem4",
+                                :distribution_system_idref => "HVACDistribution3",
+                                :heating_system_type => "Furnace",
+                                :heating_system_fuel => "electricity",
+                                :heating_capacity => 6400,
+                                :heating_efficiency_afue => 1,
+                                :fraction_heat_load_served => 0.1 })
+    hpxml.heating_systems.add({ :id => "HeatingSystem5",
+                                :distribution_system_idref => "HVACDistribution4",
+                                :heating_system_type => "Furnace",
+                                :heating_system_fuel => "natural gas",
+                                :heating_capacity => 6400,
+                                :heating_efficiency_afue => 0.92,
+                                :fraction_heat_load_served => 0.1,
+                                :electric_auxiliary_energy => 700 })
+    hpxml.heating_systems.add({ :id => "HeatingSystem6",
+                                :heating_system_type => "Stove",
+                                :heating_system_fuel => "fuel oil",
+                                :heating_capacity => 6400,
+                                :heating_efficiency_percent => 0.8,
+                                :fraction_heat_load_served => 0.1,
+                                :electric_auxiliary_energy => 200 })
+    hpxml.heating_systems.add({ :id => "HeatingSystem7",
+                                :heating_system_type => "WallFurnace",
+                                :heating_system_fuel => "propane",
+                                :heating_capacity => 6400,
+                                :heating_efficiency_afue => 0.8,
+                                :fraction_heat_load_served => 0.1,
+                                :electric_auxiliary_energy => 200 })
   elsif ['invalid_files/hvac-frac-load-served.xml'].include? hpxml_file
     hpxml.heating_systems[0].fraction_heat_load_served += 0.1
   elsif ['base-hvac-portable-heater-electric-only.xml'].include? hpxml_file
@@ -1774,13 +1774,13 @@ end
 
 def set_hpxml_cooling_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.cooling_systems = [HPXML::CoolingSystem.new({ :id => "CoolingSystem",
-                                                        :distribution_system_idref => "HVACDistribution",
-                                                        :cooling_system_type => "central air conditioner",
-                                                        :cooling_system_fuel => "electricity",
-                                                        :cooling_capacity => 48000,
-                                                        :fraction_cool_load_served => 1,
-                                                        :cooling_efficiency_seer => 13 })]
+    hpxml.cooling_systems.add({ :id => "CoolingSystem",
+                                :distribution_system_idref => "HVACDistribution",
+                                :cooling_system_type => "central air conditioner",
+                                :cooling_system_fuel => "electricity",
+                                :cooling_capacity => 48000,
+                                :fraction_cool_load_served => 1,
+                                :cooling_efficiency_seer => 13 })
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-air-to-air-heat-pump-var-speed.xml',
@@ -1805,7 +1805,7 @@ def set_hpxml_cooling_systems(hpxml_file, hpxml)
          'base-hvac-wall-furnace-elec-only.xml',
          'base-hvac-wall-furnace-propane-only.xml',
          'base-hvac-wall-furnace-wood-only.xml'].include? hpxml_file
-    hpxml.cooling_systems = []
+    hpxml.cooling_systems.clear
   elsif ['base-hvac-central-ac-only-1-speed-detailed.xml'].include? hpxml_file
     hpxml.cooling_systems[0].cooling_shr = 0.7
     hpxml.cooling_systems[0].compressor_type = "single stage"
@@ -1848,12 +1848,12 @@ def set_hpxml_cooling_systems(hpxml_file, hpxml)
     hpxml.cooling_systems[0].distribution_system_idref = "HVACDistribution4"
     hpxml.cooling_systems[0].fraction_cool_load_served = 0.2
     hpxml.cooling_systems[0].cooling_capacity *= 0.2
-    hpxml.cooling_systems << HPXML::CoolingSystem.new({ :id => "CoolingSystem2",
-                                                        :cooling_system_type => "room air conditioner",
-                                                        :cooling_system_fuel => "electricity",
-                                                        :cooling_capacity => 9600,
-                                                        :fraction_cool_load_served => 0.2,
-                                                        :cooling_efficiency_eer => 8.5 })
+    hpxml.cooling_systems.add({ :id => "CoolingSystem2",
+                                :cooling_system_type => "room air conditioner",
+                                :cooling_system_fuel => "electricity",
+                                :cooling_capacity => 9600,
+                                :fraction_cool_load_served => 0.2,
+                                :cooling_efficiency_eer => 8.5 })
   elsif ['invalid_files/hvac-frac-load-served.xml'].include? hpxml_file
     hpxml.cooling_systems[0].fraction_cool_load_served += 0.2
   elsif ['invalid_files/hvac-dse-multiple-attached-cooling.xml'].include? hpxml_file
@@ -1885,82 +1885,80 @@ def set_hpxml_cooling_systems(hpxml_file, hpxml)
 end
 
 def set_hpxml_heat_pumps(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.heat_pumps = []
-  elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
-         'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'].include? hpxml_file
-    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
-                                              :distribution_system_idref => "HVACDistribution",
-                                              :heat_pump_type => "air-to-air",
-                                              :heat_pump_fuel => "electricity",
-                                              :heating_capacity => 42000,
-                                              :cooling_capacity => 48000,
-                                              :backup_heating_fuel => "electricity",
-                                              :backup_heating_capacity => 34121,
-                                              :backup_heating_efficiency_percent => 1.0,
-                                              :fraction_heat_load_served => 1,
-                                              :fraction_cool_load_served => 1,
-                                              :heating_efficiency_hspf => 7.7,
-                                              :cooling_efficiency_seer => 13 })
+  if ['base-hvac-air-to-air-heat-pump-1-speed.xml',
+      'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'].include? hpxml_file
+    hpxml.heat_pumps.add({ :id => "HeatPump",
+                           :distribution_system_idref => "HVACDistribution",
+                           :heat_pump_type => "air-to-air",
+                           :heat_pump_fuel => "electricity",
+                           :heating_capacity => 42000,
+                           :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
+                           :backup_heating_capacity => 34121,
+                           :backup_heating_efficiency_percent => 1.0,
+                           :fraction_heat_load_served => 1,
+                           :fraction_cool_load_served => 1,
+                           :heating_efficiency_hspf => 7.7,
+                           :cooling_efficiency_seer => 13 })
     if hpxml_file == 'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'
       hpxml.heat_pumps[0].fraction_cool_load_served = 0
     end
   elsif ['base-hvac-air-to-air-heat-pump-2-speed.xml'].include? hpxml_file
-    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
-                                              :distribution_system_idref => "HVACDistribution",
-                                              :heat_pump_type => "air-to-air",
-                                              :heat_pump_fuel => "electricity",
-                                              :heating_capacity => 42000,
-                                              :cooling_capacity => 48000,
-                                              :backup_heating_fuel => "electricity",
-                                              :backup_heating_capacity => 34121,
-                                              :backup_heating_efficiency_percent => 1.0,
-                                              :fraction_heat_load_served => 1,
-                                              :fraction_cool_load_served => 1,
-                                              :heating_efficiency_hspf => 9.3,
-                                              :cooling_efficiency_seer => 18 })
+    hpxml.heat_pumps.add({ :id => "HeatPump",
+                           :distribution_system_idref => "HVACDistribution",
+                           :heat_pump_type => "air-to-air",
+                           :heat_pump_fuel => "electricity",
+                           :heating_capacity => 42000,
+                           :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
+                           :backup_heating_capacity => 34121,
+                           :backup_heating_efficiency_percent => 1.0,
+                           :fraction_heat_load_served => 1,
+                           :fraction_cool_load_served => 1,
+                           :heating_efficiency_hspf => 9.3,
+                           :cooling_efficiency_seer => 18 })
   elsif ['base-hvac-air-to-air-heat-pump-var-speed.xml'].include? hpxml_file
-    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
-                                              :distribution_system_idref => "HVACDistribution",
-                                              :heat_pump_type => "air-to-air",
-                                              :heat_pump_fuel => "electricity",
-                                              :heating_capacity => 42000,
-                                              :cooling_capacity => 48000,
-                                              :backup_heating_fuel => "electricity",
-                                              :backup_heating_capacity => 34121,
-                                              :backup_heating_efficiency_percent => 1.0,
-                                              :fraction_heat_load_served => 1,
-                                              :fraction_cool_load_served => 1,
-                                              :heating_efficiency_hspf => 10,
-                                              :cooling_efficiency_seer => 22 })
+    hpxml.heat_pumps.add({ :id => "HeatPump",
+                           :distribution_system_idref => "HVACDistribution",
+                           :heat_pump_type => "air-to-air",
+                           :heat_pump_fuel => "electricity",
+                           :heating_capacity => 42000,
+                           :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
+                           :backup_heating_capacity => 34121,
+                           :backup_heating_efficiency_percent => 1.0,
+                           :fraction_heat_load_served => 1,
+                           :fraction_cool_load_served => 1,
+                           :heating_efficiency_hspf => 10,
+                           :cooling_efficiency_seer => 22 })
   elsif ['base-hvac-ground-to-air-heat-pump.xml'].include? hpxml_file
-    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
-                                              :distribution_system_idref => "HVACDistribution",
-                                              :heat_pump_type => "ground-to-air",
-                                              :heat_pump_fuel => "electricity",
-                                              :heating_capacity => 42000,
-                                              :cooling_capacity => 48000,
-                                              :backup_heating_fuel => "electricity",
-                                              :backup_heating_capacity => 34121,
-                                              :backup_heating_efficiency_percent => 1.0,
-                                              :fraction_heat_load_served => 1,
-                                              :fraction_cool_load_served => 1,
-                                              :heating_efficiency_cop => 3.6,
-                                              :cooling_efficiency_eer => 16.6 })
+    hpxml.heat_pumps.add({ :id => "HeatPump",
+                           :distribution_system_idref => "HVACDistribution",
+                           :heat_pump_type => "ground-to-air",
+                           :heat_pump_fuel => "electricity",
+                           :heating_capacity => 42000,
+                           :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
+                           :backup_heating_capacity => 34121,
+                           :backup_heating_efficiency_percent => 1.0,
+                           :fraction_heat_load_served => 1,
+                           :fraction_cool_load_served => 1,
+                           :heating_efficiency_cop => 3.6,
+                           :cooling_efficiency_eer => 16.6 })
   elsif ['base-hvac-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
-                                              :distribution_system_idref => "HVACDistribution",
-                                              :heat_pump_type => "mini-split",
-                                              :heat_pump_fuel => "electricity",
-                                              :heating_capacity => 52000,
-                                              :cooling_capacity => 48000,
-                                              :backup_heating_fuel => "electricity",
-                                              :backup_heating_capacity => 34121,
-                                              :backup_heating_efficiency_percent => 1.0,
-                                              :fraction_heat_load_served => 1,
-                                              :fraction_cool_load_served => 1,
-                                              :heating_efficiency_hspf => 10,
-                                              :cooling_efficiency_seer => 19 })
+    hpxml.heat_pumps.add({ :id => "HeatPump",
+                           :distribution_system_idref => "HVACDistribution",
+                           :heat_pump_type => "mini-split",
+                           :heat_pump_fuel => "electricity",
+                           :heating_capacity => 52000,
+                           :cooling_capacity => 48000,
+                           :backup_heating_fuel => "electricity",
+                           :backup_heating_capacity => 34121,
+                           :backup_heating_efficiency_percent => 1.0,
+                           :fraction_heat_load_served => 1,
+                           :fraction_cool_load_served => 1,
+                           :heating_efficiency_hspf => 10,
+                           :cooling_efficiency_seer => 19 })
   elsif ['base-hvac-mini-split-heat-pump-ductless.xml'].include? hpxml_file
     hpxml.heat_pumps[0].distribution_system_idref = nil
   elsif ['base-hvac-mini-split-heat-pump-ductless-no-backup.xml'].include? hpxml_file
@@ -1994,44 +1992,44 @@ def set_hpxml_heat_pumps(hpxml_file, hpxml)
   elsif ['base-hvac-ground-to-air-heat-pump-detailed.xml'].include? hpxml_file
     hpxml.heat_pumps[0].cooling_shr = 0.7
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
-                                              :distribution_system_idref => "HVACDistribution5",
-                                              :heat_pump_type => "air-to-air",
-                                              :heat_pump_fuel => "electricity",
-                                              :heating_capacity => 4800,
-                                              :cooling_capacity => 4800,
-                                              :backup_heating_fuel => "electricity",
-                                              :backup_heating_capacity => 3412,
-                                              :backup_heating_efficiency_percent => 1.0,
-                                              :fraction_heat_load_served => 0.1,
-                                              :fraction_cool_load_served => 0.2,
-                                              :heating_efficiency_hspf => 7.7,
-                                              :cooling_efficiency_seer => 13 })
-    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump2",
-                                              :distribution_system_idref => "HVACDistribution6",
-                                              :heat_pump_type => "ground-to-air",
-                                              :heat_pump_fuel => "electricity",
-                                              :heating_capacity => 4800,
-                                              :cooling_capacity => 4800,
-                                              :backup_heating_fuel => "electricity",
-                                              :backup_heating_capacity => 3412,
-                                              :backup_heating_efficiency_percent => 1.0,
-                                              :fraction_heat_load_served => 0.1,
-                                              :fraction_cool_load_served => 0.2,
-                                              :heating_efficiency_cop => 3.6,
-                                              :cooling_efficiency_eer => 16.6 })
-    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump3",
-                                              :heat_pump_type => "mini-split",
-                                              :heat_pump_fuel => "electricity",
-                                              :heating_capacity => 4800,
-                                              :cooling_capacity => 4800,
-                                              :backup_heating_fuel => "electricity",
-                                              :backup_heating_capacity => 3412,
-                                              :backup_heating_efficiency_percent => 1.0,
-                                              :fraction_heat_load_served => 0.1,
-                                              :fraction_cool_load_served => 0.2,
-                                              :heating_efficiency_hspf => 10,
-                                              :cooling_efficiency_seer => 19 })
+    hpxml.heat_pumps.add({ :id => "HeatPump",
+                           :distribution_system_idref => "HVACDistribution5",
+                           :heat_pump_type => "air-to-air",
+                           :heat_pump_fuel => "electricity",
+                           :heating_capacity => 4800,
+                           :cooling_capacity => 4800,
+                           :backup_heating_fuel => "electricity",
+                           :backup_heating_capacity => 3412,
+                           :backup_heating_efficiency_percent => 1.0,
+                           :fraction_heat_load_served => 0.1,
+                           :fraction_cool_load_served => 0.2,
+                           :heating_efficiency_hspf => 7.7,
+                           :cooling_efficiency_seer => 13 })
+    hpxml.heat_pumps.add({ :id => "HeatPump2",
+                           :distribution_system_idref => "HVACDistribution6",
+                           :heat_pump_type => "ground-to-air",
+                           :heat_pump_fuel => "electricity",
+                           :heating_capacity => 4800,
+                           :cooling_capacity => 4800,
+                           :backup_heating_fuel => "electricity",
+                           :backup_heating_capacity => 3412,
+                           :backup_heating_efficiency_percent => 1.0,
+                           :fraction_heat_load_served => 0.1,
+                           :fraction_cool_load_served => 0.2,
+                           :heating_efficiency_cop => 3.6,
+                           :cooling_efficiency_eer => 16.6 })
+    hpxml.heat_pumps.add({ :id => "HeatPump3",
+                           :heat_pump_type => "mini-split",
+                           :heat_pump_fuel => "electricity",
+                           :heating_capacity => 4800,
+                           :cooling_capacity => 4800,
+                           :backup_heating_fuel => "electricity",
+                           :backup_heating_capacity => 3412,
+                           :backup_heating_efficiency_percent => 1.0,
+                           :fraction_heat_load_served => 0.1,
+                           :fraction_cool_load_served => 0.2,
+                           :heating_efficiency_hspf => 10,
+                           :cooling_efficiency_seer => 19 })
   elsif ['invalid_files/hvac-distribution-multiple-attached-heating.xml'].include? hpxml_file
     hpxml.heat_pumps[0].distribution_system_idref = "HVACDistribution3"
   elsif ['invalid_files/hvac-distribution-multiple-attached-cooling.xml'].include? hpxml_file
@@ -2082,12 +2080,12 @@ end
 
 def set_hpxml_hvac_control(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.hvac_control = HPXML::HVACControl.new({ :id => "HVACControl",
-                                                  :control_type => "manual thermostat",
-                                                  :heating_setpoint_temp => 68,
-                                                  :cooling_setpoint_temp => 78 })
+    hpxml.set_hvac_control({ :id => "HVACControl",
+                             :control_type => "manual thermostat",
+                             :heating_setpoint_temp => 68,
+                             :cooling_setpoint_temp => 78 })
   elsif ['base-hvac-none.xml'].include? hpxml_file
-    hpxml.hvac_control = nil
+    hpxml.set_hvac_control({})
   elsif ['base-hvac-programmable-thermostat.xml'].include? hpxml_file
     hpxml.hvac_control.control_type = "programmable thermostat"
     hpxml.hvac_control.heating_setback_temp = 66
@@ -2106,50 +2104,50 @@ end
 
 def set_hpxml_hvac_distributions(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.hvac_distributions = [HPXML::HVACDistribution.new({ :id => "HVACDistribution",
-                                                              :distribution_system_type => "AirDistribution" })]
-    hpxml.hvac_distributions[0].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
-                                                                                                 :duct_leakage_units => "CFM25",
-                                                                                                 :duct_leakage_value => 75 }),
-                                                             HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
-                                                                                                 :duct_leakage_units => "CFM25",
-                                                                                                 :duct_leakage_value => 25 })]
-    hpxml.hvac_distributions[0].ducts = [HPXML::Duct.new({ :duct_type => "supply",
-                                                           :duct_insulation_r_value => 4,
-                                                           :duct_location => "attic - unvented",
-                                                           :duct_surface_area => 150 }),
-                                         HPXML::Duct.new({ :duct_type => "return",
-                                                           :duct_insulation_r_value => 0,
-                                                           :duct_location => "attic - unvented",
-                                                           :duct_surface_area => 50 })]
+    hpxml.hvac_distributions.add({ :id => "HVACDistribution",
+                                   :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[0].duct_leakage_measurements.add({ :duct_type => "supply",
+                                                                :duct_leakage_units => "CFM25",
+                                                                :duct_leakage_value => 75 })
+    hpxml.hvac_distributions[0].duct_leakage_measurements.add({ :duct_type => "return",
+                                                                :duct_leakage_units => "CFM25",
+                                                                :duct_leakage_value => 25 })
+    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "supply",
+                                            :duct_insulation_r_value => 4,
+                                            :duct_location => "attic - unvented",
+                                            :duct_surface_area => 150 })
+    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "return",
+                                            :duct_insulation_r_value => 0,
+                                            :duct_location => "attic - unvented",
+                                            :duct_surface_area => 50 })
   elsif ['base-hvac-boiler-elec-only.xml',
          'base-hvac-boiler-gas-only.xml',
          'base-hvac-boiler-oil-only.xml',
          'base-hvac-boiler-propane-only.xml',
          'base-hvac-boiler-wood-only.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].distribution_system_type = "HydronicDistribution"
-    hpxml.hvac_distributions[0].duct_leakage_measurements = []
-    hpxml.hvac_distributions[0].ducts = []
+    hpxml.hvac_distributions[0].duct_leakage_measurements.clear
+    hpxml.hvac_distributions[0].ducts.clear
   elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].distribution_system_type = "HydronicDistribution"
-    hpxml.hvac_distributions[0].duct_leakage_measurements = []
-    hpxml.hvac_distributions[0].ducts = []
-    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution2",
-                                                              :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 75 }),
-                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 25 })]
-    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
-                                                            :duct_insulation_r_value => 4,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 150 }),
-                                          HPXML::Duct.new({ :duct_type => "return",
-                                                            :duct_insulation_r_value => 0,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 50 })]
+    hpxml.hvac_distributions[0].duct_leakage_measurements.clear
+    hpxml.hvac_distributions[0].ducts.clear
+    hpxml.hvac_distributions.add({ :id => "HVACDistribution2",
+                                   :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 75 })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 25 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
+                                             :duct_insulation_r_value => 4,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 150 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
+                                             :duct_insulation_r_value => 0,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 50 })
   elsif ['base-hvac-none.xml',
          'base-hvac-elec-resistance-only.xml',
          'base-hvac-evap-cooler-only.xml',
@@ -2161,79 +2159,77 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
          'base-hvac-wall-furnace-elec-only.xml',
          'base-hvac-wall-furnace-propane-only.xml',
          'base-hvac-wall-furnace-wood-only.xml'].include? hpxml_file
-    hpxml.hvac_distributions = []
+    hpxml.hvac_distributions.clear
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].distribution_system_type = "HydronicDistribution"
-    hpxml.hvac_distributions[0].duct_leakage_measurements = []
-    hpxml.hvac_distributions[0].ducts = []
-    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution2",
-                                                              :distribution_system_type => "HydronicDistribution",
-                                                              :duct_leakage_measurements => [],
-                                                              :ducts => [] })
-    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution3",
-                                                              :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 75 }),
-                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 25 })]
-    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
-                                                            :duct_insulation_r_value => 4,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 150 }),
-                                          HPXML::Duct.new({ :duct_type => "return",
-                                                            :duct_insulation_r_value => 0,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 50 })]
-    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution4",
-                                                              :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 75 }),
-                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 25 })]
-    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
-                                                            :duct_insulation_r_value => 4,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 150 }),
-                                          HPXML::Duct.new({ :duct_type => "return",
-                                                            :duct_insulation_r_value => 0,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 50 })]
-    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution5",
-                                                              :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 75 }),
-                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 25 })]
-    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
-                                                            :duct_insulation_r_value => 4,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 150 }),
-                                          HPXML::Duct.new({ :duct_type => "return",
-                                                            :duct_insulation_r_value => 0,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 50 })]
-    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution6",
-                                                              :distribution_system_type => "AirDistribution" })
-    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 75 }),
-                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
-                                                                                                  :duct_leakage_units => "CFM25",
-                                                                                                  :duct_leakage_value => 25 })]
-    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
-                                                            :duct_insulation_r_value => 4,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 150 }),
-                                          HPXML::Duct.new({ :duct_type => "return",
-                                                            :duct_insulation_r_value => 0,
-                                                            :duct_location => "attic - unvented",
-                                                            :duct_surface_area => 50 })]
+    hpxml.hvac_distributions[0].duct_leakage_measurements.clear
+    hpxml.hvac_distributions[0].ducts.clear
+    hpxml.hvac_distributions.add({ :id => "HVACDistribution2",
+                                   :distribution_system_type => "HydronicDistribution" })
+    hpxml.hvac_distributions.add({ :id => "HVACDistribution3",
+                                   :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 75 })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 25 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
+                                             :duct_insulation_r_value => 4,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 150 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
+                                             :duct_insulation_r_value => 0,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 50 })
+    hpxml.hvac_distributions.add({ :id => "HVACDistribution4",
+                                   :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 75 })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 25 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
+                                             :duct_insulation_r_value => 4,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 150 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
+                                             :duct_insulation_r_value => 0,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 50 })
+    hpxml.hvac_distributions.add({ :id => "HVACDistribution5",
+                                   :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 75 })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 25 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
+                                             :duct_insulation_r_value => 4,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 150 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
+                                             :duct_insulation_r_value => 0,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 50 })
+    hpxml.hvac_distributions.add({ :id => "HVACDistribution6",
+                                   :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "supply",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 75 })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements.add({ :duct_type => "return",
+                                                                 :duct_leakage_units => "CFM25",
+                                                                 :duct_leakage_value => 25 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "supply",
+                                             :duct_insulation_r_value => 4,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 150 })
+    hpxml.hvac_distributions[-1].ducts.add({ :duct_type => "return",
+                                             :duct_insulation_r_value => 0,
+                                             :duct_location => "attic - unvented",
+                                             :duct_surface_area => 50 })
   elsif ['base-hvac-dse.xml',
          'base-dhw-indirect-dse.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].distribution_system_type = "DSE"
@@ -2259,12 +2255,13 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
     hpxml.hvac_distributions[0].duct_leakage_measurements.pop
     hpxml.hvac_distributions[0].ducts.pop
   elsif ['base-hvac-ducts-leakage-percent.xml'].include? hpxml_file
-    hpxml.hvac_distributions[0].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
-                                                                                                 :duct_leakage_units => "Percent",
-                                                                                                 :duct_leakage_value => 0.1 }),
-                                                             HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
-                                                                                                 :duct_leakage_units => "Percent",
-                                                                                                 :duct_leakage_value => 0.05 })]
+    hpxml.hvac_distributions[0].duct_leakage_measurements.clear
+    hpxml.hvac_distributions[0].duct_leakage_measurements.add({ :duct_type => "supply",
+                                                                :duct_leakage_units => "Percent",
+                                                                :duct_leakage_value => 0.1 })
+    hpxml.hvac_distributions[0].duct_leakage_measurements.add({ :duct_type => "return",
+                                                                :duct_leakage_units => "Percent",
+                                                                :duct_leakage_value => 0.05 })
   elsif ['base-hvac-undersized.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value /= 10.0
     hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value /= 10.0
@@ -2298,22 +2295,22 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
   elsif ['base-hvac-ducts-locations.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].ducts[1].duct_location = "attic - unvented"
   elsif ['base-hvac-ducts-multiple.xml'].include? hpxml_file
-    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "supply",
-                                                           :duct_insulation_r_value => 8,
-                                                           :duct_location => "attic - unvented",
-                                                           :duct_surface_area => 300 })
-    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "supply",
-                                                           :duct_insulation_r_value => 8,
-                                                           :duct_location => "outside",
-                                                           :duct_surface_area => 300 })
-    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "return",
-                                                           :duct_insulation_r_value => 4,
-                                                           :duct_location => "attic - unvented",
-                                                           :duct_surface_area => 100 })
-    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "return",
-                                                           :duct_insulation_r_value => 4,
-                                                           :duct_location => "outside",
-                                                           :duct_surface_area => 100 })
+    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "supply",
+                                            :duct_insulation_r_value => 8,
+                                            :duct_location => "attic - unvented",
+                                            :duct_surface_area => 300 })
+    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "supply",
+                                            :duct_insulation_r_value => 8,
+                                            :duct_location => "outside",
+                                            :duct_surface_area => 300 })
+    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "return",
+                                            :duct_insulation_r_value => 4,
+                                            :duct_location => "attic - unvented",
+                                            :duct_surface_area => 100 })
+    hpxml.hvac_distributions[0].ducts.add({ :duct_type => "return",
+                                            :duct_insulation_r_value => 4,
+                                            :duct_location => "outside",
+                                            :duct_surface_area => 100 })
   elsif ['base-atticroof-conditioned.xml',
          'base-enclosure-adiabatic-surfaces.xml',
          'base-atticroof-cathedral.xml',
@@ -2335,9 +2332,9 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
       hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value = 0.0
       hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value = 0.0
     end
-    hpxml.hvac_distributions[0].ducts = []
+    hpxml.hvac_distributions[0].ducts.clear
   elsif hpxml_file.include? 'hvac_multiple' and not hpxml.hvac_distributions.empty?
-    hpxml.hvac_distributions[0].ducts = []
+    hpxml.hvac_distributions[0].ducts.clear
     if not hpxml.hvac_distributions[0].duct_leakage_measurements.empty?
       hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value = 0.0
       hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value = 0.0
@@ -2347,10 +2344,8 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
     hpxml.hvac_distributions << hpxml.hvac_distributions[0].dup
     hpxml.hvac_distributions[2].id = "HVACDistribution3"
   elsif ['invalid_files/hvac-invalid-distribution-system-type.xml'].include? hpxml_file
-    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution2",
-                                                              :distribution_system_type => "HydronicDistribution",
-                                                              :duct_leakage_measurements => [],
-                                                              :ducts => [] })
+    hpxml.hvac_distributions.add({ :id => "HVACDistribution2",
+                                   :distribution_system_type => "HydronicDistribution" })
   elsif ['invalid_files/hvac-distribution-return-duct-leakage-missing.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "return",
                                                            :duct_insulation_r_value => 0,
@@ -2360,138 +2355,136 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
 end
 
 def set_hpxml_ventilation_fans(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.ventilation_fans = []
-  elsif ['base-mechvent-balanced.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "balanced",
-                                                          :tested_flow_rate => 110,
-                                                          :hours_in_operation => 24,
-                                                          :fan_power => 60,
-                                                          :used_for_whole_building_ventilation => true })
+  if ['base-mechvent-balanced.xml'].include? hpxml_file
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "balanced",
+                                 :tested_flow_rate => 110,
+                                 :hours_in_operation => 24,
+                                 :fan_power => 60,
+                                 :used_for_whole_building_ventilation => true })
   elsif ['invalid_files/unattached-cfis.xml',
          'invalid_files/cfis-with-hydronic-distribution.xml',
          'base-mechvent-cfis.xml',
          'base-mechvent-cfis-evap-cooler-only-ducted.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "central fan integrated supply",
-                                                          :tested_flow_rate => 330,
-                                                          :hours_in_operation => 8,
-                                                          :fan_power => 300,
-                                                          :used_for_whole_building_ventilation => true,
-                                                          :distribution_system_idref => "HVACDistribution" })
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "central fan integrated supply",
+                                 :tested_flow_rate => 330,
+                                 :hours_in_operation => 8,
+                                 :fan_power => 300,
+                                 :used_for_whole_building_ventilation => true,
+                                 :distribution_system_idref => "HVACDistribution" })
     if ['invalid_files/unattached-cfis.xml'].include? hpxml_file
       hpxml.ventilation_fans[0].distribution_system_idref = "foobar"
     end
   elsif ['base-mechvent-erv.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "energy recovery ventilator",
-                                                          :tested_flow_rate => 110,
-                                                          :hours_in_operation => 24,
-                                                          :total_recovery_efficiency => 0.48,
-                                                          :sensible_recovery_efficiency => 0.72,
-                                                          :fan_power => 60,
-                                                          :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "energy recovery ventilator",
+                                 :tested_flow_rate => 110,
+                                 :hours_in_operation => 24,
+                                 :total_recovery_efficiency => 0.48,
+                                 :sensible_recovery_efficiency => 0.72,
+                                 :fan_power => 60,
+                                 :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-erv-atre-asre.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "energy recovery ventilator",
-                                                          :tested_flow_rate => 110,
-                                                          :hours_in_operation => 24,
-                                                          :total_recovery_efficiency_adjusted => 0.526,
-                                                          :sensible_recovery_efficiency_adjusted => 0.79,
-                                                          :fan_power => 60,
-                                                          :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "energy recovery ventilator",
+                                 :tested_flow_rate => 110,
+                                 :hours_in_operation => 24,
+                                 :total_recovery_efficiency_adjusted => 0.526,
+                                 :sensible_recovery_efficiency_adjusted => 0.79,
+                                 :fan_power => 60,
+                                 :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-exhaust.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "exhaust only",
-                                                          :tested_flow_rate => 110,
-                                                          :hours_in_operation => 24,
-                                                          :fan_power => 30,
-                                                          :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "exhaust only",
+                                 :tested_flow_rate => 110,
+                                 :hours_in_operation => 24,
+                                 :fan_power => 30,
+                                 :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-exhaust-rated-flow-rate.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "exhaust only",
-                                                          :rated_flow_rate => 110,
-                                                          :hours_in_operation => 24,
-                                                          :fan_power => 30,
-                                                          :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "exhaust only",
+                                 :rated_flow_rate => 110,
+                                 :hours_in_operation => 24,
+                                 :fan_power => 30,
+                                 :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-hrv.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "heat recovery ventilator",
-                                                          :tested_flow_rate => 110,
-                                                          :hours_in_operation => 24,
-                                                          :sensible_recovery_efficiency => 0.72,
-                                                          :fan_power => 60,
-                                                          :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "heat recovery ventilator",
+                                 :tested_flow_rate => 110,
+                                 :hours_in_operation => 24,
+                                 :sensible_recovery_efficiency => 0.72,
+                                 :fan_power => 60,
+                                 :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-hrv-asre.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "heat recovery ventilator",
-                                                          :tested_flow_rate => 110,
-                                                          :hours_in_operation => 24,
-                                                          :sensible_recovery_efficiency_adjusted => 0.790,
-                                                          :fan_power => 60,
-                                                          :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "heat recovery ventilator",
+                                 :tested_flow_rate => 110,
+                                 :hours_in_operation => 24,
+                                 :sensible_recovery_efficiency_adjusted => 0.790,
+                                 :fan_power => 60,
+                                 :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-supply.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
-                                                          :fan_type => "supply only",
-                                                          :tested_flow_rate => 110,
-                                                          :hours_in_operation => 24,
-                                                          :fan_power => 30,
-                                                          :used_for_whole_building_ventilation => true })
+    hpxml.ventilation_fans.add({ :id => "MechanicalVentilation",
+                                 :fan_type => "supply only",
+                                 :tested_flow_rate => 110,
+                                 :hours_in_operation => 24,
+                                 :fan_power => 30,
+                                 :used_for_whole_building_ventilation => true })
   elsif ['base-misc-whole-house-fan.xml'].include? hpxml_file
-    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "WholeHouseFan",
-                                                          :rated_flow_rate => 4500,
-                                                          :fan_power => 300,
-                                                          :used_for_seasonal_cooling_load_reduction => true })
+    hpxml.ventilation_fans.add({ :id => "WholeHouseFan",
+                                 :rated_flow_rate => 4500,
+                                 :fan_power => 300,
+                                 :used_for_seasonal_cooling_load_reduction => true })
   end
 end
 
 def set_hpxml_water_heating_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.water_heating_systems = [HPXML::WaterHeatingSystem.new({ :id => "WaterHeater",
-                                                                   :fuel_type => "electricity",
-                                                                   :water_heater_type => "storage water heater",
-                                                                   :location => "living space",
-                                                                   :tank_volume => 40,
-                                                                   :fraction_dhw_load_served => 1,
-                                                                   :heating_capacity => 18767,
-                                                                   :energy_factor => 0.95 })]
+    hpxml.water_heating_systems.add({ :id => "WaterHeater",
+                                      :fuel_type => "electricity",
+                                      :water_heater_type => "storage water heater",
+                                      :location => "living space",
+                                      :tank_volume => 40,
+                                      :fraction_dhw_load_served => 1,
+                                      :heating_capacity => 18767,
+                                      :energy_factor => 0.95 })
   elsif ['base-dhw-multiple.xml'].include? hpxml_file
     hpxml.water_heating_systems[0].fraction_dhw_load_served = 0.2
-    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater2",
-                                                                   :fuel_type => "natural gas",
-                                                                   :water_heater_type => "storage water heater",
-                                                                   :location => "living space",
-                                                                   :tank_volume => 50,
-                                                                   :fraction_dhw_load_served => 0.2,
-                                                                   :heating_capacity => 40000,
-                                                                   :energy_factor => 0.59,
-                                                                   :recovery_efficiency => 0.76 })
-    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater3",
-                                                                   :fuel_type => "electricity",
-                                                                   :water_heater_type => "heat pump water heater",
-                                                                   :location => "living space",
-                                                                   :tank_volume => 80,
-                                                                   :fraction_dhw_load_served => 0.2,
-                                                                   :energy_factor => 2.3 })
-    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater4",
-                                                                   :fuel_type => "electricity",
-                                                                   :water_heater_type => "instantaneous water heater",
-                                                                   :location => "living space",
-                                                                   :fraction_dhw_load_served => 0.2,
-                                                                   :energy_factor => 0.99 })
-    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater5",
-                                                                   :fuel_type => "natural gas",
-                                                                   :water_heater_type => "instantaneous water heater",
-                                                                   :location => "living space",
-                                                                   :fraction_dhw_load_served => 0.1,
-                                                                   :energy_factor => 0.82 })
-    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater6",
-                                                                   :water_heater_type => "space-heating boiler with storage tank",
-                                                                   :location => "living space",
-                                                                   :tank_volume => 50,
-                                                                   :fraction_dhw_load_served => 0.1,
-                                                                   :related_hvac => "HeatingSystem" })
+    hpxml.water_heating_systems.add({ :id => "WaterHeater2",
+                                      :fuel_type => "natural gas",
+                                      :water_heater_type => "storage water heater",
+                                      :location => "living space",
+                                      :tank_volume => 50,
+                                      :fraction_dhw_load_served => 0.2,
+                                      :heating_capacity => 40000,
+                                      :energy_factor => 0.59,
+                                      :recovery_efficiency => 0.76 })
+    hpxml.water_heating_systems.add({ :id => "WaterHeater3",
+                                      :fuel_type => "electricity",
+                                      :water_heater_type => "heat pump water heater",
+                                      :location => "living space",
+                                      :tank_volume => 80,
+                                      :fraction_dhw_load_served => 0.2,
+                                      :energy_factor => 2.3 })
+    hpxml.water_heating_systems.add({ :id => "WaterHeater4",
+                                      :fuel_type => "electricity",
+                                      :water_heater_type => "instantaneous water heater",
+                                      :location => "living space",
+                                      :fraction_dhw_load_served => 0.2,
+                                      :energy_factor => 0.99 })
+    hpxml.water_heating_systems.add({ :id => "WaterHeater5",
+                                      :fuel_type => "natural gas",
+                                      :water_heater_type => "instantaneous water heater",
+                                      :location => "living space",
+                                      :fraction_dhw_load_served => 0.1,
+                                      :energy_factor => 0.82 })
+    hpxml.water_heating_systems.add({ :id => "WaterHeater6",
+                                      :water_heater_type => "space-heating boiler with storage tank",
+                                      :location => "living space",
+                                      :tank_volume => 50,
+                                      :fraction_dhw_load_served => 0.1,
+                                      :related_hvac => "HeatingSystem" })
   elsif ['invalid_files/dhw-frac-load-served.xml'].include? hpxml_file
     hpxml.water_heating_systems[0].fraction_dhw_load_served += 0.15
   elsif ['base-dhw-tank-gas.xml',
@@ -2647,16 +2640,16 @@ def set_hpxml_water_heating_systems(hpxml_file, hpxml)
   elsif ['base-dhw-temperature.xml'].include? hpxml_file
     hpxml.water_heating_systems[0].temperature = 130.0
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hpxml.water_heating_systems = []
+    hpxml.water_heating_systems.clear
   end
 end
 
 def set_hpxml_hot_water_distribution(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.hot_water_distribution = HPXML::HotWaterDistribution.new({ :id => "HotWaterDstribution",
-                                                                     :system_type => "Standard",
-                                                                     :standard_piping_length => 50, # Chosen to test a negative EC_adj
-                                                                     :pipe_r_value => 0.0 })
+    hpxml.set_hot_water_distribution({ :id => "HotWaterDstribution",
+                                       :system_type => "Standard",
+                                       :standard_piping_length => 50, # Chosen to test a negative EC_adj
+                                       :pipe_r_value => 0.0 })
   elsif ['base-dhw-dwhr.xml'].include? hpxml_file
     hpxml.hot_water_distribution.dwhr_facilities_connected = "all"
     hpxml.hot_water_distribution.dwhr_equal_flow = true
@@ -2694,54 +2687,52 @@ def set_hpxml_hot_water_distribution(hpxml_file, hpxml)
     hpxml.hot_water_distribution.recirculation_branch_piping_length = 50
     hpxml.hot_water_distribution.recirculation_pump_power = 50
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hpxml.hot_water_distribution = nil
+    hpxml.set_hot_water_distribution({})
   end
 end
 
 def set_hpxml_water_fixtures(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.water_fixtures = [HPXML::WaterFixture.new({ :id => "WaterFixture",
-                                                      :water_fixture_type => "shower head",
-                                                      :low_flow => true }),
-                            HPXML::WaterFixture.new({ :id => "WaterFixture2",
-                                                      :water_fixture_type => "faucet",
-                                                      :low_flow => false })]
+    hpxml.water_fixtures.add({ :id => "WaterFixture",
+                               :water_fixture_type => "shower head",
+                               :low_flow => true })
+    hpxml.water_fixtures.add({ :id => "WaterFixture2",
+                               :water_fixture_type => "faucet",
+                               :low_flow => false })
   elsif ['base-dhw-low-flow-fixtures.xml'].include? hpxml_file
     hpxml.water_fixtures[1].low_flow = true
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hpxml.water_fixtures = []
+    hpxml.water_fixtures.clear
   end
 end
 
 def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.solar_thermal_system = nil
-  elsif ['base-dhw-solar-fraction.xml',
-         'base-dhw-multiple.xml',
-         'base-dhw-tank-heat-pump-with-solar-fraction.xml',
-         'base-dhw-tankless-gas-with-solar-fraction.xml',
-         'invalid_files/solar-thermal-system-with-combi-tankless.xml',
-         'invalid_files/solar-thermal-system-with-desuperheater.xml',
-         'invalid_files/solar-thermal-system-with-dhw-indirect.xml'].include? hpxml_file
-    hpxml.solar_thermal_system = HPXML::SolarThermalSystem.new({ :id => "SolarThermalSystem",
-                                                                 :system_type => "hot water",
-                                                                 :water_heating_system_idref => "WaterHeater",
-                                                                 :solar_fraction => 0.65 })
+  if ['base-dhw-solar-fraction.xml',
+      'base-dhw-multiple.xml',
+      'base-dhw-tank-heat-pump-with-solar-fraction.xml',
+      'base-dhw-tankless-gas-with-solar-fraction.xml',
+      'invalid_files/solar-thermal-system-with-combi-tankless.xml',
+      'invalid_files/solar-thermal-system-with-desuperheater.xml',
+      'invalid_files/solar-thermal-system-with-dhw-indirect.xml'].include? hpxml_file
+    hpxml.set_solar_thermal_system({ :id => "SolarThermalSystem",
+                                     :system_type => "hot water",
+                                     :water_heating_system_idref => "WaterHeater",
+                                     :solar_fraction => 0.65 })
   elsif ['base-dhw-solar-direct-flat-plate.xml',
          'base-dhw-solar-indirect-flat-plate.xml',
          'base-dhw-solar-thermosyphon-flat-plate.xml',
          'base-dhw-tank-heat-pump-with-solar.xml',
          'base-dhw-tankless-gas-with-solar.xml'].include? hpxml_file
-    hpxml.solar_thermal_system = HPXML::SolarThermalSystem.new({ :id => "SolarThermalSystem",
-                                                                 :system_type => "hot water",
-                                                                 :collector_area => 40,
-                                                                 :collector_type => "single glazing black",
-                                                                 :collector_azimuth => 180,
-                                                                 :collector_tilt => 20,
-                                                                 :collector_frta => 0.77,
-                                                                 :collector_frul => 0.793,
-                                                                 :storage_volume => 60,
-                                                                 :water_heating_system_idref => "WaterHeater" })
+    hpxml.set_solar_thermal_system({ :id => "SolarThermalSystem",
+                                     :system_type => "hot water",
+                                     :collector_area => 40,
+                                     :collector_type => "single glazing black",
+                                     :collector_azimuth => 180,
+                                     :collector_tilt => 20,
+                                     :collector_frta => 0.77,
+                                     :collector_frul => 0.793,
+                                     :storage_volume => 60,
+                                     :water_heating_system_idref => "WaterHeater" })
     if hpxml_file == 'base-dhw-solar-direct-flat-plate.xml'
       hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-flat-plate.xml'
@@ -2752,16 +2743,16 @@ def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
   elsif ['base-dhw-solar-indirect-evacuated-tube.xml',
          'base-dhw-solar-direct-evacuated-tube.xml',
          'base-dhw-solar-thermosyphon-evacuated-tube.xml'].include? hpxml_file
-    hpxml.solar_thermal_system = HPXML::SolarThermalSystem.new({ :id => "SolarThermalSystem",
-                                                                 :system_type => "hot water",
-                                                                 :collector_area => 40,
-                                                                 :collector_type => "evacuated tube",
-                                                                 :collector_azimuth => 180,
-                                                                 :collector_tilt => 20,
-                                                                 :collector_frta => 0.50,
-                                                                 :collector_frul => 0.2799,
-                                                                 :storage_volume => 60,
-                                                                 :water_heating_system_idref => "WaterHeater" })
+    hpxml.set_solar_thermal_system({ :id => "SolarThermalSystem",
+                                     :system_type => "hot water",
+                                     :collector_area => 40,
+                                     :collector_type => "evacuated tube",
+                                     :collector_azimuth => 180,
+                                     :collector_tilt => 20,
+                                     :collector_frta => 0.50,
+                                     :collector_frul => 0.2799,
+                                     :storage_volume => 60,
+                                     :water_heating_system_idref => "WaterHeater" })
     if hpxml_file == 'base-dhw-solar-direct-evacuated-tube.xml'
       hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-evacuated-tube.xml'
@@ -2771,16 +2762,16 @@ def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
     end
   elsif ['base-dhw-solar-direct-ics.xml',
          'base-dhw-solar-thermosyphon-ics.xml'].include? hpxml_file
-    hpxml.solar_thermal_system = HPXML::SolarThermalSystem.new({ :id => "SolarThermalSystem",
-                                                                 :system_type => "hot water",
-                                                                 :collector_area => 40,
-                                                                 :collector_type => "integrated collector storage",
-                                                                 :collector_azimuth => 180,
-                                                                 :collector_tilt => 20,
-                                                                 :collector_frta => 0.77,
-                                                                 :collector_frul => 0.793,
-                                                                 :storage_volume => 60,
-                                                                 :water_heating_system_idref => "WaterHeater" })
+    hpxml.set_solar_thermal_system({ :id => "SolarThermalSystem",
+                                     :system_type => "hot water",
+                                     :collector_area => 40,
+                                     :collector_type => "integrated collector storage",
+                                     :collector_azimuth => 180,
+                                     :collector_tilt => 20,
+                                     :collector_frta => 0.77,
+                                     :collector_frul => 0.793,
+                                     :storage_volume => 60,
+                                     :water_heating_system_idref => "WaterHeater" })
     if hpxml_file == 'base-dhw-solar-direct-ics.xml'
       hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-ics.xml'
@@ -2792,42 +2783,40 @@ def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
 end
 
 def set_hpxml_pv_systems(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.pv_systems = []
-  elsif ['base-pv.xml'].include? hpxml_file
-    hpxml.pv_systems << HPXML::PVSystem.new({ :id => "PVSystem",
-                                              :module_type => "standard",
-                                              :location => "roof",
-                                              :tracking => "fixed",
-                                              :array_azimuth => 180,
-                                              :array_tilt => 20,
-                                              :max_power_output => 4000,
-                                              :inverter_efficiency => 0.96,
-                                              :system_losses_fraction => 0.14 })
-    hpxml.pv_systems << HPXML::PVSystem.new({ :id => "PVSystem2",
-                                              :module_type => "premium",
-                                              :location => "roof",
-                                              :tracking => "fixed",
-                                              :array_azimuth => 90,
-                                              :array_tilt => 20,
-                                              :max_power_output => 1500,
-                                              :inverter_efficiency => 0.96,
-                                              :system_losses_fraction => 0.14 })
+  if ['base-pv.xml'].include? hpxml_file
+    hpxml.pv_systems.add({ :id => "PVSystem",
+                           :module_type => "standard",
+                           :location => "roof",
+                           :tracking => "fixed",
+                           :array_azimuth => 180,
+                           :array_tilt => 20,
+                           :max_power_output => 4000,
+                           :inverter_efficiency => 0.96,
+                           :system_losses_fraction => 0.14 })
+    hpxml.pv_systems.add({ :id => "PVSystem2",
+                           :module_type => "premium",
+                           :location => "roof",
+                           :tracking => "fixed",
+                           :array_azimuth => 90,
+                           :array_tilt => 20,
+                           :max_power_output => 1500,
+                           :inverter_efficiency => 0.96,
+                           :system_losses_fraction => 0.14 })
   end
 end
 
 def set_hpxml_clothes_washer(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.clothes_washer = HPXML::ClothesWasher.new({ :id => "ClothesWasher",
-                                                      :location => "living space",
-                                                      :modified_energy_factor => 0.8,
-                                                      :rated_annual_kwh => 700.0,
-                                                      :label_electric_rate => 0.10,
-                                                      :label_gas_rate => 0.60,
-                                                      :label_annual_gas_cost => 25.0,
-                                                      :capacity => 3.0 })
+    hpxml.set_clothes_washer({ :id => "ClothesWasher",
+                               :location => "living space",
+                               :modified_energy_factor => 0.8,
+                               :rated_annual_kwh => 700.0,
+                               :label_electric_rate => 0.10,
+                               :label_gas_rate => 0.60,
+                               :label_annual_gas_cost => 25.0,
+                               :capacity => 3.0 })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.clothes_washer = nil
+    hpxml.set_clothes_washer({})
   elsif ['base-appliances-modified.xml'].include? hpxml_file
     hpxml.clothes_washer.modified_energy_factor = nil
     hpxml.clothes_washer.integrated_modified_energy_factor = 0.73
@@ -2845,26 +2834,26 @@ end
 
 def set_hpxml_clothes_dryer(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.clothes_dryer = HPXML::ClothesDryer.new({ :id => "ClothesDryer",
-                                                    :location => "living space",
-                                                    :fuel_type => "electricity",
-                                                    :energy_factor => 2.95,
-                                                    :control_type => "timer" })
+    hpxml.set_clothes_dryer({ :id => "ClothesDryer",
+                              :location => "living space",
+                              :fuel_type => "electricity",
+                              :energy_factor => 2.95,
+                              :control_type => "timer" })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.clothes_dryer = nil
+    hpxml.set_clothes_dryer({})
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    hpxml.clothes_dryer = HPXML::ClothesDryer.new({ :id => "ClothesDryer",
-                                                    :location => "living space",
-                                                    :fuel_type => "electricity",
-                                                    :combined_energy_factor => 2.62,
-                                                    :control_type => "moisture" })
+    hpxml.set_clothes_dryer({ :id => "ClothesDryer",
+                              :location => "living space",
+                              :fuel_type => "electricity",
+                              :combined_energy_factor => 2.62,
+                              :control_type => "moisture" })
   elsif ['base-appliances-gas.xml',
          'base-appliances-propane.xml',
          'base-appliances-oil.xml'].include? hpxml_file
-    hpxml.clothes_dryer = HPXML::ClothesDryer.new({ :id => "ClothesDryer",
-                                                    :location => "living space",
-                                                    :energy_factor => 2.67,
-                                                    :control_type => "moisture" })
+    hpxml.set_clothes_dryer({ :id => "ClothesDryer",
+                              :location => "living space",
+                              :energy_factor => 2.67,
+                              :control_type => "moisture" })
     if hpxml_file == 'base-appliances-gas.xml'
       hpxml.clothes_dryer.fuel_type = "natural gas"
     elsif hpxml_file == 'base-appliances-propane.xml'
@@ -2873,11 +2862,11 @@ def set_hpxml_clothes_dryer(hpxml_file, hpxml)
       hpxml.clothes_dryer.fuel_type = "fuel oil"
     end
   elsif ['base-appliances-wood.xml'].include? hpxml_file
-    hpxml.clothes_dryer = HPXML::ClothesDryer.new({ :id => "ClothesDryer",
-                                                    :location => "living space",
-                                                    :fuel_type => "wood",
-                                                    :energy_factor => 2.67,
-                                                    :control_type => "moisture" })
+    hpxml.set_clothes_dryer({ :id => "ClothesDryer",
+                              :location => "living space",
+                              :fuel_type => "wood",
+                              :energy_factor => 2.67,
+                              :control_type => "moisture" })
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     hpxml.clothes_dryer.location = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
@@ -2892,27 +2881,27 @@ end
 
 def set_hpxml_dishwasher(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.dishwasher = HPXML::Dishwasher.new({ :id => "Dishwasher",
-                                               :rated_annual_kwh => 450,
-                                               :place_setting_capacity => 12 })
+    hpxml.set_dishwasher({ :id => "Dishwasher",
+                           :rated_annual_kwh => 450,
+                           :place_setting_capacity => 12 })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.dishwasher = nil
+    hpxml.set_dishwasher({})
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    hpxml.dishwasher = HPXML::Dishwasher.new({ :id => "Dishwasher",
-                                               :energy_factor => 0.5,
-                                               :place_setting_capacity => 12 })
+    hpxml.set_dishwasher({ :id => "Dishwasher",
+                           :energy_factor => 0.5,
+                           :place_setting_capacity => 12 })
   end
 end
 
 def set_hpxml_refrigerator(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.refrigerator = HPXML::Refrigerator.new({ :id => "Refrigerator",
-                                                   :location => "living space",
-                                                   :rated_annual_kwh => 650 })
+    hpxml.set_refrigerator({ :id => "Refrigerator",
+                             :location => "living space",
+                             :rated_annual_kwh => 650 })
   elsif ['base-appliances-modified.xml'].include? hpxml_file
     hpxml.refrigerator.adjusted_annual_kwh = 600
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.refrigerator = nil
+    hpxml.set_refrigerator({})
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     hpxml.refrigerator.location = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
@@ -2927,11 +2916,11 @@ end
 
 def set_hpxml_cooking_range(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.cooking_range = HPXML::CookingRange.new({ :id => "Range",
-                                                    :fuel_type => "electricity",
-                                                    :is_induction => false })
+    hpxml.set_cooking_range({ :id => "Range",
+                              :fuel_type => "electricity",
+                              :is_induction => false })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.cooking_range = nil
+    hpxml.set_cooking_range({})
   elsif ['base-appliances-gas.xml'].include? hpxml_file
     hpxml.cooking_range.fuel_type = "natural gas"
     hpxml.cooking_range.is_induction = false
@@ -2948,61 +2937,58 @@ end
 
 def set_hpxml_oven(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.oven = HPXML::Oven.new({ :id => "Oven",
-                                   :is_convection => false })
+    hpxml.set_oven({ :id => "Oven",
+                     :is_convection => false })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.oven = nil
+    hpxml.set_oven({})
   end
 end
 
 def set_hpxml_lighting(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml.lighting = HPXML::Lighting.new({ :fraction_tier_i_interior => 0.5,
-                                           :fraction_tier_i_exterior => 0.5,
-                                           :fraction_tier_i_garage => 0.5,
-                                           :fraction_tier_ii_interior => 0.25,
-                                           :fraction_tier_ii_exterior => 0.25,
-                                           :fraction_tier_ii_garage => 0.25 })
+    hpxml.set_lighting({ :fraction_tier_i_interior => 0.5,
+                         :fraction_tier_i_exterior => 0.5,
+                         :fraction_tier_i_garage => 0.5,
+                         :fraction_tier_ii_interior => 0.25,
+                         :fraction_tier_ii_exterior => 0.25,
+                         :fraction_tier_ii_garage => 0.25 })
   elsif ['base-misc-lighting-none.xml'].include? hpxml_file
-    hpxml.lighting = nil
+    hpxml.set_lighting({})
   end
 end
 
 def set_hpxml_ceiling_fans(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.ceiling_fans = []
-  elsif ['base-misc-ceiling-fans.xml'].include? hpxml_file
-    hpxml.ceiling_fans << HPXML::CeilingFan.new({ :id => "CeilingFan",
-                                                  :efficiency => 100,
-                                                  :quantity => 2 })
+  if ['base-misc-ceiling-fans.xml'].include? hpxml_file
+    hpxml.ceiling_fans.add({ :id => "CeilingFan",
+                             :efficiency => 100,
+                             :quantity => 2 })
   end
 end
 
 def set_hpxml_plug_loads(hpxml_file, hpxml)
-  if ['base-misc-loads-detailed.xml'].include? hpxml_file
-    hpxml.plug_loads = [HPXML::PlugLoad.new({ :id => "PlugLoadMisc",
-                                              :plug_load_type => "other",
-                                              :kWh_per_year => 7302,
-                                              :frac_sensible => 0.82,
-                                              :frac_latent => 0.18 }),
-                        HPXML::PlugLoad.new({ :id => "PlugLoadMisc2",
-                                              :plug_load_type => "TV other",
-                                              :kWh_per_year => 400 })]
-  else
-    hpxml.plug_loads = [HPXML::PlugLoad.new({ :id => "PlugLoadMisc",
-                                              :plug_load_type => "other" }),
-                        HPXML::PlugLoad.new({ :id => "PlugLoadMisc2",
-                                              :plug_load_type => "TV other" })]
+  if ['base.xml'].include? hpxml_file
+    hpxml.plug_loads.add({ :id => "PlugLoadMisc",
+                           :plug_load_type => "other" })
+    hpxml.plug_loads.add({ :id => "PlugLoadMisc2",
+                           :plug_load_type => "TV other" })
+  elsif ['base-misc-loads-detailed.xml'].include? hpxml_file
+    hpxml.plug_loads.clear
+    hpxml.plug_loads.add({ :id => "PlugLoadMisc",
+                           :plug_load_type => "other",
+                           :kWh_per_year => 7302,
+                           :frac_sensible => 0.82,
+                           :frac_latent => 0.18 })
+    hpxml.plug_loads.add({ :id => "PlugLoadMisc2",
+                           :plug_load_type => "TV other",
+                           :kWh_per_year => 400 })
   end
 end
 
 def set_hpxml_misc_load_schedule(hpxml_file, hpxml)
-  if ['base.xml'].include? hpxml_file
-    hpxml.misc_load_schedule = nil
-  elsif ['base-misc-loads-detailed.xml'].include? hpxml_file
-    hpxml.misc_load_schedule = HPXML::MiscLoads.new({ :weekday_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
-                                                      :weekend_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
-                                                      :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0" })
+  if ['base-misc-loads-detailed.xml'].include? hpxml_file
+    hpxml.set_misc_loads_schedule({ :weekday_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
+                                    :weekend_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
+                                    :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0" })
   end
 end
 
@@ -3081,14 +3067,14 @@ if ARGV[0].to_sym == :update_measures
   ENV['HOMEDRIVE'] = 'C:\\' if !ENV['HOMEDRIVE'].nil? and ENV['HOMEDRIVE'].start_with? 'U:'
 
   # Apply rubocop
-  command = "rubocop --auto-correct --format simple --only Layout"
-  puts "Applying rubocop style to measures..."
-  system(command)
+  #command = "rubocop --auto-correct --format simple --only Layout"
+  #puts "Applying rubocop style to measures..."
+  #system(command)
 
   # Update measures XMLs
-  command = "#{OpenStudio.getOpenStudioCLI} measure -t '#{File.dirname(__FILE__)}'"
-  puts "Updating measure.xmls..."
-  system(command, [:out, :err] => File::NULL)
+  #command = "#{OpenStudio.getOpenStudioCLI} measure -t '#{File.dirname(__FILE__)}'"
+  #puts "Updating measure.xmls..."
+  #system(command, [:out, :err] => File::NULL)
 
   create_hpxmls
 

--- a/tasks.rb
+++ b/tasks.rb
@@ -375,51 +375,50 @@ def create_hpxmls
         end
       end
 
-      hpxml_data = {}
+      hpxml = HPXML.new
       hpxml_files.each do |hpxml_file|
-        set_hpxml_data_header_values(hpxml_file, hpxml_data)
-        set_hpxml_data_site_values(hpxml_file, hpxml_data)
-        set_hpxml_data_neighbor_buildings_values(hpxml_file, hpxml_data)
-        set_hpxml_data_building_occupancy_values(hpxml_file, hpxml_data)
-        set_hpxml_data_building_construction_values(hpxml_file, hpxml_data)
-        set_hpxml_data_climate_and_risk_zones_values(hpxml_file, hpxml_data)
-        set_hpxml_data_attics_values(hpxml_file, hpxml_data)
-        set_hpxml_data_foundations_values(hpxml_file, hpxml_data)
-        set_hpxml_data_air_infiltration_measurements_values(hpxml_file, hpxml_data)
-        set_hpxml_data_roofs_values(hpxml_file, hpxml_data)
-        set_hpxml_data_rim_joists_values(hpxml_file, hpxml_data)
-        set_hpxml_data_walls_values(hpxml_file, hpxml_data)
-        set_hpxml_data_foundation_walls_values(hpxml_file, hpxml_data)
-        set_hpxml_data_frame_floors_values(hpxml_file, hpxml_data)
-        set_hpxml_data_slabs_values(hpxml_file, hpxml_data)
-        set_hpxml_data_windows_values(hpxml_file, hpxml_data)
-        set_hpxml_data_skylights_values(hpxml_file, hpxml_data)
-        set_hpxml_data_doors_values(hpxml_file, hpxml_data)
-        set_hpxml_data_heating_systems_values(hpxml_file, hpxml_data)
-        set_hpxml_data_cooling_systems_values(hpxml_file, hpxml_data)
-        set_hpxml_data_heat_pumps_values(hpxml_file, hpxml_data)
-        set_hpxml_data_hvac_control_values(hpxml_file, hpxml_data)
-        set_hpxml_data_hvac_distributions_values(hpxml_file, hpxml_data)
-        set_hpxml_data_ventilation_fans_values(hpxml_file, hpxml_data)
-        set_hpxml_data_water_heating_systems_values(hpxml_file, hpxml_data)
-        set_hpxml_data_hot_water_distribution_values(hpxml_file, hpxml_data)
-        set_hpxml_data_water_fixtures_values(hpxml_file, hpxml_data)
-        set_hpxml_data_solar_thermal_system_values(hpxml_file, hpxml_data)
-        set_hpxml_data_pv_systems_values(hpxml_file, hpxml_data)
-        set_hpxml_data_clothes_washer_values(hpxml_file, hpxml_data)
-        set_hpxml_data_clothes_dryer_values(hpxml_file, hpxml_data)
-        set_hpxml_data_dishwasher_values(hpxml_file, hpxml_data)
-        set_hpxml_data_refrigerator_values(hpxml_file, hpxml_data)
-        set_hpxml_data_cooking_range_values(hpxml_file, hpxml_data)
-        set_hpxml_data_oven_values(hpxml_file, hpxml_data)
-        set_hpxml_data_lighting_values(hpxml_file, hpxml_data)
-        set_hpxml_data_ceiling_fans_values(hpxml_file, hpxml_data)
-        set_hpxml_data_plug_loads_values(hpxml_file, hpxml_data)
-        set_hpxml_data_misc_load_schedule_values(hpxml_file, hpxml_data)
+        set_hpxml_header(hpxml_file, hpxml)
+        set_hpxml_site(hpxml_file, hpxml)
+        set_hpxml_neighbor_buildings(hpxml_file, hpxml)
+        set_hpxml_building_occupancy(hpxml_file, hpxml)
+        set_hpxml_building_construction(hpxml_file, hpxml)
+        set_hpxml_climate_and_risk_zones(hpxml_file, hpxml)
+        set_hpxml_attics(hpxml_file, hpxml)
+        set_hpxml_foundations(hpxml_file, hpxml)
+        set_hpxml_air_infiltration_measurements(hpxml_file, hpxml)
+        set_hpxml_roofs(hpxml_file, hpxml)
+        set_hpxml_rim_joists(hpxml_file, hpxml)
+        set_hpxml_walls(hpxml_file, hpxml)
+        set_hpxml_foundation_walls(hpxml_file, hpxml)
+        set_hpxml_frame_floors(hpxml_file, hpxml)
+        set_hpxml_slabs(hpxml_file, hpxml)
+        set_hpxml_windows(hpxml_file, hpxml)
+        set_hpxml_skylights(hpxml_file, hpxml)
+        set_hpxml_doors(hpxml_file, hpxml)
+        set_hpxml_heating_systems(hpxml_file, hpxml)
+        set_hpxml_cooling_systems(hpxml_file, hpxml)
+        set_hpxml_heat_pumps(hpxml_file, hpxml)
+        set_hpxml_hvac_control(hpxml_file, hpxml)
+        set_hpxml_hvac_distributions(hpxml_file, hpxml)
+        set_hpxml_ventilation_fans(hpxml_file, hpxml)
+        set_hpxml_water_heating_systems(hpxml_file, hpxml)
+        set_hpxml_hot_water_distribution(hpxml_file, hpxml)
+        set_hpxml_water_fixtures(hpxml_file, hpxml)
+        set_hpxml_solar_thermal_system(hpxml_file, hpxml)
+        set_hpxml_pv_systems(hpxml_file, hpxml)
+        set_hpxml_clothes_washer(hpxml_file, hpxml)
+        set_hpxml_clothes_dryer(hpxml_file, hpxml)
+        set_hpxml_dishwasher(hpxml_file, hpxml)
+        set_hpxml_refrigerator(hpxml_file, hpxml)
+        set_hpxml_cooking_range(hpxml_file, hpxml)
+        set_hpxml_oven(hpxml_file, hpxml)
+        set_hpxml_lighting(hpxml_file, hpxml)
+        set_hpxml_ceiling_fans(hpxml_file, hpxml)
+        set_hpxml_plug_loads(hpxml_file, hpxml)
+        set_hpxml_misc_load_schedule(hpxml_file, hpxml)
       end
 
-      hpxml = HPXML.new(hpxml_data: hpxml_data)
-      hpxml_doc = hpxml.to_object()
+      hpxml_doc = hpxml.to_rexml()
 
       if ['invalid_files/missing-elements.xml'].include? derivative
         hpxml_doc.elements["/HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction"].elements.delete("NumberofConditionedFloors")
@@ -463,1124 +462,1121 @@ def create_hpxmls
   end
 end
 
-def set_hpxml_data_header_values(hpxml_file, hpxml_data)
+def set_hpxml_header(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:header] = { :xml_type => "HPXML",
-                            :xml_generated_by => "Rakefile",
-                            :transaction => "create",
-                            :software_program_used => nil,
-                            :software_program_version => nil,
-                            :eri_calculation_version => nil,
-                            :building_id => "MyBuilding",
-                            :event_type => "proposed workscope",
-                            :created_date_and_time => Time.new(2000, 1, 1).strftime("%Y-%m-%dT%H:%M:%S%:z") } # Hard-code to prevent diffs
+    hpxml.header = HPXML::Header.new({ :xml_type => "HPXML",
+                                       :xml_generated_by => "Rakefile",
+                                       :transaction => "create",
+                                       :building_id => "MyBuilding",
+                                       :event_type => "proposed workscope",
+                                       :created_date_and_time => Time.new(2000, 1, 1).strftime("%Y-%m-%dT%H:%M:%S%:z") }) # Hard-code to prevent diffs
   elsif ['base-version-2014.xml'].include? hpxml_file
-    hpxml_data[:header][:eri_calculation_version] = "2014"
+    hpxml.header.eri_calculation_version = "2014"
   elsif ['base-version-2014A.xml'].include? hpxml_file
-    hpxml_data[:header][:eri_calculation_version] = "2014A"
+    hpxml.header.eri_calculation_version = "2014A"
   elsif ['base-version-2014AE.xml'].include? hpxml_file
-    hpxml_data[:header][:eri_calculation_version] = "2014AE"
+    hpxml.header.eri_calculation_version = "2014AE"
   elsif ['base-version-2014AEG.xml'].include? hpxml_file
-    hpxml_data[:header][:eri_calculation_version] = "2014AEG"
+    hpxml.header.eri_calculation_version = "2014AEG"
   elsif ['base-version-latest.xml'].include? hpxml_file
-    hpxml_data[:header][:eri_calculation_version] = 'latest'
+    hpxml.header.eri_calculation_version = 'latest'
   elsif ['base-misc-timestep-10-mins.xml'].include? hpxml_file
-    hpxml_data[:header][:timestep] = 10
+    hpxml.header.timestep = 10
   elsif ['base-misc-timestep-60-mins.xml'].include? hpxml_file
-    hpxml_data[:header][:timestep] = 60
+    hpxml.header.timestep = 60
   elsif ['invalid_files/invalid-timestep.xml'].include? hpxml_file
-    hpxml_data[:header][:timestep] = 45
+    hpxml.header.timestep = 45
   end
 end
 
-def set_hpxml_data_site_values(hpxml_file, hpxml_data)
+def set_hpxml_site(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:site] = { :fuels => ["electricity", "natural gas"] }
+    hpxml.site = HPXML::Site.new({ :fuels => ["electricity", "natural gas"] })
   elsif ['base-hvac-none-no-fuel-access.xml'].include? hpxml_file
-    hpxml_data[:site][:fuels] = ["electricity"]
+    hpxml.site.fuels = ["electricity"]
   end
 end
 
-def set_hpxml_data_neighbor_buildings_values(hpxml_file, hpxml_data)
+def set_hpxml_neighbor_buildings(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:neighbor_buildings] = []
+    hpxml.neighbor_buildings = []
   elsif ['base-site-neighbors.xml'].include? hpxml_file
-    hpxml_data[:neighbor_buildings] << { :azimuth => 0,
-                                         :distance => 10 }
-    hpxml_data[:neighbor_buildings] << { :azimuth => 180,
-                                         :distance => 15,
-                                         :height => 12 }
+    hpxml.neighbor_buildings << HPXML::NeighborBuilding.new({ :azimuth => 0,
+                                                              :distance => 10 })
+    hpxml.neighbor_buildings << HPXML::NeighborBuilding.new({ :azimuth => 180,
+                                                              :distance => 15,
+                                                              :height => 12 })
   elsif ['invalid_files/bad-site-neighbor-azimuth.xml'].include? hpxml_file
-    hpxml_data[:neighbor_buildings][0][:azimuth] = 145
+    hpxml.neighbor_buildings[0].azimuth = 145
   end
 end
 
-def set_hpxml_data_building_occupancy_values(hpxml_file, hpxml_data)
+def set_hpxml_building_occupancy(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:building_occupants] = {}
+    hpxml.building_occupancy = nil
   elsif ['base-misc-number-of-occupants.xml'].include? hpxml_file
-    hpxml_data[:building_occupants] = { :number_of_residents => 5 }
+    hpxml.building_occupancy = HPXML::BuildingOccupancy.new({ :number_of_residents => 5 })
   end
 end
 
-def set_hpxml_data_building_construction_values(hpxml_file, hpxml_data)
+def set_hpxml_building_construction(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:building_construction] = { :number_of_conditioned_floors => 2,
-                                           :number_of_conditioned_floors_above_grade => 1,
-                                           :number_of_bedrooms => 3,
-                                           :conditioned_floor_area => 2700,
-                                           :conditioned_building_volume => 2700 * 8,
-                                           :fraction_of_operable_window_area => 0.33 }
+    hpxml.building_construction = HPXML::BuildingConstruction.new({ :number_of_conditioned_floors => 2,
+                                                                    :number_of_conditioned_floors_above_grade => 1,
+                                                                    :number_of_bedrooms => 3,
+                                                                    :conditioned_floor_area => 2700,
+                                                                    :conditioned_building_volume => 2700 * 8,
+                                                                    :fraction_of_operable_window_area => 0.33 })
   elsif ['base-enclosure-beds-1.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:number_of_bedrooms] = 1
+    hpxml.building_construction.number_of_bedrooms = 1
   elsif ['base-enclosure-beds-2.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:number_of_bedrooms] = 2
+    hpxml.building_construction.number_of_bedrooms = 2
   elsif ['base-enclosure-beds-4.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:number_of_bedrooms] = 4
+    hpxml.building_construction.number_of_bedrooms = 4
   elsif ['base-enclosure-beds-5.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:number_of_bedrooms] = 5
+    hpxml.building_construction.number_of_bedrooms = 5
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml',
          'base-foundation-unconditioned-basement.xml',
          'base-foundation-unvented-crawlspace.xml',
          'base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:number_of_conditioned_floors] -= 1
-    hpxml_data[:building_construction][:conditioned_floor_area] -= 1350
-    hpxml_data[:building_construction][:conditioned_building_volume] -= 1350 * 8
+    hpxml.building_construction.number_of_conditioned_floors -= 1
+    hpxml.building_construction.conditioned_floor_area -= 1350
+    hpxml.building_construction.conditioned_building_volume -= 1350 * 8
   elsif ['base-hvac-ideal-air.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:use_only_ideal_air_system] = true
+    hpxml.building_construction.use_only_ideal_air_system = true
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:number_of_conditioned_floors] += 1
-    hpxml_data[:building_construction][:number_of_conditioned_floors_above_grade] += 1
-    hpxml_data[:building_construction][:conditioned_floor_area] += 900
-    hpxml_data[:building_construction][:conditioned_building_volume] += 2250
+    hpxml.building_construction.number_of_conditioned_floors += 1
+    hpxml.building_construction.number_of_conditioned_floors_above_grade += 1
+    hpxml.building_construction.conditioned_floor_area += 900
+    hpxml.building_construction.conditioned_building_volume += 2250
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:conditioned_building_volume] += 10800
+    hpxml.building_construction.conditioned_building_volume += 10800
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:number_of_conditioned_floors] += 1
-    hpxml_data[:building_construction][:number_of_conditioned_floors_above_grade] += 1
-    hpxml_data[:building_construction][:conditioned_floor_area] += 1350
-    hpxml_data[:building_construction][:conditioned_building_volume] += 1350 * 8
+    hpxml.building_construction.number_of_conditioned_floors += 1
+    hpxml.building_construction.number_of_conditioned_floors_above_grade += 1
+    hpxml.building_construction.conditioned_floor_area += 1350
+    hpxml.building_construction.conditioned_building_volume += 1350 * 8
   elsif ['base-enclosure-windows-inoperable.xml'].include? hpxml_file
-    hpxml_data[:building_construction][:fraction_of_operable_window_area] = 0.0
+    hpxml.building_construction.fraction_of_operable_window_area = 0.0
   end
 end
 
-def set_hpxml_data_climate_and_risk_zones_values(hpxml_file, hpxml_data)
+def set_hpxml_climate_and_risk_zones(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "5B",
-                                            :weather_station_id => "WeatherStation",
-                                            :weather_station_name => "Denver, CO",
-                                            :weather_station_wmo => "725650" }
+    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "5B",
+                                                                    :weather_station_id => "WeatherStation",
+                                                                    :weather_station_name => "Denver, CO",
+                                                                    :weather_station_wmo => "725650" })
   elsif ['base-location-baltimore-md.xml'].include? hpxml_file
-    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "4A",
-                                            :weather_station_id => "WeatherStation",
-                                            :weather_station_name => "Baltimore, MD",
-                                            :weather_station_wmo => "724060" }
+    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "4A",
+                                                                    :weather_station_id => "WeatherStation",
+                                                                    :weather_station_name => "Baltimore, MD",
+                                                                    :weather_station_wmo => "724060" })
   elsif ['base-location-dallas-tx.xml'].include? hpxml_file
-    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "3A",
-                                            :weather_station_id => "WeatherStation",
-                                            :weather_station_name => "Dallas, TX",
-                                            :weather_station_wmo => "722590" }
+    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "3A",
+                                                                    :weather_station_id => "WeatherStation",
+                                                                    :weather_station_name => "Dallas, TX",
+                                                                    :weather_station_wmo => "722590" })
   elsif ['base-location-duluth-mn.xml'].include? hpxml_file
-    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "7",
-                                            :weather_station_id => "WeatherStation",
-                                            :weather_station_name => "Duluth, MN",
-                                            :weather_station_wmo => "727450" }
+    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "7",
+                                                                    :weather_station_id => "WeatherStation",
+                                                                    :weather_station_name => "Duluth, MN",
+                                                                    :weather_station_wmo => "727450" })
   elsif ['base-location-miami-fl.xml'].include? hpxml_file
-    hpxml_data[:climate_and_risk_zones] = { :iecc2006 => "1A",
-                                            :weather_station_id => "WeatherStation",
-                                            :weather_station_name => "Miami, FL",
-                                            :weather_station_wmo => "722020" }
+    hpxml.climate_and_risk_zones = HPXML::ClimateandRiskZones.new({ :iecc2006 => "1A",
+                                                                    :weather_station_id => "WeatherStation",
+                                                                    :weather_station_name => "Miami, FL",
+                                                                    :weather_station_wmo => "722020" })
   elsif ['base-location-epw-filename.xml'].include? hpxml_file
-    hpxml_data[:climate_and_risk_zones][:weather_station_wmo] = nil
-    hpxml_data[:climate_and_risk_zones][:weather_station_epw_filename] = "USA_CO_Denver.Intl.AP.725650_TMY3.epw"
+    hpxml.climate_and_risk_zones.weather_station_wmo = nil
+    hpxml.climate_and_risk_zones.weather_station_epw_filename = "USA_CO_Denver.Intl.AP.725650_TMY3.epw"
   elsif ['invalid_files/bad-wmo.xml'].include? hpxml_file
-    hpxml_data[:climate_and_risk_zones][:weather_station_wmo] = "999999"
+    hpxml.climate_and_risk_zones.weather_station_wmo = "999999"
   end
 end
 
-def set_hpxml_data_air_infiltration_measurements_values(hpxml_file, hpxml_data)
-  infil_volume = hpxml_data[:building_construction][:conditioned_building_volume]
+def set_hpxml_air_infiltration_measurements(hpxml_file, hpxml)
+  infil_volume = hpxml.building_construction.conditioned_building_volume
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:air_infiltration_measurements] = [{ :id => "InfiltrationMeasurement",
-                                                    :house_pressure => 50,
-                                                    :unit_of_measure => "ACH",
-                                                    :air_leakage => 3.0 }]
+    hpxml.air_infiltration_measurements = [HPXML::AirInfiltrationMeasurement.new({ :id => "InfiltrationMeasurement",
+                                                                                   :house_pressure => 50,
+                                                                                   :unit_of_measure => "ACH",
+                                                                                   :air_leakage => 3.0 })]
   elsif ['base-infiltration-ach-natural.xml'].include? hpxml_file
-    hpxml_data[:air_infiltration_measurements] = [{ :id => "InfiltrationMeasurement",
-                                                    :constant_ach_natural => 0.67 }]
+    hpxml.air_infiltration_measurements = [HPXML::AirInfiltrationMeasurement.new({ :id => "InfiltrationMeasurement",
+                                                                                   :constant_ach_natural => 0.67 })]
   elsif ['base-enclosure-infil-cfm50.xml'].include? hpxml_file
-    hpxml_data[:air_infiltration_measurements] = [{ :id => "InfiltrationMeasurement",
-                                                    :house_pressure => 50,
-                                                    :unit_of_measure => "CFM",
-                                                    :air_leakage => 3.0 / 60.0 * infil_volume }]
+    hpxml.air_infiltration_measurements = [HPXML::AirInfiltrationMeasurement.new({ :id => "InfiltrationMeasurement",
+                                                                                   :house_pressure => 50,
+                                                                                   :unit_of_measure => "CFM",
+                                                                                   :air_leakage => 3.0 / 60.0 * infil_volume })]
   end
-  hpxml_data[:air_infiltration_measurements][0][:infiltration_volume] = infil_volume
+  hpxml.air_infiltration_measurements[0].infiltration_volume = infil_volume
 end
 
-def set_hpxml_data_attics_values(hpxml_file, hpxml_data)
+def set_hpxml_attics(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:attics] = []
+    hpxml.attics = []
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    hpxml_data[:attics] << { :id => "VentedAttic",
-                             :attic_type => "VentedAttic",
-                             :vented_attic_sla => 0.003 }
+    hpxml.attics << HPXML::Attic.new({ :id => "VentedAttic",
+                                       :attic_type => "VentedAttic",
+                                       :vented_attic_sla => 0.003 })
   end
 end
 
-def set_hpxml_data_foundations_values(hpxml_file, hpxml_data)
+def set_hpxml_foundations(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:foundations] = []
+    hpxml.foundations = []
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml_data[:foundations] << { :id => "VentedCrawlspace",
-                                  :foundation_type => "VentedCrawlspace",
-                                  :vented_crawlspace_sla => 0.00667 }
+    hpxml.foundations << HPXML::Foundation.new({ :id => "VentedCrawlspace",
+                                                 :foundation_type => "VentedCrawlspace",
+                                                 :vented_crawlspace_sla => 0.00667 })
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:foundations] << { :id => "UnconditionedBasement",
-                                  :foundation_type => "UnconditionedBasement",
-                                  :unconditioned_basement_thermal_boundary => "frame floor" }
+    hpxml.foundations << HPXML::Foundation.new({ :id => "UnconditionedBasement",
+                                                 :foundation_type => "UnconditionedBasement",
+                                                 :unconditioned_basement_thermal_boundary => "frame floor" })
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    hpxml_data[:foundations][0][:unconditioned_basement_thermal_boundary] = "foundation wall"
+    hpxml.foundations[0].unconditioned_basement_thermal_boundary = "foundation wall"
   end
 end
 
-def set_hpxml_data_roofs_values(hpxml_file, hpxml_data)
+def set_hpxml_roofs(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:roofs] = [{ :id => "Roof",
-                            :interior_adjacent_to => "attic - unvented",
-                            :area => 1510,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :pitch => 6,
-                            :radiant_barrier => false,
-                            :insulation_assembly_r_value => 2.3 }]
+    hpxml.roofs = [HPXML::Roof.new({ :id => "Roof",
+                                     :interior_adjacent_to => "attic - unvented",
+                                     :area => 1510,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :pitch => 6,
+                                     :radiant_barrier => false,
+                                     :insulation_assembly_r_value => 2.3 })]
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
-    hpxml_data[:roofs] = [{ :id => "Roof",
-                            :interior_adjacent_to => "living space",
-                            :area => 1350,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :pitch => 0,
-                            :radiant_barrier => false,
-                            :insulation_assembly_r_value => 25.8 }]
+    hpxml.roofs = [HPXML::Roof.new({ :id => "Roof",
+                                     :interior_adjacent_to => "living space",
+                                     :area => 1350,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :pitch => 0,
+                                     :radiant_barrier => false,
+                                     :insulation_assembly_r_value => 25.8 })]
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:roofs] = [{ :id => "RoofCond",
-                            :interior_adjacent_to => "living space",
-                            :area => 1006,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :pitch => 6,
-                            :radiant_barrier => false,
-                            :insulation_assembly_r_value => 25.8 },
-                          { :id => "RoofUncond",
-                            :interior_adjacent_to => "attic - unvented",
-                            :area => 504,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :pitch => 6,
-                            :radiant_barrier => false,
-                            :insulation_assembly_r_value => 2.3 }]
+    hpxml.roofs = [HPXML::Roof.new({ :id => "RoofCond",
+                                     :interior_adjacent_to => "living space",
+                                     :area => 1006,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :pitch => 6,
+                                     :radiant_barrier => false,
+                                     :insulation_assembly_r_value => 25.8 }),
+                   HPXML::Roof.new({ :id => "RoofUncond",
+                                     :interior_adjacent_to => "attic - unvented",
+                                     :area => 504,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :pitch => 6,
+                                     :radiant_barrier => false,
+                                     :insulation_assembly_r_value => 2.3 })]
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    hpxml_data[:roofs][0][:interior_adjacent_to] = "attic - vented"
+    hpxml.roofs[0].interior_adjacent_to = "attic - vented"
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    hpxml_data[:roofs][0][:interior_adjacent_to] = "living space"
-    hpxml_data[:roofs][0][:insulation_assembly_r_value] = 25.8
+    hpxml.roofs[0].interior_adjacent_to = "living space"
+    hpxml.roofs[0].insulation_assembly_r_value = 25.8
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml_data[:roofs] << { :id => "RoofGarage",
-                            :interior_adjacent_to => "garage",
-                            :area => 670,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :pitch => 6,
-                            :radiant_barrier => false,
-                            :insulation_assembly_r_value => 2.3 }
+    hpxml.roofs << HPXML::Roof.new({ :id => "RoofGarage",
+                                     :interior_adjacent_to => "garage",
+                                     :area => 670,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :pitch => 6,
+                                     :radiant_barrier => false,
+                                     :insulation_assembly_r_value => 2.3 })
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
-    hpxml_data[:roofs][0][:insulation_assembly_r_value] = 25.8
+    hpxml.roofs[0].insulation_assembly_r_value = 25.8
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    hpxml_data[:roofs] = []
+    hpxml.roofs = []
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..hpxml_data[:roofs].size
-      hpxml_data[:roofs][n - 1][:area] /= 10.0
+    for n in 1..hpxml.roofs.size
+      hpxml.roofs[n - 1].area /= 10.0
       for i in 2..10
-        hpxml_data[:roofs] << hpxml_data[:roofs][n - 1].dup
-        hpxml_data[:roofs][-1][:id] += i.to_s
+        hpxml.roofs << hpxml.roofs[n - 1].dup
+        hpxml.roofs[-1].id += i.to_s
       end
     end
   elsif ['base-atticroof-radiant-barrier.xml'].include? hpxml_file
-    hpxml_data[:roofs][0][:radiant_barrier] = true
+    hpxml.roofs[0].radiant_barrier = true
   end
 end
 
-def set_hpxml_data_rim_joists_values(hpxml_file, hpxml_data)
+def set_hpxml_rim_joists(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
     # TODO: Other geometry values (e.g., building volume) assume
     # no rim joists.
-    hpxml_data[:rim_joists] = [{ :id => "RimJoistFoundation",
-                                 :exterior_adjacent_to => "outside",
-                                 :interior_adjacent_to => "basement - conditioned",
-                                 :area => 116,
-                                 :solar_absorptance => 0.7,
-                                 :emittance => 0.92,
-                                 :insulation_assembly_r_value => 23.0 }]
+    hpxml.rim_joists = [HPXML::RimJoist.new({ :id => "RimJoistFoundation",
+                                              :exterior_adjacent_to => "outside",
+                                              :interior_adjacent_to => "basement - conditioned",
+                                              :area => 116,
+                                              :solar_absorptance => 0.7,
+                                              :emittance => 0.92,
+                                              :insulation_assembly_r_value => 23.0 })]
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml'].include? hpxml_file
-    hpxml_data[:rim_joists] = []
+    hpxml.rim_joists = []
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    for i in 0..hpxml_data[:rim_joists].size - 1
-      hpxml_data[:rim_joists][i][:interior_adjacent_to] = "basement - unconditioned"
-      hpxml_data[:rim_joists][i][:insulation_assembly_r_value] = 2.3
+    for i in 0..hpxml.rim_joists.size - 1
+      hpxml.rim_joists[i].interior_adjacent_to = "basement - unconditioned"
+      hpxml.rim_joists[i].insulation_assembly_r_value = 2.3
     end
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    for i in 0..hpxml_data[:rim_joists].size - 1
-      hpxml_data[:rim_joists][i][:insulation_assembly_r_value] = 23.0
+    for i in 0..hpxml.rim_joists.size - 1
+      hpxml.rim_joists[i].insulation_assembly_r_value = 23.0
     end
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    for i in 0..hpxml_data[:rim_joists].size - 1
-      hpxml_data[:rim_joists][i][:interior_adjacent_to] = "crawlspace - unvented"
+    for i in 0..hpxml.rim_joists.size - 1
+      hpxml.rim_joists[i].interior_adjacent_to = "crawlspace - unvented"
     end
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    for i in 0..hpxml_data[:rim_joists].size - 1
-      hpxml_data[:rim_joists][i][:interior_adjacent_to] = "crawlspace - vented"
+    for i in 0..hpxml.rim_joists.size - 1
+      hpxml.rim_joists[i].interior_adjacent_to = "crawlspace - vented"
     end
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
-    hpxml_data[:rim_joists][0][:exterior_adjacent_to] = "crawlspace - unvented"
-    hpxml_data[:rim_joists] << { :id => "RimJoistCrawlspace",
-                                 :exterior_adjacent_to => "outside",
-                                 :interior_adjacent_to => "crawlspace - unvented",
-                                 :area => 81,
-                                 :solar_absorptance => 0.7,
-                                 :emittance => 0.92,
-                                 :insulation_assembly_r_value => 2.3 }
+    hpxml.rim_joists[0].exterior_adjacent_to = "crawlspace - unvented"
+    hpxml.rim_joists << HPXML::RimJoist.new({ :id => "RimJoistCrawlspace",
+                                              :exterior_adjacent_to => "outside",
+                                              :interior_adjacent_to => "crawlspace - unvented",
+                                              :area => 81,
+                                              :solar_absorptance => 0.7,
+                                              :emittance => 0.92,
+                                              :insulation_assembly_r_value => 2.3 })
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    hpxml_data[:rim_joists] << { :id => "RimJoist2ndStory",
-                                 :exterior_adjacent_to => "outside",
-                                 :interior_adjacent_to => "living space",
-                                 :area => 116,
-                                 :solar_absorptance => 0.7,
-                                 :emittance => 0.92,
-                                 :insulation_assembly_r_value => 23.0 }
+    hpxml.rim_joists << HPXML::RimJoist.new({ :id => "RimJoist2ndStory",
+                                              :exterior_adjacent_to => "outside",
+                                              :interior_adjacent_to => "living space",
+                                              :area => 116,
+                                              :solar_absorptance => 0.7,
+                                              :emittance => 0.92,
+                                              :insulation_assembly_r_value => 23.0 })
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..hpxml_data[:rim_joists].size
-      hpxml_data[:rim_joists][n - 1][:area] /= 10.0
+    for n in 1..hpxml.rim_joists.size
+      hpxml.rim_joists[n - 1].area /= 10.0
       for i in 2..10
-        hpxml_data[:rim_joists] << hpxml_data[:rim_joists][n - 1].dup
-        hpxml_data[:rim_joists][-1][:id] += i.to_s
+        hpxml.rim_joists << hpxml.rim_joists[n - 1].dup
+        hpxml.rim_joists[-1].id += i.to_s
       end
     end
   end
 end
 
-def set_hpxml_data_walls_values(hpxml_file, hpxml_data)
+def set_hpxml_walls(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:walls] = [{ :id => "Wall",
-                            :exterior_adjacent_to => "outside",
-                            :interior_adjacent_to => "living space",
-                            :wall_type => "WoodStud",
-                            :area => 1200,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 23 },
-                          { :id => "WallAtticGable",
-                            :exterior_adjacent_to => "outside",
-                            :interior_adjacent_to => "attic - unvented",
-                            :wall_type => "WoodStud",
-                            :area => 290,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 4.0 }]
+    hpxml.walls = [HPXML::Wall.new({ :id => "Wall",
+                                     :exterior_adjacent_to => "outside",
+                                     :interior_adjacent_to => "living space",
+                                     :wall_type => "WoodStud",
+                                     :area => 1200,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 23 }),
+                   HPXML::Wall.new({ :id => "WallAtticGable",
+                                     :exterior_adjacent_to => "outside",
+                                     :interior_adjacent_to => "attic - unvented",
+                                     :wall_type => "WoodStud",
+                                     :area => 290,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 4.0 })]
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
-    hpxml_data[:walls].delete_at(1)
+    hpxml.walls.delete_at(1)
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    hpxml_data[:walls][1][:interior_adjacent_to] = "attic - vented"
+    hpxml.walls[1].interior_adjacent_to = "attic - vented"
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    hpxml_data[:walls][1][:interior_adjacent_to] = "living space"
-    hpxml_data[:walls][1][:insulation_assembly_r_value] = 23.0
+    hpxml.walls[1].interior_adjacent_to = "living space"
+    hpxml.walls[1].insulation_assembly_r_value = 23.0
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:walls].delete_at(1)
-    hpxml_data[:walls] << { :id => "WallAtticKneeWall",
-                            :exterior_adjacent_to => "attic - unvented",
-                            :interior_adjacent_to => "living space",
-                            :wall_type => "WoodStud",
-                            :area => 316,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 23.0 }
-    hpxml_data[:walls] << { :id => "WallAtticGableCond",
-                            :exterior_adjacent_to => "outside",
-                            :interior_adjacent_to => "living space",
-                            :wall_type => "WoodStud",
-                            :area => 240,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 22.3 }
-    hpxml_data[:walls] << { :id => "WallAtticGableUncond",
-                            :exterior_adjacent_to => "outside",
-                            :interior_adjacent_to => "attic - unvented",
-                            :wall_type => "WoodStud",
-                            :area => 50,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 4.0 }
+    hpxml.walls.delete_at(1)
+    hpxml.walls << HPXML::Wall.new({ :id => "WallAtticKneeWall",
+                                     :exterior_adjacent_to => "attic - unvented",
+                                     :interior_adjacent_to => "living space",
+                                     :wall_type => "WoodStud",
+                                     :area => 316,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 23.0 })
+    hpxml.walls << HPXML::Wall.new({ :id => "WallAtticGableCond",
+                                     :exterior_adjacent_to => "outside",
+                                     :interior_adjacent_to => "living space",
+                                     :wall_type => "WoodStud",
+                                     :area => 240,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 22.3 })
+    hpxml.walls << HPXML::Wall.new({ :id => "WallAtticGableUncond",
+                                     :exterior_adjacent_to => "outside",
+                                     :interior_adjacent_to => "attic - unvented",
+                                     :wall_type => "WoodStud",
+                                     :area => 50,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 4.0 })
   elsif ['base-enclosure-walltype-cmu.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "ConcreteMasonryUnit"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 12
+    hpxml.walls[0].wall_type = "ConcreteMasonryUnit"
+    hpxml.walls[0].insulation_assembly_r_value = 12
   elsif ['base-enclosure-walltype-doublestud.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "DoubleWoodStud"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 28.7
+    hpxml.walls[0].wall_type = "DoubleWoodStud"
+    hpxml.walls[0].insulation_assembly_r_value = 28.7
   elsif ['base-enclosure-walltype-icf.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "InsulatedConcreteForms"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 21
+    hpxml.walls[0].wall_type = "InsulatedConcreteForms"
+    hpxml.walls[0].insulation_assembly_r_value = 21
   elsif ['base-enclosure-walltype-log.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "LogWall"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 7.1
+    hpxml.walls[0].wall_type = "LogWall"
+    hpxml.walls[0].insulation_assembly_r_value = 7.1
   elsif ['base-enclosure-walltype-sip.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "StructurallyInsulatedPanel"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 16.1
+    hpxml.walls[0].wall_type = "StructurallyInsulatedPanel"
+    hpxml.walls[0].insulation_assembly_r_value = 16.1
   elsif ['base-enclosure-walltype-solidconcrete.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "SolidConcrete"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 1.35
+    hpxml.walls[0].wall_type = "SolidConcrete"
+    hpxml.walls[0].insulation_assembly_r_value = 1.35
   elsif ['base-enclosure-walltype-steelstud.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "SteelFrame"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 8.1
+    hpxml.walls[0].wall_type = "SteelFrame"
+    hpxml.walls[0].insulation_assembly_r_value = 8.1
   elsif ['base-enclosure-walltype-stone.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "Stone"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 5.4
+    hpxml.walls[0].wall_type = "Stone"
+    hpxml.walls[0].insulation_assembly_r_value = 5.4
   elsif ['base-enclosure-walltype-strawbale.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "StrawBale"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 58.8
+    hpxml.walls[0].wall_type = "StrawBale"
+    hpxml.walls[0].insulation_assembly_r_value = 58.8
   elsif ['base-enclosure-walltype-structuralbrick.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:wall_type] = "StructuralBrick"
-    hpxml_data[:walls][0][:insulation_assembly_r_value] = 7.9
+    hpxml.walls[0].wall_type = "StructuralBrick"
+    hpxml.walls[0].insulation_assembly_r_value = 7.9
   elsif ['invalid_files/missing-surfaces.xml'].include? hpxml_file
-    hpxml_data[:walls] << { :id => "WallGarage",
-                            :exterior_adjacent_to => "garage",
-                            :interior_adjacent_to => "living space",
-                            :wall_type => "WoodStud",
-                            :area => 100,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 4 }
+    hpxml.walls << HPXML::Wall.new({ :id => "WallGarage",
+                                     :exterior_adjacent_to => "garage",
+                                     :interior_adjacent_to => "living space",
+                                     :wall_type => "WoodStud",
+                                     :area => 100,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 4 })
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    hpxml_data[:walls][0][:area] *= 2.0
+    hpxml.walls[0].area *= 2.0
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    hpxml_data[:walls] = [{ :id => "Wall",
-                            :exterior_adjacent_to => "outside",
-                            :interior_adjacent_to => "living space",
-                            :wall_type => "WoodStud",
-                            :area => 880,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 23 },
-                          { :id => "WallGarageInterior",
-                            :exterior_adjacent_to => "garage",
-                            :interior_adjacent_to => "living space",
-                            :wall_type => "WoodStud",
-                            :area => 320,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 23 },
-                          { :id => "WallGarageExterior",
-                            :exterior_adjacent_to => "outside",
-                            :interior_adjacent_to => "garage",
-                            :wall_type => "WoodStud",
-                            :area => 800,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 4 }]
+    hpxml.walls = [HPXML::Wall.new({ :id => "Wall",
+                                     :exterior_adjacent_to => "outside",
+                                     :interior_adjacent_to => "living space",
+                                     :wall_type => "WoodStud",
+                                     :area => 880,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 23 }),
+                   HPXML::Wall.new({ :id => "WallGarageInterior",
+                                     :exterior_adjacent_to => "garage",
+                                     :interior_adjacent_to => "living space",
+                                     :wall_type => "WoodStud",
+                                     :area => 320,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 23 }),
+                   HPXML::Wall.new({ :id => "WallGarageExterior",
+                                     :exterior_adjacent_to => "outside",
+                                     :interior_adjacent_to => "garage",
+                                     :wall_type => "WoodStud",
+                                     :area => 800,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 4 })]
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml_data[:walls] = [{ :id => "Wall",
-                            :exterior_adjacent_to => "outside",
-                            :interior_adjacent_to => "living space",
-                            :wall_type => "WoodStud",
-                            :area => 960,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 23 },
-                          { :id => "WallGarageInterior",
-                            :exterior_adjacent_to => "garage",
-                            :interior_adjacent_to => "living space",
-                            :wall_type => "WoodStud",
-                            :area => 240,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 23 },
-                          { :id => "WallGarageExterior",
-                            :exterior_adjacent_to => "outside",
-                            :interior_adjacent_to => "garage",
-                            :wall_type => "WoodStud",
-                            :area => 560,
-                            :solar_absorptance => 0.7,
-                            :emittance => 0.92,
-                            :insulation_assembly_r_value => 4 }]
+    hpxml.walls = [HPXML::Wall.new({ :id => "Wall",
+                                     :exterior_adjacent_to => "outside",
+                                     :interior_adjacent_to => "living space",
+                                     :wall_type => "WoodStud",
+                                     :area => 960,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 23 }),
+                   HPXML::Wall.new({ :id => "WallGarageInterior",
+                                     :exterior_adjacent_to => "garage",
+                                     :interior_adjacent_to => "living space",
+                                     :wall_type => "WoodStud",
+                                     :area => 240,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 23 }),
+                   HPXML::Wall.new({ :id => "WallGarageExterior",
+                                     :exterior_adjacent_to => "outside",
+                                     :interior_adjacent_to => "garage",
+                                     :wall_type => "WoodStud",
+                                     :area => 560,
+                                     :solar_absorptance => 0.7,
+                                     :emittance => 0.92,
+                                     :insulation_assembly_r_value => 4 })]
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
-    hpxml_data[:walls][1][:insulation_assembly_r_value] = 23
+    hpxml.walls[1].insulation_assembly_r_value = 23
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    hpxml_data[:walls].delete_at(1)
-    hpxml_data[:walls] << hpxml_data[:walls][0].dup
-    hpxml_data[:walls][0][:area] *= 0.35
-    hpxml_data[:walls][-1][:area] *= 0.65
-    hpxml_data[:walls][-1][:id] += "Adiabatic"
-    hpxml_data[:walls][-1][:exterior_adjacent_to] = "other housing unit"
-    hpxml_data[:walls][-1][:insulation_assembly_r_value] = 4
+    hpxml.walls.delete_at(1)
+    hpxml.walls << hpxml.walls[0].dup
+    hpxml.walls[0].area *= 0.35
+    hpxml.walls[-1].area *= 0.65
+    hpxml.walls[-1].id += "Adiabatic"
+    hpxml.walls[-1].exterior_adjacent_to = "other housing unit"
+    hpxml.walls[-1].insulation_assembly_r_value = 4
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..hpxml_data[:walls].size
-      hpxml_data[:walls][n - 1][:area] /= 10.0
+    for n in 1..hpxml.walls.size
+      hpxml.walls[n - 1].area /= 10.0
       for i in 2..10
-        hpxml_data[:walls] << hpxml_data[:walls][n - 1].dup
-        hpxml_data[:walls][-1][:id] += i.to_s
+        hpxml.walls << hpxml.walls[n - 1].dup
+        hpxml.walls[-1].id += i.to_s
       end
     end
   end
 end
 
-def set_hpxml_data_foundation_walls_values(hpxml_file, hpxml_data)
+def set_hpxml_foundation_walls(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls] = [{ :id => "FoundationWall",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 8,
-                                       :area => 1200,
-                                       :thickness => 8,
-                                       :depth_below_grade => 7,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 8,
-                                       :insulation_exterior_r_value => 8.9 }]
+    hpxml.foundation_walls = [HPXML::FoundationWall.new({ :id => "FoundationWall",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 8,
+                                                          :area => 1200,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 7,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 8,
+                                                          :insulation_exterior_r_value => 8.9 })]
   elsif ['base-foundation-conditioned-basement-wall-interior-insulation.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls][0][:insulation_interior_distance_to_top] = 0
-    hpxml_data[:foundation_walls][0][:insulation_interior_distance_to_bottom] = 8
-    hpxml_data[:foundation_walls][0][:insulation_interior_r_value] = 10
-    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_top] = 1
-    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] = 8
+    hpxml.foundation_walls[0].insulation_interior_distance_to_top = 0
+    hpxml.foundation_walls[0].insulation_interior_distance_to_bottom = 8
+    hpxml.foundation_walls[0].insulation_interior_r_value = 10
+    hpxml.foundation_walls[0].insulation_exterior_distance_to_top = 1
+    hpxml.foundation_walls[0].insulation_exterior_distance_to_bottom = 8
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls][0][:interior_adjacent_to] = "basement - unconditioned"
-    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] = 0
-    hpxml_data[:foundation_walls][0][:insulation_exterior_r_value] = 0
+    hpxml.foundation_walls[0].interior_adjacent_to = "basement - unconditioned"
+    hpxml.foundation_walls[0].insulation_exterior_distance_to_bottom = 0
+    hpxml.foundation_walls[0].insulation_exterior_r_value = 0
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] = 4
-    hpxml_data[:foundation_walls][0][:insulation_exterior_r_value] = 8.9
+    hpxml.foundation_walls[0].insulation_exterior_distance_to_bottom = 4
+    hpxml.foundation_walls[0].insulation_exterior_r_value = 8.9
   elsif ['base-foundation-unconditioned-basement-assembly-r.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_top] = nil
-    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] = nil
-    hpxml_data[:foundation_walls][0][:insulation_exterior_r_value] = nil
-    hpxml_data[:foundation_walls][0][:insulation_interior_distance_to_top] = nil
-    hpxml_data[:foundation_walls][0][:insulation_interior_distance_to_bottom] = nil
-    hpxml_data[:foundation_walls][0][:insulation_interior_r_value] = nil
-    hpxml_data[:foundation_walls][0][:insulation_assembly_r_value] = 10.69
+    hpxml.foundation_walls[0].insulation_exterior_distance_to_top = nil
+    hpxml.foundation_walls[0].insulation_exterior_distance_to_bottom = nil
+    hpxml.foundation_walls[0].insulation_exterior_r_value = nil
+    hpxml.foundation_walls[0].insulation_interior_distance_to_top = nil
+    hpxml.foundation_walls[0].insulation_interior_distance_to_bottom = nil
+    hpxml.foundation_walls[0].insulation_interior_r_value = nil
+    hpxml.foundation_walls[0].insulation_assembly_r_value = 10.69
   elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls][0][:depth_below_grade] = 4
+    hpxml.foundation_walls[0].depth_below_grade = 4
   elsif ['base-foundation-unvented-crawlspace.xml',
          'base-foundation-vented-crawlspace.xml'].include? hpxml_file
     if ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-      hpxml_data[:foundation_walls][0][:interior_adjacent_to] = "crawlspace - unvented"
+      hpxml.foundation_walls[0].interior_adjacent_to = "crawlspace - unvented"
     else
-      hpxml_data[:foundation_walls][0][:interior_adjacent_to] = "crawlspace - vented"
+      hpxml.foundation_walls[0].interior_adjacent_to = "crawlspace - vented"
     end
-    hpxml_data[:foundation_walls][0][:height] -= 4
-    hpxml_data[:foundation_walls][0][:area] /= 2.0
-    hpxml_data[:foundation_walls][0][:depth_below_grade] -= 4
-    hpxml_data[:foundation_walls][0][:insulation_exterior_distance_to_bottom] -= 4
+    hpxml.foundation_walls[0].height -= 4
+    hpxml.foundation_walls[0].area /= 2.0
+    hpxml.foundation_walls[0].depth_below_grade -= 4
+    hpxml.foundation_walls[0].insulation_exterior_distance_to_bottom -= 4
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls][0][:area] = 600
-    hpxml_data[:foundation_walls] << { :id => "FoundationWallInterior",
-                                       :exterior_adjacent_to => "crawlspace - unvented",
-                                       :interior_adjacent_to => "basement - unconditioned",
-                                       :height => 8,
-                                       :area => 360,
-                                       :thickness => 8,
-                                       :depth_below_grade => 4,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 0,
-                                       :insulation_exterior_r_value => 0 }
-    hpxml_data[:foundation_walls] << { :id => "FoundationWallCrawlspace",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "crawlspace - unvented",
-                                       :height => 4,
-                                       :area => 600,
-                                       :thickness => 8,
-                                       :depth_below_grade => 3,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 0,
-                                       :insulation_exterior_r_value => 0 }
+    hpxml.foundation_walls[0].area = 600
+    hpxml.foundation_walls << HPXML::FoundationWall.new({ :id => "FoundationWallInterior",
+                                                          :exterior_adjacent_to => "crawlspace - unvented",
+                                                          :interior_adjacent_to => "basement - unconditioned",
+                                                          :height => 8,
+                                                          :area => 360,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 4,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 0,
+                                                          :insulation_exterior_r_value => 0 })
+    hpxml.foundation_walls << HPXML::FoundationWall.new({ :id => "FoundationWallCrawlspace",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "crawlspace - unvented",
+                                                          :height => 4,
+                                                          :area => 600,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 3,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 0,
+                                                          :insulation_exterior_r_value => 0 })
   elsif ['base-foundation-ambient.xml',
          'base-foundation-slab.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls] = []
+    hpxml.foundation_walls = []
   elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls] = [{ :id => "FoundationWall1",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 8,
-                                       :area => 480,
-                                       :thickness => 8,
-                                       :depth_below_grade => 7,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 8,
-                                       :insulation_exterior_r_value => 8.9 },
-                                     { :id => "FoundationWall2",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 4,
-                                       :area => 120,
-                                       :thickness => 8,
-                                       :depth_below_grade => 3,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 4,
-                                       :insulation_exterior_r_value => 8.9 },
-                                     { :id => "FoundationWall3",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 2,
-                                       :area => 60,
-                                       :thickness => 8,
-                                       :depth_below_grade => 1,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 2,
-                                       :insulation_exterior_r_value => 8.9 }]
+    hpxml.foundation_walls = [HPXML::FoundationWall.new({ :id => "FoundationWall1",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 8,
+                                                          :area => 480,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 7,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 8,
+                                                          :insulation_exterior_r_value => 8.9 }),
+                              HPXML::FoundationWall.new({ :id => "FoundationWall2",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 4,
+                                                          :area => 120,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 3,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 4,
+                                                          :insulation_exterior_r_value => 8.9 }),
+                              HPXML::FoundationWall.new({ :id => "FoundationWall3",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 2,
+                                                          :area => 60,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 1,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 2,
+                                                          :insulation_exterior_r_value => 8.9 })]
   elsif ['base-foundation-complex.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls] = [{ :id => "FoundationWall1",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 8,
-                                       :area => 160,
-                                       :thickness => 8,
-                                       :depth_below_grade => 7,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 0,
-                                       :insulation_exterior_r_value => 0.0 },
-                                     { :id => "FoundationWall2",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 8,
-                                       :area => 240,
-                                       :thickness => 8,
-                                       :depth_below_grade => 7,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 8,
-                                       :insulation_exterior_r_value => 8.9 },
-                                     { :id => "FoundationWall3",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 4,
-                                       :area => 160,
-                                       :thickness => 8,
-                                       :depth_below_grade => 3,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 0,
-                                       :insulation_exterior_r_value => 0.0 },
-                                     { :id => "FoundationWall4",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 4,
-                                       :area => 120,
-                                       :thickness => 8,
-                                       :depth_below_grade => 3,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 4,
-                                       :insulation_exterior_r_value => 8.9 },
-                                     { :id => "FoundationWall5",
-                                       :exterior_adjacent_to => "ground",
-                                       :interior_adjacent_to => "basement - conditioned",
-                                       :height => 4,
-                                       :area => 80,
-                                       :thickness => 8,
-                                       :depth_below_grade => 3,
-                                       :insulation_interior_r_value => 0,
-                                       :insulation_interior_distance_to_top => 0,
-                                       :insulation_interior_distance_to_bottom => 0,
-                                       :insulation_exterior_distance_to_top => 0,
-                                       :insulation_exterior_distance_to_bottom => 4,
-                                       :insulation_exterior_r_value => 8.9 }]
+    hpxml.foundation_walls = [HPXML::FoundationWall.new({ :id => "FoundationWall1",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 8,
+                                                          :area => 160,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 7,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 0,
+                                                          :insulation_exterior_r_value => 0.0 }),
+                              HPXML::FoundationWall.new({ :id => "FoundationWall2",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 8,
+                                                          :area => 240,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 7,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 8,
+                                                          :insulation_exterior_r_value => 8.9 }),
+                              HPXML::FoundationWall.new({ :id => "FoundationWall3",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 4,
+                                                          :area => 160,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 3,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 0,
+                                                          :insulation_exterior_r_value => 0.0 }),
+                              HPXML::FoundationWall.new({ :id => "FoundationWall4",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 4,
+                                                          :area => 120,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 3,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 4,
+                                                          :insulation_exterior_r_value => 8.9 }),
+                              HPXML::FoundationWall.new({ :id => "FoundationWall5",
+                                                          :exterior_adjacent_to => "ground",
+                                                          :interior_adjacent_to => "basement - conditioned",
+                                                          :height => 4,
+                                                          :area => 80,
+                                                          :thickness => 8,
+                                                          :depth_below_grade => 3,
+                                                          :insulation_interior_r_value => 0,
+                                                          :insulation_interior_distance_to_top => 0,
+                                                          :insulation_interior_distance_to_bottom => 0,
+                                                          :insulation_exterior_distance_to_top => 0,
+                                                          :insulation_exterior_distance_to_bottom => 4,
+                                                          :insulation_exterior_r_value => 8.9 })]
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..hpxml_data[:foundation_walls].size
-      hpxml_data[:foundation_walls][n - 1][:area] /= 10.0
+    for n in 1..hpxml.foundation_walls.size
+      hpxml.foundation_walls[n - 1].area /= 10.0
       for i in 2..10
-        hpxml_data[:foundation_walls] << hpxml_data[:foundation_walls][n - 1].dup
-        hpxml_data[:foundation_walls][-1][:id] += i.to_s
+        hpxml.foundation_walls << hpxml.foundation_walls[n - 1].dup
+        hpxml.foundation_walls[-1].id += i.to_s
       end
     end
   elsif ['invalid_files/mismatched-slab-and-foundation-wall.xml'].include? hpxml_file
-    hpxml_data[:foundation_walls] << hpxml_data[:foundation_walls][0].dup
-    hpxml_data[:foundation_walls][1][:id] = "FoundationWall2"
-    hpxml_data[:foundation_walls][1][:interior_adjacent_to] = "garage"
+    hpxml.foundation_walls << hpxml.foundation_walls[0].dup
+    hpxml.foundation_walls[1].id = "FoundationWall2"
+    hpxml.foundation_walls[1].interior_adjacent_to = "garage"
   end
 end
 
-def set_hpxml_data_frame_floors_values(hpxml_file, hpxml_data)
+def set_hpxml_frame_floors(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:frame_floors] = [{ :id => "FloorBelowAttic",
-                                   :exterior_adjacent_to => "attic - unvented",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 1350,
-                                   :insulation_assembly_r_value => 39.3 }]
+    hpxml.frame_floors = [HPXML::FrameFloor.new({ :id => "FloorBelowAttic",
+                                                  :exterior_adjacent_to => "attic - unvented",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 1350,
+                                                  :insulation_assembly_r_value => 39.3 })]
   elsif ['base-atticroof-flat.xml',
          'base-atticroof-cathedral.xml'].include? hpxml_file
-    hpxml_data[:frame_floors].delete_at(0)
+    hpxml.frame_floors.delete_at(0)
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    hpxml_data[:frame_floors][0][:exterior_adjacent_to] = "attic - vented"
+    hpxml.frame_floors[0].exterior_adjacent_to = "attic - vented"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:frame_floors][0][:area] = 450
+    hpxml.frame_floors[0].area = 450
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml_data[:frame_floors] << { :id => "FloorBetweenAtticGarage",
-                                   :exterior_adjacent_to => "attic - unvented",
-                                   :interior_adjacent_to => "garage",
-                                   :area => 600,
-                                   :insulation_assembly_r_value => 2.1 }
+    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorBetweenAtticGarage",
+                                                  :exterior_adjacent_to => "attic - unvented",
+                                                  :interior_adjacent_to => "garage",
+                                                  :area => 600,
+                                                  :insulation_assembly_r_value => 2.1 })
   elsif ['base-foundation-ambient.xml'].include? hpxml_file
-    hpxml_data[:frame_floors] << { :id => "FloorAboveAmbient",
-                                   :exterior_adjacent_to => "outside",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 1350,
-                                   :insulation_assembly_r_value => 18.7 }
+    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveAmbient",
+                                                  :exterior_adjacent_to => "outside",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 1350,
+                                                  :insulation_assembly_r_value => 18.7 })
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:frame_floors] << { :id => "FloorAboveUncondBasement",
-                                   :exterior_adjacent_to => "basement - unconditioned",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 1350,
-                                   :insulation_assembly_r_value => 18.7 }
+    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveUncondBasement",
+                                                  :exterior_adjacent_to => "basement - unconditioned",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 1350,
+                                                  :insulation_assembly_r_value => 18.7 })
   elsif ['base-foundation-unconditioned-basement-wall-insulation.xml'].include? hpxml_file
-    hpxml_data[:frame_floors][1][:insulation_assembly_r_value] = 2.1
+    hpxml.frame_floors[1].insulation_assembly_r_value = 2.1
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    hpxml_data[:frame_floors] << { :id => "FloorAboveUnventedCrawl",
-                                   :exterior_adjacent_to => "crawlspace - unvented",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 1350,
-                                   :insulation_assembly_r_value => 18.7 }
+    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveUnventedCrawl",
+                                                  :exterior_adjacent_to => "crawlspace - unvented",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 1350,
+                                                  :insulation_assembly_r_value => 18.7 })
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml_data[:frame_floors] << { :id => "FloorAboveVentedCrawl",
-                                   :exterior_adjacent_to => "crawlspace - vented",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 1350,
-                                   :insulation_assembly_r_value => 18.7 }
+    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveVentedCrawl",
+                                                  :exterior_adjacent_to => "crawlspace - vented",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 1350,
+                                                  :insulation_assembly_r_value => 18.7 })
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
-    hpxml_data[:frame_floors][1][:area] = 675
-    hpxml_data[:frame_floors] << { :id => "FloorAboveUnventedCrawlspace",
-                                   :exterior_adjacent_to => "crawlspace - unvented",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 675,
-                                   :insulation_assembly_r_value => 18.7 }
+    hpxml.frame_floors[1].area = 675
+    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveUnventedCrawlspace",
+                                                  :exterior_adjacent_to => "crawlspace - unvented",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 675,
+                                                  :insulation_assembly_r_value => 18.7 })
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    hpxml_data[:frame_floors] << { :id => "FloorAboveGarage",
-                                   :exterior_adjacent_to => "garage",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 400,
-                                   :insulation_assembly_r_value => 18.7 }
+    hpxml.frame_floors << HPXML::FrameFloor.new({ :id => "FloorAboveGarage",
+                                                  :exterior_adjacent_to => "garage",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 400,
+                                                  :insulation_assembly_r_value => 18.7 })
   elsif ['base-atticroof-unvented-insulated-roof.xml'].include? hpxml_file
-    hpxml_data[:frame_floors][0][:insulation_assembly_r_value] = 2.1
+    hpxml.frame_floors[0].insulation_assembly_r_value = 2.1
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    hpxml_data[:frame_floors] = [{ :id => "FloorAboveAdiabatic",
-                                   :exterior_adjacent_to => "other housing unit below",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 1350,
-                                   :insulation_assembly_r_value => 2.1 },
-                                 { :id => "FloorBelowAdiabatic",
-                                   :exterior_adjacent_to => "other housing unit above",
-                                   :interior_adjacent_to => "living space",
-                                   :area => 1350,
-                                   :insulation_assembly_r_value => 2.1 }]
+    hpxml.frame_floors = [HPXML::FrameFloor.new({ :id => "FloorAboveAdiabatic",
+                                                  :exterior_adjacent_to => "other housing unit below",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 1350,
+                                                  :insulation_assembly_r_value => 2.1 }),
+                          HPXML::FrameFloor.new({ :id => "FloorBelowAdiabatic",
+                                                  :exterior_adjacent_to => "other housing unit above",
+                                                  :interior_adjacent_to => "living space",
+                                                  :area => 1350,
+                                                  :insulation_assembly_r_value => 2.1 })]
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..hpxml_data[:frame_floors].size
-      hpxml_data[:frame_floors][n - 1][:area] /= 10.0
+    for n in 1..hpxml.frame_floors.size
+      hpxml.frame_floors[n - 1].area /= 10.0
       for i in 2..10
-        hpxml_data[:frame_floors] << hpxml_data[:frame_floors][n - 1].dup
-        hpxml_data[:frame_floors][-1][:id] += i.to_s
+        hpxml.frame_floors << hpxml.frame_floors[n - 1].dup
+        hpxml.frame_floors[-1].id += i.to_s
       end
     end
   end
 end
 
-def set_hpxml_data_slabs_values(hpxml_file, hpxml_data)
+def set_hpxml_slabs(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:slabs] = [{ :id => "Slab",
-                            :interior_adjacent_to => "basement - conditioned",
-                            :area => 1350,
-                            :thickness => 4,
-                            :exposed_perimeter => 150,
-                            :perimeter_insulation_depth => 0,
-                            :under_slab_insulation_width => 0,
-                            :perimeter_insulation_r_value => 0,
-                            :under_slab_insulation_r_value => 0,
-                            :carpet_fraction => 0,
-                            :carpet_r_value => 0 }]
+    hpxml.slabs = [HPXML::Slab.new({ :id => "Slab",
+                                     :interior_adjacent_to => "basement - conditioned",
+                                     :area => 1350,
+                                     :thickness => 4,
+                                     :exposed_perimeter => 150,
+                                     :perimeter_insulation_depth => 0,
+                                     :under_slab_insulation_width => 0,
+                                     :perimeter_insulation_r_value => 0,
+                                     :under_slab_insulation_r_value => 0,
+                                     :carpet_fraction => 0,
+                                     :carpet_r_value => 0 })]
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:slabs][0][:interior_adjacent_to] = "basement - unconditioned"
+    hpxml.slabs[0].interior_adjacent_to = "basement - unconditioned"
   elsif ['base-foundation-conditioned-basement-slab-insulation.xml'].include? hpxml_file
-    hpxml_data[:slabs][0][:under_slab_insulation_width] = 4
-    hpxml_data[:slabs][0][:under_slab_insulation_r_value] = 10
+    hpxml.slabs[0].under_slab_insulation_width = 4
+    hpxml.slabs[0].under_slab_insulation_r_value = 10
   elsif ['base-foundation-slab.xml'].include? hpxml_file
-    hpxml_data[:slabs][0][:interior_adjacent_to] = "living space"
-    hpxml_data[:slabs][0][:under_slab_insulation_width] = nil
-    hpxml_data[:slabs][0][:under_slab_insulation_spans_entire_slab] = true
-    hpxml_data[:slabs][0][:depth_below_grade] = 0
-    hpxml_data[:slabs][0][:under_slab_insulation_r_value] = 5
-    hpxml_data[:slabs][0][:carpet_fraction] = 1
-    hpxml_data[:slabs][0][:carpet_r_value] = 2.5
+    hpxml.slabs[0].interior_adjacent_to = "living space"
+    hpxml.slabs[0].under_slab_insulation_width = nil
+    hpxml.slabs[0].under_slab_insulation_spans_entire_slab = true
+    hpxml.slabs[0].depth_below_grade = 0
+    hpxml.slabs[0].under_slab_insulation_r_value = 5
+    hpxml.slabs[0].carpet_fraction = 1
+    hpxml.slabs[0].carpet_r_value = 2.5
   elsif ['base-foundation-unvented-crawlspace.xml',
          'base-foundation-vented-crawlspace.xml'].include? hpxml_file
     if ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-      hpxml_data[:slabs][0][:interior_adjacent_to] = "crawlspace - unvented"
+      hpxml.slabs[0].interior_adjacent_to = "crawlspace - unvented"
     else
-      hpxml_data[:slabs][0][:interior_adjacent_to] = "crawlspace - vented"
+      hpxml.slabs[0].interior_adjacent_to = "crawlspace - vented"
     end
-    hpxml_data[:slabs][0][:thickness] = 0
-    hpxml_data[:slabs][0][:carpet_r_value] = 2.5
+    hpxml.slabs[0].thickness = 0
+    hpxml.slabs[0].carpet_r_value = 2.5
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
-    hpxml_data[:slabs][0][:area] = 675
-    hpxml_data[:slabs][0][:exposed_perimeter] = 75
-    hpxml_data[:slabs] << { :id => "SlabUnderCrawlspace",
-                            :interior_adjacent_to => "crawlspace - unvented",
-                            :area => 675,
-                            :thickness => 0,
-                            :exposed_perimeter => 75,
-                            :perimeter_insulation_depth => 0,
-                            :under_slab_insulation_width => 0,
-                            :perimeter_insulation_r_value => 0,
-                            :under_slab_insulation_r_value => 0,
-                            :carpet_fraction => 0,
-                            :carpet_r_value => 0 }
+    hpxml.slabs[0].area = 675
+    hpxml.slabs[0].exposed_perimeter = 75
+    hpxml.slabs << HPXML::Slab.new({ :id => "SlabUnderCrawlspace",
+                                     :interior_adjacent_to => "crawlspace - unvented",
+                                     :area => 675,
+                                     :thickness => 0,
+                                     :exposed_perimeter => 75,
+                                     :perimeter_insulation_depth => 0,
+                                     :under_slab_insulation_width => 0,
+                                     :perimeter_insulation_r_value => 0,
+                                     :under_slab_insulation_r_value => 0,
+                                     :carpet_fraction => 0,
+                                     :carpet_r_value => 0 })
   elsif ['base-foundation-ambient.xml'].include? hpxml_file
-    hpxml_data[:slabs] = []
+    hpxml.slabs = []
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
-    hpxml_data[:slabs][0][:area] -= 400
-    hpxml_data[:slabs][0][:exposed_perimeter] -= 40
-    hpxml_data[:slabs] << { :id => "SlabUnderGarage",
-                            :interior_adjacent_to => "garage",
-                            :area => 400,
-                            :thickness => 4,
-                            :exposed_perimeter => 40,
-                            :perimeter_insulation_depth => 0,
-                            :under_slab_insulation_width => 0,
-                            :depth_below_grade => 0,
-                            :perimeter_insulation_r_value => 0,
-                            :under_slab_insulation_r_value => 0,
-                            :carpet_fraction => 0,
-                            :carpet_r_value => 0 }
+    hpxml.slabs[0].area -= 400
+    hpxml.slabs[0].exposed_perimeter -= 40
+    hpxml.slabs << HPXML::Slab.new({ :id => "SlabUnderGarage",
+                                     :interior_adjacent_to => "garage",
+                                     :area => 400,
+                                     :thickness => 4,
+                                     :exposed_perimeter => 40,
+                                     :perimeter_insulation_depth => 0,
+                                     :under_slab_insulation_width => 0,
+                                     :depth_below_grade => 0,
+                                     :perimeter_insulation_r_value => 0,
+                                     :under_slab_insulation_r_value => 0,
+                                     :carpet_fraction => 0,
+                                     :carpet_r_value => 0 })
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml_data[:slabs][0][:exposed_perimeter] -= 30
-    hpxml_data[:slabs] << { :id => "SlabUnderGarage",
-                            :interior_adjacent_to => "garage",
-                            :area => 600,
-                            :thickness => 4,
-                            :exposed_perimeter => 70,
-                            :perimeter_insulation_depth => 0,
-                            :under_slab_insulation_width => 0,
-                            :depth_below_grade => 0,
-                            :perimeter_insulation_r_value => 0,
-                            :under_slab_insulation_r_value => 0,
-                            :carpet_fraction => 0,
-                            :carpet_r_value => 0 }
+    hpxml.slabs[0].exposed_perimeter -= 30
+    hpxml.slabs << HPXML::Slab.new({ :id => "SlabUnderGarage",
+                                     :interior_adjacent_to => "garage",
+                                     :area => 600,
+                                     :thickness => 4,
+                                     :exposed_perimeter => 70,
+                                     :perimeter_insulation_depth => 0,
+                                     :under_slab_insulation_width => 0,
+                                     :depth_below_grade => 0,
+                                     :perimeter_insulation_r_value => 0,
+                                     :under_slab_insulation_r_value => 0,
+                                     :carpet_fraction => 0,
+                                     :carpet_r_value => 0 })
   elsif ['base-foundation-complex.xml'].include? hpxml_file
-    hpxml_data[:slabs] = [{ :id => "Slab1",
-                            :interior_adjacent_to => "basement - conditioned",
-                            :area => 675,
-                            :thickness => 4,
-                            :exposed_perimeter => 75,
-                            :perimeter_insulation_depth => 0,
-                            :under_slab_insulation_width => 0,
-                            :perimeter_insulation_r_value => 0,
-                            :under_slab_insulation_r_value => 0,
-                            :carpet_fraction => 0,
-                            :carpet_r_value => 0 },
-                          { :id => "Slab2",
-                            :interior_adjacent_to => "basement - conditioned",
-                            :area => 405,
-                            :thickness => 4,
-                            :exposed_perimeter => 45,
-                            :perimeter_insulation_depth => 1,
-                            :under_slab_insulation_width => 0,
-                            :perimeter_insulation_r_value => 5,
-                            :under_slab_insulation_r_value => 0,
-                            :carpet_fraction => 0,
-                            :carpet_r_value => 0 },
-                          { :id => "Slab3",
-                            :interior_adjacent_to => "basement - conditioned",
-                            :area => 270,
-                            :thickness => 4,
-                            :exposed_perimeter => 30,
-                            :perimeter_insulation_depth => 1,
-                            :under_slab_insulation_width => 0,
-                            :perimeter_insulation_r_value => 5,
-                            :under_slab_insulation_r_value => 0,
-                            :carpet_fraction => 0,
-                            :carpet_r_value => 0 }]
+    hpxml.slabs = [HPXML::Slab.new({ :id => "Slab1",
+                                     :interior_adjacent_to => "basement - conditioned",
+                                     :area => 675,
+                                     :thickness => 4,
+                                     :exposed_perimeter => 75,
+                                     :perimeter_insulation_depth => 0,
+                                     :under_slab_insulation_width => 0,
+                                     :perimeter_insulation_r_value => 0,
+                                     :under_slab_insulation_r_value => 0,
+                                     :carpet_fraction => 0,
+                                     :carpet_r_value => 0 }),
+                   HPXML::Slab.new({ :id => "Slab2",
+                                     :interior_adjacent_to => "basement - conditioned",
+                                     :area => 405,
+                                     :thickness => 4,
+                                     :exposed_perimeter => 45,
+                                     :perimeter_insulation_depth => 1,
+                                     :under_slab_insulation_width => 0,
+                                     :perimeter_insulation_r_value => 5,
+                                     :under_slab_insulation_r_value => 0,
+                                     :carpet_fraction => 0,
+                                     :carpet_r_value => 0 }),
+                   HPXML::Slab.new({ :id => "Slab3",
+                                     :interior_adjacent_to => "basement - conditioned",
+                                     :area => 270,
+                                     :thickness => 4,
+                                     :exposed_perimeter => 30,
+                                     :perimeter_insulation_depth => 1,
+                                     :under_slab_insulation_width => 0,
+                                     :perimeter_insulation_r_value => 5,
+                                     :under_slab_insulation_r_value => 0,
+                                     :carpet_fraction => 0,
+                                     :carpet_r_value => 0 })]
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..hpxml_data[:slabs].size
-      hpxml_data[:slabs][n - 1][:area] /= 10.0
-      hpxml_data[:slabs][n - 1][:exposed_perimeter] /= 10.0
+    for n in 1..hpxml.slabs.size
+      hpxml.slabs[n - 1].area /= 10.0
+      hpxml.slabs[n - 1].exposed_perimeter /= 10.0
       for i in 2..10
-        hpxml_data[:slabs] << hpxml_data[:slabs][n - 1].dup
-        hpxml_data[:slabs][-1][:id] += i.to_s
+        hpxml.slabs << hpxml.slabs[n - 1].dup
+        hpxml.slabs[-1].id += i.to_s
       end
     end
   elsif ['invalid_files/mismatched-slab-and-foundation-wall.xml'].include? hpxml_file
-    hpxml_data[:slabs][0][:interior_adjacent_to] = "basement - unconditioned"
-    hpxml_data[:slabs][0][:depth_below_grade] = 7.0
+    hpxml.slabs[0].interior_adjacent_to = "basement - unconditioned"
+    hpxml.slabs[0].depth_below_grade = 7.0
   elsif ['invalid_files/slab-zero-exposed-perimeter.xml'].include? hpxml_file
-    hpxml_data[:slabs][0][:exposed_perimeter] = 0
+    hpxml.slabs[0].exposed_perimeter = 0
   end
 end
 
-def set_hpxml_data_windows_values(hpxml_file, hpxml_data)
+def set_hpxml_windows(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:windows] = [{ :id => "WindowNorth",
-                              :area => 108,
-                              :azimuth => 0,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "Wall" },
-                            { :id => "WindowSouth",
-                              :area => 108,
-                              :azimuth => 180,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "Wall" },
-                            { :id => "WindowEast",
-                              :area => 72,
-                              :azimuth => 90,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "Wall" },
-                            { :id => "WindowWest",
-                              :area => 72,
-                              :azimuth => 270,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "Wall" }]
+    hpxml.windows = [HPXML::Window.new({ :id => "WindowNorth",
+                                         :area => 108,
+                                         :azimuth => 0,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "Wall" }),
+                     HPXML::Window.new({ :id => "WindowSouth",
+                                         :area => 108,
+                                         :azimuth => 180,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "Wall" }),
+                     HPXML::Window.new({ :id => "WindowEast",
+                                         :area => 72,
+                                         :azimuth => 90,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "Wall" }),
+                     HPXML::Window.new({ :id => "WindowWest",
+                                         :area => 72,
+                                         :azimuth => 270,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "Wall" })]
   elsif ['base-enclosure-overhangs.xml'].include? hpxml_file
-    hpxml_data[:windows][0][:overhangs_depth] = 2.5
-    hpxml_data[:windows][0][:overhangs_distance_to_top_of_window] = 0
-    hpxml_data[:windows][0][:overhangs_distance_to_bottom_of_window] = 4
-    hpxml_data[:windows][2][:overhangs_depth] = 1.5
-    hpxml_data[:windows][2][:overhangs_distance_to_top_of_window] = 2
-    hpxml_data[:windows][2][:overhangs_distance_to_bottom_of_window] = 6
-    hpxml_data[:windows][3][:overhangs_depth] = 1.5
-    hpxml_data[:windows][3][:overhangs_distance_to_top_of_window] = 2
-    hpxml_data[:windows][3][:overhangs_distance_to_bottom_of_window] = 7
+    hpxml.windows[0].overhangs_depth = 2.5
+    hpxml.windows[0].overhangs_distance_to_top_of_window = 0
+    hpxml.windows[0].overhangs_distance_to_bottom_of_window = 4
+    hpxml.windows[2].overhangs_depth = 1.5
+    hpxml.windows[2].overhangs_distance_to_top_of_window = 2
+    hpxml.windows[2].overhangs_distance_to_bottom_of_window = 6
+    hpxml.windows[3].overhangs_depth = 1.5
+    hpxml.windows[3].overhangs_distance_to_top_of_window = 2
+    hpxml.windows[3].overhangs_distance_to_bottom_of_window = 7
   elsif ['base-enclosure-windows-interior-shading.xml'].include? hpxml_file
-    hpxml_data[:windows][0][:interior_shading_factor_summer] = 0.7
-    hpxml_data[:windows][0][:interior_shading_factor_winter] = 0.85
-    hpxml_data[:windows][1][:interior_shading_factor_summer] = 0.01
-    hpxml_data[:windows][1][:interior_shading_factor_winter] = 0.99
-    hpxml_data[:windows][2][:interior_shading_factor_summer] = 0.0
-    hpxml_data[:windows][2][:interior_shading_factor_winter] = 0.5
-    hpxml_data[:windows][3][:interior_shading_factor_summer] = 1.0
-    hpxml_data[:windows][3][:interior_shading_factor_winter] = 1.0
+    hpxml.windows[0].interior_shading_factor_summer = 0.7
+    hpxml.windows[0].interior_shading_factor_winter = 0.85
+    hpxml.windows[1].interior_shading_factor_summer = 0.01
+    hpxml.windows[1].interior_shading_factor_winter = 0.99
+    hpxml.windows[2].interior_shading_factor_summer = 0.0
+    hpxml.windows[2].interior_shading_factor_winter = 0.5
+    hpxml.windows[3].interior_shading_factor_summer = 1.0
+    hpxml.windows[3].interior_shading_factor_winter = 1.0
   elsif ['invalid_files/invalid-window-interior-shading.xml'].include? hpxml_file
-    hpxml_data[:windows][0][:interior_shading_factor_summer] = 0.85
-    hpxml_data[:windows][0][:interior_shading_factor_winter] = 0.7
+    hpxml.windows[0].interior_shading_factor_summer = 0.85
+    hpxml.windows[0].interior_shading_factor_winter = 0.7
   elsif ['base-enclosure-windows-none.xml'].include? hpxml_file
-    hpxml_data[:windows] = []
+    hpxml.windows = []
   elsif ['invalid_files/net-area-negative-wall.xml'].include? hpxml_file
-    hpxml_data[:windows][0][:area] = 1000
+    hpxml.windows[0].area = 1000
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:windows][0][:area] = 108
-    hpxml_data[:windows][1][:area] = 108
-    hpxml_data[:windows][2][:area] = 108
-    hpxml_data[:windows][3][:area] = 108
-    hpxml_data[:windows] << { :id => "AtticGableWindowEast",
-                              :area => 12,
-                              :azimuth => 90,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "WallAtticGableCond" }
-    hpxml_data[:windows] << { :id => "AtticGableWindowWest",
-                              :area => 62,
-                              :azimuth => 270,
-                              :ufactor => 0.3,
-                              :shgc => 0.45,
-                              :wall_idref => "WallAtticGableCond" }
+    hpxml.windows[0].area = 108
+    hpxml.windows[1].area = 108
+    hpxml.windows[2].area = 108
+    hpxml.windows[3].area = 108
+    hpxml.windows << HPXML::Window.new({ :id => "AtticGableWindowEast",
+                                         :area => 12,
+                                         :azimuth => 90,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "WallAtticGableCond" })
+    hpxml.windows << HPXML::Window.new({ :id => "AtticGableWindowWest",
+                                         :area => 62,
+                                         :azimuth => 270,
+                                         :ufactor => 0.3,
+                                         :shgc => 0.45,
+                                         :wall_idref => "WallAtticGableCond" })
   elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    hpxml_data[:windows][0][:area] = 108
-    hpxml_data[:windows][1][:area] = 108
-    hpxml_data[:windows][2][:area] = 108
-    hpxml_data[:windows][3][:area] = 108
-    hpxml_data[:windows] << { :id => "AtticGableWindowEast",
-                              :area => 12,
-                              :azimuth => 90,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "WallAtticGable" }
-    hpxml_data[:windows] << { :id => "AtticGableWindowWest",
-                              :area => 12,
-                              :azimuth => 270,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "WallAtticGable" }
+    hpxml.windows[0].area = 108
+    hpxml.windows[1].area = 108
+    hpxml.windows[2].area = 108
+    hpxml.windows[3].area = 108
+    hpxml.windows << HPXML::Window.new({ :id => "AtticGableWindowEast",
+                                         :area => 12,
+                                         :azimuth => 90,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "WallAtticGable" })
+    hpxml.windows << HPXML::Window.new({ :id => "AtticGableWindowWest",
+                                         :area => 12,
+                                         :azimuth => 270,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "WallAtticGable" })
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml_data[:windows].delete_at(2)
-    hpxml_data[:windows] << { :id => "GarageWindowEast",
-                              :area => 12,
-                              :azimuth => 90,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "WallGarageExterior" }
+    hpxml.windows.delete_at(2)
+    hpxml.windows << HPXML::Window.new({ :id => "GarageWindowEast",
+                                         :area => 12,
+                                         :azimuth => 90,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "WallGarageExterior" })
   elsif ['base-enclosure-2stories.xml'].include? hpxml_file
-    hpxml_data[:windows][0][:area] = 216
-    hpxml_data[:windows][1][:area] = 216
-    hpxml_data[:windows][2][:area] = 144
-    hpxml_data[:windows][3][:area] = 144
+    hpxml.windows[0].area = 216
+    hpxml.windows[1].area = 216
+    hpxml.windows[2].area = 144
+    hpxml.windows[3].area = 144
   elsif ['base-enclosure-2stories-garage'].include? hpxml_file
-    hpxml_data[:windows][0][:area] = 168
-    hpxml_data[:windows][1][:area] = 216
-    hpxml_data[:windows][2][:area] = 144
-    hpxml_data[:windows][3][:area] = 96
+    hpxml.windows[0].area = 168
+    hpxml.windows[1].area = 216
+    hpxml.windows[2].area = 144
+    hpxml.windows[3].area = 96
   elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
-    hpxml_data[:windows] << { :id => "FoundationWindowNorth",
-                              :area => 20,
-                              :azimuth => 0,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "FoundationWall" }
-    hpxml_data[:windows] << { :id => "FoundationWindowSouth",
-                              :area => 20,
-                              :azimuth => 180,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "FoundationWall" }
-    hpxml_data[:windows] << { :id => "FoundationWindowEast",
-                              :area => 10,
-                              :azimuth => 90,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "FoundationWall" }
-    hpxml_data[:windows] << { :id => "FoundationWindowWest",
-                              :area => 10,
-                              :azimuth => 270,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "FoundationWall" }
+    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindowNorth",
+                                         :area => 20,
+                                         :azimuth => 0,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "FoundationWall" })
+    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindowSouth",
+                                         :area => 20,
+                                         :azimuth => 180,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "FoundationWall" })
+    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindowEast",
+                                         :area => 10,
+                                         :azimuth => 90,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "FoundationWall" })
+    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindowWest",
+                                         :area => 10,
+                                         :azimuth => 270,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "FoundationWall" })
   elsif ['base-enclosure-adiabatic-surfaces.xml'].include? hpxml_file
-    for n in 1..hpxml_data[:windows].size
-      hpxml_data[:windows][n - 1][:area] *= 0.35
+    for n in 1..hpxml.windows.size
+      hpxml.windows[n - 1].area *= 0.35
     end
   elsif ['invalid_files/unattached-window.xml'].include? hpxml_file
-    hpxml_data[:windows][0][:wall_idref] = "foobar"
+    hpxml.windows[0].wall_idref = "foobar"
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     area_adjustments = []
-    for n in 1..hpxml_data[:windows].size
-      hpxml_data[:windows][n - 1][:area] /= 10.0
+    for n in 1..hpxml.windows.size
+      hpxml.windows[n - 1].area /= 10.0
       for i in 2..10
-        hpxml_data[:windows] << hpxml_data[:windows][n - 1].dup
-        hpxml_data[:windows][-1][:id] += i.to_s
-        hpxml_data[:windows][-1][:wall_idref] += i.to_s
+        hpxml.windows << hpxml.windows[n - 1].dup
+        hpxml.windows[-1].id += i.to_s
+        hpxml.windows[-1].wall_idref += i.to_s
       end
     end
   elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
-    hpxml_data[:windows] << { :id => "FoundationWindow",
-                              :area => 20,
-                              :azimuth => 0,
-                              :ufactor => 0.33,
-                              :shgc => 0.45,
-                              :wall_idref => "FoundationWall3" }
+    hpxml.windows << HPXML::Window.new({ :id => "FoundationWindow",
+                                         :area => 20,
+                                         :azimuth => 0,
+                                         :ufactor => 0.33,
+                                         :shgc => 0.45,
+                                         :wall_idref => "FoundationWall3" })
   elsif ['invalid_files/invalid-window-height.xml'].include? hpxml_file
-    hpxml_data[:windows][2][:overhangs_distance_to_bottom_of_window] = hpxml_data[:windows][2][:overhangs_distance_to_top_of_window]
+    hpxml.windows[2].overhangs_distance_to_bottom_of_window = hpxml.windows[2].overhangs_distance_to_top_of_window
   end
 end
 
-def set_hpxml_data_skylights_values(hpxml_file, hpxml_data)
+def set_hpxml_skylights(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:skylights] = []
+    hpxml.skylights = []
   elsif ['base-enclosure-skylights.xml'].include? hpxml_file
-    hpxml_data[:skylights] << { :id => "SkylightNorth",
-                                :area => 45,
-                                :azimuth => 0,
-                                :ufactor => 0.33,
-                                :shgc => 0.45,
-                                :roof_idref => "Roof" }
-    hpxml_data[:skylights] << { :id => "SkylightSouth",
-                                :area => 45,
-                                :azimuth => 180,
-                                :ufactor => 0.35,
-                                :shgc => 0.47,
-                                :roof_idref => "Roof" }
+    hpxml.skylights << HPXML::Skylight.new({ :id => "SkylightNorth",
+                                             :area => 45,
+                                             :azimuth => 0,
+                                             :ufactor => 0.33,
+                                             :shgc => 0.45,
+                                             :roof_idref => "Roof" })
+    hpxml.skylights << HPXML::Skylight.new({ :id => "SkylightSouth",
+                                             :area => 45,
+                                             :azimuth => 180,
+                                             :ufactor => 0.35,
+                                             :shgc => 0.47,
+                                             :roof_idref => "Roof" })
   elsif ['invalid_files/net-area-negative-roof.xml'].include? hpxml_file
-    hpxml_data[:skylights][0][:area] = 4000
+    hpxml.skylights[0].area = 4000
   elsif ['invalid_files/unattached-skylight.xml'].include? hpxml_file
-    hpxml_data[:skylights][0][:roof_idref] = "foobar"
+    hpxml.skylights[0].roof_idref = "foobar"
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
-    for n in 1..hpxml_data[:skylights].size
-      hpxml_data[:skylights][n - 1][:area] /= 10.0
+    for n in 1..hpxml.skylights.size
+      hpxml.skylights[n - 1].area /= 10.0
       for i in 2..10
-        hpxml_data[:skylights] << hpxml_data[:skylights][n - 1].dup
-        hpxml_data[:skylights][-1][:id] += i.to_s
-        hpxml_data[:skylights][-1][:roof_idref] += i.to_s if i % 2 == 0
+        hpxml.skylights << hpxml.skylights[n - 1].dup
+        hpxml.skylights[-1].id += i.to_s
+        hpxml.skylights[-1].roof_idref += i.to_s if i % 2 == 0
       end
     end
   end
 end
 
-def set_hpxml_data_doors_values(hpxml_file, hpxml_data)
+def set_hpxml_doors(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:doors] = [{ :id => "DoorNorth",
-                            :wall_idref => "Wall",
-                            :area => 40,
-                            :azimuth => 0,
-                            :r_value => 4.4 },
-                          { :id => "DoorSouth",
-                            :wall_idref => "Wall",
-                            :area => 40,
-                            :azimuth => 180,
-                            :r_value => 4.4 }]
+    hpxml.doors = [HPXML::Door.new({ :id => "DoorNorth",
+                                     :wall_idref => "Wall",
+                                     :area => 40,
+                                     :azimuth => 0,
+                                     :r_value => 4.4 }),
+                   HPXML::Door.new({ :id => "DoorSouth",
+                                     :wall_idref => "Wall",
+                                     :area => 40,
+                                     :azimuth => 180,
+                                     :r_value => 4.4 })]
   elsif ['base-enclosure-garage.xml',
          'base-enclosure-2stories-garage.xml'].include? hpxml_file
-    hpxml_data[:doors] << { :id => "GarageDoorSouth",
-                            :wall_idref => "WallGarageExterior",
-                            :area => 70,
-                            :azimuth => 180,
-                            :r_value => 4.4 }
+    hpxml.doors << HPXML::Door.new({ :id => "GarageDoorSouth",
+                                     :wall_idref => "WallGarageExterior",
+                                     :area => 70,
+                                     :azimuth => 180,
+                                     :r_value => 4.4 })
   elsif ['invalid_files/unattached-door.xml'].include? hpxml_file
-    hpxml_data[:doors][0][:wall_idref] = "foobar"
+    hpxml.doors[0].wall_idref = "foobar"
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     area_adjustments = []
-    for n in 1..hpxml_data[:doors].size
-      hpxml_data[:doors][n - 1][:area] /= 10.0
+    for n in 1..hpxml.doors.size
+      hpxml.doors[n - 1].area /= 10.0
       for i in 2..10
-        hpxml_data[:doors] << hpxml_data[:doors][n - 1].dup
-        hpxml_data[:doors][-1][:id] += i.to_s
-        hpxml_data[:doors][-1][:wall_idref] += i.to_s
+        hpxml.doors << hpxml.doors[n - 1].dup
+        hpxml.doors[-1].id += i.to_s
+        hpxml.doors[-1].wall_idref += i.to_s
       end
     end
   end
 end
 
-def set_hpxml_data_heating_systems_values(hpxml_file, hpxml_data)
+def set_hpxml_heating_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:heating_systems] = [{ :id => "HeatingSystem",
-                                      :distribution_system_idref => "HVACDistribution",
-                                      :heating_system_type => "Furnace",
-                                      :heating_system_fuel => "natural gas",
-                                      :heating_capacity => 64000,
-                                      :heating_efficiency_afue => 0.92,
-                                      :fraction_heat_load_served => 1 }]
+    hpxml.heating_systems = [HPXML::HeatingSystem.new({ :id => "HeatingSystem",
+                                                        :distribution_system_idref => "HVACDistribution",
+                                                        :heating_system_type => "Furnace",
+                                                        :heating_system_fuel => "natural gas",
+                                                        :heating_capacity => 64000,
+                                                        :heating_efficiency_afue => 0.92,
+                                                        :fraction_heat_load_served => 1 })]
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-air-to-air-heat-pump-var-speed.xml',
@@ -1596,195 +1592,195 @@ def set_hpxml_data_heating_systems_values(hpxml_file, hpxml_data)
          'base-hvac-none.xml',
          'base-hvac-room-ac-only.xml',
          'invalid_files/orphaned-hvac-distribution.xml'].include? hpxml_file
-    hpxml_data[:heating_systems] = []
+    hpxml.heating_systems = []
   elsif ['base-hvac-boiler-elec-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 1
+    hpxml.heating_systems[0].heating_system_type = "Boiler"
+    hpxml.heating_systems[0].heating_system_fuel = "electricity"
+    hpxml.heating_systems[0].heating_efficiency_afue = 1
   elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml',
          'base-hvac-boiler-gas-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
+    hpxml.heating_systems[0].heating_system_type = "Boiler"
+    hpxml.heating_systems[0].electric_auxiliary_energy = 200
   elsif ['base-hvac-boiler-oil-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "fuel oil"
+    hpxml.heating_systems[0].heating_system_type = "Boiler"
+    hpxml.heating_systems[0].heating_system_fuel = "fuel oil"
   elsif ['base-hvac-boiler-propane-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "propane"
+    hpxml.heating_systems[0].heating_system_type = "Boiler"
+    hpxml.heating_systems[0].heating_system_fuel = "propane"
   elsif ['base-hvac-boiler-wood-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "wood"
+    hpxml.heating_systems[0].heating_system_type = "Boiler"
+    hpxml.heating_systems[0].heating_system_fuel = "wood"
   elsif ['base-hvac-elec-resistance-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
-    hpxml_data[:heating_systems][0][:heating_system_type] = "ElectricResistance"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = nil
-    hpxml_data[:heating_systems][0][:heating_efficiency_percent] = 1
+    hpxml.heating_systems[0].distribution_system_idref = nil
+    hpxml.heating_systems[0].heating_system_type = "ElectricResistance"
+    hpxml.heating_systems[0].heating_system_fuel = "electricity"
+    hpxml.heating_systems[0].heating_efficiency_afue = nil
+    hpxml.heating_systems[0].heating_efficiency_percent = 1
   elsif ['base-hvac-furnace-elec-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 1
+    hpxml.heating_systems[0].heating_system_fuel = "electricity"
+    hpxml.heating_systems[0].heating_efficiency_afue = 1
   elsif ['base-hvac-furnace-gas-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 700
+    hpxml.heating_systems[0].electric_auxiliary_energy = 700
   elsif ['base-hvac-furnace-gas-only-no-eae.xml',
          'base-hvac-boiler-gas-only-no-eae.xml',
          'base-hvac-stove-oil-only-no-eae.xml',
          'base-hvac-wall-furnace-propane-only-no-eae.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = nil
+    hpxml.heating_systems[0].electric_auxiliary_energy = nil
   elsif ['base-hvac-furnace-oil-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "fuel oil"
+    hpxml.heating_systems[0].heating_system_fuel = "fuel oil"
   elsif ['base-hvac-furnace-propane-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "propane"
+    hpxml.heating_systems[0].heating_system_fuel = "propane"
   elsif ['base-hvac-furnace-wood-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "wood"
+    hpxml.heating_systems[0].heating_system_fuel = "wood"
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_system_type] = "Boiler"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 1
-    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.1
-    hpxml_data[:heating_systems][0][:heating_capacity] *= 0.1
-    hpxml_data[:heating_systems] << { :id => "HeatingSystem2",
-                                      :distribution_system_idref => "HVACDistribution2",
-                                      :heating_system_type => "Boiler",
-                                      :heating_system_fuel => "natural gas",
-                                      :heating_capacity => 6400,
-                                      :heating_efficiency_afue => 0.92,
-                                      :fraction_heat_load_served => 0.1,
-                                      :electric_auxiliary_energy => 200 }
-    hpxml_data[:heating_systems] << { :id => "HeatingSystem3",
-                                      :heating_system_type => "ElectricResistance",
-                                      :heating_system_fuel => "electricity",
-                                      :heating_capacity => 6400,
-                                      :heating_efficiency_percent => 1,
-                                      :fraction_heat_load_served => 0.1 }
-    hpxml_data[:heating_systems] << { :id => "HeatingSystem4",
-                                      :distribution_system_idref => "HVACDistribution3",
-                                      :heating_system_type => "Furnace",
-                                      :heating_system_fuel => "electricity",
-                                      :heating_capacity => 6400,
-                                      :heating_efficiency_afue => 1,
-                                      :fraction_heat_load_served => 0.1 }
-    hpxml_data[:heating_systems] << { :id => "HeatingSystem5",
-                                      :distribution_system_idref => "HVACDistribution4",
-                                      :heating_system_type => "Furnace",
-                                      :heating_system_fuel => "natural gas",
-                                      :heating_capacity => 6400,
-                                      :heating_efficiency_afue => 0.92,
-                                      :fraction_heat_load_served => 0.1,
-                                      :electric_auxiliary_energy => 700 }
-    hpxml_data[:heating_systems] << { :id => "HeatingSystem6",
-                                      :heating_system_type => "Stove",
-                                      :heating_system_fuel => "fuel oil",
-                                      :heating_capacity => 6400,
-                                      :heating_efficiency_percent => 0.8,
-                                      :fraction_heat_load_served => 0.1,
-                                      :electric_auxiliary_energy => 200 }
-    hpxml_data[:heating_systems] << { :id => "HeatingSystem7",
-                                      :heating_system_type => "WallFurnace",
-                                      :heating_system_fuel => "propane",
-                                      :heating_capacity => 6400,
-                                      :heating_efficiency_afue => 0.8,
-                                      :fraction_heat_load_served => 0.1,
-                                      :electric_auxiliary_energy => 200 }
+    hpxml.heating_systems[0].heating_system_type = "Boiler"
+    hpxml.heating_systems[0].heating_system_fuel = "electricity"
+    hpxml.heating_systems[0].heating_efficiency_afue = 1
+    hpxml.heating_systems[0].fraction_heat_load_served = 0.1
+    hpxml.heating_systems[0].heating_capacity *= 0.1
+    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem2",
+                                                        :distribution_system_idref => "HVACDistribution2",
+                                                        :heating_system_type => "Boiler",
+                                                        :heating_system_fuel => "natural gas",
+                                                        :heating_capacity => 6400,
+                                                        :heating_efficiency_afue => 0.92,
+                                                        :fraction_heat_load_served => 0.1,
+                                                        :electric_auxiliary_energy => 200 })
+    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem3",
+                                                        :heating_system_type => "ElectricResistance",
+                                                        :heating_system_fuel => "electricity",
+                                                        :heating_capacity => 6400,
+                                                        :heating_efficiency_percent => 1,
+                                                        :fraction_heat_load_served => 0.1 })
+    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem4",
+                                                        :distribution_system_idref => "HVACDistribution3",
+                                                        :heating_system_type => "Furnace",
+                                                        :heating_system_fuel => "electricity",
+                                                        :heating_capacity => 6400,
+                                                        :heating_efficiency_afue => 1,
+                                                        :fraction_heat_load_served => 0.1 })
+    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem5",
+                                                        :distribution_system_idref => "HVACDistribution4",
+                                                        :heating_system_type => "Furnace",
+                                                        :heating_system_fuel => "natural gas",
+                                                        :heating_capacity => 6400,
+                                                        :heating_efficiency_afue => 0.92,
+                                                        :fraction_heat_load_served => 0.1,
+                                                        :electric_auxiliary_energy => 700 })
+    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem6",
+                                                        :heating_system_type => "Stove",
+                                                        :heating_system_fuel => "fuel oil",
+                                                        :heating_capacity => 6400,
+                                                        :heating_efficiency_percent => 0.8,
+                                                        :fraction_heat_load_served => 0.1,
+                                                        :electric_auxiliary_energy => 200 })
+    hpxml.heating_systems << HPXML::HeatingSystem.new({ :id => "HeatingSystem7",
+                                                        :heating_system_type => "WallFurnace",
+                                                        :heating_system_fuel => "propane",
+                                                        :heating_capacity => 6400,
+                                                        :heating_efficiency_afue => 0.8,
+                                                        :fraction_heat_load_served => 0.1,
+                                                        :electric_auxiliary_energy => 200 })
   elsif ['invalid_files/hvac-frac-load-served.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:fraction_heat_load_served] += 0.1
+    hpxml.heating_systems[0].fraction_heat_load_served += 0.1
   elsif ['base-hvac-portable-heater-electric-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
-    hpxml_data[:heating_systems][0][:heating_system_type] = "PortableHeater"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = nil
-    hpxml_data[:heating_systems][0][:heating_efficiency_percent] = 1.0
+    hpxml.heating_systems[0].distribution_system_idref = nil
+    hpxml.heating_systems[0].heating_system_type = "PortableHeater"
+    hpxml.heating_systems[0].heating_system_fuel = "electricity"
+    hpxml.heating_systems[0].heating_efficiency_afue = nil
+    hpxml.heating_systems[0].heating_efficiency_percent = 1.0
   elsif ['base-hvac-stove-oil-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
-    hpxml_data[:heating_systems][0][:heating_system_type] = "Stove"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "fuel oil"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = nil
-    hpxml_data[:heating_systems][0][:heating_efficiency_percent] = 0.8
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
+    hpxml.heating_systems[0].distribution_system_idref = nil
+    hpxml.heating_systems[0].heating_system_type = "Stove"
+    hpxml.heating_systems[0].heating_system_fuel = "fuel oil"
+    hpxml.heating_systems[0].heating_efficiency_afue = nil
+    hpxml.heating_systems[0].heating_efficiency_percent = 0.8
+    hpxml.heating_systems[0].electric_auxiliary_energy = 200
   elsif ['base-hvac-stove-wood-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
-    hpxml_data[:heating_systems][0][:heating_system_type] = "Stove"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "wood"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = nil
-    hpxml_data[:heating_systems][0][:heating_efficiency_percent] = 0.8
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
+    hpxml.heating_systems[0].distribution_system_idref = nil
+    hpxml.heating_systems[0].heating_system_type = "Stove"
+    hpxml.heating_systems[0].heating_system_fuel = "wood"
+    hpxml.heating_systems[0].heating_efficiency_afue = nil
+    hpxml.heating_systems[0].heating_efficiency_percent = 0.8
+    hpxml.heating_systems[0].electric_auxiliary_energy = 200
   elsif ['base-hvac-wall-furnace-elec-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
-    hpxml_data[:heating_systems][0][:heating_system_type] = "WallFurnace"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "electricity"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 1.0
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
+    hpxml.heating_systems[0].distribution_system_idref = nil
+    hpxml.heating_systems[0].heating_system_type = "WallFurnace"
+    hpxml.heating_systems[0].heating_system_fuel = "electricity"
+    hpxml.heating_systems[0].heating_efficiency_afue = 1.0
+    hpxml.heating_systems[0].electric_auxiliary_energy = 200
   elsif ['base-hvac-wall-furnace-propane-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
-    hpxml_data[:heating_systems][0][:heating_system_type] = "WallFurnace"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "propane"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 0.8
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
+    hpxml.heating_systems[0].distribution_system_idref = nil
+    hpxml.heating_systems[0].heating_system_type = "WallFurnace"
+    hpxml.heating_systems[0].heating_system_fuel = "propane"
+    hpxml.heating_systems[0].heating_efficiency_afue = 0.8
+    hpxml.heating_systems[0].electric_auxiliary_energy = 200
   elsif ['base-hvac-wall-furnace-wood-only.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = nil
-    hpxml_data[:heating_systems][0][:heating_system_type] = "WallFurnace"
-    hpxml_data[:heating_systems][0][:heating_system_fuel] = "wood"
-    hpxml_data[:heating_systems][0][:heating_efficiency_afue] = 0.8
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] = 200
+    hpxml.heating_systems[0].distribution_system_idref = nil
+    hpxml.heating_systems[0].heating_system_type = "WallFurnace"
+    hpxml.heating_systems[0].heating_system_fuel = "wood"
+    hpxml.heating_systems[0].heating_efficiency_afue = 0.8
+    hpxml.heating_systems[0].electric_auxiliary_energy = 200
   elsif ['base-hvac-furnace-x3-dse.xml'].include? hpxml_file
-    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][0].dup
-    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][1].dup
-    hpxml_data[:heating_systems][1][:id] = "HeatingSystem2"
-    hpxml_data[:heating_systems][1][:distribution_system_idref] = "HVACDistribution2"
-    hpxml_data[:heating_systems][2][:id] = "HeatingSystem3"
-    hpxml_data[:heating_systems][2][:distribution_system_idref] = "HVACDistribution3"
+    hpxml.heating_systems << hpxml.heating_systems[0].dup
+    hpxml.heating_systems << hpxml.heating_systems[1].dup
+    hpxml.heating_systems[1].id = "HeatingSystem2"
+    hpxml.heating_systems[1].distribution_system_idref = "HVACDistribution2"
+    hpxml.heating_systems[2].id = "HeatingSystem3"
+    hpxml.heating_systems[2].distribution_system_idref = "HVACDistribution3"
     for i in 0..2
-      hpxml_data[:heating_systems][i][:heating_capacity] /= 3.0
-      hpxml_data[:heating_systems][i][:fraction_heat_load_served] = 0.333
+      hpxml.heating_systems[i].heating_capacity /= 3.0
+      hpxml.heating_systems[i].fraction_heat_load_served = 0.333
     end
   elsif ['invalid_files/unattached-hvac-distribution.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = "foobar"
+    hpxml.heating_systems[0].distribution_system_idref = "foobar"
   elsif ['invalid_files/hvac-invalid-distribution-system-type.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:distribution_system_idref] = "HVACDistribution2"
+    hpxml.heating_systems[0].distribution_system_idref = "HVACDistribution2"
   elsif ['invalid_files/hvac-dse-multiple-attached-heating.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.5
-    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][0].dup
-    hpxml_data[:heating_systems][1][:id] += "2"
+    hpxml.heating_systems[0].fraction_heat_load_served = 0.5
+    hpxml.heating_systems << hpxml.heating_systems[0].dup
+    hpxml.heating_systems[1].id += "2"
   elsif ['base-hvac-undersized.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_capacity] /= 10.0
+    hpxml.heating_systems[0].heating_capacity /= 10.0
   elsif ['base-hvac-flowrate.xml'].include? hpxml_file
-    hpxml_data[:heating_systems][0][:heating_cfm] = hpxml_data[:heating_systems][0][:heating_capacity] * 360.0 / 12000.0
-  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml_data[:heating_systems].nil? and hpxml_data[:heating_systems].size > 0
-    hpxml_data[:heating_systems][0][:heating_capacity] = -1
-  elsif hpxml_file.include? '-zero-heat.xml' and not hpxml_data[:heating_systems].nil? and hpxml_data[:heating_systems].size > 0
-    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0
-    hpxml_data[:heating_systems][0][:heating_capacity] = 0
-  elsif hpxml_file.include? 'hvac_multiple' and not hpxml_data[:heating_systems].nil? and hpxml_data[:heating_systems].size > 0
-    hpxml_data[:heating_systems][0][:heating_capacity] /= 3.0
-    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.333
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] /= 3.0 unless hpxml_data[:heating_systems][0][:electric_auxiliary_energy].nil?
-    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][0].dup
-    hpxml_data[:heating_systems][1][:id] = "HeatingSystem2"
-    hpxml_data[:heating_systems][1][:distribution_system_idref] = "HVACDistribution2" unless hpxml_data[:heating_systems][1][:distribution_system_idref].nil?
-    hpxml_data[:heating_systems] << hpxml_data[:heating_systems][0].dup
-    hpxml_data[:heating_systems][2][:id] = "HeatingSystem3"
-    hpxml_data[:heating_systems][2][:distribution_system_idref] = "HVACDistribution3" unless hpxml_data[:heating_systems][2][:distribution_system_idref].nil?
+    hpxml.heating_systems[0].heating_cfm = hpxml.heating_systems[0].heating_capacity * 360.0 / 12000.0
+  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml.heating_systems.nil? and hpxml.heating_systems.size > 0
+    hpxml.heating_systems[0].heating_capacity = -1
+  elsif hpxml_file.include? '-zero-heat.xml' and not hpxml.heating_systems.nil? and hpxml.heating_systems.size > 0
+    hpxml.heating_systems[0].fraction_heat_load_served = 0
+    hpxml.heating_systems[0].heating_capacity = 0
+  elsif hpxml_file.include? 'hvac_multiple' and not hpxml.heating_systems.nil? and hpxml.heating_systems.size > 0
+    hpxml.heating_systems[0].heating_capacity /= 3.0
+    hpxml.heating_systems[0].fraction_heat_load_served = 0.333
+    hpxml.heating_systems[0].electric_auxiliary_energy /= 3.0 unless hpxml.heating_systems[0].electric_auxiliary_energy.nil?
+    hpxml.heating_systems << hpxml.heating_systems[0].dup
+    hpxml.heating_systems[1].id = "HeatingSystem2"
+    hpxml.heating_systems[1].distribution_system_idref = "HVACDistribution2" unless hpxml.heating_systems[1].distribution_system_idref.nil?
+    hpxml.heating_systems << hpxml.heating_systems[0].dup
+    hpxml.heating_systems[2].id = "HeatingSystem3"
+    hpxml.heating_systems[2].distribution_system_idref = "HVACDistribution3" unless hpxml.heating_systems[2].distribution_system_idref.nil?
     if ['hvac_multiple/base-hvac-boiler-gas-only-x3.xml'].include? hpxml_file
       # Test a file where sum is slightly greater than 1
-      hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.33
-      hpxml_data[:heating_systems][1][:fraction_heat_load_served] = 0.33
-      hpxml_data[:heating_systems][2][:fraction_heat_load_served] = 0.35
+      hpxml.heating_systems[0].fraction_heat_load_served = 0.33
+      hpxml.heating_systems[1].fraction_heat_load_served = 0.33
+      hpxml.heating_systems[2].fraction_heat_load_served = 0.35
     end
-  elsif hpxml_file.include? 'hvac_partial' and not hpxml_data[:heating_systems].nil? and hpxml_data[:heating_systems].size > 0
-    hpxml_data[:heating_systems][0][:heating_capacity] /= 3.0
-    hpxml_data[:heating_systems][0][:fraction_heat_load_served] = 0.333
-    hpxml_data[:heating_systems][0][:electric_auxiliary_energy] /= 3.0 unless hpxml_data[:heating_systems][0][:electric_auxiliary_energy].nil?
+  elsif hpxml_file.include? 'hvac_partial' and not hpxml.heating_systems.nil? and hpxml.heating_systems.size > 0
+    hpxml.heating_systems[0].heating_capacity /= 3.0
+    hpxml.heating_systems[0].fraction_heat_load_served = 0.333
+    hpxml.heating_systems[0].electric_auxiliary_energy /= 3.0 unless hpxml.heating_systems[0].electric_auxiliary_energy.nil?
   end
 end
 
-def set_hpxml_data_cooling_systems_values(hpxml_file, hpxml_data)
+def set_hpxml_cooling_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems] = [{ :id => "CoolingSystem",
-                                      :distribution_system_idref => "HVACDistribution",
-                                      :cooling_system_type => "central air conditioner",
-                                      :cooling_system_fuel => "electricity",
-                                      :cooling_capacity => 48000,
-                                      :fraction_cool_load_served => 1,
-                                      :cooling_efficiency_seer => 13 }]
+    hpxml.cooling_systems = [HPXML::CoolingSystem.new({ :id => "CoolingSystem",
+                                                        :distribution_system_idref => "HVACDistribution",
+                                                        :cooling_system_type => "central air conditioner",
+                                                        :cooling_system_fuel => "electricity",
+                                                        :cooling_capacity => 48000,
+                                                        :fraction_cool_load_served => 1,
+                                                        :cooling_efficiency_seer => 13 })]
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-air-to-air-heat-pump-var-speed.xml',
@@ -1809,351 +1805,351 @@ def set_hpxml_data_cooling_systems_values(hpxml_file, hpxml_data)
          'base-hvac-wall-furnace-elec-only.xml',
          'base-hvac-wall-furnace-propane-only.xml',
          'base-hvac-wall-furnace-wood-only.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems] = []
+    hpxml.cooling_systems = []
   elsif ['base-hvac-central-ac-only-1-speed-detailed.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_shr] = 0.7
-    hpxml_data[:cooling_systems][0][:compressor_type] = "single stage"
+    hpxml.cooling_systems[0].cooling_shr = 0.7
+    hpxml.cooling_systems[0].compressor_type = "single stage"
   elsif ['base-hvac-central-ac-only-2-speed-detailed.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_shr] = 0.7
-    hpxml_data[:cooling_systems][0][:compressor_type] = "two stage"
+    hpxml.cooling_systems[0].cooling_shr = 0.7
+    hpxml.cooling_systems[0].compressor_type = "two stage"
   elsif ['base-hvac-central-ac-only-var-speed-detailed.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_shr] = 0.7
-    hpxml_data[:cooling_systems][0][:compressor_type] = "variable speed"
+    hpxml.cooling_systems[0].cooling_shr = 0.7
+    hpxml.cooling_systems[0].compressor_type = "variable speed"
   elsif ['base-hvac-room-ac-only-detailed.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_shr] = 0.7
+    hpxml.cooling_systems[0].cooling_shr = 0.7
   elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:distribution_system_idref] = "HVACDistribution2"
+    hpxml.cooling_systems[0].distribution_system_idref = "HVACDistribution2"
   elsif ['base-hvac-furnace-gas-central-ac-2-speed.xml',
          'base-hvac-central-ac-only-2-speed.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_efficiency_seer] = 18
+    hpxml.cooling_systems[0].cooling_efficiency_seer = 18
   elsif ['base-hvac-furnace-gas-central-ac-var-speed.xml',
          'base-hvac-central-ac-only-var-speed.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_efficiency_seer] = 24
+    hpxml.cooling_systems[0].cooling_efficiency_seer = 24
   elsif ['base-hvac-furnace-gas-room-ac.xml',
          'base-hvac-room-ac-only.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:distribution_system_idref] = nil
-    hpxml_data[:cooling_systems][0][:cooling_system_type] = "room air conditioner"
-    hpxml_data[:cooling_systems][0][:cooling_efficiency_seer] = nil
-    hpxml_data[:cooling_systems][0][:cooling_efficiency_eer] = 8.5
+    hpxml.cooling_systems[0].distribution_system_idref = nil
+    hpxml.cooling_systems[0].cooling_system_type = "room air conditioner"
+    hpxml.cooling_systems[0].cooling_efficiency_seer = nil
+    hpxml.cooling_systems[0].cooling_efficiency_eer = 8.5
   elsif ['base-hvac-evap-cooler-only-ducted.xml',
          'base-hvac-evap-cooler-furnace-gas.xml',
          'base-hvac-evap-cooler-only.xml',
          'hvac_autosizing/base-hvac-evap-cooler-furnace-gas-autosize.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_system_type] = "evaporative cooler"
-    hpxml_data[:cooling_systems][0][:cooling_efficiency_seer] = nil
-    hpxml_data[:cooling_systems][0][:cooling_efficiency_eer] = nil
-    hpxml_data[:cooling_systems][0][:cooling_capacity] = nil
+    hpxml.cooling_systems[0].cooling_system_type = "evaporative cooler"
+    hpxml.cooling_systems[0].cooling_efficiency_seer = nil
+    hpxml.cooling_systems[0].cooling_efficiency_eer = nil
+    hpxml.cooling_systems[0].cooling_capacity = nil
     if ['base-hvac-evap-cooler-furnace-gas.xml',
         'hvac_autosizing/base-hvac-evap-cooler-furnace-gas-autosize.xml',
         'base-hvac-evap-cooler-only.xml'].include? hpxml_file
-      hpxml_data[:cooling_systems][0][:distribution_system_idref] = nil
+      hpxml.cooling_systems[0].distribution_system_idref = nil
     end
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:distribution_system_idref] = "HVACDistribution4"
-    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0.2
-    hpxml_data[:cooling_systems][0][:cooling_capacity] *= 0.2
-    hpxml_data[:cooling_systems] << { :id => "CoolingSystem2",
-                                      :cooling_system_type => "room air conditioner",
-                                      :cooling_system_fuel => "electricity",
-                                      :cooling_capacity => 9600,
-                                      :fraction_cool_load_served => 0.2,
-                                      :cooling_efficiency_eer => 8.5 }
+    hpxml.cooling_systems[0].distribution_system_idref = "HVACDistribution4"
+    hpxml.cooling_systems[0].fraction_cool_load_served = 0.2
+    hpxml.cooling_systems[0].cooling_capacity *= 0.2
+    hpxml.cooling_systems << HPXML::CoolingSystem.new({ :id => "CoolingSystem2",
+                                                        :cooling_system_type => "room air conditioner",
+                                                        :cooling_system_fuel => "electricity",
+                                                        :cooling_capacity => 9600,
+                                                        :fraction_cool_load_served => 0.2,
+                                                        :cooling_efficiency_eer => 8.5 })
   elsif ['invalid_files/hvac-frac-load-served.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] += 0.2
+    hpxml.cooling_systems[0].fraction_cool_load_served += 0.2
   elsif ['invalid_files/hvac-dse-multiple-attached-cooling.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0.5
-    hpxml_data[:cooling_systems] << hpxml_data[:cooling_systems][0].dup
-    hpxml_data[:cooling_systems][1][:id] += "2"
+    hpxml.cooling_systems[0].fraction_cool_load_served = 0.5
+    hpxml.cooling_systems << hpxml.cooling_systems[0].dup
+    hpxml.cooling_systems[1].id += "2"
   elsif ['base-hvac-undersized.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_capacity] /= 10.0
+    hpxml.cooling_systems[0].cooling_capacity /= 10.0
   elsif ['base-hvac-flowrate.xml'].include? hpxml_file
-    hpxml_data[:cooling_systems][0][:cooling_cfm] = hpxml_data[:cooling_systems][0][:cooling_capacity] * 360.0 / 12000.0
-  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml_data[:cooling_systems].nil? and hpxml_data[:cooling_systems].size > 0
-    hpxml_data[:cooling_systems][0][:cooling_capacity] = -1
-  elsif hpxml_file.include? '-zero-cool.xml' and not hpxml_data[:cooling_systems].nil? and hpxml_data[:cooling_systems].size > 0
-    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0
-    hpxml_data[:cooling_systems][0][:cooling_capacity] = 0
-  elsif hpxml_file.include? 'hvac_multiple' and not hpxml_data[:cooling_systems].nil? and hpxml_data[:cooling_systems].size > 0
-    hpxml_data[:cooling_systems][0][:cooling_capacity] /= 3.0 unless hpxml_data[:cooling_systems][0][:cooling_capacity].nil?
-    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0.333
-    hpxml_data[:cooling_systems] << hpxml_data[:cooling_systems][0].dup
-    hpxml_data[:cooling_systems][1][:id] = "CoolingSystem2"
-    hpxml_data[:cooling_systems][1][:distribution_system_idref] = "HVACDistribution2" unless hpxml_data[:cooling_systems][1][:distribution_system_idref].nil?
-    hpxml_data[:cooling_systems] << hpxml_data[:cooling_systems][0].dup
-    hpxml_data[:cooling_systems][2][:id] = "CoolingSystem3"
-    hpxml_data[:cooling_systems][2][:distribution_system_idref] = "HVACDistribution3" unless hpxml_data[:cooling_systems][2][:distribution_system_idref].nil?
-  elsif hpxml_file.include? 'hvac_partial' and not hpxml_data[:cooling_systems].nil? and hpxml_data[:cooling_systems].size > 0
-    hpxml_data[:cooling_systems][0][:cooling_capacity] /= 3.0 unless hpxml_data[:cooling_systems][0][:cooling_capacity].nil?
-    hpxml_data[:cooling_systems][0][:fraction_cool_load_served] = 0.333
+    hpxml.cooling_systems[0].cooling_cfm = hpxml.cooling_systems[0].cooling_capacity * 360.0 / 12000.0
+  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml.cooling_systems.nil? and hpxml.cooling_systems.size > 0
+    hpxml.cooling_systems[0].cooling_capacity = -1
+  elsif hpxml_file.include? '-zero-cool.xml' and not hpxml.cooling_systems.nil? and hpxml.cooling_systems.size > 0
+    hpxml.cooling_systems[0].fraction_cool_load_served = 0
+    hpxml.cooling_systems[0].cooling_capacity = 0
+  elsif hpxml_file.include? 'hvac_multiple' and not hpxml.cooling_systems.nil? and hpxml.cooling_systems.size > 0
+    hpxml.cooling_systems[0].cooling_capacity /= 3.0 unless hpxml.cooling_systems[0].cooling_capacity.nil?
+    hpxml.cooling_systems[0].fraction_cool_load_served = 0.333
+    hpxml.cooling_systems << hpxml.cooling_systems[0].dup
+    hpxml.cooling_systems[1].id = "CoolingSystem2"
+    hpxml.cooling_systems[1].distribution_system_idref = "HVACDistribution2" unless hpxml.cooling_systems[1].distribution_system_idref.nil?
+    hpxml.cooling_systems << hpxml.cooling_systems[0].dup
+    hpxml.cooling_systems[2].id = "CoolingSystem3"
+    hpxml.cooling_systems[2].distribution_system_idref = "HVACDistribution3" unless hpxml.cooling_systems[2].distribution_system_idref.nil?
+  elsif hpxml_file.include? 'hvac_partial' and not hpxml.cooling_systems.nil? and hpxml.cooling_systems.size > 0
+    hpxml.cooling_systems[0].cooling_capacity /= 3.0 unless hpxml.cooling_systems[0].cooling_capacity.nil?
+    hpxml.cooling_systems[0].fraction_cool_load_served = 0.333
   end
 end
 
-def set_hpxml_data_heat_pumps_values(hpxml_file, hpxml_data)
+def set_hpxml_heat_pumps(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps] = []
+    hpxml.heat_pumps = []
   elsif ['base-hvac-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps] << { :id => "HeatPump",
-                                 :distribution_system_idref => "HVACDistribution",
-                                 :heat_pump_type => "air-to-air",
-                                 :heat_pump_fuel => "electricity",
-                                 :heating_capacity => 42000,
-                                 :cooling_capacity => 48000,
-                                 :backup_heating_fuel => "electricity",
-                                 :backup_heating_capacity => 34121,
-                                 :backup_heating_efficiency_percent => 1.0,
-                                 :fraction_heat_load_served => 1,
-                                 :fraction_cool_load_served => 1,
-                                 :heating_efficiency_hspf => 7.7,
-                                 :cooling_efficiency_seer => 13 }
+    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
+                                              :distribution_system_idref => "HVACDistribution",
+                                              :heat_pump_type => "air-to-air",
+                                              :heat_pump_fuel => "electricity",
+                                              :heating_capacity => 42000,
+                                              :cooling_capacity => 48000,
+                                              :backup_heating_fuel => "electricity",
+                                              :backup_heating_capacity => 34121,
+                                              :backup_heating_efficiency_percent => 1.0,
+                                              :fraction_heat_load_served => 1,
+                                              :fraction_cool_load_served => 1,
+                                              :heating_efficiency_hspf => 7.7,
+                                              :cooling_efficiency_seer => 13 })
     if hpxml_file == 'base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml'
-      hpxml_data[:heat_pumps][0][:fraction_cool_load_served] = 0
+      hpxml.heat_pumps[0].fraction_cool_load_served = 0
     end
   elsif ['base-hvac-air-to-air-heat-pump-2-speed.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps] << { :id => "HeatPump",
-                                 :distribution_system_idref => "HVACDistribution",
-                                 :heat_pump_type => "air-to-air",
-                                 :heat_pump_fuel => "electricity",
-                                 :heating_capacity => 42000,
-                                 :cooling_capacity => 48000,
-                                 :backup_heating_fuel => "electricity",
-                                 :backup_heating_capacity => 34121,
-                                 :backup_heating_efficiency_percent => 1.0,
-                                 :fraction_heat_load_served => 1,
-                                 :fraction_cool_load_served => 1,
-                                 :heating_efficiency_hspf => 9.3,
-                                 :cooling_efficiency_seer => 18 }
+    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
+                                              :distribution_system_idref => "HVACDistribution",
+                                              :heat_pump_type => "air-to-air",
+                                              :heat_pump_fuel => "electricity",
+                                              :heating_capacity => 42000,
+                                              :cooling_capacity => 48000,
+                                              :backup_heating_fuel => "electricity",
+                                              :backup_heating_capacity => 34121,
+                                              :backup_heating_efficiency_percent => 1.0,
+                                              :fraction_heat_load_served => 1,
+                                              :fraction_cool_load_served => 1,
+                                              :heating_efficiency_hspf => 9.3,
+                                              :cooling_efficiency_seer => 18 })
   elsif ['base-hvac-air-to-air-heat-pump-var-speed.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps] << { :id => "HeatPump",
-                                 :distribution_system_idref => "HVACDistribution",
-                                 :heat_pump_type => "air-to-air",
-                                 :heat_pump_fuel => "electricity",
-                                 :heating_capacity => 42000,
-                                 :cooling_capacity => 48000,
-                                 :backup_heating_fuel => "electricity",
-                                 :backup_heating_capacity => 34121,
-                                 :backup_heating_efficiency_percent => 1.0,
-                                 :fraction_heat_load_served => 1,
-                                 :fraction_cool_load_served => 1,
-                                 :heating_efficiency_hspf => 10,
-                                 :cooling_efficiency_seer => 22 }
+    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
+                                              :distribution_system_idref => "HVACDistribution",
+                                              :heat_pump_type => "air-to-air",
+                                              :heat_pump_fuel => "electricity",
+                                              :heating_capacity => 42000,
+                                              :cooling_capacity => 48000,
+                                              :backup_heating_fuel => "electricity",
+                                              :backup_heating_capacity => 34121,
+                                              :backup_heating_efficiency_percent => 1.0,
+                                              :fraction_heat_load_served => 1,
+                                              :fraction_cool_load_served => 1,
+                                              :heating_efficiency_hspf => 10,
+                                              :cooling_efficiency_seer => 22 })
   elsif ['base-hvac-ground-to-air-heat-pump.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps] << { :id => "HeatPump",
-                                 :distribution_system_idref => "HVACDistribution",
-                                 :heat_pump_type => "ground-to-air",
-                                 :heat_pump_fuel => "electricity",
-                                 :heating_capacity => 42000,
-                                 :cooling_capacity => 48000,
-                                 :backup_heating_fuel => "electricity",
-                                 :backup_heating_capacity => 34121,
-                                 :backup_heating_efficiency_percent => 1.0,
-                                 :fraction_heat_load_served => 1,
-                                 :fraction_cool_load_served => 1,
-                                 :heating_efficiency_cop => 3.6,
-                                 :cooling_efficiency_eer => 16.6 }
+    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
+                                              :distribution_system_idref => "HVACDistribution",
+                                              :heat_pump_type => "ground-to-air",
+                                              :heat_pump_fuel => "electricity",
+                                              :heating_capacity => 42000,
+                                              :cooling_capacity => 48000,
+                                              :backup_heating_fuel => "electricity",
+                                              :backup_heating_capacity => 34121,
+                                              :backup_heating_efficiency_percent => 1.0,
+                                              :fraction_heat_load_served => 1,
+                                              :fraction_cool_load_served => 1,
+                                              :heating_efficiency_cop => 3.6,
+                                              :cooling_efficiency_eer => 16.6 })
   elsif ['base-hvac-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps] << { :id => "HeatPump",
-                                 :distribution_system_idref => "HVACDistribution",
-                                 :heat_pump_type => "mini-split",
-                                 :heat_pump_fuel => "electricity",
-                                 :heating_capacity => 52000,
-                                 :cooling_capacity => 48000,
-                                 :backup_heating_fuel => "electricity",
-                                 :backup_heating_capacity => 34121,
-                                 :backup_heating_efficiency_percent => 1.0,
-                                 :fraction_heat_load_served => 1,
-                                 :fraction_cool_load_served => 1,
-                                 :heating_efficiency_hspf => 10,
-                                 :cooling_efficiency_seer => 19 }
+    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
+                                              :distribution_system_idref => "HVACDistribution",
+                                              :heat_pump_type => "mini-split",
+                                              :heat_pump_fuel => "electricity",
+                                              :heating_capacity => 52000,
+                                              :cooling_capacity => 48000,
+                                              :backup_heating_fuel => "electricity",
+                                              :backup_heating_capacity => 34121,
+                                              :backup_heating_efficiency_percent => 1.0,
+                                              :fraction_heat_load_served => 1,
+                                              :fraction_cool_load_served => 1,
+                                              :heating_efficiency_hspf => 10,
+                                              :cooling_efficiency_seer => 19 })
   elsif ['base-hvac-mini-split-heat-pump-ductless.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:distribution_system_idref] = nil
+    hpxml.heat_pumps[0].distribution_system_idref = nil
   elsif ['base-hvac-mini-split-heat-pump-ductless-no-backup.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:backup_heating_fuel] = nil
+    hpxml.heat_pumps[0].backup_heating_fuel = nil
   elsif ['invalid_files/heat-pump-mixed-fixed-and-autosize-capacities.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:heating_capacity] = -1
+    hpxml.heat_pumps[0].heating_capacity = -1
   elsif ['invalid_files/heat-pump-mixed-fixed-and-autosize-capacities2.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:cooling_capacity] = -1
+    hpxml.heat_pumps[0].cooling_capacity = -1
   elsif ['invalid_files/heat-pump-mixed-fixed-and-autosize-capacities3.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:cooling_capacity] = -1
-    hpxml_data[:heat_pumps][0][:heating_capacity] = -1
-    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = 25000
+    hpxml.heat_pumps[0].cooling_capacity = -1
+    hpxml.heat_pumps[0].heating_capacity = -1
+    hpxml.heat_pumps[0].heating_capacity_17F = 25000
   elsif ['invalid_files/heat-pump-mixed-fixed-and-autosize-capacities4.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:backup_heating_capacity] = -1
+    hpxml.heat_pumps[0].backup_heating_capacity = -1
   elsif ['base-hvac-air-to-air-heat-pump-1-speed-detailed.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = hpxml_data[:heat_pumps][0][:heating_capacity] * 0.630 # Based on OAT slope of default curves
-    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
-    hpxml_data[:heat_pumps][0][:compressor_type] = "single stage"
+    hpxml.heat_pumps[0].heating_capacity_17F = hpxml.heat_pumps[0].heating_capacity * 0.630 # Based on OAT slope of default curves
+    hpxml.heat_pumps[0].cooling_shr = 0.7
+    hpxml.heat_pumps[0].compressor_type = "single stage"
   elsif ['base-hvac-air-to-air-heat-pump-2-speed-detailed.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = hpxml_data[:heat_pumps][0][:heating_capacity] * 0.590 # Based on OAT slope of default curves
-    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
-    hpxml_data[:heat_pumps][0][:compressor_type] = "two stage"
+    hpxml.heat_pumps[0].heating_capacity_17F = hpxml.heat_pumps[0].heating_capacity * 0.590 # Based on OAT slope of default curves
+    hpxml.heat_pumps[0].cooling_shr = 0.7
+    hpxml.heat_pumps[0].compressor_type = "two stage"
   elsif ['base-hvac-air-to-air-heat-pump-var-speed-detailed.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = hpxml_data[:heat_pumps][0][:heating_capacity] * 0.640 # Based on OAT slope of default curves
-    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
-    hpxml_data[:heat_pumps][0][:compressor_type] = "variable speed"
+    hpxml.heat_pumps[0].heating_capacity_17F = hpxml.heat_pumps[0].heating_capacity * 0.640 # Based on OAT slope of default curves
+    hpxml.heat_pumps[0].cooling_shr = 0.7
+    hpxml.heat_pumps[0].compressor_type = "variable speed"
   elsif ['base-hvac-mini-split-heat-pump-ducted-detailed.xml'].include? hpxml_file
     f = 1.0 - (1.0 - 0.25) / (47.0 + 5.0) * (47.0 - 17.0)
-    hpxml_data[:heat_pumps][0][:heating_capacity_17F] = hpxml_data[:heat_pumps][0][:heating_capacity] * f
-    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
+    hpxml.heat_pumps[0].heating_capacity_17F = hpxml.heat_pumps[0].heating_capacity * f
+    hpxml.heat_pumps[0].cooling_shr = 0.7
   elsif ['base-hvac-ground-to-air-heat-pump-detailed.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:cooling_shr] = 0.7
+    hpxml.heat_pumps[0].cooling_shr = 0.7
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps] << { :id => "HeatPump",
-                                 :distribution_system_idref => "HVACDistribution5",
-                                 :heat_pump_type => "air-to-air",
-                                 :heat_pump_fuel => "electricity",
-                                 :heating_capacity => 4800,
-                                 :cooling_capacity => 4800,
-                                 :backup_heating_fuel => "electricity",
-                                 :backup_heating_capacity => 3412,
-                                 :backup_heating_efficiency_percent => 1.0,
-                                 :fraction_heat_load_served => 0.1,
-                                 :fraction_cool_load_served => 0.2,
-                                 :heating_efficiency_hspf => 7.7,
-                                 :cooling_efficiency_seer => 13 }
-    hpxml_data[:heat_pumps] << { :id => "HeatPump2",
-                                 :distribution_system_idref => "HVACDistribution6",
-                                 :heat_pump_type => "ground-to-air",
-                                 :heat_pump_fuel => "electricity",
-                                 :heating_capacity => 4800,
-                                 :cooling_capacity => 4800,
-                                 :backup_heating_fuel => "electricity",
-                                 :backup_heating_capacity => 3412,
-                                 :backup_heating_efficiency_percent => 1.0,
-                                 :fraction_heat_load_served => 0.1,
-                                 :fraction_cool_load_served => 0.2,
-                                 :heating_efficiency_cop => 3.6,
-                                 :cooling_efficiency_eer => 16.6 }
-    hpxml_data[:heat_pumps] << { :id => "HeatPump3",
-                                 :heat_pump_type => "mini-split",
-                                 :heat_pump_fuel => "electricity",
-                                 :heating_capacity => 4800,
-                                 :cooling_capacity => 4800,
-                                 :backup_heating_fuel => "electricity",
-                                 :backup_heating_capacity => 3412,
-                                 :backup_heating_efficiency_percent => 1.0,
-                                 :fraction_heat_load_served => 0.1,
-                                 :fraction_cool_load_served => 0.2,
-                                 :heating_efficiency_hspf => 10,
-                                 :cooling_efficiency_seer => 19 }
+    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump",
+                                              :distribution_system_idref => "HVACDistribution5",
+                                              :heat_pump_type => "air-to-air",
+                                              :heat_pump_fuel => "electricity",
+                                              :heating_capacity => 4800,
+                                              :cooling_capacity => 4800,
+                                              :backup_heating_fuel => "electricity",
+                                              :backup_heating_capacity => 3412,
+                                              :backup_heating_efficiency_percent => 1.0,
+                                              :fraction_heat_load_served => 0.1,
+                                              :fraction_cool_load_served => 0.2,
+                                              :heating_efficiency_hspf => 7.7,
+                                              :cooling_efficiency_seer => 13 })
+    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump2",
+                                              :distribution_system_idref => "HVACDistribution6",
+                                              :heat_pump_type => "ground-to-air",
+                                              :heat_pump_fuel => "electricity",
+                                              :heating_capacity => 4800,
+                                              :cooling_capacity => 4800,
+                                              :backup_heating_fuel => "electricity",
+                                              :backup_heating_capacity => 3412,
+                                              :backup_heating_efficiency_percent => 1.0,
+                                              :fraction_heat_load_served => 0.1,
+                                              :fraction_cool_load_served => 0.2,
+                                              :heating_efficiency_cop => 3.6,
+                                              :cooling_efficiency_eer => 16.6 })
+    hpxml.heat_pumps << HPXML::HeatPump.new({ :id => "HeatPump3",
+                                              :heat_pump_type => "mini-split",
+                                              :heat_pump_fuel => "electricity",
+                                              :heating_capacity => 4800,
+                                              :cooling_capacity => 4800,
+                                              :backup_heating_fuel => "electricity",
+                                              :backup_heating_capacity => 3412,
+                                              :backup_heating_efficiency_percent => 1.0,
+                                              :fraction_heat_load_served => 0.1,
+                                              :fraction_cool_load_served => 0.2,
+                                              :heating_efficiency_hspf => 10,
+                                              :cooling_efficiency_seer => 19 })
   elsif ['invalid_files/hvac-distribution-multiple-attached-heating.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:distribution_system_idref] = "HVACDistribution3"
+    hpxml.heat_pumps[0].distribution_system_idref = "HVACDistribution3"
   elsif ['invalid_files/hvac-distribution-multiple-attached-cooling.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:distribution_system_idref] = "HVACDistribution4"
+    hpxml.heat_pumps[0].distribution_system_idref = "HVACDistribution4"
   elsif ['base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml',
          'base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.xml',
          'base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.xml',
          'base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:backup_heating_fuel] = "natural gas"
-    hpxml_data[:heat_pumps][0][:backup_heating_capacity] = 36000
-    hpxml_data[:heat_pumps][0][:backup_heating_efficiency_percent] = nil
-    hpxml_data[:heat_pumps][0][:backup_heating_efficiency_afue] = 0.95
-    hpxml_data[:heat_pumps][0][:backup_heating_switchover_temp] = 25
+    hpxml.heat_pumps[0].backup_heating_fuel = "natural gas"
+    hpxml.heat_pumps[0].backup_heating_capacity = 36000
+    hpxml.heat_pumps[0].backup_heating_efficiency_percent = nil
+    hpxml.heat_pumps[0].backup_heating_efficiency_afue = 0.95
+    hpxml.heat_pumps[0].backup_heating_switchover_temp = 25
   elsif ['base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml'].include? hpxml_file
-    hpxml_data[:heat_pumps][0][:backup_heating_fuel] = "electricity"
-    hpxml_data[:heat_pumps][0][:backup_heating_efficiency_afue] = 1.0
-  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
-    hpxml_data[:heat_pumps][0][:cooling_capacity] = -1
-    hpxml_data[:heat_pumps][0][:heating_capacity] = -1
-    hpxml_data[:heat_pumps][0][:backup_heating_capacity] = -1
-  elsif hpxml_file.include? '-zero-heat.xml' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
-    hpxml_data[:heat_pumps][0][:fraction_heat_load_served] = 0
-    hpxml_data[:heat_pumps][0][:heating_capacity] = 0
-    hpxml_data[:heat_pumps][0][:backup_heating_capacity] = 0
-  elsif hpxml_file.include? '-zero-cool.xml' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
-    hpxml_data[:heat_pumps][0][:fraction_cool_load_served] = 0
-    hpxml_data[:heat_pumps][0][:cooling_capacity] = 0
-  elsif hpxml_file.include? 'hvac_multiple' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
-    hpxml_data[:heat_pumps][0][:cooling_capacity] /= 3.0
-    hpxml_data[:heat_pumps][0][:heating_capacity] /= 3.0
-    hpxml_data[:heat_pumps][0][:backup_heating_capacity] /= 3.0
-    hpxml_data[:heat_pumps][0][:fraction_heat_load_served] = 0.333
-    hpxml_data[:heat_pumps][0][:fraction_cool_load_served] = 0.333
-    hpxml_data[:heat_pumps] << hpxml_data[:heat_pumps][0].dup
-    hpxml_data[:heat_pumps][1][:id] = "HeatPump2"
-    hpxml_data[:heat_pumps][1][:distribution_system_idref] = "HVACDistribution2" unless hpxml_data[:heat_pumps][1][:distribution_system_idref].nil?
-    hpxml_data[:heat_pumps] << hpxml_data[:heat_pumps][0].dup
-    hpxml_data[:heat_pumps][2][:id] = "HeatPump3"
-    hpxml_data[:heat_pumps][2][:distribution_system_idref] = "HVACDistribution3" unless hpxml_data[:heat_pumps][2][:distribution_system_idref].nil?
-  elsif hpxml_file.include? 'hvac_partial' and not hpxml_data[:heat_pumps].nil? and hpxml_data[:heat_pumps].size > 0
-    hpxml_data[:heat_pumps][0][:cooling_capacity] /= 3.0
-    hpxml_data[:heat_pumps][0][:heating_capacity] /= 3.0
-    hpxml_data[:heat_pumps][0][:backup_heating_capacity] /= 3.0
-    hpxml_data[:heat_pumps][0][:fraction_heat_load_served] = 0.333
-    hpxml_data[:heat_pumps][0][:fraction_cool_load_served] = 0.333
+    hpxml.heat_pumps[0].backup_heating_fuel = "electricity"
+    hpxml.heat_pumps[0].backup_heating_efficiency_afue = 1.0
+  elsif hpxml_file.include? 'hvac_autosizing' and not hpxml.heat_pumps.nil? and hpxml.heat_pumps.size > 0
+    hpxml.heat_pumps[0].cooling_capacity = -1
+    hpxml.heat_pumps[0].heating_capacity = -1
+    hpxml.heat_pumps[0].backup_heating_capacity = -1
+  elsif hpxml_file.include? '-zero-heat.xml' and not hpxml.heat_pumps.nil? and hpxml.heat_pumps.size > 0
+    hpxml.heat_pumps[0].fraction_heat_load_served = 0
+    hpxml.heat_pumps[0].heating_capacity = 0
+    hpxml.heat_pumps[0].backup_heating_capacity = 0
+  elsif hpxml_file.include? '-zero-cool.xml' and not hpxml.heat_pumps.nil? and hpxml.heat_pumps.size > 0
+    hpxml.heat_pumps[0].fraction_cool_load_served = 0
+    hpxml.heat_pumps[0].cooling_capacity = 0
+  elsif hpxml_file.include? 'hvac_multiple' and not hpxml.heat_pumps.nil? and hpxml.heat_pumps.size > 0
+    hpxml.heat_pumps[0].cooling_capacity /= 3.0
+    hpxml.heat_pumps[0].heating_capacity /= 3.0
+    hpxml.heat_pumps[0].backup_heating_capacity /= 3.0
+    hpxml.heat_pumps[0].fraction_heat_load_served = 0.333
+    hpxml.heat_pumps[0].fraction_cool_load_served = 0.333
+    hpxml.heat_pumps << hpxml.heat_pumps[0].dup
+    hpxml.heat_pumps[1].id = "HeatPump2"
+    hpxml.heat_pumps[1].distribution_system_idref = "HVACDistribution2" unless hpxml.heat_pumps[1].distribution_system_idref.nil?
+    hpxml.heat_pumps << hpxml.heat_pumps[0].dup
+    hpxml.heat_pumps[2].id = "HeatPump3"
+    hpxml.heat_pumps[2].distribution_system_idref = "HVACDistribution3" unless hpxml.heat_pumps[2].distribution_system_idref.nil?
+  elsif hpxml_file.include? 'hvac_partial' and not hpxml.heat_pumps.nil? and hpxml.heat_pumps.size > 0
+    hpxml.heat_pumps[0].cooling_capacity /= 3.0
+    hpxml.heat_pumps[0].heating_capacity /= 3.0
+    hpxml.heat_pumps[0].backup_heating_capacity /= 3.0
+    hpxml.heat_pumps[0].fraction_heat_load_served = 0.333
+    hpxml.heat_pumps[0].fraction_cool_load_served = 0.333
   end
 end
 
-def set_hpxml_data_hvac_control_values(hpxml_file, hpxml_data)
+def set_hpxml_hvac_control(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:hvac_control] = { :id => "HVACControl",
-                                  :control_type => "manual thermostat",
-                                  :heating_setpoint_temp => 68,
-                                  :cooling_setpoint_temp => 78 }
+    hpxml.hvac_control = HPXML::HVACControl.new({ :id => "HVACControl",
+                                                  :control_type => "manual thermostat",
+                                                  :heating_setpoint_temp => 68,
+                                                  :cooling_setpoint_temp => 78 })
   elsif ['base-hvac-none.xml'].include? hpxml_file
-    hpxml_data[:hvac_control] = {}
+    hpxml.hvac_control = nil
   elsif ['base-hvac-programmable-thermostat.xml'].include? hpxml_file
-    hpxml_data[:hvac_control][:control_type] = "programmable thermostat"
-    hpxml_data[:hvac_control][:heating_setback_temp] = 66
-    hpxml_data[:hvac_control][:heating_setback_hours_per_week] = 7 * 7
-    hpxml_data[:hvac_control][:heating_setback_start_hour] = 23 # 11pm
-    hpxml_data[:hvac_control][:cooling_setup_temp] = 80
-    hpxml_data[:hvac_control][:cooling_setup_hours_per_week] = 6 * 7
-    hpxml_data[:hvac_control][:cooling_setup_start_hour] = 9 # 9am
+    hpxml.hvac_control.control_type = "programmable thermostat"
+    hpxml.hvac_control.heating_setback_temp = 66
+    hpxml.hvac_control.heating_setback_hours_per_week = 7 * 7
+    hpxml.hvac_control.heating_setback_start_hour = 23 # 11pm
+    hpxml.hvac_control.cooling_setup_temp = 80
+    hpxml.hvac_control.cooling_setup_hours_per_week = 6 * 7
+    hpxml.hvac_control.cooling_setup_start_hour = 9 # 9am
   elsif ['base-hvac-setpoints.xml'].include? hpxml_file
-    hpxml_data[:hvac_control][:heating_setpoint_temp] = 60
-    hpxml_data[:hvac_control][:cooling_setpoint_temp] = 80
+    hpxml.hvac_control.heating_setpoint_temp = 60
+    hpxml.hvac_control.cooling_setpoint_temp = 80
   elsif ['base-misc-ceiling-fans.xml'].include? hpxml_file
-    hpxml_data[:hvac_control][:ceiling_fan_cooling_setpoint_temp_offset] = 0.5
+    hpxml.hvac_control.ceiling_fan_cooling_setpoint_temp_offset = 0.5
   end
 end
 
-def set_hpxml_data_hvac_distributions_values(hpxml_file, hpxml_data)
+def set_hpxml_hvac_distributions(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions] = [{ :id => "HVACDistribution",
-                                         :distribution_system_type => "AirDistribution",
-                                         :duct_leakage_measurements => [{ :duct_type => "supply",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 75 },
-                                                                        { :duct_type => "return",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 25 }],
-                                         :ducts => [{ :duct_type => "supply",
-                                                      :duct_insulation_r_value => 4,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 150 },
-                                                    { :duct_type => "return",
-                                                      :duct_insulation_r_value => 0,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 50 }] }]
+    hpxml.hvac_distributions = [HPXML::HVACDistribution.new({ :id => "HVACDistribution",
+                                                              :distribution_system_type => "AirDistribution" })]
+    hpxml.hvac_distributions[0].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
+                                                                                                 :duct_leakage_units => "CFM25",
+                                                                                                 :duct_leakage_value => 75 }),
+                                                             HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
+                                                                                                 :duct_leakage_units => "CFM25",
+                                                                                                 :duct_leakage_value => 25 })]
+    hpxml.hvac_distributions[0].ducts = [HPXML::Duct.new({ :duct_type => "supply",
+                                                           :duct_insulation_r_value => 4,
+                                                           :duct_location => "attic - unvented",
+                                                           :duct_surface_area => 150 }),
+                                         HPXML::Duct.new({ :duct_type => "return",
+                                                           :duct_insulation_r_value => 0,
+                                                           :duct_location => "attic - unvented",
+                                                           :duct_surface_area => 50 })]
   elsif ['base-hvac-boiler-elec-only.xml',
          'base-hvac-boiler-gas-only.xml',
          'base-hvac-boiler-oil-only.xml',
          'base-hvac-boiler-propane-only.xml',
          'base-hvac-boiler-wood-only.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "HydronicDistribution"
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements] = []
-    hpxml_data[:hvac_distributions][0][:ducts] = []
+    hpxml.hvac_distributions[0].distribution_system_type = "HydronicDistribution"
+    hpxml.hvac_distributions[0].duct_leakage_measurements = []
+    hpxml.hvac_distributions[0].ducts = []
   elsif ['base-hvac-boiler-gas-central-ac-1-speed.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "HydronicDistribution"
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements] = []
-    hpxml_data[:hvac_distributions][0][:ducts] = []
-    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution2",
-                                         :distribution_system_type => "AirDistribution",
-                                         :duct_leakage_measurements => [{ :duct_type => "supply",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 75 },
-                                                                        { :duct_type => "return",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 25 }],
-                                         :ducts => [{ :duct_type => "supply",
-                                                      :duct_insulation_r_value => 4,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 150 },
-                                                    { :duct_type => "return",
-                                                      :duct_insulation_r_value => 0,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 50 }] }
+    hpxml.hvac_distributions[0].distribution_system_type = "HydronicDistribution"
+    hpxml.hvac_distributions[0].duct_leakage_measurements = []
+    hpxml.hvac_distributions[0].ducts = []
+    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution2",
+                                                              :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 75 }),
+                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 25 })]
+    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
+                                                            :duct_insulation_r_value => 4,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 150 }),
+                                          HPXML::Duct.new({ :duct_type => "return",
+                                                            :duct_insulation_r_value => 0,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 50 })]
   elsif ['base-hvac-none.xml',
          'base-hvac-elec-resistance-only.xml',
          'base-hvac-evap-cooler-only.xml',
@@ -2165,561 +2161,561 @@ def set_hpxml_data_hvac_distributions_values(hpxml_file, hpxml_data)
          'base-hvac-wall-furnace-elec-only.xml',
          'base-hvac-wall-furnace-propane-only.xml',
          'base-hvac-wall-furnace-wood-only.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions] = []
+    hpxml.hvac_distributions = []
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "HydronicDistribution"
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements] = []
-    hpxml_data[:hvac_distributions][0][:ducts] = []
-    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution2",
-                                         :distribution_system_type => "HydronicDistribution",
-                                         :duct_leakage_measurements => [],
-                                         :ducts => [] }
-    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution3",
-                                         :distribution_system_type => "AirDistribution",
-                                         :duct_leakage_measurements => [{ :duct_type => "supply",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 75 },
-                                                                        { :duct_type => "return",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 25 }],
-                                         :ducts => [{ :duct_type => "supply",
-                                                      :duct_insulation_r_value => 4,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 150 },
-                                                    { :duct_type => "return",
-                                                      :duct_insulation_r_value => 0,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 50 }] }
-    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution4",
-                                         :distribution_system_type => "AirDistribution",
-                                         :duct_leakage_measurements => [{ :duct_type => "supply",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 75 },
-                                                                        { :duct_type => "return",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 25 }],
-                                         :ducts => [{ :duct_type => "supply",
-                                                      :duct_insulation_r_value => 4,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 150 },
-                                                    { :duct_type => "return",
-                                                      :duct_insulation_r_value => 0,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 50 }] }
-    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution5",
-                                         :distribution_system_type => "AirDistribution",
-                                         :duct_leakage_measurements => [{ :duct_type => "supply",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 75 },
-                                                                        { :duct_type => "return",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 25 }],
-                                         :ducts => [{ :duct_type => "supply",
-                                                      :duct_insulation_r_value => 4,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 150 },
-                                                    { :duct_type => "return",
-                                                      :duct_insulation_r_value => 0,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 50 }] }
-    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution6",
-                                         :distribution_system_type => "AirDistribution",
-                                         :duct_leakage_measurements => [{ :duct_type => "supply",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 75 },
-                                                                        { :duct_type => "return",
-                                                                          :duct_leakage_units => "CFM25",
-                                                                          :duct_leakage_value => 25 }],
-                                         :ducts => [{ :duct_type => "supply",
-                                                      :duct_insulation_r_value => 4,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 150 },
-                                                    { :duct_type => "return",
-                                                      :duct_insulation_r_value => 0,
-                                                      :duct_location => "attic - unvented",
-                                                      :duct_surface_area => 50 }] }
+    hpxml.hvac_distributions[0].distribution_system_type = "HydronicDistribution"
+    hpxml.hvac_distributions[0].duct_leakage_measurements = []
+    hpxml.hvac_distributions[0].ducts = []
+    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution2",
+                                                              :distribution_system_type => "HydronicDistribution",
+                                                              :duct_leakage_measurements => [],
+                                                              :ducts => [] })
+    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution3",
+                                                              :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 75 }),
+                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 25 })]
+    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
+                                                            :duct_insulation_r_value => 4,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 150 }),
+                                          HPXML::Duct.new({ :duct_type => "return",
+                                                            :duct_insulation_r_value => 0,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 50 })]
+    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution4",
+                                                              :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 75 }),
+                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 25 })]
+    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
+                                                            :duct_insulation_r_value => 4,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 150 }),
+                                          HPXML::Duct.new({ :duct_type => "return",
+                                                            :duct_insulation_r_value => 0,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 50 })]
+    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution5",
+                                                              :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 75 }),
+                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 25 })]
+    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
+                                                            :duct_insulation_r_value => 4,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 150 }),
+                                          HPXML::Duct.new({ :duct_type => "return",
+                                                            :duct_insulation_r_value => 0,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 50 })]
+    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution6",
+                                                              :distribution_system_type => "AirDistribution" })
+    hpxml.hvac_distributions[-1].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 75 }),
+                                                              HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
+                                                                                                  :duct_leakage_units => "CFM25",
+                                                                                                  :duct_leakage_value => 25 })]
+    hpxml.hvac_distributions[-1].ducts = [HPXML::Duct.new({ :duct_type => "supply",
+                                                            :duct_insulation_r_value => 4,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 150 }),
+                                          HPXML::Duct.new({ :duct_type => "return",
+                                                            :duct_insulation_r_value => 0,
+                                                            :duct_location => "attic - unvented",
+                                                            :duct_surface_area => 50 })]
   elsif ['base-hvac-dse.xml',
          'base-dhw-indirect-dse.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "DSE"
-    hpxml_data[:hvac_distributions][0][:annual_heating_dse] = 0.8
-    hpxml_data[:hvac_distributions][0][:annual_cooling_dse] = 0.7
+    hpxml.hvac_distributions[0].distribution_system_type = "DSE"
+    hpxml.hvac_distributions[0].annual_heating_dse = 0.8
+    hpxml.hvac_distributions[0].annual_cooling_dse = 0.7
   elsif ['base-hvac-furnace-x3-dse.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:distribution_system_type] = "DSE"
-    hpxml_data[:hvac_distributions][0][:annual_heating_dse] = 0.8
-    hpxml_data[:hvac_distributions][0][:annual_cooling_dse] = 0.7
-    hpxml_data[:hvac_distributions] << hpxml_data[:hvac_distributions][0].dup
-    hpxml_data[:hvac_distributions][1][:id] = "HVACDistribution2"
-    hpxml_data[:hvac_distributions][1][:annual_cooling_dse] = nil
-    hpxml_data[:hvac_distributions] << hpxml_data[:hvac_distributions][0].dup
-    hpxml_data[:hvac_distributions][2][:id] = "HVACDistribution3"
-    hpxml_data[:hvac_distributions][2][:annual_cooling_dse] = nil
+    hpxml.hvac_distributions[0].distribution_system_type = "DSE"
+    hpxml.hvac_distributions[0].annual_heating_dse = 0.8
+    hpxml.hvac_distributions[0].annual_cooling_dse = 0.7
+    hpxml.hvac_distributions << hpxml.hvac_distributions[0].dup
+    hpxml.hvac_distributions[1].id = "HVACDistribution2"
+    hpxml.hvac_distributions[1].annual_cooling_dse = nil
+    hpxml.hvac_distributions << hpxml.hvac_distributions[0].dup
+    hpxml.hvac_distributions[2].id = "HVACDistribution3"
+    hpxml.hvac_distributions[2].annual_cooling_dse = nil
   elsif ['base-hvac-mini-split-heat-pump-ducted.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 15
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 5
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_insulation_r_value] = 0
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_surface_area] = 30
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_surface_area] = 10
+    hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value = 15
+    hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value = 5
+    hpxml.hvac_distributions[0].ducts[0].duct_insulation_r_value = 0
+    hpxml.hvac_distributions[0].ducts[0].duct_surface_area = 30
+    hpxml.hvac_distributions[0].ducts[1].duct_surface_area = 10
   elsif ['base-hvac-evap-cooler-only-ducted.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements].pop
-    hpxml_data[:hvac_distributions][0][:ducts].pop
+    hpxml.hvac_distributions[0].duct_leakage_measurements.pop
+    hpxml.hvac_distributions[0].ducts.pop
   elsif ['base-hvac-ducts-leakage-percent.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements] = [{ :duct_type => "supply",
-                                                                        :duct_leakage_units => "Percent",
-                                                                        :duct_leakage_value => 0.1 },
-                                                                      { :duct_type => "return",
-                                                                        :duct_leakage_units => "Percent",
-                                                                        :duct_leakage_value => 0.05 }]
+    hpxml.hvac_distributions[0].duct_leakage_measurements = [HPXML::DuctLeakageMeasurement.new({ :duct_type => "supply",
+                                                                                                 :duct_leakage_units => "Percent",
+                                                                                                 :duct_leakage_value => 0.1 }),
+                                                             HPXML::DuctLeakageMeasurement.new({ :duct_type => "return",
+                                                                                                 :duct_leakage_units => "Percent",
+                                                                                                 :duct_leakage_value => 0.05 })]
   elsif ['base-hvac-undersized.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] /= 10.0
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] /= 10.0
+    hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value /= 10.0
+    hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value /= 10.0
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "basement - unconditioned"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "basement - unconditioned"
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "basement - unconditioned"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "basement - unconditioned"
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "crawlspace - unvented"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "crawlspace - unvented"
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "crawlspace - unvented"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "crawlspace - unvented"
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "crawlspace - vented"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "crawlspace - vented"
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "crawlspace - vented"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "crawlspace - vented"
   elsif ['base-atticroof-flat.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 0.0
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 0.0
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "basement - conditioned"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "basement - conditioned"
+    hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value = 0.0
+    hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value = 0.0
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "basement - conditioned"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "basement - conditioned"
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "attic - vented"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "attic - vented"
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "attic - vented"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "attic - vented"
   elsif ['base-enclosure-garage.xml',
          'invalid_files/duct-location.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "garage"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "garage"
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "garage"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "garage"
   elsif ['invalid_files/duct-location-other.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "unconditioned space"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "unconditioned space"
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "unconditioned space"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "unconditioned space"
   elsif ['base-hvac-ducts-outside.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "outside"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "outside"
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "outside"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "outside"
   elsif ['base-hvac-ducts-locations.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "attic - unvented"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "attic - unvented"
   elsif ['base-hvac-ducts-multiple.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "supply",
-                                                    :duct_insulation_r_value => 8,
-                                                    :duct_location => "attic - unvented",
-                                                    :duct_surface_area => 300 }
-    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "supply",
-                                                    :duct_insulation_r_value => 8,
-                                                    :duct_location => "outside",
-                                                    :duct_surface_area => 300 }
-    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "return",
-                                                    :duct_insulation_r_value => 4,
-                                                    :duct_location => "attic - unvented",
-                                                    :duct_surface_area => 100 }
-    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "return",
-                                                    :duct_insulation_r_value => 4,
-                                                    :duct_location => "outside",
-                                                    :duct_surface_area => 100 }
+    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "supply",
+                                                           :duct_insulation_r_value => 8,
+                                                           :duct_location => "attic - unvented",
+                                                           :duct_surface_area => 300 })
+    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "supply",
+                                                           :duct_insulation_r_value => 8,
+                                                           :duct_location => "outside",
+                                                           :duct_surface_area => 300 })
+    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "return",
+                                                           :duct_insulation_r_value => 4,
+                                                           :duct_location => "attic - unvented",
+                                                           :duct_surface_area => 100 })
+    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "return",
+                                                           :duct_insulation_r_value => 4,
+                                                           :duct_location => "outside",
+                                                           :duct_surface_area => 100 })
   elsif ['base-atticroof-conditioned.xml',
          'base-enclosure-adiabatic-surfaces.xml',
          'base-atticroof-cathedral.xml',
          'base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "living space"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "living space"
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 0.0
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 0.0
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "living space"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "living space"
+    hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value = 0.0
+    hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value = 0.0
 
   elsif ['base-hvac-ducts-in-conditioned-space.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts][0][:duct_location] = "living space"
-    hpxml_data[:hvac_distributions][0][:ducts][1][:duct_location] = "living space"
+    hpxml.hvac_distributions[0].ducts[0].duct_location = "living space"
+    hpxml.hvac_distributions[0].ducts[1].duct_location = "living space"
     # Test leakage to outside when all ducts in conditioned space
     # (e.g., ducts may be in floor cavities which have leaky rims)
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 1.5
-    hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 1.5
-  elsif (hpxml_file.include? 'hvac_partial' or hpxml_file.include? 'hvac_base') and not hpxml_data[:hvac_distributions].empty?
-    if not hpxml_data[:hvac_distributions][0][:duct_leakage_measurements].empty?
-      hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 0.0
-      hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 0.0
+    hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value = 1.5
+    hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value = 1.5
+  elsif (hpxml_file.include? 'hvac_partial' or hpxml_file.include? 'hvac_base') and not hpxml.hvac_distributions.empty?
+    if not hpxml.hvac_distributions[0].duct_leakage_measurements.empty?
+      hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value = 0.0
+      hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value = 0.0
     end
-    hpxml_data[:hvac_distributions][0][:ducts] = []
-  elsif hpxml_file.include? 'hvac_multiple' and not hpxml_data[:hvac_distributions].empty?
-    hpxml_data[:hvac_distributions][0][:ducts] = []
-    if not hpxml_data[:hvac_distributions][0][:duct_leakage_measurements].empty?
-      hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][0][:duct_leakage_value] = 0.0
-      hpxml_data[:hvac_distributions][0][:duct_leakage_measurements][1][:duct_leakage_value] = 0.0
+    hpxml.hvac_distributions[0].ducts = []
+  elsif hpxml_file.include? 'hvac_multiple' and not hpxml.hvac_distributions.empty?
+    hpxml.hvac_distributions[0].ducts = []
+    if not hpxml.hvac_distributions[0].duct_leakage_measurements.empty?
+      hpxml.hvac_distributions[0].duct_leakage_measurements[0].duct_leakage_value = 0.0
+      hpxml.hvac_distributions[0].duct_leakage_measurements[1].duct_leakage_value = 0.0
     end
-    hpxml_data[:hvac_distributions] << hpxml_data[:hvac_distributions][0].dup
-    hpxml_data[:hvac_distributions][1][:id] = "HVACDistribution2"
-    hpxml_data[:hvac_distributions] << hpxml_data[:hvac_distributions][0].dup
-    hpxml_data[:hvac_distributions][2][:id] = "HVACDistribution3"
+    hpxml.hvac_distributions << hpxml.hvac_distributions[0].dup
+    hpxml.hvac_distributions[1].id = "HVACDistribution2"
+    hpxml.hvac_distributions << hpxml.hvac_distributions[0].dup
+    hpxml.hvac_distributions[2].id = "HVACDistribution3"
   elsif ['invalid_files/hvac-invalid-distribution-system-type.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions] << { :id => "HVACDistribution2",
-                                         :distribution_system_type => "HydronicDistribution",
-                                         :duct_leakage_measurements => [],
-                                         :ducts => [] }
+    hpxml.hvac_distributions << HPXML::HVACDistribution.new({ :id => "HVACDistribution2",
+                                                              :distribution_system_type => "HydronicDistribution",
+                                                              :duct_leakage_measurements => [],
+                                                              :ducts => [] })
   elsif ['invalid_files/hvac-distribution-return-duct-leakage-missing.xml'].include? hpxml_file
-    hpxml_data[:hvac_distributions][0][:ducts] << { :duct_type => "return",
-                                                    :duct_insulation_r_value => 0,
-                                                    :duct_location => "attic - unvented",
-                                                    :duct_surface_area => 50 }
+    hpxml.hvac_distributions[0].ducts << HPXML::Duct.new({ :duct_type => "return",
+                                                           :duct_insulation_r_value => 0,
+                                                           :duct_location => "attic - unvented",
+                                                           :duct_surface_area => 50 })
   end
 end
 
-def set_hpxml_data_ventilation_fans_values(hpxml_file, hpxml_data)
+def set_hpxml_ventilation_fans(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] = []
+    hpxml.ventilation_fans = []
   elsif ['base-mechvent-balanced.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "balanced",
-                                       :tested_flow_rate => 110,
-                                       :hours_in_operation => 24,
-                                       :fan_power => 60,
-                                       :used_for_whole_building_ventilation => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "balanced",
+                                                          :tested_flow_rate => 110,
+                                                          :hours_in_operation => 24,
+                                                          :fan_power => 60,
+                                                          :used_for_whole_building_ventilation => true })
   elsif ['invalid_files/unattached-cfis.xml',
          'invalid_files/cfis-with-hydronic-distribution.xml',
          'base-mechvent-cfis.xml',
          'base-mechvent-cfis-evap-cooler-only-ducted.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "central fan integrated supply",
-                                       :tested_flow_rate => 330,
-                                       :hours_in_operation => 8,
-                                       :fan_power => 300,
-                                       :used_for_whole_building_ventilation => true,
-                                       :distribution_system_idref => "HVACDistribution" }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "central fan integrated supply",
+                                                          :tested_flow_rate => 330,
+                                                          :hours_in_operation => 8,
+                                                          :fan_power => 300,
+                                                          :used_for_whole_building_ventilation => true,
+                                                          :distribution_system_idref => "HVACDistribution" })
     if ['invalid_files/unattached-cfis.xml'].include? hpxml_file
-      hpxml_data[:ventilation_fans][0][:distribution_system_idref] = "foobar"
+      hpxml.ventilation_fans[0].distribution_system_idref = "foobar"
     end
   elsif ['base-mechvent-erv.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "energy recovery ventilator",
-                                       :tested_flow_rate => 110,
-                                       :hours_in_operation => 24,
-                                       :total_recovery_efficiency => 0.48,
-                                       :sensible_recovery_efficiency => 0.72,
-                                       :fan_power => 60,
-                                       :used_for_whole_building_ventilation => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "energy recovery ventilator",
+                                                          :tested_flow_rate => 110,
+                                                          :hours_in_operation => 24,
+                                                          :total_recovery_efficiency => 0.48,
+                                                          :sensible_recovery_efficiency => 0.72,
+                                                          :fan_power => 60,
+                                                          :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-erv-atre-asre.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "energy recovery ventilator",
-                                       :tested_flow_rate => 110,
-                                       :hours_in_operation => 24,
-                                       :total_recovery_efficiency_adjusted => 0.526,
-                                       :sensible_recovery_efficiency_adjusted => 0.79,
-                                       :fan_power => 60,
-                                       :used_for_whole_building_ventilation => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "energy recovery ventilator",
+                                                          :tested_flow_rate => 110,
+                                                          :hours_in_operation => 24,
+                                                          :total_recovery_efficiency_adjusted => 0.526,
+                                                          :sensible_recovery_efficiency_adjusted => 0.79,
+                                                          :fan_power => 60,
+                                                          :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-exhaust.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "exhaust only",
-                                       :tested_flow_rate => 110,
-                                       :hours_in_operation => 24,
-                                       :fan_power => 30,
-                                       :used_for_whole_building_ventilation => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "exhaust only",
+                                                          :tested_flow_rate => 110,
+                                                          :hours_in_operation => 24,
+                                                          :fan_power => 30,
+                                                          :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-exhaust-rated-flow-rate.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "exhaust only",
-                                       :rated_flow_rate => 110,
-                                       :hours_in_operation => 24,
-                                       :fan_power => 30,
-                                       :used_for_whole_building_ventilation => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "exhaust only",
+                                                          :rated_flow_rate => 110,
+                                                          :hours_in_operation => 24,
+                                                          :fan_power => 30,
+                                                          :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-hrv.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "heat recovery ventilator",
-                                       :tested_flow_rate => 110,
-                                       :hours_in_operation => 24,
-                                       :sensible_recovery_efficiency => 0.72,
-                                       :fan_power => 60,
-                                       :used_for_whole_building_ventilation => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "heat recovery ventilator",
+                                                          :tested_flow_rate => 110,
+                                                          :hours_in_operation => 24,
+                                                          :sensible_recovery_efficiency => 0.72,
+                                                          :fan_power => 60,
+                                                          :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-hrv-asre.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "heat recovery ventilator",
-                                       :tested_flow_rate => 110,
-                                       :hours_in_operation => 24,
-                                       :sensible_recovery_efficiency_adjusted => 0.790,
-                                       :fan_power => 60,
-                                       :used_for_whole_building_ventilation => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "heat recovery ventilator",
+                                                          :tested_flow_rate => 110,
+                                                          :hours_in_operation => 24,
+                                                          :sensible_recovery_efficiency_adjusted => 0.790,
+                                                          :fan_power => 60,
+                                                          :used_for_whole_building_ventilation => true })
   elsif ['base-mechvent-supply.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "MechanicalVentilation",
-                                       :fan_type => "supply only",
-                                       :tested_flow_rate => 110,
-                                       :hours_in_operation => 24,
-                                       :fan_power => 30,
-                                       :used_for_whole_building_ventilation => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "MechanicalVentilation",
+                                                          :fan_type => "supply only",
+                                                          :tested_flow_rate => 110,
+                                                          :hours_in_operation => 24,
+                                                          :fan_power => 30,
+                                                          :used_for_whole_building_ventilation => true })
   elsif ['base-misc-whole-house-fan.xml'].include? hpxml_file
-    hpxml_data[:ventilation_fans] << { :id => "WholeHouseFan",
-                                       :rated_flow_rate => 4500,
-                                       :fan_power => 300,
-                                       :used_for_seasonal_cooling_load_reduction => true }
+    hpxml.ventilation_fans << HPXML::VentilationFan.new({ :id => "WholeHouseFan",
+                                                          :rated_flow_rate => 4500,
+                                                          :fan_power => 300,
+                                                          :used_for_seasonal_cooling_load_reduction => true })
   end
 end
 
-def set_hpxml_data_water_heating_systems_values(hpxml_file, hpxml_data)
+def set_hpxml_water_heating_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems] = [{ :id => "WaterHeater",
-                                            :fuel_type => "electricity",
-                                            :water_heater_type => "storage water heater",
-                                            :location => "living space",
-                                            :tank_volume => 40,
-                                            :fraction_dhw_load_served => 1,
-                                            :heating_capacity => 18767,
-                                            :energy_factor => 0.95 }]
+    hpxml.water_heating_systems = [HPXML::WaterHeatingSystem.new({ :id => "WaterHeater",
+                                                                   :fuel_type => "electricity",
+                                                                   :water_heater_type => "storage water heater",
+                                                                   :location => "living space",
+                                                                   :tank_volume => 40,
+                                                                   :fraction_dhw_load_served => 1,
+                                                                   :heating_capacity => 18767,
+                                                                   :energy_factor => 0.95 })]
   elsif ['base-dhw-multiple.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fraction_dhw_load_served] = 0.2
-    hpxml_data[:water_heating_systems] << { :id => "WaterHeater2",
-                                            :fuel_type => "natural gas",
-                                            :water_heater_type => "storage water heater",
-                                            :location => "living space",
-                                            :tank_volume => 50,
-                                            :fraction_dhw_load_served => 0.2,
-                                            :heating_capacity => 40000,
-                                            :energy_factor => 0.59,
-                                            :recovery_efficiency => 0.76 }
-    hpxml_data[:water_heating_systems] << { :id => "WaterHeater3",
-                                            :fuel_type => "electricity",
-                                            :water_heater_type => "heat pump water heater",
-                                            :location => "living space",
-                                            :tank_volume => 80,
-                                            :fraction_dhw_load_served => 0.2,
-                                            :energy_factor => 2.3 }
-    hpxml_data[:water_heating_systems] << { :id => "WaterHeater4",
-                                            :fuel_type => "electricity",
-                                            :water_heater_type => "instantaneous water heater",
-                                            :location => "living space",
-                                            :fraction_dhw_load_served => 0.2,
-                                            :energy_factor => 0.99 }
-    hpxml_data[:water_heating_systems] << { :id => "WaterHeater5",
-                                            :fuel_type => "natural gas",
-                                            :water_heater_type => "instantaneous water heater",
-                                            :location => "living space",
-                                            :fraction_dhw_load_served => 0.1,
-                                            :energy_factor => 0.82 }
-    hpxml_data[:water_heating_systems] << { :id => "WaterHeater6",
-                                            :water_heater_type => "space-heating boiler with storage tank",
-                                            :location => "living space",
-                                            :tank_volume => 50,
-                                            :fraction_dhw_load_served => 0.1,
-                                            :related_hvac => "HeatingSystem" }
+    hpxml.water_heating_systems[0].fraction_dhw_load_served = 0.2
+    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater2",
+                                                                   :fuel_type => "natural gas",
+                                                                   :water_heater_type => "storage water heater",
+                                                                   :location => "living space",
+                                                                   :tank_volume => 50,
+                                                                   :fraction_dhw_load_served => 0.2,
+                                                                   :heating_capacity => 40000,
+                                                                   :energy_factor => 0.59,
+                                                                   :recovery_efficiency => 0.76 })
+    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater3",
+                                                                   :fuel_type => "electricity",
+                                                                   :water_heater_type => "heat pump water heater",
+                                                                   :location => "living space",
+                                                                   :tank_volume => 80,
+                                                                   :fraction_dhw_load_served => 0.2,
+                                                                   :energy_factor => 2.3 })
+    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater4",
+                                                                   :fuel_type => "electricity",
+                                                                   :water_heater_type => "instantaneous water heater",
+                                                                   :location => "living space",
+                                                                   :fraction_dhw_load_served => 0.2,
+                                                                   :energy_factor => 0.99 })
+    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater5",
+                                                                   :fuel_type => "natural gas",
+                                                                   :water_heater_type => "instantaneous water heater",
+                                                                   :location => "living space",
+                                                                   :fraction_dhw_load_served => 0.1,
+                                                                   :energy_factor => 0.82 })
+    hpxml.water_heating_systems << HPXML::WaterHeatingSystem.new({ :id => "WaterHeater6",
+                                                                   :water_heater_type => "space-heating boiler with storage tank",
+                                                                   :location => "living space",
+                                                                   :tank_volume => 50,
+                                                                   :fraction_dhw_load_served => 0.1,
+                                                                   :related_hvac => "HeatingSystem" })
   elsif ['invalid_files/dhw-frac-load-served.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fraction_dhw_load_served] += 0.15
+    hpxml.water_heating_systems[0].fraction_dhw_load_served += 0.15
   elsif ['base-dhw-tank-gas.xml',
          'base-dhw-tank-gas-outside.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fuel_type] = "natural gas"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = 40000
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.59
-    hpxml_data[:water_heating_systems][0][:recovery_efficiency] = 0.76
+    hpxml.water_heating_systems[0].fuel_type = "natural gas"
+    hpxml.water_heating_systems[0].tank_volume = 50
+    hpxml.water_heating_systems[0].heating_capacity = 40000
+    hpxml.water_heating_systems[0].energy_factor = 0.59
+    hpxml.water_heating_systems[0].recovery_efficiency = 0.76
     if hpxml_file == 'base-dhw-tank-gas-outside.xml'
-      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
+      hpxml.water_heating_systems[0].location = "other exterior"
     end
   elsif ['base-dhw-tank-wood.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fuel_type] = "wood"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = 40000
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.59
-    hpxml_data[:water_heating_systems][0][:recovery_efficiency] = 0.76
+    hpxml.water_heating_systems[0].fuel_type = "wood"
+    hpxml.water_heating_systems[0].tank_volume = 50
+    hpxml.water_heating_systems[0].heating_capacity = 40000
+    hpxml.water_heating_systems[0].energy_factor = 0.59
+    hpxml.water_heating_systems[0].recovery_efficiency = 0.76
   elsif ['base-dhw-tank-heat-pump.xml',
          'base-dhw-tank-heat-pump-outside.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "heat pump water heater"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = 80
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 2.3
+    hpxml.water_heating_systems[0].water_heater_type = "heat pump water heater"
+    hpxml.water_heating_systems[0].tank_volume = 80
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].energy_factor = 2.3
     if hpxml_file == 'base-dhw-tank-heat-pump-outside.xml'
-      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
+      hpxml.water_heating_systems[0].location = "other exterior"
     end
   elsif ['base-dhw-tankless-electric.xml',
          'base-dhw-tankless-electric-outside.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.99
+    hpxml.water_heating_systems[0].water_heater_type = "instantaneous water heater"
+    hpxml.water_heating_systems[0].tank_volume = nil
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].energy_factor = 0.99
     if hpxml_file == 'base-dhw-tankless-electric-outside.xml'
-      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
+      hpxml.water_heating_systems[0].location = "other exterior"
     end
   elsif ['base-dhw-tankless-gas.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fuel_type] = "natural gas"
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.82
+    hpxml.water_heating_systems[0].fuel_type = "natural gas"
+    hpxml.water_heating_systems[0].water_heater_type = "instantaneous water heater"
+    hpxml.water_heating_systems[0].tank_volume = nil
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].energy_factor = 0.82
   elsif ['base-dhw-tankless-oil.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fuel_type] = "fuel oil"
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.82
+    hpxml.water_heating_systems[0].fuel_type = "fuel oil"
+    hpxml.water_heating_systems[0].water_heater_type = "instantaneous water heater"
+    hpxml.water_heating_systems[0].tank_volume = nil
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].energy_factor = 0.82
   elsif ['base-dhw-tankless-propane.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fuel_type] = "propane"
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.82
+    hpxml.water_heating_systems[0].fuel_type = "propane"
+    hpxml.water_heating_systems[0].water_heater_type = "instantaneous water heater"
+    hpxml.water_heating_systems[0].tank_volume = nil
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].energy_factor = 0.82
   elsif ['base-dhw-tankless-wood.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fuel_type] = "wood"
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.82
+    hpxml.water_heating_systems[0].fuel_type = "wood"
+    hpxml.water_heating_systems[0].water_heater_type = "instantaneous water heater"
+    hpxml.water_heating_systems[0].tank_volume = nil
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].energy_factor = 0.82
   elsif ['base-dhw-tank-oil.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fuel_type] = "fuel oil"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = 40000
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.59
-    hpxml_data[:water_heating_systems][0][:recovery_efficiency] = 0.76
+    hpxml.water_heating_systems[0].fuel_type = "fuel oil"
+    hpxml.water_heating_systems[0].tank_volume = 50
+    hpxml.water_heating_systems[0].heating_capacity = 40000
+    hpxml.water_heating_systems[0].energy_factor = 0.59
+    hpxml.water_heating_systems[0].recovery_efficiency = 0.76
   elsif ['base-dhw-tank-propane.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fuel_type] = "propane"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = 40000
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.59
-    hpxml_data[:water_heating_systems][0][:recovery_efficiency] = 0.76
+    hpxml.water_heating_systems[0].fuel_type = "propane"
+    hpxml.water_heating_systems[0].tank_volume = 50
+    hpxml.water_heating_systems[0].heating_capacity = 40000
+    hpxml.water_heating_systems[0].energy_factor = 0.59
+    hpxml.water_heating_systems[0].recovery_efficiency = 0.76
   elsif ['base-dhw-uef.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:energy_factor] = nil
-    hpxml_data[:water_heating_systems][0][:uniform_energy_factor] = 0.93
+    hpxml.water_heating_systems[0].energy_factor = nil
+    hpxml.water_heating_systems[0].uniform_energy_factor = 0.93
   elsif ['base-dhw-desuperheater.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
+    hpxml.water_heating_systems[0].uses_desuperheater = true
+    hpxml.water_heating_systems[0].related_hvac = "CoolingSystem"
   elsif ['base-dhw-desuperheater-tankless.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "instantaneous water heater"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
-    hpxml_data[:water_heating_systems][0][:energy_factor] = 0.99
-    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
+    hpxml.water_heating_systems[0].water_heater_type = "instantaneous water heater"
+    hpxml.water_heating_systems[0].tank_volume = nil
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].energy_factor = 0.99
+    hpxml.water_heating_systems[0].uses_desuperheater = true
+    hpxml.water_heating_systems[0].related_hvac = "CoolingSystem"
   elsif ['base-dhw-desuperheater-2-speed.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
+    hpxml.water_heating_systems[0].uses_desuperheater = true
+    hpxml.water_heating_systems[0].related_hvac = "CoolingSystem"
   elsif ['base-dhw-desuperheater-var-speed.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
+    hpxml.water_heating_systems[0].uses_desuperheater = true
+    hpxml.water_heating_systems[0].related_hvac = "CoolingSystem"
   elsif ['base-dhw-desuperheater-gshp.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "HeatPump"
+    hpxml.water_heating_systems[0].uses_desuperheater = true
+    hpxml.water_heating_systems[0].related_hvac = "HeatPump"
   elsif ['base-dhw-jacket-electric.xml',
          'base-dhw-jacket-indirect.xml',
          'base-dhw-jacket-gas.xml',
          'base-dhw-jacket-hpwh.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:jacket_r_value] = 10.0
+    hpxml.water_heating_systems[0].jacket_r_value = 10.0
   elsif ['base-dhw-indirect.xml',
          'base-dhw-indirect-outside.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "space-heating boiler with storage tank"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = 50
-    hpxml_data[:water_heating_systems][0][:heating_capacity] = nil
-    hpxml_data[:water_heating_systems][0][:energy_factor] = nil
-    hpxml_data[:water_heating_systems][0][:fuel_type] = nil
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "HeatingSystem"
+    hpxml.water_heating_systems[0].water_heater_type = "space-heating boiler with storage tank"
+    hpxml.water_heating_systems[0].tank_volume = 50
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].energy_factor = nil
+    hpxml.water_heating_systems[0].fuel_type = nil
+    hpxml.water_heating_systems[0].related_hvac = "HeatingSystem"
     if hpxml_file == 'base-dhw-indirect-outside.xml'
-      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
+      hpxml.water_heating_systems[0].location = "other exterior"
     end
   elsif ['base-dhw-indirect-standbyloss.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:standby_loss] = 1.0
+    hpxml.water_heating_systems[0].standby_loss = 1.0
   elsif ['base-dhw-combi-tankless.xml',
          'base-dhw-combi-tankless-outside.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:water_heater_type] = "space-heating boiler with tankless coil"
-    hpxml_data[:water_heating_systems][0][:tank_volume] = nil
+    hpxml.water_heating_systems[0].water_heater_type = "space-heating boiler with tankless coil"
+    hpxml.water_heating_systems[0].tank_volume = nil
     if hpxml_file == 'base-dhw-combi-tankless-outside.xml'
-      hpxml_data[:water_heating_systems][0][:location] = "other exterior"
+      hpxml.water_heating_systems[0].location = "other exterior"
     end
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "basement - unconditioned"
+    hpxml.water_heating_systems[0].location = "basement - unconditioned"
   elsif ['base-foundation-unvented-crawlspace.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "crawlspace - unvented"
+    hpxml.water_heating_systems[0].location = "crawlspace - unvented"
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "crawlspace - vented"
+    hpxml.water_heating_systems[0].location = "crawlspace - vented"
   elsif ['base-foundation-slab.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "living space"
+    hpxml.water_heating_systems[0].location = "living space"
   elsif ['base-atticroof-vented.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "attic - vented"
+    hpxml.water_heating_systems[0].location = "attic - vented"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "basement - conditioned"
+    hpxml.water_heating_systems[0].location = "basement - conditioned"
   elsif ['invalid_files/water-heater-location.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "crawlspace - vented"
+    hpxml.water_heating_systems[0].location = "crawlspace - vented"
   elsif ['invalid_files/water-heater-location-other.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "unconditioned space"
+    hpxml.water_heating_systems[0].location = "unconditioned space"
   elsif ['invalid_files/invalid-relatedhvac-desuperheater.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem_bad"
+    hpxml.water_heating_systems[0].uses_desuperheater = true
+    hpxml.water_heating_systems[0].related_hvac = "CoolingSystem_bad"
   elsif ['invalid_files/repeated-relatedhvac-desuperheater.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fraction_dhw_load_served] = 0.5
-    hpxml_data[:water_heating_systems][0][:uses_desuperheater] = true
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "CoolingSystem"
-    hpxml_data[:water_heating_systems] << hpxml_data[:water_heating_systems][0].dup
-    hpxml_data[:water_heating_systems][1][:id] = "WaterHeater2"
+    hpxml.water_heating_systems[0].fraction_dhw_load_served = 0.5
+    hpxml.water_heating_systems[0].uses_desuperheater = true
+    hpxml.water_heating_systems[0].related_hvac = "CoolingSystem"
+    hpxml.water_heating_systems << hpxml.water_heating_systems[0].dup
+    hpxml.water_heating_systems[1].id = "WaterHeater2"
   elsif ['invalid_files/invalid-relatedhvac-dhw-indirect.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:related_hvac] = "HeatingSystem_bad"
+    hpxml.water_heating_systems[0].related_hvac = "HeatingSystem_bad"
   elsif ['invalid_files/repeated-relatedhvac-dhw-indirect.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:fraction_dhw_load_served] = 0.5
-    hpxml_data[:water_heating_systems] << hpxml_data[:water_heating_systems][0].dup
-    hpxml_data[:water_heating_systems][1][:id] = "WaterHeater2"
+    hpxml.water_heating_systems[0].fraction_dhw_load_served = 0.5
+    hpxml.water_heating_systems << hpxml.water_heating_systems[0].dup
+    hpxml.water_heating_systems[1].id = "WaterHeater2"
   elsif ['base-enclosure-garage.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:location] = "garage"
+    hpxml.water_heating_systems[0].location = "garage"
   elsif ['base-dhw-temperature.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems][0][:temperature] = 130.0
+    hpxml.water_heating_systems[0].temperature = 130.0
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hpxml_data[:water_heating_systems] = []
+    hpxml.water_heating_systems = []
   end
 end
 
-def set_hpxml_data_hot_water_distribution_values(hpxml_file, hpxml_data)
+def set_hpxml_hot_water_distribution(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:hot_water_distribution] = { :id => "HotWaterDstribution",
-                                            :system_type => "Standard",
-                                            :standard_piping_length => 50, # Chosen to test a negative EC_adj
-                                            :pipe_r_value => 0.0 }
+    hpxml.hot_water_distribution = HPXML::HotWaterDistribution.new({ :id => "HotWaterDstribution",
+                                                                     :system_type => "Standard",
+                                                                     :standard_piping_length => 50, # Chosen to test a negative EC_adj
+                                                                     :pipe_r_value => 0.0 })
   elsif ['base-dhw-dwhr.xml'].include? hpxml_file
-    hpxml_data[:hot_water_distribution][:dwhr_facilities_connected] = "all"
-    hpxml_data[:hot_water_distribution][:dwhr_equal_flow] = true
-    hpxml_data[:hot_water_distribution][:dwhr_efficiency] = 0.55
+    hpxml.hot_water_distribution.dwhr_facilities_connected = "all"
+    hpxml.hot_water_distribution.dwhr_equal_flow = true
+    hpxml.hot_water_distribution.dwhr_efficiency = 0.55
   elsif ['base-dhw-recirc-demand.xml'].include? hpxml_file
-    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
-    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "presence sensor demand control"
-    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
-    hpxml_data[:hot_water_distribution][:pipe_r_value] = 3
+    hpxml.hot_water_distribution.system_type = "Recirculation"
+    hpxml.hot_water_distribution.recirculation_control_type = "presence sensor demand control"
+    hpxml.hot_water_distribution.recirculation_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_branch_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_pump_power = 50
+    hpxml.hot_water_distribution.pipe_r_value = 3
   elsif ['base-dhw-recirc-manual.xml'].include? hpxml_file
-    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
-    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "manual demand control"
-    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
-    hpxml_data[:hot_water_distribution][:pipe_r_value] = 3
+    hpxml.hot_water_distribution.system_type = "Recirculation"
+    hpxml.hot_water_distribution.recirculation_control_type = "manual demand control"
+    hpxml.hot_water_distribution.recirculation_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_branch_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_pump_power = 50
+    hpxml.hot_water_distribution.pipe_r_value = 3
   elsif ['base-dhw-recirc-nocontrol.xml'].include? hpxml_file
-    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
-    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "no control"
-    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
+    hpxml.hot_water_distribution.system_type = "Recirculation"
+    hpxml.hot_water_distribution.recirculation_control_type = "no control"
+    hpxml.hot_water_distribution.recirculation_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_branch_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_pump_power = 50
   elsif ['base-dhw-recirc-temperature.xml'].include? hpxml_file
-    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
-    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "temperature"
-    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
+    hpxml.hot_water_distribution.system_type = "Recirculation"
+    hpxml.hot_water_distribution.recirculation_control_type = "temperature"
+    hpxml.hot_water_distribution.recirculation_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_branch_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_pump_power = 50
   elsif ['base-dhw-recirc-timer.xml'].include? hpxml_file
-    hpxml_data[:hot_water_distribution][:system_type] = "Recirculation"
-    hpxml_data[:hot_water_distribution][:recirculation_control_type] = "timer"
-    hpxml_data[:hot_water_distribution][:recirculation_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_branch_piping_length] = 50
-    hpxml_data[:hot_water_distribution][:recirculation_pump_power] = 50
+    hpxml.hot_water_distribution.system_type = "Recirculation"
+    hpxml.hot_water_distribution.recirculation_control_type = "timer"
+    hpxml.hot_water_distribution.recirculation_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_branch_piping_length = 50
+    hpxml.hot_water_distribution.recirculation_pump_power = 50
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hpxml_data[:hot_water_distribution] = {}
+    hpxml.hot_water_distribution = nil
   end
 end
 
-def set_hpxml_data_water_fixtures_values(hpxml_file, hpxml_data)
+def set_hpxml_water_fixtures(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:water_fixtures] = [{ :id => "WaterFixture",
-                                     :water_fixture_type => "shower head",
-                                     :low_flow => true },
-                                   { :id => "WaterFixture2",
-                                     :water_fixture_type => "faucet",
-                                     :low_flow => false }]
+    hpxml.water_fixtures = [HPXML::WaterFixture.new({ :id => "WaterFixture",
+                                                      :water_fixture_type => "shower head",
+                                                      :low_flow => true }),
+                            HPXML::WaterFixture.new({ :id => "WaterFixture2",
+                                                      :water_fixture_type => "faucet",
+                                                      :low_flow => false })]
   elsif ['base-dhw-low-flow-fixtures.xml'].include? hpxml_file
-    hpxml_data[:water_fixtures][1][:low_flow] = true
+    hpxml.water_fixtures[1].low_flow = true
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hpxml_data[:water_fixtures] = []
+    hpxml.water_fixtures = []
   end
 end
 
-def set_hpxml_data_solar_thermal_system_values(hpxml_file, hpxml_data)
+def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:solar_thermal_system] = {}
+    hpxml.solar_thermal_system = nil
   elsif ['base-dhw-solar-fraction.xml',
          'base-dhw-multiple.xml',
          'base-dhw-tank-heat-pump-with-solar-fraction.xml',
@@ -2727,286 +2723,286 @@ def set_hpxml_data_solar_thermal_system_values(hpxml_file, hpxml_data)
          'invalid_files/solar-thermal-system-with-combi-tankless.xml',
          'invalid_files/solar-thermal-system-with-desuperheater.xml',
          'invalid_files/solar-thermal-system-with-dhw-indirect.xml'].include? hpxml_file
-    hpxml_data[:solar_thermal_system] = { :id => "SolarThermalSystem",
-                                          :system_type => "hot water",
-                                          :water_heating_system_idref => "WaterHeater",
-                                          :solar_fraction => 0.65 }
+    hpxml.solar_thermal_system = HPXML::SolarThermalSystem.new({ :id => "SolarThermalSystem",
+                                                                 :system_type => "hot water",
+                                                                 :water_heating_system_idref => "WaterHeater",
+                                                                 :solar_fraction => 0.65 })
   elsif ['base-dhw-solar-direct-flat-plate.xml',
          'base-dhw-solar-indirect-flat-plate.xml',
          'base-dhw-solar-thermosyphon-flat-plate.xml',
          'base-dhw-tank-heat-pump-with-solar.xml',
          'base-dhw-tankless-gas-with-solar.xml'].include? hpxml_file
-    hpxml_data[:solar_thermal_system] = { :id => "SolarThermalSystem",
-                                          :system_type => "hot water",
-                                          :collector_area => 40,
-                                          :collector_type => "single glazing black",
-                                          :collector_azimuth => 180,
-                                          :collector_tilt => 20,
-                                          :collector_frta => 0.77,
-                                          :collector_frul => 0.793,
-                                          :storage_volume => 60,
-                                          :water_heating_system_idref => "WaterHeater" }
+    hpxml.solar_thermal_system = HPXML::SolarThermalSystem.new({ :id => "SolarThermalSystem",
+                                                                 :system_type => "hot water",
+                                                                 :collector_area => 40,
+                                                                 :collector_type => "single glazing black",
+                                                                 :collector_azimuth => 180,
+                                                                 :collector_tilt => 20,
+                                                                 :collector_frta => 0.77,
+                                                                 :collector_frul => 0.793,
+                                                                 :storage_volume => 60,
+                                                                 :water_heating_system_idref => "WaterHeater" })
     if hpxml_file == 'base-dhw-solar-direct-flat-plate.xml'
-      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid direct"
+      hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-flat-plate.xml'
-      hpxml_data[:solar_thermal_system][:collector_loop_type] = "passive thermosyphon"
+      hpxml.solar_thermal_system.collector_loop_type = "passive thermosyphon"
     else
-      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid indirect"
+      hpxml.solar_thermal_system.collector_loop_type = "liquid indirect"
     end
   elsif ['base-dhw-solar-indirect-evacuated-tube.xml',
          'base-dhw-solar-direct-evacuated-tube.xml',
          'base-dhw-solar-thermosyphon-evacuated-tube.xml'].include? hpxml_file
-    hpxml_data[:solar_thermal_system] = { :id => "SolarThermalSystem",
-                                          :system_type => "hot water",
-                                          :collector_area => 40,
-                                          :collector_type => "evacuated tube",
-                                          :collector_azimuth => 180,
-                                          :collector_tilt => 20,
-                                          :collector_frta => 0.50,
-                                          :collector_frul => 0.2799,
-                                          :storage_volume => 60,
-                                          :water_heating_system_idref => "WaterHeater" }
+    hpxml.solar_thermal_system = HPXML::SolarThermalSystem.new({ :id => "SolarThermalSystem",
+                                                                 :system_type => "hot water",
+                                                                 :collector_area => 40,
+                                                                 :collector_type => "evacuated tube",
+                                                                 :collector_azimuth => 180,
+                                                                 :collector_tilt => 20,
+                                                                 :collector_frta => 0.50,
+                                                                 :collector_frul => 0.2799,
+                                                                 :storage_volume => 60,
+                                                                 :water_heating_system_idref => "WaterHeater" })
     if hpxml_file == 'base-dhw-solar-direct-evacuated-tube.xml'
-      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid direct"
+      hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-evacuated-tube.xml'
-      hpxml_data[:solar_thermal_system][:collector_loop_type] = "passive thermosyphon"
+      hpxml.solar_thermal_system.collector_loop_type = "passive thermosyphon"
     else
-      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid indirect"
+      hpxml.solar_thermal_system.collector_loop_type = "liquid indirect"
     end
   elsif ['base-dhw-solar-direct-ics.xml',
          'base-dhw-solar-thermosyphon-ics.xml'].include? hpxml_file
-    hpxml_data[:solar_thermal_system] = { :id => "SolarThermalSystem",
-                                          :system_type => "hot water",
-                                          :collector_area => 40,
-                                          :collector_type => "integrated collector storage",
-                                          :collector_azimuth => 180,
-                                          :collector_tilt => 20,
-                                          :collector_frta => 0.77,
-                                          :collector_frul => 0.793,
-                                          :storage_volume => 60,
-                                          :water_heating_system_idref => "WaterHeater" }
+    hpxml.solar_thermal_system = HPXML::SolarThermalSystem.new({ :id => "SolarThermalSystem",
+                                                                 :system_type => "hot water",
+                                                                 :collector_area => 40,
+                                                                 :collector_type => "integrated collector storage",
+                                                                 :collector_azimuth => 180,
+                                                                 :collector_tilt => 20,
+                                                                 :collector_frta => 0.77,
+                                                                 :collector_frul => 0.793,
+                                                                 :storage_volume => 60,
+                                                                 :water_heating_system_idref => "WaterHeater" })
     if hpxml_file == 'base-dhw-solar-direct-ics.xml'
-      hpxml_data[:solar_thermal_system][:collector_loop_type] = "liquid direct"
+      hpxml.solar_thermal_system.collector_loop_type = "liquid direct"
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-ics.xml'
-      hpxml_data[:solar_thermal_system][:collector_loop_type] = "passive thermosyphon"
+      hpxml.solar_thermal_system.collector_loop_type = "passive thermosyphon"
     end
   elsif ['invalid_files/unattached-solar-thermal-system.xml'].include? hpxml_file
-    hpxml_data[:solar_thermal_system][:water_heating_system_idref] = "foobar"
+    hpxml.solar_thermal_system.water_heating_system_idref = "foobar"
   end
 end
 
-def set_hpxml_data_pv_systems_values(hpxml_file, hpxml_data)
+def set_hpxml_pv_systems(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:pv_systems] = []
+    hpxml.pv_systems = []
   elsif ['base-pv.xml'].include? hpxml_file
-    hpxml_data[:pv_systems] << { :id => "PVSystem",
-                                 :module_type => "standard",
-                                 :location => "roof",
-                                 :tracking => "fixed",
-                                 :array_azimuth => 180,
-                                 :array_tilt => 20,
-                                 :max_power_output => 4000,
-                                 :inverter_efficiency => 0.96,
-                                 :system_losses_fraction => 0.14 }
-    hpxml_data[:pv_systems] << { :id => "PVSystem2",
-                                 :module_type => "premium",
-                                 :location => "roof",
-                                 :tracking => "fixed",
-                                 :array_azimuth => 90,
-                                 :array_tilt => 20,
-                                 :max_power_output => 1500,
-                                 :inverter_efficiency => 0.96,
-                                 :system_losses_fraction => 0.14 }
+    hpxml.pv_systems << HPXML::PVSystem.new({ :id => "PVSystem",
+                                              :module_type => "standard",
+                                              :location => "roof",
+                                              :tracking => "fixed",
+                                              :array_azimuth => 180,
+                                              :array_tilt => 20,
+                                              :max_power_output => 4000,
+                                              :inverter_efficiency => 0.96,
+                                              :system_losses_fraction => 0.14 })
+    hpxml.pv_systems << HPXML::PVSystem.new({ :id => "PVSystem2",
+                                              :module_type => "premium",
+                                              :location => "roof",
+                                              :tracking => "fixed",
+                                              :array_azimuth => 90,
+                                              :array_tilt => 20,
+                                              :max_power_output => 1500,
+                                              :inverter_efficiency => 0.96,
+                                              :system_losses_fraction => 0.14 })
   end
 end
 
-def set_hpxml_data_clothes_washer_values(hpxml_file, hpxml_data)
+def set_hpxml_clothes_washer(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:clothes_washer] = { :id => "ClothesWasher",
-                                    :location => "living space",
-                                    :modified_energy_factor => 0.8,
-                                    :rated_annual_kwh => 700.0,
-                                    :label_electric_rate => 0.10,
-                                    :label_gas_rate => 0.60,
-                                    :label_annual_gas_cost => 25.0,
-                                    :capacity => 3.0 }
+    hpxml.clothes_washer = HPXML::ClothesWasher.new({ :id => "ClothesWasher",
+                                                      :location => "living space",
+                                                      :modified_energy_factor => 0.8,
+                                                      :rated_annual_kwh => 700.0,
+                                                      :label_electric_rate => 0.10,
+                                                      :label_gas_rate => 0.60,
+                                                      :label_annual_gas_cost => 25.0,
+                                                      :capacity => 3.0 })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml_data[:clothes_washer] = {}
+    hpxml.clothes_washer = nil
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    hpxml_data[:clothes_washer][:modified_energy_factor] = nil
-    hpxml_data[:clothes_washer][:integrated_modified_energy_factor] = 0.73
+    hpxml.clothes_washer.modified_energy_factor = nil
+    hpxml.clothes_washer.integrated_modified_energy_factor = 0.73
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:clothes_washer][:location] = "basement - unconditioned"
+    hpxml.clothes_washer.location = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:clothes_washer][:location] = "basement - conditioned"
+    hpxml.clothes_washer.location = "basement - conditioned"
   elsif ['base-enclosure-garage.xml',
          'invalid_files/clothes-washer-location.xml'].include? hpxml_file
-    hpxml_data[:clothes_washer][:location] = "garage"
+    hpxml.clothes_washer.location = "garage"
   elsif ['invalid_files/clothes-washer-location-other.xml'].include? hpxml_file
-    hpxml_data[:clothes_washer][:location] = "other"
+    hpxml.clothes_washer.location = "other"
   end
 end
 
-def set_hpxml_data_clothes_dryer_values(hpxml_file, hpxml_data)
+def set_hpxml_clothes_dryer(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer] = { :id => "ClothesDryer",
-                                   :location => "living space",
-                                   :fuel_type => "electricity",
-                                   :energy_factor => 2.95,
-                                   :control_type => "timer" }
+    hpxml.clothes_dryer = HPXML::ClothesDryer.new({ :id => "ClothesDryer",
+                                                    :location => "living space",
+                                                    :fuel_type => "electricity",
+                                                    :energy_factor => 2.95,
+                                                    :control_type => "timer" })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer] = {}
+    hpxml.clothes_dryer = nil
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer] = { :id => "ClothesDryer",
-                                   :location => "living space",
-                                   :fuel_type => "electricity",
-                                   :combined_energy_factor => 2.62,
-                                   :control_type => "moisture" }
+    hpxml.clothes_dryer = HPXML::ClothesDryer.new({ :id => "ClothesDryer",
+                                                    :location => "living space",
+                                                    :fuel_type => "electricity",
+                                                    :combined_energy_factor => 2.62,
+                                                    :control_type => "moisture" })
   elsif ['base-appliances-gas.xml',
          'base-appliances-propane.xml',
          'base-appliances-oil.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer] = { :id => "ClothesDryer",
-                                   :location => "living space",
-                                   :energy_factor => 2.67,
-                                   :control_type => "moisture" }
+    hpxml.clothes_dryer = HPXML::ClothesDryer.new({ :id => "ClothesDryer",
+                                                    :location => "living space",
+                                                    :energy_factor => 2.67,
+                                                    :control_type => "moisture" })
     if hpxml_file == 'base-appliances-gas.xml'
-      hpxml_data[:clothes_dryer][:fuel_type] = "natural gas"
+      hpxml.clothes_dryer.fuel_type = "natural gas"
     elsif hpxml_file == 'base-appliances-propane.xml'
-      hpxml_data[:clothes_dryer][:fuel_type] = "propane"
+      hpxml.clothes_dryer.fuel_type = "propane"
     elsif hpxml_file == 'base-appliances-oil.xml'
-      hpxml_data[:clothes_dryer][:fuel_type] = "fuel oil"
+      hpxml.clothes_dryer.fuel_type = "fuel oil"
     end
   elsif ['base-appliances-wood.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer] = { :id => "ClothesDryer",
-                                   :location => "living space",
-                                   :fuel_type => "wood",
-                                   :energy_factor => 2.67,
-                                   :control_type => "moisture" }
+    hpxml.clothes_dryer = HPXML::ClothesDryer.new({ :id => "ClothesDryer",
+                                                    :location => "living space",
+                                                    :fuel_type => "wood",
+                                                    :energy_factor => 2.67,
+                                                    :control_type => "moisture" })
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer][:location] = "basement - unconditioned"
+    hpxml.clothes_dryer.location = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer][:location] = "basement - conditioned"
+    hpxml.clothes_dryer.location = "basement - conditioned"
   elsif ['base-enclosure-garage.xml',
          'invalid_files/clothes-dryer-location.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer][:location] = "garage"
+    hpxml.clothes_dryer.location = "garage"
   elsif ['invalid_files/clothes-dryer-location-other.xml'].include? hpxml_file
-    hpxml_data[:clothes_dryer][:location] = "other"
+    hpxml.clothes_dryer.location = "other"
   end
 end
 
-def set_hpxml_data_dishwasher_values(hpxml_file, hpxml_data)
+def set_hpxml_dishwasher(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:dishwasher] = { :id => "Dishwasher",
-                                :rated_annual_kwh => 450,
-                                :place_setting_capacity => 12 }
+    hpxml.dishwasher = HPXML::Dishwasher.new({ :id => "Dishwasher",
+                                               :rated_annual_kwh => 450,
+                                               :place_setting_capacity => 12 })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml_data[:dishwasher] = {}
+    hpxml.dishwasher = nil
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    hpxml_data[:dishwasher] = { :id => "Dishwasher",
-                                :energy_factor => 0.5,
-                                :place_setting_capacity => 12 }
+    hpxml.dishwasher = HPXML::Dishwasher.new({ :id => "Dishwasher",
+                                               :energy_factor => 0.5,
+                                               :place_setting_capacity => 12 })
   end
 end
 
-def set_hpxml_data_refrigerator_values(hpxml_file, hpxml_data)
+def set_hpxml_refrigerator(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:refrigerator] = { :id => "Refrigerator",
-                                  :location => "living space",
-                                  :rated_annual_kwh => 650 }
+    hpxml.refrigerator = HPXML::Refrigerator.new({ :id => "Refrigerator",
+                                                   :location => "living space",
+                                                   :rated_annual_kwh => 650 })
   elsif ['base-appliances-modified.xml'].include? hpxml_file
-    hpxml_data[:refrigerator][:adjusted_annual_kwh] = 600
+    hpxml.refrigerator.adjusted_annual_kwh = 600
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml_data[:refrigerator] = {}
+    hpxml.refrigerator = nil
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
-    hpxml_data[:refrigerator][:location] = "basement - unconditioned"
+    hpxml.refrigerator.location = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
-    hpxml_data[:refrigerator][:location] = "basement - conditioned"
+    hpxml.refrigerator.location = "basement - conditioned"
   elsif ['base-enclosure-garage.xml',
          'invalid_files/refrigerator-location.xml'].include? hpxml_file
-    hpxml_data[:refrigerator][:location] = "garage"
+    hpxml.refrigerator.location = "garage"
   elsif ['invalid_files/refrigerator-location-other.xml'].include? hpxml_file
-    hpxml_data[:refrigerator][:location] = "other"
+    hpxml.refrigerator.location = "other"
   end
 end
 
-def set_hpxml_data_cooking_range_values(hpxml_file, hpxml_data)
+def set_hpxml_cooking_range(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:cooking_range] = { :id => "Range",
-                                   :fuel_type => "electricity",
-                                   :is_induction => false }
+    hpxml.cooking_range = HPXML::CookingRange.new({ :id => "Range",
+                                                    :fuel_type => "electricity",
+                                                    :is_induction => false })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml_data[:cooking_range] = {}
+    hpxml.cooking_range = nil
   elsif ['base-appliances-gas.xml'].include? hpxml_file
-    hpxml_data[:cooking_range][:fuel_type] = "natural gas"
-    hpxml_data[:cooking_range][:is_induction] = false
+    hpxml.cooking_range.fuel_type = "natural gas"
+    hpxml.cooking_range.is_induction = false
   elsif ['base-appliances-propane.xml'].include? hpxml_file
-    hpxml_data[:cooking_range][:fuel_type] = "propane"
-    hpxml_data[:cooking_range][:is_induction] = false
+    hpxml.cooking_range.fuel_type = "propane"
+    hpxml.cooking_range.is_induction = false
   elsif ['base-appliances-oil.xml'].include? hpxml_file
-    hpxml_data[:cooking_range][:fuel_type] = "fuel oil"
+    hpxml.cooking_range.fuel_type = "fuel oil"
   elsif ['base-appliances-wood.xml'].include? hpxml_file
-    hpxml_data[:cooking_range][:fuel_type] = "wood"
-    hpxml_data[:cooking_range][:is_induction] = false
+    hpxml.cooking_range.fuel_type = "wood"
+    hpxml.cooking_range.is_induction = false
   end
 end
 
-def set_hpxml_data_oven_values(hpxml_file, hpxml_data)
+def set_hpxml_oven(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:oven] = { :id => "Oven",
-                          :is_convection => false }
+    hpxml.oven = HPXML::Oven.new({ :id => "Oven",
+                                   :is_convection => false })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml_data[:oven] = {}
+    hpxml.oven = nil
   end
 end
 
-def set_hpxml_data_lighting_values(hpxml_file, hpxml_data)
+def set_hpxml_lighting(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:lighting] = { :fraction_tier_i_interior => 0.5,
-                              :fraction_tier_i_exterior => 0.5,
-                              :fraction_tier_i_garage => 0.5,
-                              :fraction_tier_ii_interior => 0.25,
-                              :fraction_tier_ii_exterior => 0.25,
-                              :fraction_tier_ii_garage => 0.25 }
+    hpxml.lighting = HPXML::Lighting.new({ :fraction_tier_i_interior => 0.5,
+                                           :fraction_tier_i_exterior => 0.5,
+                                           :fraction_tier_i_garage => 0.5,
+                                           :fraction_tier_ii_interior => 0.25,
+                                           :fraction_tier_ii_exterior => 0.25,
+                                           :fraction_tier_ii_garage => 0.25 })
   elsif ['base-misc-lighting-none.xml'].include? hpxml_file
-    hpxml_data[:lighting] = {}
+    hpxml.lighting = nil
   end
 end
 
-def set_hpxml_data_ceiling_fans_values(hpxml_file, hpxml_data)
+def set_hpxml_ceiling_fans(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:ceiling_fans] = []
+    hpxml.ceiling_fans = []
   elsif ['base-misc-ceiling-fans.xml'].include? hpxml_file
-    hpxml_data[:ceiling_fans] << { :id => "CeilingFan",
-                                   :efficiency => 100,
-                                   :quantity => 2 }
+    hpxml.ceiling_fans << HPXML::CeilingFan.new({ :id => "CeilingFan",
+                                                  :efficiency => 100,
+                                                  :quantity => 2 })
   end
 end
 
-def set_hpxml_data_plug_loads_values(hpxml_file, hpxml_data)
+def set_hpxml_plug_loads(hpxml_file, hpxml)
   if ['base-misc-loads-detailed.xml'].include? hpxml_file
-    hpxml_data[:plug_loads] = [{ :id => "PlugLoadMisc",
-                                 :plug_load_type => "other",
-                                 :kWh_per_year => 7302,
-                                 :frac_sensible => 0.82,
-                                 :frac_latent => 0.18 },
-                               { :id => "PlugLoadMisc2",
-                                 :plug_load_type => "TV other",
-                                 :kWh_per_year => 400 }]
+    hpxml.plug_loads = [HPXML::PlugLoad.new({ :id => "PlugLoadMisc",
+                                              :plug_load_type => "other",
+                                              :kWh_per_year => 7302,
+                                              :frac_sensible => 0.82,
+                                              :frac_latent => 0.18 }),
+                        HPXML::PlugLoad.new({ :id => "PlugLoadMisc2",
+                                              :plug_load_type => "TV other",
+                                              :kWh_per_year => 400 })]
   else
-    hpxml_data[:plug_loads] = [{ :id => "PlugLoadMisc",
-                                 :plug_load_type => "other" },
-                               { :id => "PlugLoadMisc2",
-                                 :plug_load_type => "TV other" }]
+    hpxml.plug_loads = [HPXML::PlugLoad.new({ :id => "PlugLoadMisc",
+                                              :plug_load_type => "other" }),
+                        HPXML::PlugLoad.new({ :id => "PlugLoadMisc2",
+                                              :plug_load_type => "TV other" })]
   end
 end
 
-def set_hpxml_data_misc_load_schedule_values(hpxml_file, hpxml_data)
+def set_hpxml_misc_load_schedule(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
-    hpxml_data[:misc_load_schedule] = {}
+    hpxml.misc_load_schedule = nil
   elsif ['base-misc-loads-detailed.xml'].include? hpxml_file
-    hpxml_data[:misc_load_schedule] = { :weekday_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
-                                        :weekend_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
-                                        :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0" }
+    hpxml.misc_load_schedule = HPXML::MiscLoads.new({ :weekday_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
+                                                      :weekend_fractions => "0.020, 0.020, 0.020, 0.020, 0.020, 0.034, 0.043, 0.085, 0.050, 0.030, 0.030, 0.041, 0.030, 0.025, 0.026, 0.026, 0.039, 0.042, 0.045, 0.070, 0.070, 0.073, 0.073, 0.066",
+                                                      :monthly_multipliers => "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0" })
   end
 end
 

--- a/tasks.rb
+++ b/tasks.rb
@@ -2085,7 +2085,7 @@ def set_hpxml_hvac_control(hpxml_file, hpxml)
                              :heating_setpoint_temp => 68,
                              :cooling_setpoint_temp => 78 })
   elsif ['base-hvac-none.xml'].include? hpxml_file
-    hpxml.set_hvac_control({})
+    hpxml.set_hvac_control(nil)
   elsif ['base-hvac-programmable-thermostat.xml'].include? hpxml_file
     hpxml.hvac_control.control_type = "programmable thermostat"
     hpxml.hvac_control.heating_setback_temp = 66
@@ -2687,7 +2687,7 @@ def set_hpxml_hot_water_distribution(hpxml_file, hpxml)
     hpxml.hot_water_distribution.recirculation_branch_piping_length = 50
     hpxml.hot_water_distribution.recirculation_pump_power = 50
   elsif ['base-dhw-none.xml'].include? hpxml_file
-    hpxml.set_hot_water_distribution({})
+    hpxml.set_hot_water_distribution(nil)
   end
 end
 
@@ -2816,7 +2816,7 @@ def set_hpxml_clothes_washer(hpxml_file, hpxml)
                                :label_annual_gas_cost => 25.0,
                                :capacity => 3.0 })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_clothes_washer({})
+    hpxml.set_clothes_washer(nil)
   elsif ['base-appliances-modified.xml'].include? hpxml_file
     hpxml.clothes_washer.modified_energy_factor = nil
     hpxml.clothes_washer.integrated_modified_energy_factor = 0.73
@@ -2840,7 +2840,7 @@ def set_hpxml_clothes_dryer(hpxml_file, hpxml)
                               :energy_factor => 2.95,
                               :control_type => "timer" })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_clothes_dryer({})
+    hpxml.set_clothes_dryer(nil)
   elsif ['base-appliances-modified.xml'].include? hpxml_file
     hpxml.set_clothes_dryer({ :id => "ClothesDryer",
                               :location => "living space",
@@ -2885,7 +2885,7 @@ def set_hpxml_dishwasher(hpxml_file, hpxml)
                            :rated_annual_kwh => 450,
                            :place_setting_capacity => 12 })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_dishwasher({})
+    hpxml.set_dishwasher(nil)
   elsif ['base-appliances-modified.xml'].include? hpxml_file
     hpxml.set_dishwasher({ :id => "Dishwasher",
                            :energy_factor => 0.5,
@@ -2901,7 +2901,7 @@ def set_hpxml_refrigerator(hpxml_file, hpxml)
   elsif ['base-appliances-modified.xml'].include? hpxml_file
     hpxml.refrigerator.adjusted_annual_kwh = 600
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_refrigerator({})
+    hpxml.set_refrigerator(nil)
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     hpxml.refrigerator.location = "basement - unconditioned"
   elsif ['base-atticroof-conditioned.xml'].include? hpxml_file
@@ -2920,7 +2920,7 @@ def set_hpxml_cooking_range(hpxml_file, hpxml)
                               :fuel_type => "electricity",
                               :is_induction => false })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_cooking_range({})
+    hpxml.set_cooking_range(nil)
   elsif ['base-appliances-gas.xml'].include? hpxml_file
     hpxml.cooking_range.fuel_type = "natural gas"
     hpxml.cooking_range.is_induction = false
@@ -2940,7 +2940,7 @@ def set_hpxml_oven(hpxml_file, hpxml)
     hpxml.set_oven({ :id => "Oven",
                      :is_convection => false })
   elsif ['base-appliances-none.xml'].include? hpxml_file
-    hpxml.set_oven({})
+    hpxml.set_oven(nil)
   end
 end
 
@@ -2953,7 +2953,7 @@ def set_hpxml_lighting(hpxml_file, hpxml)
                          :fraction_tier_ii_exterior => 0.25,
                          :fraction_tier_ii_garage => 0.25 })
   elsif ['base-misc-lighting-none.xml'].include? hpxml_file
-    hpxml.set_lighting({})
+    hpxml.set_lighting(nil)
   end
 end
 
@@ -3067,14 +3067,14 @@ if ARGV[0].to_sym == :update_measures
   ENV['HOMEDRIVE'] = 'C:\\' if !ENV['HOMEDRIVE'].nil? and ENV['HOMEDRIVE'].start_with? 'U:'
 
   # Apply rubocop
-  #command = "rubocop --auto-correct --format simple --only Layout"
-  #puts "Applying rubocop style to measures..."
-  #system(command)
+  command = "rubocop --auto-correct --format simple --only Layout"
+  puts "Applying rubocop style to measures..."
+  system(command)
 
   # Update measures XMLs
-  #command = "#{OpenStudio.getOpenStudioCLI} measure -t '#{File.dirname(__FILE__)}'"
-  #puts "Updating measure.xmls..."
-  #system(command, [:out, :err] => File::NULL)
+  command = "#{OpenStudio.getOpenStudioCLI} measure -t '#{File.dirname(__FILE__)}'"
+  puts "Updating measure.xmls..."
+  system(command, [:out, :err] => File::NULL)
 
   create_hpxmls
 

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -848,7 +848,7 @@ class HPXMLTest < MiniTest::Test
         query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Exterior Fenestration' AND RowName='#{subsurface_id}' AND ColumnName='Tilt' AND Units='deg'"
         sql_value = sqlFile.execAndReturnFirstDouble(query).get
         assert_in_epsilon(90.0, sql_value, 0.01)
-      elsif subsurface[:roof_idref].nil?
+      elsif not subsurface[:roof_idref].nil?
         hpxml_value = nil
         hpxml.roofs.each do |roof|
           next if roof[:id] != subsurface[:roof_idref]
@@ -961,7 +961,7 @@ class HPXMLTest < MiniTest::Test
         hp_cap_clg *= 1.20 # TODO: Generalize this
         hp_cap_htg *= 1.20 # TODO: Generalize this
       end
-      supp_hp_cap = heat_pump[:backup_heating_capacity]
+      supp_hp_cap = heat_pump[:backup_heating_capacity].to_f
       if hp_cap_clg > 0
         clg_cap = 0 if clg_cap.nil?
         clg_cap += hp_cap_clg

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -159,9 +159,7 @@ class HPXMLTest < MiniTest::Test
                             'unattached-window.xml' => ["Attached wall 'foobar' not found for window 'WindowNorth'."],
                             'water-heater-location.xml' => ["WaterHeatingSystem location is 'crawlspace - vented' but building does not have this location specified."],
                             'water-heater-location-other.xml' => ["Expected [1] element(s) but found 0 element(s) for xpath: /HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem[Location="],
-                            'mismatched-slab-and-foundation-wall.xml' => ["Foundation wall 'FoundationWall' is adjacent to 'basement - conditioned' but no corresponding slab was found adjacent to",
-                                                                          "Foundation wall 'FoundationWall2' is adjacent to 'garage' but no corresponding slab was found adjacent to",
-                                                                          "Slab 'Slab' is adjacent to 'basement - unconditioned' but no corresponding foundation walls were found adjacent to"] }
+                            'mismatched-slab-and-foundation-wall.xml' => ["Foundation wall 'FoundationWall' is adjacent to 'basement - conditioned' but no corresponding slab was found adjacent to"] }
 
     # Test simulations
     Dir["#{sample_files_dir}/invalid_files/*.xml"].sort.each do |xml|
@@ -976,7 +974,7 @@ class HPXMLTest < MiniTest::Test
         htg_cap = 0 if htg_cap.nil?
         htg_cap += supp_hp_cap
       end
-      if heat_pump[:cooling_efficiency_seer] > 15
+      if heat_pump[:cooling_efficiency_seer].to_f > 15
         has_multispeed_dx_heating_coil = true
       end
       if hp_type == "ground-to-air"

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -886,7 +886,7 @@ class HPXMLTest < MiniTest::Test
     end
 
     # HVAC Heating Systems
-    
+
     num_htg_sys = hpxml.heating_systems.size
     hpxml.heating_systems.each do |heating_system|
       htg_sys_type = heating_system.heating_system_type
@@ -1124,7 +1124,6 @@ class HPXMLTest < MiniTest::Test
         sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, "m^3/s", "cfm")
         assert_in_delta(hpxml_value, sql_value, 0.01)
       end
-
     end
 
     # Clothes Washer

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -3,8 +3,6 @@ require 'openstudio'
 require 'openstudio/ruleset/ShowRunnerOutput'
 require 'minitest/autorun'
 require 'fileutils'
-require 'rexml/document'
-require 'rexml/xpath'
 require_relative '../../HPXMLtoOpenStudio/measure.rb'
 require_relative '../../HPXMLtoOpenStudio/resources/constants'
 require_relative '../../HPXMLtoOpenStudio/resources/meta_measure'
@@ -636,28 +634,26 @@ class HPXMLTest < MiniTest::Test
     assert(File.exists? sql_path)
 
     sqlFile = OpenStudio::SqlFile.new(sql_path, false)
-    hpxml_doc = REXML::Document.new(File.read(hpxml_path))
+    hpxml = HPXML.new(hpxml_path: hpxml_path)
+    hpxml.collapse_enclosure()
 
     # Timestep
-    timestep = hpxml_doc.elements['/HPXML/SoftwareInfo/extension/SimulationControl/Timestep']
+    timestep = hpxml.header[:timestep]
     if timestep.nil?
       timestep = 60
-    else
-      timestep = Integer(timestep.text)
     end
     query = "SELECT NumTimestepsPerHour FROM Simulations"
     sql_value = sqlFile.execAndReturnFirstDouble(query).get
     assert_equal(60 / timestep, sql_value)
 
-    bldg_details = hpxml_doc.elements['/HPXML/Building/BuildingDetails']
-    
     # Conditioned Floor Area
-    sum_hvac_load_frac = (bldg_details.elements['sum(Systems/HVAC/HVACPlant/CoolingSystem/FractionCoolLoadServed)'] +
-                          bldg_details.elements['sum(Systems/HVAC/HVACPlant/HeatingSystem/FractionHeatLoadServed)'] +
-                          bldg_details.elements['sum(Systems/HVAC/HVACPlant/HeatPump/FractionCoolLoadServed)'] +
-                          bldg_details.elements['sum(Systems/HVAC/HVACPlant/HeatPump/FractionHeatLoadServed)'])
+    sum_hvac_load_frac = 0.0
+    (hpxml.heating_systems + hpxml.cooling_systems + hpxml.heat_pumps).each do |hvac_system_values|
+      sum_hvac_load_frac += hvac_system_values[:fraction_heat_load_served].to_f
+      sum_hvac_load_frac += hvac_system_values[:fraction_cool_load_served].to_f
+    end
     if sum_hvac_load_frac > 0 # EnergyPlus will only report conditioned floor area if there is an HVAC system
-      hpxml_value = Float(XMLHelper.get_value(bldg_details, 'BuildingSummary/BuildingConstruction/ConditionedFloorArea'))
+      hpxml_value = hpxml.building_construction[:conditioned_floor_area]
       query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='InputVerificationandResultsSummary' AND ReportForString='Entire Facility' AND TableName='Zone Summary' AND RowName='Conditioned Total' AND ColumnName='Area' AND Units='m2'"
       sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'm^2', 'ft^2')
       # Subtract duct return plenum conditioned floor area
@@ -666,45 +662,42 @@ class HPXMLTest < MiniTest::Test
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
     end
 
-    enclosure = bldg_details.elements["Enclosure"]
-    HPXML.collapse_enclosure(enclosure)
-
     # Enclosure Roofs
-    enclosure.elements.each('Roofs/Roof') do |roof|
-      roof_id = roof.elements["SystemIdentifier"].attributes["id"].upcase
+    hpxml.roofs.each do |roof|
+      roof_id = roof[:id].upcase
 
       # R-value
-      hpxml_value = Float(XMLHelper.get_value(roof, 'Insulation/AssemblyEffectiveRValue'))
+      hpxml_value = roof[:insulation_assembly_r_value]
       query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{roof_id}' OR RowName LIKE '#{roof_id}:%') AND ColumnName='U-Factor with Film' AND Units='W/m2-K'"
       sql_value = 1.0 / UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'W/(m^2*K)', 'Btu/(hr*ft^2*F)')
       assert_in_epsilon(hpxml_value, sql_value, 0.1) # TODO: Higher due to outside air film?
 
       # Net area
-      hpxml_value = Float(XMLHelper.get_value(roof, 'Area'))
-      enclosure.elements.each('Skylights/Skylight') do |subsurface|
-        next if subsurface.elements["AttachedToRoof"].attributes["idref"].upcase != roof_id
+      hpxml_value = roof[:area]
+      hpxml.skylights.each do |subsurface|
+        next if subsurface[:roof_idref].upcase != roof_id
 
-        hpxml_value -= Float(XMLHelper.get_value(subsurface, 'Area'))
+        hpxml_value -= subsurface[:area]
       end
       query = "SELECT SUM(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{roof_id}' OR RowName LIKE '#{roof_id}:%') AND ColumnName='Net Area' AND Units='m2'"
       sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'm^2', 'ft^2')
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
 
       # Solar absorptance
-      hpxml_value = Float(XMLHelper.get_value(roof, 'SolarAbsorptance'))
+      hpxml_value = roof[:solar_absorptance]
       query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{roof_id}' OR RowName LIKE '#{roof_id}:%') AND ColumnName='Reflectance'"
       sql_value = 1.0 - sqlFile.execAndReturnFirstDouble(query).get
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
 
       # Tilt
-      hpxml_value = UnitConversions.convert(Math.atan(Float(XMLHelper.get_value(roof, "Pitch")) / 12.0), "rad", "deg")
+      hpxml_value = UnitConversions.convert(Math.atan(roof[:pitch] / 12.0), "rad", "deg")
       query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{roof_id}' OR RowName LIKE '#{roof_id}:%') AND ColumnName='Tilt' AND Units='deg'"
       sql_value = sqlFile.execAndReturnFirstDouble(query).get
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
 
       # Azimuth
-      if XMLHelper.has_element(roof, 'Azimuth') and Float(XMLHelper.get_value(roof, "Pitch")) > 0
-        hpxml_value = Float(XMLHelper.get_value(roof, 'Azimuth'))
+      if not roof[:azimuth].nil? and Float(roof[:pitch]) > 0
+        hpxml_value = roof[:azimuth]
         query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{roof_id}' OR RowName LIKE '#{roof_id}:%') AND ColumnName='Azimuth' AND Units='deg'"
         sql_value = sqlFile.execAndReturnFirstDouble(query).get
         assert_in_epsilon(hpxml_value, sql_value, 0.01)
@@ -738,13 +731,13 @@ class HPXMLTest < MiniTest::Test
     end
 
     # Enclosure Foundation Slabs
-    num_slabs = enclosure.elements['count(Slabs/Slab)']
+    num_slabs = hpxml.slabs.size
     if num_slabs <= 1 and num_kiva_instances <= 1 # The slab surfaces may be combined in these situations, so skip tests
-      enclosure.elements.each('Slabs/Slab') do |slab|
-        slab_id = slab.elements["SystemIdentifier"].attributes["id"].upcase
+      hpxml.slabs.each do |slab|
+        slab_id = slab[:id].upcase
 
         # Exposed Area
-        hpxml_value = Float(XMLHelper.get_value(slab, 'Area'))
+        hpxml_value = Float(slab[:area])
         query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND RowName='#{slab_id}' AND ColumnName='Gross Area' AND Units='m2'"
         sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'm^2', 'ft^2')
         assert_in_epsilon(hpxml_value, sql_value, 0.01)
@@ -757,39 +750,41 @@ class HPXMLTest < MiniTest::Test
     end
 
     # Enclosure Walls/RimJoists/FoundationWalls
-    enclosure.elements.each('Walls/Wall[ExteriorAdjacentTo="outside"] | RimJoists/RimJoist[ExteriorAdjacentTo="outside"] | FoundationWalls/FoundationWall[ExteriorAdjacentTo="ground"]') do |wall|
-      wall_id = wall.elements["SystemIdentifier"].attributes["id"].upcase
+    (hpxml.walls + hpxml.rim_joists + hpxml.foundation_walls).each do |wall|
+      next unless ['outside', 'ground'].include? wall[:exterior_adjacent_to]
+      wall_id = wall[:id].upcase
 
       # R-value
-      if XMLHelper.has_element(wall, 'Insulation/AssemblyEffectiveRValue') and not hpxml_path.include? "base-foundation-unconditioned-basement-assembly-r.xml" # This file uses Foundation:Kiva for insulation, so skip it
-        hpxml_value = Float(XMLHelper.get_value(wall, 'Insulation/AssemblyEffectiveRValue'))
+      if not wall[:insulation_assembly_r_value].nil? and not hpxml_path.include? "base-foundation-unconditioned-basement-assembly-r.xml" # This file uses Foundation:Kiva for insulation, so skip it
+        hpxml_value = wall[:insulation_assembly_r_value]
         query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{wall_id}' OR RowName LIKE '#{wall_id}:%') AND ColumnName='U-Factor with Film' AND Units='W/m2-K'"
         sql_value = 1.0 / UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'W/(m^2*K)', 'Btu/(hr*ft^2*F)')
         assert_in_epsilon(hpxml_value, sql_value, 0.03)
       end
 
       # Net area
-      hpxml_value = Float(XMLHelper.get_value(wall, 'Area'))
-      enclosure.elements.each('Windows/Window | Doors/Door') do |subsurface|
-        next if subsurface.elements["AttachedToWall"].attributes["idref"].upcase != wall_id
+      hpxml_value = wall[:area]
+      (hpxml.windows + hpxml.doors).each do |subsurface|
+        next if subsurface[:wall_idref].upcase != wall_id
 
-        hpxml_value -= Float(XMLHelper.get_value(subsurface, 'Area'))
+        hpxml_value -= subsurface[:area]
       end
-      if XMLHelper.get_value(wall, "ExteriorAdjacentTo") == "ground"
+      if wall[:exterior_adjacent_to] == "ground"
         # Calculate total length of walls
         wall_total_length = 0
-        enclosure.elements.each('FoundationWalls/FoundationWall[ExteriorAdjacentTo="ground"]') do |fwall|
-          next unless XMLHelper.get_value(wall, "InteriorAdjacentTo") == XMLHelper.get_value(fwall, "InteriorAdjacentTo")
+        hpxml.foundation_walls.each do |foundation_wall|
+          next unless foundation_wall[:exterior_adjacent_to] == 'ground'
+          next unless wall[:interior_adjacent_to] == foundation_wall[:interior_adjacent_to]
 
-          wall_total_length += Float(XMLHelper.get_value(fwall, "Area")) / Float(XMLHelper.get_value(fwall, "Height"))
+          wall_total_length += foundation_wall[:area] / foundation_wall[:height]
         end
 
         # Calculate total slab exposed perimeter
         slab_exposed_length = 0
-        enclosure.elements.each('Slabs/Slab') do |slab|
-          next unless XMLHelper.get_value(wall, "InteriorAdjacentTo") == XMLHelper.get_value(slab, "InteriorAdjacentTo")
+        hpxml.slabs.each do |slab|
+          next unless wall[:interior_adjacent_to] == slab[:interior_adjacent_to]
 
-          slab_exposed_length += Float(XMLHelper.get_value(slab, "ExposedPerimeter"))
+          slab_exposed_length += slab[:exposed_perimeter]
         end
 
         # Calculate exposed foundation wall area
@@ -802,8 +797,8 @@ class HPXMLTest < MiniTest::Test
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
 
       # Solar absorptance
-      if XMLHelper.has_element(wall, 'SolarAbsorptance')
-        hpxml_value = Float(XMLHelper.get_value(wall, 'SolarAbsorptance'))
+      if not wall[:solar_absorptance].nil?
+        hpxml_value = wall[:solar_absorptance]
         query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{wall_id}' OR RowName LIKE '#{wall_id}:%') AND ColumnName='Reflectance'"
         sql_value = 1.0 - sqlFile.execAndReturnFirstDouble(query).get
         assert_in_epsilon(hpxml_value, sql_value, 0.01)
@@ -815,8 +810,8 @@ class HPXMLTest < MiniTest::Test
       assert_in_epsilon(90.0, sql_value, 0.01)
 
       # Azimuth
-      if XMLHelper.has_element(wall, 'Azimuth')
-        hpxml_value = Float(XMLHelper.get_value(wall, 'Azimuth'))
+      if not wall[:azimuth].nil?
+        hpxml_value = wall[:azimuth]
         query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Opaque Exterior' AND (RowName='#{wall_id}' OR RowName LIKE '#{wall_id}:%') AND ColumnName='Azimuth' AND Units='deg'"
         sql_value = sqlFile.execAndReturnFirstDouble(query).get
         assert_in_epsilon(hpxml_value, sql_value, 0.01)
@@ -826,17 +821,17 @@ class HPXMLTest < MiniTest::Test
     # TODO: Enclosure FrameFloors
 
     # Enclosure Windows/Skylights
-    enclosure.elements.each('Windows/Window | Skylights/Skylight') do |subsurface|
-      subsurface_id = subsurface.elements["SystemIdentifier"].attributes["id"].upcase
+    (hpxml.windows + hpxml.skylights).each do |subsurface|
+      subsurface_id = subsurface[:id].upcase
 
       # Area
-      hpxml_value = Float(XMLHelper.get_value(subsurface, 'Area'))
+      hpxml_value = subsurface[:area]
       query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Exterior Fenestration' AND RowName='#{subsurface_id}' AND ColumnName='Area of Multiplied Openings' AND Units='m2'"
       sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'm^2', 'ft^2')
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
 
       # U-Factor
-      hpxml_value = Float(XMLHelper.get_value(subsurface, 'UFactor'))
+      hpxml_value = subsurface[:ufactor]
       query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Exterior Fenestration' AND RowName='#{subsurface_id}' AND ColumnName='Glass U-Factor' AND Units='W/m2-K'"
       sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'W/(m^2*K)', 'Btu/(hr*ft^2*F)')
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
@@ -845,22 +840,22 @@ class HPXMLTest < MiniTest::Test
       # TODO: Affected by interior shading
 
       # Azimuth
-      hpxml_value = Float(XMLHelper.get_value(subsurface, 'Azimuth'))
+      hpxml_value = subsurface[:azimuth]
       query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Exterior Fenestration' AND RowName='#{subsurface_id}' AND ColumnName='Azimuth' AND Units='deg'"
       sql_value = sqlFile.execAndReturnFirstDouble(query).get
       assert_in_epsilon(hpxml_value, sql_value, 0.01)
 
       # Tilt
-      if XMLHelper.has_element(subsurface, "AttachedToWall")
+      if not subsurface[:wall_idref].nil?
         query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Exterior Fenestration' AND RowName='#{subsurface_id}' AND ColumnName='Tilt' AND Units='deg'"
         sql_value = sqlFile.execAndReturnFirstDouble(query).get
         assert_in_epsilon(90.0, sql_value, 0.01)
-      elsif XMLHelper.has_element(subsurface, "AttachedToRoof")
+      elsif subsurface[:roof_idref].nil?
         hpxml_value = nil
-        enclosure.elements.each('Roofs/Roof') do |roof|
-          next if roof.elements["SystemIdentifier"].attributes["id"] != subsurface.elements["AttachedToRoof"].attributes["idref"]
+        hpxml.roofs.each do |roof|
+          next if roof[:id] != subsurface[:roof_idref]
 
-          hpxml_value = UnitConversions.convert(Math.atan(Float(XMLHelper.get_value(roof, "Pitch")) / 12.0), "rad", "deg")
+          hpxml_value = UnitConversions.convert(Math.atan(roof[:pitch] / 12.0), "rad", "deg")
         end
         query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Exterior Fenestration' AND RowName='#{subsurface_id}' AND ColumnName='Tilt' AND Units='deg'"
         sql_value = sqlFile.execAndReturnFirstDouble(query).get
@@ -871,22 +866,20 @@ class HPXMLTest < MiniTest::Test
     end
 
     # Enclosure Doors
-    enclosure.elements.each('Doors/Door') do |door|
-      door_id = door.elements["SystemIdentifier"].attributes["id"].upcase
+    hpxml.doors.each do |door|
+      door_id = door[:id].upcase
 
       # Area
-      door_area = XMLHelper.get_value(door, 'Area')
-      if not door_area.nil?
-        hpxml_value = Float(door_area)
+      if not door[:area].nil?
+        hpxml_value = door[:area]
         query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Exterior Door' AND RowName='#{door_id}' AND ColumnName='Gross Area' AND Units='m2'"
         sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'm^2', 'ft^2')
         assert_in_epsilon(hpxml_value, sql_value, 0.01)
       end
 
       # R-Value
-      door_rvalue = XMLHelper.get_value(door, 'RValue')
-      if not door_rvalue.nil?
-        hpxml_value = Float(door_rvalue)
+      if not door[:r_value].nil?
+        hpxml_value = door[:r_value]
         query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EnvelopeSummary' AND ReportForString='Entire Facility' AND TableName='Exterior Door' AND RowName='#{door_id}' AND ColumnName='U-Factor with Film' AND Units='W/m2-K'"
         sql_value = 1.0 / UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'W/(m^2*K)', 'Btu/(hr*ft^2*F)')
         assert_in_epsilon(hpxml_value, sql_value, 0.02)
@@ -894,27 +887,27 @@ class HPXMLTest < MiniTest::Test
     end
 
     # HVAC Heating Systems
-    num_htg_sys = bldg_details.elements['count(Systems/HVAC/HVACPlant/HeatingSystem)']
-    bldg_details.elements.each('Systems/HVAC/HVACPlant/HeatingSystem') do |htg_sys|
-      htg_sys_type = XMLHelper.get_child_name(htg_sys, 'HeatingSystemType')
-      htg_sys_fuel = XMLHelper.get_value(htg_sys, 'HeatingSystemFuel')
-      htg_load_frac = Float(XMLHelper.get_value(htg_sys, "FractionHeatLoadServed"))
+    
+    num_htg_sys = hpxml.heating_systems.size
+    hpxml.heating_systems.each do |heating_system|
+      htg_sys_type = heating_system[:heating_system_type]
+      htg_sys_fuel = heating_system[:heating_system_fuel]
+      htg_load_frac = heating_system[:fraction_heat_load_served]
 
       if htg_load_frac > 0
 
         # Electric Auxiliary Energy
         # For now, skip if multiple equipment
         if num_htg_sys == 1 and ['Furnace', 'Boiler', 'WallFurnace', 'Stove'].include? htg_sys_type and htg_sys_fuel != 'electricity'
-          if XMLHelper.has_element(htg_sys, 'ElectricAuxiliaryEnergy')
-            hpxml_value = Float(XMLHelper.get_value(htg_sys, 'ElectricAuxiliaryEnergy')) / 2.08
+          if not heating_system[:electric_auxiliary_energy].nil?
+            hpxml_value = heating_system[:electric_auxiliary_energy] / 2.08
           else
             furnace_capacity_kbtuh = nil
             if htg_sys_type == 'Furnace'
               query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EquipmentSummary' AND ReportForString='Entire Facility' AND TableName='Heating Coils' AND RowName LIKE '%#{Constants.ObjectNameFurnace.upcase}%' AND ColumnName='Nominal Total Capacity' AND Units='W'"
               furnace_capacity_kbtuh = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'W', 'kBtu/hr')
             end
-            frac_load_served = Float(XMLHelper.get_value(htg_sys, "FractionHeatLoadServed"))
-            hpxml_value = HVAC.get_default_eae(htg_sys_type, htg_sys_fuel, frac_load_served, furnace_capacity_kbtuh) / 2.08
+            hpxml_value = HVAC.get_default_eae(htg_sys_type, htg_sys_fuel, htg_load_frac, furnace_capacity_kbtuh) / 2.08
           end
 
           if htg_sys_type == 'Boiler'
@@ -948,29 +941,29 @@ class HPXMLTest < MiniTest::Test
     clg_cap = nil
     has_multispeed_dx_heating_coil = false # FIXME: Remove this when https://github.com/NREL/EnergyPlus/issues/7381 is fixed
     has_gshp_coil = false # FIXME: Remove this when https://github.com/NREL/EnergyPlus/issues/7381 is fixed
-    bldg_details.elements.each('Systems/HVAC/HVACPlant/HeatingSystem') do |htg_sys|
-      htg_sys_cap = Float(XMLHelper.get_value(htg_sys, "HeatingCapacity"))
+    hpxml.heating_systems.each do |heating_system|
+      htg_sys_cap = heating_system[:heating_capacity]
       if htg_sys_cap > 0
         htg_cap = 0 if htg_cap.nil?
         htg_cap += htg_sys_cap
       end
     end
-    bldg_details.elements.each('Systems/HVAC/HVACPlant/CoolingSystem') do |clg_sys|
-      clg_sys_cap = XMLHelper.get_value(clg_sys, "CoolingCapacity")
+    hpxml.cooling_systems.each do |cooling_system|
+      clg_sys_cap = cooling_system[:cooling_capacity]
       if not clg_sys_cap.nil? and Float(clg_sys_cap) > 0
         clg_cap = 0 if clg_cap.nil?
         clg_cap += Float(clg_sys_cap)
       end
     end
-    bldg_details.elements.each('Systems/HVAC/HVACPlant/HeatPump') do |hp|
-      hp_type = XMLHelper.get_value(hp, "HeatPumpType")
-      hp_cap_clg = Float(XMLHelper.get_value(hp, "CoolingCapacity"))
-      hp_cap_htg = Float(XMLHelper.get_value(hp, "HeatingCapacity"))
+    hpxml.heat_pumps.each do |heat_pump|
+      hp_type = heat_pump[:heat_pump_type]
+      hp_cap_clg = heat_pump[:cooling_capacity]
+      hp_cap_htg = heat_pump[:heating_capacity]
       if hp_type == "mini-split"
         hp_cap_clg *= 1.20 # TODO: Generalize this
         hp_cap_htg *= 1.20 # TODO: Generalize this
       end
-      supp_hp_cap = XMLHelper.get_value(hp, "BackupHeatingCapacity").to_f
+      supp_hp_cap = heat_pump[:backup_heating_capacity]
       if hp_cap_clg > 0
         clg_cap = 0 if clg_cap.nil?
         clg_cap += hp_cap_clg
@@ -983,7 +976,7 @@ class HPXMLTest < MiniTest::Test
         htg_cap = 0 if htg_cap.nil?
         htg_cap += supp_hp_cap
       end
-      if XMLHelper.get_value(hp, "AnnualCoolingEfficiency[Units='SEER']/Value").to_f > 15
+      if heat_pump[:cooling_efficiency_seer] > 15
         has_multispeed_dx_heating_coil = true
       end
       if hp_type == "ground-to-air"
@@ -1014,15 +1007,9 @@ class HPXMLTest < MiniTest::Test
     # HVAC Load Fractions
     htg_load_frac = 0.0
     clg_load_frac = 0.0
-    bldg_details.elements.each('Systems/HVAC/HVACPlant/HeatingSystem') do |htg_sys|
-      htg_load_frac += Float(XMLHelper.get_value(htg_sys, "FractionHeatLoadServed"))
-    end
-    bldg_details.elements.each('Systems/HVAC/HVACPlant/CoolingSystem') do |clg_sys|
-      clg_load_frac += Float(XMLHelper.get_value(clg_sys, "FractionCoolLoadServed"))
-    end
-    bldg_details.elements.each('Systems/HVAC/HVACPlant/HeatPump') do |hp|
-      htg_load_frac += Float(XMLHelper.get_value(hp, "FractionHeatLoadServed"))
-      clg_load_frac += Float(XMLHelper.get_value(hp, "FractionCoolLoadServed"))
+    (hpxml.heating_systems + hpxml.cooling_systems + hpxml.heat_pumps).each do |hvac_system|
+      htg_load_frac += hvac_system[:fraction_heat_load_served].to_f
+      clg_load_frac += hvac_system[:fraction_cool_load_served].to_f
     end
     if htg_load_frac == 0
       found_htg_energy = false
@@ -1044,8 +1031,7 @@ class HPXMLTest < MiniTest::Test
     end
 
     # Water Heater
-    wh = bldg_details.elements["Systems/WaterHeating/WaterHeatingSystem"]
-    if not wh.nil?
+    if hpxml.water_heating_systems.size > 0
       # EC_adj, compare calculated value to value obtained from simulation results
       calculated_ec_adj = nil
       runner.result.stepInfo.each do |s|
@@ -1097,18 +1083,19 @@ class HPXMLTest < MiniTest::Test
     end
 
     # Mechanical Ventilation
-    mv = bldg_details.elements["Systems/MechanicalVentilation/VentilationFans/VentilationFan[UsedForWholeBuildingVentilation='true']"]
-    if not mv.nil?
+    hpxml.ventilation_fans.each do |ventilation_fan|
+      next unless ventilation_fan[:used_for_whole_building_ventilation]
+
       mv_energy = 0.0
       results.keys.each do |k|
         next if k[0] != 'Electricity' or k[1] != 'Interior Equipment' or not k[2].start_with? Constants.ObjectNameMechanicalVentilation
 
         mv_energy = results[k]
       end
-      if XMLHelper.has_element(mv, "AttachedToHVACDistributionSystem")
+      fan_w = ventilation_fan[:fan_power]
+      hrs_per_day = ventilation_fan[:hours_in_operation]
+      if not ventilation_fan[:distribution_system_idref].nil?
         # CFIS, check for positive mech vent energy that is less than the energy if it had run 24/7
-        fan_w = Float(XMLHelper.get_value(mv, "FanPower"))
-        hrs_per_day = Float(XMLHelper.get_value(mv, "HoursInOperation"))
         fan_kwhs = UnitConversions.convert(fan_w * hrs_per_day * 365.0, 'Wh', 'GJ')
         if fan_kwhs > 0
           assert_operator(mv_energy, :>, 0)
@@ -1118,22 +1105,20 @@ class HPXMLTest < MiniTest::Test
         end
       else
         # Supply, exhaust, ERV, HRV, etc., check for appropriate mech vent energy
-        fan_w = Float(XMLHelper.get_value(mv, "FanPower"))
-        hrs_per_day = Float(XMLHelper.get_value(mv, "HoursInOperation"))
         fan_kwhs = UnitConversions.convert(fan_w * hrs_per_day * 365.0, 'Wh', 'GJ')
         assert_in_delta(mv_energy, fan_kwhs, 0.1)
       end
 
       # CFIS
-      if XMLHelper.get_value(mv, "FanType") == 'central fan integrated supply'
+      if ventilation_fan[:fan_type] == 'central fan integrated supply'
         # Fan power
-        hpxml_value = Float(XMLHelper.get_value(mv, "FanPower"))
+        hpxml_value = fan_w
         query = "SELECT Value FROM ReportData WHERE ReportDataDictionaryIndex IN (SELECT ReportDataDictionaryIndex FROM ReportDataDictionary WHERE Name='#{@cfis_fan_power_output_var.variableName}' AND ReportingFrequency='Run Period')"
         sql_value = sqlFile.execAndReturnFirstDouble(query).get
         assert_in_delta(hpxml_value, sql_value, 0.01)
 
         # Flow rate
-        hpxml_value = Float(XMLHelper.get_value(mv, "TestedFlowRate")) * Float(XMLHelper.get_value(mv, "HoursInOperation")) / 24.0
+        hpxml_value = ventilation_fan[:tested_flow_rate] * hrs_per_day / 24.0
         query = "SELECT Value FROM ReportData WHERE ReportDataDictionaryIndex IN (SELECT ReportDataDictionaryIndex FROM ReportDataDictionary WHERE Name='#{@cfis_flow_rate_output_var.variableName}' AND ReportingFrequency='Run Period')"
         sql_value = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, "m^3/s", "cfm")
         assert_in_delta(hpxml_value, sql_value, 0.01)
@@ -1142,10 +1127,9 @@ class HPXMLTest < MiniTest::Test
     end
 
     # Clothes Washer
-    cw = bldg_details.elements["Appliances/ClothesWasher"]
-    if not cw.nil? and not wh.nil?
+    if not hpxml.clothes_washer.empty? and hpxml.water_heating_systems.size > 0
       # Location
-      hpxml_value = XMLHelper.get_value(cw, "Location")
+      hpxml_value = hpxml.clothes_washer[:location]
       if hpxml_value.nil? or hpxml_value == 'basement - conditioned'
         hpxml_value = 'living space'
       end
@@ -1156,10 +1140,9 @@ class HPXMLTest < MiniTest::Test
     end
 
     # Clothes Dryer
-    cd = bldg_details.elements["Appliances/ClothesDryer"]
-    if not cd.nil? and not wh.nil?
+    if not hpxml.clothes_dryer.empty? and hpxml.water_heating_systems.size > 0
       # Location
-      hpxml_value = XMLHelper.get_value(cd, "Location")
+      hpxml_value = hpxml.clothes_dryer[:location]
       if hpxml_value.nil? or hpxml_value == 'basement - conditioned'
         hpxml_value = 'living space'
       end
@@ -1170,10 +1153,9 @@ class HPXMLTest < MiniTest::Test
     end
 
     # Refrigerator
-    refr = bldg_details.elements["Appliances/Refrigerator"]
-    if not refr.nil?
+    if not hpxml.refrigerator.empty? and hpxml.water_heating_systems.size > 0
       # Location
-      hpxml_value = XMLHelper.get_value(refr, "Location")
+      hpxml_value = hpxml.refrigerator[:location]
       if hpxml_value.nil? or hpxml_value == 'basement - conditioned'
         hpxml_value = 'living space'
       end
@@ -1190,31 +1172,42 @@ class HPXMLTest < MiniTest::Test
 
       found_ltg_energy = true
     end
-    assert_equal(bldg_details.elements["Lighting"].nil?, !found_ltg_energy)
+    assert_equal(!hpxml.lighting.empty?, found_ltg_energy)
+
+    # Get fuels
+    htg_fuels = []
+    hpxml.heating_systems.each do |heating_system|
+      htg_fuels << heating_system[:heating_system_fuel]
+    end
+    hpxml.heat_pumps.each do |heat_pump|
+      htg_fuels << heat_pump[:backup_heating_fuel]
+    end
+    wh_fuels = []
+    hpxml.water_heating_systems.each do |water_heating_system|
+      wh_fuels << water_heating_system[:fuel_type]
+    end
 
     # Natural Gas check
     ng_htg = results.fetch(["Natural Gas", "Heating", "General", "GJ"], 0) + results.fetch(["Natural Gas", "Heating", "Other", "GJ"], 0)
     ng_dhw = results.fetch(["Natural Gas", "Water Systems", "General", "GJ"], 0)
     ng_cd = results.fetch(["Natural Gas", "Interior Equipment", "clothes dryer", "GJ"], 0)
     ng_cr = results.fetch(["Natural Gas", "Interior Equipment", "cooking range", "GJ"], 0)
-    if not hpxml_path.include? "location-miami" and
-       (not bldg_details.elements["Systems/HVAC/HVACPlant/HeatingSystem[HeatingSystemFuel='natural gas']"].nil? or
-       not bldg_details.elements["Systems/HVAC/HVACPlant/HeatPump[BackupSystemFuel='natural gas']"].nil?)
+    if not hpxml_path.include? "location-miami" and htg_fuels.include? 'natural gas'
       assert_operator(ng_htg, :>, 0)
     else
       assert_equal(ng_htg, 0)
     end
-    if not bldg_details.elements["Systems/WaterHeating/WaterHeatingSystem[FuelType='natural gas']"].nil?
+    if wh_fuels.include? 'natural gas'
       assert_operator(ng_dhw, :>, 0)
     else
       assert_equal(ng_dhw, 0)
     end
-    if not bldg_details.elements["Appliances/ClothesDryer[FuelType='natural gas']"].nil?
+    if not hpxml.clothes_dryer.empty? and hpxml.clothes_dryer[:fuel_type] == 'natural gas'
       assert_operator(ng_cd, :>, 0)
     else
       assert_equal(ng_cd, 0)
     end
-    if not bldg_details.elements["Appliances/CookingRange[FuelType='natural gas']"].nil?
+    if not hpxml.cooking_range.empty? and hpxml.cooking_range[:fuel_type] == 'natural gas'
       assert_operator(ng_cr, :>, 0)
     else
       assert_equal(ng_cr, 0)
@@ -1225,24 +1218,22 @@ class HPXMLTest < MiniTest::Test
     af_dhw = results.fetch(["Additional Fuel", "Water Systems", "General", "GJ"], 0)
     af_cd = results.fetch(["Additional Fuel", "Interior Equipment", "clothes dryer", "GJ"], 0)
     af_cr = results.fetch(["Additional Fuel", "Interior Equipment", "cooking range", "GJ"], 0)
-    if not hpxml_path.include? "location-miami" and
-       (not bldg_details.elements["Systems/HVAC/HVACPlant/HeatingSystem[HeatingSystemFuel='fuel oil' or HeatingSystemFuel='propane' or HeatingSystemFuel='wood']"].nil? or
-       not bldg_details.elements["Systems/HVAC/HVACPlant/HeatPump[BackupSystemFuel='fuel oil' or BackupSystemFuel='propane' or BackupSystemFuel='wood']"].nil?)
+    if not hpxml_path.include? "location-miami" and (htg_fuels.include? 'fuel oil' or htg_fuels.include? 'propane' or htg_fuels.include? 'wood')
       assert_operator(af_htg, :>, 0)
     else
       assert_equal(af_htg, 0)
     end
-    if not bldg_details.elements["Systems/WaterHeating/WaterHeatingSystem[FuelType='fuel oil' or FuelType='propane' or FuelType='wood']"].nil?
+    if wh_fuels.include? 'fuel oil' or wh_fuels.include? 'propane' or wh_fuels.include? 'wood'
       assert_operator(af_dhw, :>, 0)
     else
       assert_equal(af_dhw, 0)
     end
-    if not bldg_details.elements["Appliances/ClothesDryer[FuelType='fuel oil' or FuelType='propane' or FuelType='wood']"].nil?
+    if not hpxml.clothes_dryer.empty? and ['fuel oil', 'propane', 'wood'].include? hpxml.clothes_dryer[:fuel_type]
       assert_operator(af_cd, :>, 0)
     else
       assert_equal(af_cd, 0)
     end
-    if not bldg_details.elements["Appliances/CookingRange[FuelType='fuel oil' or FuelType='propane' or FuelType='wood']"].nil?
+    if not hpxml.cooking_range.empty? and ['fuel oil', 'propane', 'wood'].include? hpxml.cooking_range[:fuel_type]
       assert_operator(af_cr, :>, 0)
     else
       assert_equal(af_cr, 0)


### PR DESCRIPTION
Major refactor of HPXML class to make it more OO. This has several benefits:
1. Helps to reduce bugs/errors (particularly when accessing keys not in a hash).
2. Provides some performance improvements.
3. Provides a simpler path to switching to another XML library like nokogiri. REXML is now only used inside hpxml.rb.
4. Eliminates the need to call add_foo methods in the right order (previously needed to ensure the HPXML file is structured correctly).