### PR TITLE
Remove partition surfaces

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f25ccd4e-3c3c-4693-aac7-31e61dccc84c</version_id>
-  <version_modified>20200318T115752Z</version_modified>
+  <version_id>7fd64933-98cb-4da5-a176-7234796b6d78</version_id>
+  <version_modified>20200319T170756Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -445,12 +445,6 @@
       <checksum>3F0E6E4D</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1713CC86</checksum>
-    </file>
-    <file>
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -466,6 +460,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>1AABBC00</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>9FFDA182</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7fd64933-98cb-4da5-a176-7234796b6d78</version_id>
-  <version_modified>20200319T170756Z</version_modified>
+  <version_id>d0e2bc86-91f6-4439-9d72-7d78e7e14bdf</version_id>
+  <version_modified>20200319T171715Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -465,7 +465,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>9FFDA182</checksum>
+      <checksum>BE0A4900</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1693,6 +1693,10 @@ class HPXML < Object
       return (is_exterior && is_thermal_boundary)
     end
 
+    def delete
+      @hpxml_object.windows.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -1791,6 +1795,10 @@ class HPXML < Object
       return (is_exterior && is_thermal_boundary)
     end
 
+    def delete
+      @hpxml_object.skylights.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -1870,6 +1878,10 @@ class HPXML < Object
       return (is_exterior && is_thermal_boundary)
     end
 
+    def delete
+      @hpxml_object.doors.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -1917,6 +1929,10 @@ class HPXML < Object
              :heating_efficiency_percent, :fraction_heat_load_served, :electric_auxiliary_energy,
              :heating_cfm, :energy_star, :seed_id]
     attr_accessor(*ATTRS)
+
+    def delete
+      @hpxml_object.heating_systems.delete(self)
+    end
 
     def to_rexml(doc)
       return if nil?
@@ -1997,6 +2013,10 @@ class HPXML < Object
              :cooling_efficiency_seer, :cooling_efficiency_eer, :cooling_shr, :cooling_cfm,
              :energy_star, :seed_id]
     attr_accessor(*ATTRS)
+
+    def delete
+      @hpxml_object.cooling_systems.delete(self)
+    end
 
     def to_rexml(doc)
       return if nil?
@@ -2079,6 +2099,10 @@ class HPXML < Object
              :cooling_efficiency_seer, :cooling_efficiency_eer, :heating_efficiency_hspf,
              :heating_efficiency_cop, :energy_star, :seed_id]
     attr_accessor(*ATTRS)
+
+    def delete
+      @hpxml_object.heat_pumps.delete(self)
+    end
 
     def to_rexml(doc)
       return if nil?
@@ -2195,6 +2219,10 @@ class HPXML < Object
              :ceiling_fan_cooling_setpoint_temp_offset]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.hvac_controls.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -2266,6 +2294,10 @@ class HPXML < Object
         list << hvac_system
       end
       return list
+    end
+
+    def delete
+      @hpxml_object.hvac_distributions.delete(self)
     end
 
     def to_rexml(doc)
@@ -2427,6 +2459,10 @@ class HPXML < Object
       fail "Attached HVAC distribution system '#{@distribution_system_idref}' not found for mechanical ventilation '#{@id}'."
     end
 
+    def delete
+      @hpxml_object.ventilation_fans.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -2498,6 +2534,10 @@ class HPXML < Object
         return hvac_system
       end
       fail "Attached HVAC system '#{@related_hvac_idref}' not found for water heating system '#{@id}'."
+    end
+
+    def delete
+      @hpxml_object.water_heating_systems.delete(self)
     end
 
     def to_rexml(doc)
@@ -2576,6 +2616,10 @@ class HPXML < Object
              :dwhr_efficiency]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.hot_water_distributions.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -2645,6 +2689,10 @@ class HPXML < Object
     ATTRS = [:id, :water_fixture_type, :low_flow]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.water_fixtures.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -2692,6 +2740,10 @@ class HPXML < Object
         return water_heater
       end
       fail "Attached water heating system '#{@water_heating_system_idref}' not found for solar thermal system '#{@id}'."
+    end
+
+    def delete
+      @hpxml_object.solar_thermal_systems.delete(self)
     end
 
     def to_rexml(doc)
@@ -2755,6 +2807,10 @@ class HPXML < Object
              :year_modules_manufactured]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.pv_systems.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -2810,6 +2866,10 @@ class HPXML < Object
              :capacity]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.clothes_washers.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -2860,6 +2920,10 @@ class HPXML < Object
     ATTRS = [:id, :location, :fuel_type, :energy_factor, :combined_energy_factor, :control_type]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.clothes_dryers.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -2904,6 +2968,10 @@ class HPXML < Object
     ATTRS = [:id, :energy_factor, :rated_annual_kwh, :place_setting_capacity]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.dishwashers.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -2943,6 +3011,10 @@ class HPXML < Object
   class Refrigerator < BaseElement
     ATTRS = [:id, :location, :rated_annual_kwh, :adjusted_annual_kwh]
     attr_accessor(*ATTRS)
+
+    def delete
+      @hpxml_object.refrigerators.delete(self)
+    end
 
     def to_rexml(doc)
       return if nil?
@@ -2985,6 +3057,10 @@ class HPXML < Object
     ATTRS = [:id, :fuel_type, :is_induction]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.cooking_ranges.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -3023,6 +3099,10 @@ class HPXML < Object
     ATTRS = [:id, :is_convection]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.ovens.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -3058,6 +3138,10 @@ class HPXML < Object
   class LightingGroup < BaseElement
     ATTRS = [:id, :location, :fration_of_units_in_location, :third_party_certification]
     attr_accessor(*ATTRS)
+
+    def delete
+      @hpxml_object.lighting_groups.delete(self)
+    end
 
     def to_rexml(doc)
       return if nil?
@@ -3099,6 +3183,10 @@ class HPXML < Object
     ATTRS = [:id, :efficiency, :quantity]
     attr_accessor(*ATTRS)
 
+    def delete
+      @hpxml_object.ceiling_fans.delete(self)
+    end
+
     def to_rexml(doc)
       return if nil?
 
@@ -3138,6 +3226,10 @@ class HPXML < Object
   class PlugLoad < BaseElement
     ATTRS = [:id, :plug_load_type, :kWh_per_year, :frac_sensible, :frac_latent]
     attr_accessor(*ATTRS)
+
+    def delete
+      @hpxml_object.plug_loads.delete(self)
+    end
 
     def to_rexml(doc)
       return if nil?


### PR DESCRIPTION
## Pull Request Description

Automatically remove partition surfaces (defined as `interior_adjacent_to` == `exterior_adjacent_to`) during creation of the HPXML object, unless disabled. We don't expect these kinds of surfaces to be defined anyway (and EPvalidator restricts them for the living space.)

Also adds `delete()` helper methods for many HPXML objects.

## Checklist

Not all may apply:

- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
