### PR TITLE
Refactors defaults

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -55,14 +55,15 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue('weather')
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument.makeStringArgument('epw_output_path', false)
-    arg.setDisplayName('EPW Output File Path')
-    arg.setDescription('Absolute/relative path of the output EPW file.')
+    arg = OpenStudio::Measure::OSArgument.makeStringArgument('output_path', true)
+    arg.setDisplayName('Path for Output Files')
+    arg.setDescription('Absolute/relative path for the output files.')
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument.makeStringArgument('osm_output_path', false)
-    arg.setDisplayName('OSM Output File Path')
-    arg.setDescription('Absolute/relative path of the output OSM file.')
+    arg = OpenStudio::Measure::OSArgument.makeBoolArgument('debug', false)
+    arg.setDisplayName('Debug Mode?')
+    arg.setDescription('If enabled: 1) Writes in.osm file, 2) Writes in.xml HPXML file with defaults filled, and 3) Generates additional log output. Any files written will be in the output path specified above.')
+    arg.setDefaultValue(false)
     args << arg
 
     return args
@@ -86,15 +87,18 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     # assign the user inputs to variables
     hpxml_path = runner.getStringArgumentValue('hpxml_path', user_arguments)
     weather_dir = runner.getStringArgumentValue('weather_dir', user_arguments)
-    epw_output_path = runner.getOptionalStringArgumentValue('epw_output_path', user_arguments)
-    osm_output_path = runner.getOptionalStringArgumentValue('osm_output_path', user_arguments)
-    debug = osm_output_path.is_initialized
+    output_path = runner.getStringArgumentValue('output_path', user_arguments)
+    debug = runner.getBoolArgumentValue('debug', user_arguments)
 
     unless (Pathname.new hpxml_path).absolute?
       hpxml_path = File.expand_path(File.join(File.dirname(__FILE__), hpxml_path))
     end
     unless File.exist?(hpxml_path) && hpxml_path.downcase.end_with?('.xml')
       fail "'#{hpxml_path}' does not exist or is not an .xml file."
+    end
+
+    unless (Pathname.new output_path).absolute?
+      output_path = File.expand_path(File.join(File.dirname(__FILE__), output_path))
     end
 
     model.getBuilding.additionalProperties.setFeature('hpxml_path', hpxml_path)
@@ -143,24 +147,25 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
           weather.dump_to_csv(file)
         end
       end
-      if epw_output_path.is_initialized
-        FileUtils.cp(epw_path, epw_output_path.get)
-      end
+      epw_output_path = File.join(output_path, 'in.epw')
+      FileUtils.cp(epw_path, epw_output_path)
+      runner.registerInfo("Copied EPW to: #{epw_output_path}")
 
       # Apply Location to obtain weather data
       weather = Location.apply(model, runner, epw_path, cache_path, 'NA', 'NA')
 
       # Create OpenStudio model
-      OSModel.create(hpxml, runner, model, weather, hpxml_path, debug)
+      OSModel.create(hpxml, runner, model, weather, hpxml_path, output_path, debug)
     rescue Exception => e
       # Report exception
       runner.registerError("#{e.message}\n#{e.backtrace.join("\n")}")
       return false
     end
 
-    if osm_output_path.is_initialized
-      File.write(osm_output_path.get, model.to_s)
-      runner.registerInfo("Wrote file: #{osm_output_path.get}")
+    if debug
+      osm_output_path = File.join(output_path, 'in.osm')
+      File.write(osm_output_path, model.to_s)
+      runner.registerInfo("Wrote file: #{osm_output_path}")
     end
 
     return true
@@ -196,48 +201,18 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
 end
 
 class OSModel
-  def self.create(hpxml, runner, model, weather, hpxml_path, debug)
+  def self.create(hpxml, runner, model, weather, hpxml_path, output_path, debug)
     @hpxml = hpxml
     @hpxml_path = hpxml_path
+    @output_path = output_path
     @debug = debug
 
     @eri_version = @hpxml.header.eri_calculation_version # Hidden feature
     @eri_version = 'latest' if @eri_version.nil?
     @eri_version = Constants.ERIVersions[-1] if @eri_version == 'latest'
 
-    # Global variables
-    @cfa = @hpxml.building_construction.conditioned_floor_area
-    @cfa_ag = @cfa
-    @hpxml.slabs.each do |slab|
-      next unless slab.interior_adjacent_to == HPXML::LocationBasementConditioned
-
-      @cfa_ag -= slab.area
-    end
-    @gfa = 0 # garage floor area
-    @hpxml.slabs.each do |slab|
-      next unless slab.interior_adjacent_to == HPXML::LocationGarage
-
-      @gfa += slab.area
-    end
-    @infilvolume = get_infiltration_volume()
-    @ncfl = @hpxml.building_construction.number_of_conditioned_floors
-    @ncfl_ag = @hpxml.building_construction.number_of_conditioned_floors_above_grade
-    @nbeds = @hpxml.building_construction.number_of_bedrooms
-    @has_uncond_bsmnt = @hpxml.has_space_type(HPXML::LocationBasementUnconditioned)
-    @has_vented_attic = @hpxml.has_space_type(HPXML::LocationAtticVented)
-    @has_vented_crawl = @hpxml.has_space_type(HPXML::LocationCrawlspaceVented)
-    @min_neighbor_distance = get_min_neighbor_distance()
-    @default_azimuths = get_default_azimuths()
-    @frac_window_area_operable = get_frac_window_area_operable()
-    @cond_bsmnt_surfaces = [] # list of surfaces in conditioned basement, used for modification of some surface properties, eg. solar absorptance, view factor, etc.
-
-    @hvac_map = {} # mapping between HPXML HVAC systems and model objects
-    @dhw_map = {}  # mapping between HPXML Water Heating systems and model objects
-
-    @use_only_ideal_air = false
-    if not @hpxml.building_construction.use_only_ideal_air_system.nil?
-      @use_only_ideal_air = @hpxml.building_construction.use_only_ideal_air_system
-    end
+    set_globals(runner)
+    set_defaults(runner)
 
     # Simulation parameters
 
@@ -252,9 +227,6 @@ class OSModel
     add_num_occupants(model, hpxml, runner)
 
     # HVAC
-
-    @total_frac_remaining_heat_load_served = 1.0
-    @total_frac_remaining_cool_load_served = 1.0
 
     add_cooling_system(runner, model)
     add_heating_system(runner, model)
@@ -283,14 +255,190 @@ class OSModel
 
   private
 
+  def self.set_globals(runner)
+    # Global variables
+    @cfa = @hpxml.building_construction.conditioned_floor_area
+    @cfa_ag = @cfa
+    @hpxml.slabs.each do |slab|
+      next unless slab.interior_adjacent_to == HPXML::LocationBasementConditioned
+
+      @cfa_ag -= slab.area
+    end
+    @gfa = 0 # garage floor area
+    @hpxml.slabs.each do |slab|
+      next unless slab.interior_adjacent_to == HPXML::LocationGarage
+
+      @gfa += slab.area
+    end
+    @infilvolume = get_infiltration_volume()
+    @ncfl = @hpxml.building_construction.number_of_conditioned_floors
+    @ncfl_ag = @hpxml.building_construction.number_of_conditioned_floors_above_grade
+    @nbeds = @hpxml.building_construction.number_of_bedrooms
+    @has_uncond_bsmnt = @hpxml.has_space_type(HPXML::LocationBasementUnconditioned)
+    @has_vented_attic = @hpxml.has_space_type(HPXML::LocationAtticVented)
+    @has_vented_crawl = @hpxml.has_space_type(HPXML::LocationCrawlspaceVented)
+    @min_neighbor_distance = get_min_neighbor_distance()
+    @default_azimuths = get_default_azimuths()
+    @frac_window_area_operable = @hpxml.fraction_of_window_area_operable(Airflow.get_default_fraction_of_operable_window_area)
+    @cond_bsmnt_surfaces = [] # list of surfaces in conditioned basement, used for modification of some surface properties, eg. solar absorptance, view factor, etc.
+
+    @hvac_map = {} # mapping between HPXML HVAC systems and model objects
+    @dhw_map = {}  # mapping between HPXML Water Heating systems and model objects
+
+    @use_only_ideal_air = false
+    if not @hpxml.building_construction.use_only_ideal_air_system.nil?
+      @use_only_ideal_air = @hpxml.building_construction.use_only_ideal_air_system
+    end
+
+    @total_frac_remaining_heat_load_served = 1.0
+    @total_frac_remaining_cool_load_served = 1.0
+  end
+
+  def self.set_defaults(runner)
+    # Misc
+    # 1. Simulation timestep
+    # 2. Shelter coefficient
+    # 3. Number of occupants
+    @hpxml.header.timestep = 60 if @hpxml.header.timestep.nil?
+    @hpxml.site.shelter_coefficient = Airflow.get_default_shelter_coefficient() if @hpxml.site.shelter_coefficient.nil?
+    @hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(@nbeds) if @hpxml.building_occupancy.number_of_residents.nil?
+
+    # Envelope
+    # 1. Attic ventilation rate
+    # 2. Crawlspace ventilation rate
+    # TODO: Neighbor building height
+    # TODO: Infiltration volume
+    # TODO: Surface azimuths
+    if @has_vented_attic
+      @hpxml.attics.each do |attic|
+        next unless attic.attic_type == HPXML::AtticTypeVented
+        next unless (attic.vented_attic_sla.nil? && attic.vented_attic_constant_ach.nil?)
+
+        attic.vented_attic_sla = Airflow.get_default_vented_attic_sla()
+      end
+    end
+    if @has_vented_crawl
+      @hpxml.foundations.each do |foundation|
+        next unless foundation.foundation_type == HPXML::FoundationTypeCrawlspaceVented
+        next unless foundation.vented_crawlspace_sla.nil?
+
+        foundation.vented_crawlspace_sla = Airflow.get_default_vented_crawl_sla()
+      end
+    end
+
+    # Windows
+    # 1. Interior shading coefficients
+    # TODO: Operable
+    default_shade_summer, default_shade_winter = Constructions.get_default_interior_shading_factors()
+    @hpxml.windows.each do |window|
+      if window.interior_shading_factor_summer.nil?
+        window.interior_shading_factor_summer = default_shade_summer
+      end
+      if window.interior_shading_factor_winter.nil?
+        window.interior_shading_factor_winter = default_shade_winter
+      end
+    end
+
+    # HVAC
+    # 1. Compressor Type
+    # 2. Sensible Heat Ratio
+    # TODO: HeatingCapacity17F
+    # TODO: Electric Auxiliary Energy (EAE)
+    @hpxml.cooling_systems.each do |cooling_system|
+      next unless cooling_system.cooling_system_type == HPXML::HVACTypeCentralAirConditioner
+      if cooling_system.compressor_type.nil?
+        cooling_system.compressor_type = HVAC.get_default_compressor_type(cooling_system.cooling_efficiency_seer)
+      end
+      if cooling_system.cooling_shr.nil?
+        if cooling_system.compressor_type == HPXML::HVACCompressorTypeSingleStage
+          cooling_system.cooling_shr = 0.73
+        elsif cooling_system.compressor_type == HPXML::HVACCompressorTypeTwoStage
+          cooling_system.cooling_shr = 0.73
+        elsif cooling_system.compressor_type == HPXML::HVACCompressorTypeVariableSpeed
+          cooling_system.cooling_shr = 0.78
+        end
+      end
+    end
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpAirToAir
+      if heat_pump.compressor_type.nil?
+        heat_pump.compressor_type = HVAC.get_default_compressor_type(heat_pump.cooling_efficiency_seer)
+      end
+    end
+
+    # Water heaters
+    # 1. Setpoint temperature
+    # 2. Tankless cycle derate (performance adjustment)
+    # TODO: Indirect water heater standby loss
+    @hpxml.water_heating_systems.each do |water_heating_system|
+      if water_heating_system.temperature.nil?
+        water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(@eri_version)
+      end
+      if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless) && water_heating_system.performance_adjustment.nil?
+        water_heating_system.performance_adjustment = Waterheater.get_tankless_cycling_derate()
+      end
+    end
+
+    # Ceiling fans
+    # 1. Efficiency
+    # 2. Quantity
+    if @hpxml.ceiling_fans.size > 0
+      ceiling_fan = @hpxml.ceiling_fans[0]
+      if ceiling_fan.efficiency.nil?
+        medium_cfm = 3000.0
+        ceiling_fan.efficiency = medium_cfm / HVAC.get_default_ceiling_fan_power()
+      end
+      if ceiling_fan.quantity.nil?
+        ceiling_fan.quantity = HVAC.get_default_ceiling_fan_quantity(@nbeds)
+      end
+    end
+
+    # Plug loads
+    @hpxml.plug_loads.each do |plug_load|
+      if plug_load.plug_load_type == HPXML::PlugLoadTypeOther
+        default_annual_kwh, default_sens_frac, default_lat_frac = MiscLoads.get_residual_mels_values(@cfa)
+        if plug_load.kWh_per_year.nil?
+          plug_load.kWh_per_year = default_annual_kwh
+        end
+        if plug_load.frac_sensible.nil?
+          plug_load.frac_sensible = default_sens_frac
+        end
+        if plug_load.frac_latent.nil?
+          plug_load.frac_latent = default_lat_frac
+        end
+      elsif plug_load.plug_load_type == HPXML::PlugLoadTypeTelevision
+        default_annual_kwh, default_sens_frac, default_lat_frac = MiscLoads.get_televisions_values(@cfa, @nbeds)
+        if plug_load.kWh_per_year.nil?
+          plug_load.kWh_per_year = default_annual_kwh
+        end
+      end
+    end
+
+    # Plug loads: Schedules
+    if @hpxml.misc_loads_schedule.weekday_fractions.nil?
+      @hpxml.misc_loads_schedule.weekday_fractions = '0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05'
+    end
+    if @hpxml.misc_loads_schedule.weekend_fractions.nil?
+      @hpxml.misc_loads_schedule.weekend_fractions = '0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05'
+    end
+    if @hpxml.misc_loads_schedule.monthly_multipliers.nil?
+      @hpxml.misc_loads_schedule.monthly_multipliers = '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248'
+    end
+
+    if @debug
+      # Write updated HPXML object to file
+      hpxml_defaults_path = File.join(@output_path, 'in.xml')
+      XMLHelper.write_file(@hpxml.to_rexml, hpxml_defaults_path)
+      runner.registerInfo("Wrote file: #{hpxml_defaults_path}")
+    end
+  end
+
   def self.add_simulation_params(model)
     sim = model.getSimulationControl
     sim.setRunSimulationforSizingPeriods(false)
 
-    timestep = @hpxml.header.timestep
-    timestep = 60 if timestep.nil?
     tstep = model.getTimestep
-    tstep.setNumberOfTimestepsPerHour(60 / timestep)
+    tstep.setNumberOfTimestepsPerHour(60 / @hpxml.header.timestep)
 
     shad = model.getShadowCalculation
     shad.setCalculationFrequency(20)
@@ -312,6 +460,17 @@ class OSModel
   def self.add_geometry_envelope(runner, model, weather)
     spaces = {}
     @foundation_top, @walls_top = get_foundation_and_walls_top()
+
+    # Since we've already obtained the fraction of operable window area, further
+    # collapse windows irrespective of their operable property. For example, if
+    # there are two identical windows that only otherwise differ based on their
+    # operable property, we will combine them so as to model a single window in
+    # EnergyPlus for reasons of speed. Also reset the operable property since it
+    # is now arbitrary and we don't want to accidentally use it.
+    @hpxml.collapse_enclosure_surfaces([:operable])
+    @hpxml.windows.each do |window|
+      window.operable = nil
+    end
 
     add_roofs(runner, model, spaces)
     add_walls(runner, model, spaces)
@@ -893,12 +1052,7 @@ class OSModel
 
   def self.add_num_occupants(model, hpxml, runner)
     # Occupants
-    num_occ = Geometry.get_occupancy_default_num(@nbeds)
-    if not @hpxml.building_occupancy.nil?
-      if not @hpxml.building_occupancy.number_of_residents.nil?
-        num_occ = @hpxml.building_occupancy.number_of_residents
-      end
-    end
+    num_occ = @hpxml.building_occupancy.number_of_residents
     if num_occ > 0
       occ_gain, hrs_per_day, sens_frac, lat_frac = Geometry.get_occupancy_default_values()
       weekday_sch = '1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 0.88310, 0.40861, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.29498, 0.55310, 0.89693, 0.89693, 0.89693, 1.00000, 1.00000, 1.00000'
@@ -947,24 +1101,6 @@ class OSModel
       azimuth -= 360
     end
     return azimuth
-  end
-
-  def self.get_frac_window_area_operable()
-    frac_window_area_operable = @hpxml.fraction_of_window_area_operable(Airflow.get_default_fraction_of_operable_window_area)
-
-    # Now that we have it, further collapse windows irrespective of their
-    # operable property. For example, if there are two identical windows that
-    # only otherwise differ based on their operable property, we will combine
-    # them so as to model a single window in EnergyPlus for reasons of speed.
-    @hpxml.collapse_enclosure_surfaces([:operable])
-
-    # Finally reset the operable property since it is now arbitrary and we
-    # don't want to accidentally use it.
-    @hpxml.windows.each do |window|
-      window.operable = nil
-    end
-
-    return frac_window_area_operable
   end
 
   def self.create_or_get_space(model, spaces, spacetype)
@@ -1738,19 +1874,8 @@ class OSModel
       end
 
       # Apply construction
-      default_shade_summer, default_shade_winter = Constructions.get_default_interior_shading_factors()
-      cool_shade_mult = default_shade_summer
-      if not window.interior_shading_factor_summer.nil?
-        cool_shade_mult = window.interior_shading_factor_summer
-      end
-      heat_shade_mult = default_shade_winter
-      if not window.interior_shading_factor_winter.nil?
-        heat_shade_mult = window.interior_shading_factor_winter
-      end
-      if cool_shade_mult > heat_shade_mult
-        fail "SummerShadingCoefficient (#{cool_shade_mult}) must be less than or equal to WinterShadingCoefficient (#{heat_shade_mult}) for window '#{window.id}'."
-      end
-
+      cool_shade_mult = window.interior_shading_factor_summer
+      heat_shade_mult = window.interior_shading_factor_winter
       Constructions.apply_window(model, [sub_surface],
                                  'WindowConstruction',
                                  weather, @clg_season_sch, window.ufactor, window.shgc,
@@ -1991,9 +2116,6 @@ class OSModel
         space = get_space_from_location(water_heating_system.location, 'WaterHeatingSystem', model, spaces)
         water_heater_spaces[sys_id] = space
         setpoint_temp = water_heating_system.temperature
-        if setpoint_temp.nil?
-          setpoint_temp = Waterheater.get_default_hot_water_temperature(@eri_version)
-        end
         avg_setpoint_temp += setpoint_temp * water_heating_system.fraction_dhw_load_served
         wh_type = water_heating_system.water_heater_type
         fuel = water_heating_system.fuel_type
@@ -2199,19 +2321,12 @@ class OSModel
 
         seer = cooling_system.cooling_efficiency_seer
         compressor_type = cooling_system.compressor_type
-        if compressor_type.nil?
-          compressor_type = HVAC.get_default_compressor_type(seer)
-        end
         crankcase_kw = 0.05 # From RESNET Publication No. 002-2017
         crankcase_temp = 50.0 # From RESNET Publication No. 002-2017
 
         if compressor_type == HPXML::HVACCompressorTypeSingleStage
 
-          if cooling_system.cooling_shr.nil?
-            shrs = [0.73]
-          else
-            shrs = [cooling_system.cooling_shr]
-          end
+          shrs = [cooling_system.cooling_shr]
           airflow_rate = cooling_system.cooling_cfm # Hidden feature; used only for HERS DSE test
           HVAC.apply_central_ac_1speed(model, runner, seer, shrs,
                                        crankcase_kw, crankcase_temp,
@@ -2220,12 +2335,8 @@ class OSModel
                                        @hvac_map, cooling_system.id)
         elsif compressor_type == HPXML::HVACCompressorTypeTwoStage
 
-          if cooling_system.cooling_shr.nil?
-            shrs = [0.71, 0.73]
-          else
-            # TODO: is the following assumption correct (revisit Dylan's data?)? OR should value from HPXML be used for both stages
-            shrs = [cooling_system.cooling_shr - 0.02, cooling_system.cooling_shr]
-          end
+          # TODO: is the following assumption correct (revisit Dylan's data?)? OR should value from HPXML be used for both stages
+          shrs = [cooling_system.cooling_shr - 0.02, cooling_system.cooling_shr]
           HVAC.apply_central_ac_2speed(model, runner, seer, shrs,
                                        crankcase_kw, crankcase_temp,
                                        cool_capacity_btuh, load_frac,
@@ -2233,12 +2344,8 @@ class OSModel
                                        @hvac_map, cooling_system.id)
         elsif compressor_type == HPXML::HVACCompressorTypeVariableSpeed
 
-          if cooling_system.cooling_shr.nil?
-            shrs = [0.87, 0.80, 0.79, 0.78]
-          else
-            var_sp_shr_mult = [1.115, 1.026, 1.013, 1.0]
-            shrs = var_sp_shr_mult.map { |m| cooling_system.cooling_shr * m }
-          end
+          var_sp_shr_mult = [1.115, 1.026, 1.013, 1.0]
+          shrs = var_sp_shr_mult.map { |m| cooling_system.cooling_shr * m }
           HVAC.apply_central_ac_4speed(model, runner, seer, shrs,
                                        crankcase_kw, crankcase_temp,
                                        cool_capacity_btuh, load_frac,
@@ -2445,12 +2552,7 @@ class OSModel
 
         seer = heat_pump.cooling_efficiency_seer
         hspf = heat_pump.heating_efficiency_hspf
-
         compressor_type = heat_pump.compressor_type
-        if compressor_type.nil?
-          compressor_type = HVAC.get_default_compressor_type(seer)
-        end
-
         crankcase_kw = 0.05 # From RESNET Publication No. 002-2017
         crankcase_temp = 50.0 # From RESNET Publication No. 002-2017
 
@@ -2747,34 +2849,11 @@ class OSModel
       next unless plug_load.plug_load_type == HPXML::PlugLoadTypeOther
 
       misc_annual_kwh = plug_load.kWh_per_year
-      if misc_annual_kwh.nil?
-        misc_annual_kwh = MiscLoads.get_residual_mels_values(@cfa)[0]
-      end
-
       misc_sens_frac = plug_load.frac_sensible
-      if misc_sens_frac.nil?
-        misc_sens_frac = MiscLoads.get_residual_mels_values(@cfa)[1]
-      end
-
       misc_lat_frac = plug_load.frac_latent
-      if misc_lat_frac.nil?
-        misc_lat_frac = MiscLoads.get_residual_mels_values(@cfa)[2]
-      end
-
       misc_weekday_sch = @hpxml.misc_loads_schedule.weekday_fractions
-      if misc_weekday_sch.nil?
-        misc_weekday_sch = '0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05'
-      end
-
       misc_weekend_sch = @hpxml.misc_loads_schedule.weekend_fractions
-      if misc_weekend_sch.nil?
-        misc_weekend_sch = '0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05'
-      end
-
       misc_monthly_sch = @hpxml.misc_loads_schedule.monthly_multipliers
-      if misc_monthly_sch.nil?
-        misc_monthly_sch = '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248'
-      end
     end
 
     # Television
@@ -2783,9 +2862,6 @@ class OSModel
       next unless plug_load.plug_load_type == HPXML::PlugLoadTypeTelevision
 
       tv_annual_kwh = plug_load.kWh_per_year
-      if tv_annual_kwh.nil?
-        tv_annual_kwh, tv_sens_frac, tv_lat_frac = MiscLoads.get_televisions_values(@cfa, @nbeds)
-      end
     end
 
     MiscLoads.apply_plug(model, misc_annual_kwh, misc_sens_frac, misc_lat_frac,
@@ -2815,8 +2891,6 @@ class OSModel
   end
 
   def self.add_airflow(runner, model, weather, spaces)
-    shelter_coef = @hpxml.site.shelter_coefficient
-
     # Infiltration
     infil_ach50 = nil
     infil_const_ach = nil
@@ -2835,13 +2909,9 @@ class OSModel
     if @has_vented_attic
       @hpxml.attics.each do |attic|
         next unless attic.attic_type == HPXML::AtticTypeVented
-        next if attic.vented_attic_sla.nil? && attic.vented_attic_constant_ach.nil? # skip additional attic elements
 
         vented_attic_sla = attic.vented_attic_sla
         vented_attic_const_ach = attic.vented_attic_constant_ach
-      end
-      if vented_attic_sla.nil? && vented_attic_const_ach.nil?
-        vented_attic_sla = Airflow.get_default_vented_attic_sla()
       end
     else
       vented_attic_sla = 0.0
@@ -2854,22 +2924,17 @@ class OSModel
 
         vented_crawl_sla = foundation.vented_crawlspace_sla
       end
-      if vented_crawl_sla.nil?
-        vented_crawl_sla = Airflow.get_default_vented_crawl_sla()
-      end
     else
       vented_crawl_sla = 0.0
     end
 
+    shelter_coef = @hpxml.site.shelter_coefficient
     living_ach50 = infil_ach50
     living_constant_ach = infil_const_ach
     garage_ach50 = infil_ach50
     unconditioned_basement_ach = 0.1
     unvented_crawl_sla = 0
     unvented_attic_sla = 0
-    if shelter_coef.nil?
-      shelter_coef = Airflow.get_default_shelter_coefficient()
-    end
     has_flue_chimney = false
     terrain = Constants.TerrainSuburban
     infil = Infiltration.new(living_ach50, living_constant_ach, shelter_coef, garage_ach50, vented_crawl_sla, unvented_crawl_sla,

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -255,6 +255,7 @@ class OSModel
   private
 
   def self.set_defaults_and_globals(runner)
+    # Set globals
     @cfa = @hpxml.building_construction.conditioned_floor_area
     @cfa_ag = @cfa
     @hpxml.slabs.each do |slab|
@@ -286,18 +287,12 @@ class OSModel
     @dhw_map = {}  # mapping between HPXML Water Heating systems and model objects
     @cond_bsmnt_surfaces = [] # list of surfaces in conditioned basement, used for modification of some surface properties, eg. solar absorptance, view factor, etc.
 
-    # Default Misc
-    # 1. Simulation timestep
-    # 2. Shelter coefficient
-    # 3. Number of occupants
+    # Default misc
     @hpxml.header.timestep = 60 if @hpxml.header.timestep.nil?
     @hpxml.site.shelter_coefficient = Airflow.get_default_shelter_coefficient() if @hpxml.site.shelter_coefficient.nil?
     @hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(@nbeds) if @hpxml.building_occupancy.number_of_residents.nil?
 
-    # Default Envelope
-    # 1. Attic ventilation rate
-    # 2. Crawlspace ventilation rate
-    # TODO: Infiltration volume
+    # Default attic/crawlspace ventilation rate
     if @hpxml.has_space_type(HPXML::LocationAtticVented)
       @hpxml.attics.each do |attic|
         next unless attic.attic_type == HPXML::AtticTypeVented
@@ -314,6 +309,8 @@ class OSModel
         foundation.vented_crawlspace_sla = Airflow.get_default_vented_crawl_sla()
       end
     end
+
+    # Default infiltration volume
     measurements = []
     infilvolume = nil
     @hpxml.air_infiltration_measurements.each do |measurement|
@@ -334,11 +331,8 @@ class OSModel
       @infilvolume = infilvolume
     end
 
-    # Default Windows
-    # 1. Interior shading coefficients
-    # 2. Fraction of operable area
+    # Default window interior shading
     default_shade_summer, default_shade_winter = Constructions.get_default_interior_shading_factors()
-    default_operable_frac = Airflow.get_default_fraction_of_operable_window_area()
     @hpxml.windows.each do |window|
       if window.interior_shading_factor_summer.nil?
         window.interior_shading_factor_summer = default_shade_summer
@@ -346,6 +340,11 @@ class OSModel
       if window.interior_shading_factor_winter.nil?
         window.interior_shading_factor_winter = default_shade_winter
       end
+    end
+
+    # Default window fraction operable
+    default_operable_frac = Airflow.get_default_fraction_of_operable_window_area()
+    @hpxml.windows.each do |window|
       next unless window.operable.nil?
       # Split into operable/inoperable windows
       @hpxml.windows << window.dup
@@ -359,17 +358,22 @@ class OSModel
     end
     @frac_window_area_operable = @hpxml.fraction_of_window_area_operable()
 
-    # Default HVAC
-    # 1. Compressor Type
-    # 2. Sensible Heat Ratio
-    # TODO: HeatingCapacity17F
-    # TODO: Electric Auxiliary Energy (EAE; requires autosized HVAC capacity)
+    # Default AC/HP compressor type
     @hpxml.cooling_systems.each do |cooling_system|
       next unless cooling_system.cooling_system_type == HPXML::HVACTypeCentralAirConditioner
-      if cooling_system.compressor_type.nil?
-        cooling_system.compressor_type = HVAC.get_default_compressor_type(cooling_system.cooling_efficiency_seer)
-      end
-      if cooling_system.cooling_shr.nil?
+      next unless cooling_system.compressor_type.nil?
+      cooling_system.compressor_type = HVAC.get_default_compressor_type(cooling_system.cooling_efficiency_seer)
+    end
+    @hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpAirToAir
+      next unless heat_pump.compressor_type.nil?
+      heat_pump.compressor_type = HVAC.get_default_compressor_type(heat_pump.cooling_efficiency_seer)
+    end
+
+    # Default AC/HP sensible heat ratio
+    @hpxml.cooling_systems.each do |cooling_system|
+      next unless cooling_system.cooling_shr.nil?
+      if cooling_system.cooling_system_type == HPXML::HVACTypeCentralAirConditioner
         if cooling_system.compressor_type == HPXML::HVACCompressorTypeSingleStage
           cooling_system.cooling_shr = 0.73
         elsif cooling_system.compressor_type == HPXML::HVACCompressorTypeTwoStage
@@ -377,27 +381,47 @@ class OSModel
         elsif cooling_system.compressor_type == HPXML::HVACCompressorTypeVariableSpeed
           cooling_system.cooling_shr = 0.78
         end
+      elsif cooling_system.cooling_system_type == HPXML::HVACTypeRoomAirConditioner
+        cooling_system.cooling_shr = 0.65
       end
     end
     @hpxml.heat_pumps.each do |heat_pump|
-      next unless heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpAirToAir
-      if heat_pump.compressor_type.nil?
-        heat_pump.compressor_type = HVAC.get_default_compressor_type(heat_pump.cooling_efficiency_seer)
+      next unless heat_pump.cooling_shr.nil?
+      if heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpAirToAir
+        if heat_pump.compressor_type == HPXML::HVACCompressorTypeSingleStage
+          heat_pump.cooling_shr = 0.73
+        elsif heat_pump.compressor_type == HPXML::HVACCompressorTypeTwoStage
+          heat_pump.cooling_shr = 0.724
+        elsif heat_pump.compressor_type == HPXML::HVACCompressorTypeVariableSpeed
+          heat_pump.cooling_shr = 0.78
+        end
+      elsif heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpMiniSplit
+        heat_pump.cooling_shr = 0.73
+      elsif heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir
+        heat_pump.cooling_shr = 0.732
       end
     end
 
-    # Default Water Heaters
-    # 1. Setpoint temperature
-    # 2. Tankless cycle derate (performance adjustment)
-    # 3. Indirect water heater standby loss
+    # TODO: Default HeatingCapacity17F
+    # TODO: Default Electric Auxiliary Energy (EAE; requires autosized HVAC capacity)
+
+    # Default hot water temperature
     @hpxml.water_heating_systems.each do |water_heating_system|
-      if water_heating_system.temperature.nil?
-        water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(@eri_version)
-      end
-      if water_heating_system.performance_adjustment.nil? && (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless)
-        water_heating_system.performance_adjustment = Waterheater.get_tankless_cycling_derate()
-      end
-      next unless water_heating_system.standby_loss.nil? && ([HPXML::WaterHeaterTypeCombiStorage].include? water_heating_system.water_heater_type)
+      next unless water_heating_system.temperature.nil?
+      water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(@eri_version)
+    end
+
+    # Default tankless water heater cycle derate (performance adjustment)
+    @hpxml.water_heating_systems.each do |water_heating_system|
+      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless
+      next unless water_heating_system.performance_adjustment.nil?
+      water_heating_system.performance_adjustment = Waterheater.get_tankless_cycling_derate()
+    end
+
+    # Default indirect water heater standby loss
+    @hpxml.water_heating_systems.each do |water_heating_system|
+      next unless [HPXML::WaterHeaterTypeCombiStorage].include? water_heating_system.water_heater_type
+      next unless water_heating_system.standby_loss.nil?
       # Use equation fit from AHRI database
       # calculate independent variable SurfaceArea/vol(physically linear to standby_loss/skin_u under test condition) to fit the linear equation from AHRI database
       act_vol = Waterheater.calc_storage_tank_actual_vol(water_heating_system.tank_volume, nil)
@@ -406,9 +430,7 @@ class OSModel
       water_heating_system.standby_loss = (2.9721 * sqft_by_gal - 0.4732).round(3) # linear equation assuming a constant u, F/hr
     end
 
-    # Default Ceiling Fans
-    # 1. Efficiency
-    # 2. Quantity
+    # Default ceiling fans efficiency/quantity
     if @hpxml.ceiling_fans.size > 0
       ceiling_fan = @hpxml.ceiling_fans[0]
       if ceiling_fan.efficiency.nil?
@@ -420,10 +442,7 @@ class OSModel
       end
     end
 
-    # Default Plug Loads
-    # 1. Kwh/year
-    # 2. Frac sensible/latent
-    # 3. Schedules
+    # Default plug loads kwh/year, frac sensible/latent
     @hpxml.plug_loads.each do |plug_load|
       if plug_load.plug_load_type == HPXML::PlugLoadTypeOther
         default_annual_kwh, default_sens_frac, default_lat_frac = MiscLoads.get_residual_mels_values(@cfa)
@@ -443,6 +462,8 @@ class OSModel
         end
       end
     end
+
+    # Default plug load schedules
     if @hpxml.misc_loads_schedule.weekday_fractions.nil?
       @hpxml.misc_loads_schedule.weekday_fractions = '0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05'
     end
@@ -2385,13 +2406,7 @@ class OSModel
       elsif clg_type == HPXML::HVACTypeRoomAirConditioner
 
         eer = cooling_system.cooling_efficiency_eer
-
-        if cooling_system.cooling_shr.nil?
-          shr = 0.65
-        else
-          shr = cooling_system.cooling_shr
-        end
-
+        shr = cooling_system.cooling_shr
         airflow_rate = 350.0
         HVAC.apply_room_ac(model, runner, eer, shr,
                            airflow_rate, cool_capacity_btuh, load_frac,
@@ -2587,12 +2602,7 @@ class OSModel
 
         if compressor_type == HPXML::HVACCompressorTypeSingleStage
 
-          if heat_pump.cooling_shr.nil?
-            shrs = [0.73]
-          else
-            shrs = [heat_pump.cooling_shr]
-          end
-
+          shrs = [heat_pump.cooling_shr]
           HVAC.apply_central_ashp_1speed(model, runner, seer, hspf, shrs,
                                          hp_compressor_min_temp, crankcase_kw, crankcase_temp,
                                          cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
@@ -2602,12 +2612,8 @@ class OSModel
                                          @living_zone, @hvac_map, heat_pump.id)
         elsif compressor_type == HPXML::HVACCompressorTypeTwoStage
 
-          if heat_pump.cooling_shr.nil?
-            shrs = [0.71, 0.724]
-          else
-            # TODO: is the following assumption correct (revisit Dylan's data?)? OR should value from HPXML be used for both stages?
-            shrs = [heat_pump.cooling_shr - 0.014, heat_pump.cooling_shr]
-          end
+          # TODO: is the following assumption correct (revisit Dylan's data?)? OR should value from HPXML be used for both stages?
+          shrs = [heat_pump.cooling_shr - 0.014, heat_pump.cooling_shr]
           HVAC.apply_central_ashp_2speed(model, runner, seer, hspf, shrs,
                                          hp_compressor_min_temp, crankcase_kw, crankcase_temp,
                                          cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
@@ -2617,12 +2623,8 @@ class OSModel
                                          @living_zone, @hvac_map, heat_pump.id)
         elsif compressor_type == HPXML::HVACCompressorTypeVariableSpeed
 
-          if heat_pump.cooling_shr.nil?
-            shrs = [0.87, 0.80, 0.79, 0.78]
-          else
-            var_sp_shr_mult = [1.115, 1.026, 1.013, 1.0]
-            shrs = var_sp_shr_mult.map { |m| heat_pump.cooling_shr * m }
-          end
+          var_sp_shr_mult = [1.115, 1.026, 1.013, 1.0]
+          shrs = var_sp_shr_mult.map { |m| heat_pump.cooling_shr * m }
           HVAC.apply_central_ashp_4speed(model, runner, seer, hspf, shrs,
                                          hp_compressor_min_temp, crankcase_kw, crankcase_temp,
                                          cool_capacity_btuh, heat_capacity_btuh, heat_capacity_btuh_17F,
@@ -2636,13 +2638,7 @@ class OSModel
 
         seer = heat_pump.cooling_efficiency_seer
         hspf = heat_pump.heating_efficiency_hspf
-
-        if heat_pump.cooling_shr.nil?
-          shr = 0.73
-        else
-          shr = heat_pump.cooling_shr
-        end
-
+        shr = heat_pump.cooling_shr
         min_cooling_capacity = 0.4
         max_cooling_capacity = 1.2
         min_cooling_airflow_rate = 200.0
@@ -2664,7 +2660,6 @@ class OSModel
           cap_retention_frac = heat_capacity_btuh_17F / heat_capacity_btuh
           cap_retention_temp = 17.0
         end
-
         pan_heater_power = 0.0
         fan_power = 0.07
         is_ducted = !heat_pump.distribution_system_idref.nil?
@@ -2685,11 +2680,7 @@ class OSModel
 
         eer = heat_pump.cooling_efficiency_eer
         cop = heat_pump.heating_efficiency_cop
-        if heat_pump.cooling_shr.nil?
-          shr = 0.732
-        else
-          shr = heat_pump.cooling_shr
-        end
+        shr = heat_pump.cooling_shr
         ground_conductivity = 0.6
         grout_conductivity = 0.4
         bore_config = Constants.SizingAuto
@@ -2816,16 +2807,8 @@ class OSModel
     weekday_sch = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
     weekend_sch = weekday_sch
     hrs_per_day = weekday_sch.inject(0, :+)
-
     cfm_per_w = ceiling_fan.efficiency
-    if cfm_per_w.nil?
-      fan_power_w = HVAC.get_default_ceiling_fan_power()
-      cfm_per_w = medium_cfm / fan_power_w
-    end
     quantity = ceiling_fan.quantity
-    if quantity.nil?
-      quantity = HVAC.get_default_ceiling_fan_quantity(@nbeds)
-    end
     annual_kwh = UnitConversions.convert(quantity * medium_cfm / cfm_per_w * hrs_per_day * 365.0, 'Wh', 'kWh')
     annual_kwh *= monthly_sch.inject(:+) / 12.0
 
@@ -3114,7 +3097,6 @@ class OSModel
                            HPXML::DuctTypeReturn => [0.0, nil] }
     hvac_distribution.duct_leakage_measurements.each do |duct_leakage_measurement|
       next unless [HPXML::UnitsCFM25, HPXML::UnitsPercent].include?(duct_leakage_measurement.duct_leakage_units) && (duct_leakage_measurement.duct_leakage_total_or_to_outside == 'to outside')
-
       next if duct_leakage_measurement.duct_type.nil?
 
       leakage_to_outside[duct_leakage_measurement.duct_type] = [duct_leakage_measurement.duct_leakage_value, duct_leakage_measurement.duct_leakage_units]
@@ -3125,17 +3107,15 @@ class OSModel
                                       HPXML::DuctTypeReturn => 0.0 }
     hvac_distribution.ducts.each do |ducts|
       next if [HPXML::LocationLivingSpace, HPXML::LocationBasementConditioned].include? ducts.duct_location
-
-      # Calculate total duct area in unconditioned spaces
       next if ducts.duct_type.nil?
 
+      # Calculate total duct area in unconditioned spaces
       total_unconditioned_duct_area[ducts.duct_type] += ducts.duct_surface_area
     end
 
     # Create duct objects
     hvac_distribution.ducts.each do |ducts|
       next if [HPXML::LocationLivingSpace, HPXML::LocationBasementConditioned].include? ducts.duct_location
-
       next if ducts.duct_type.nil?
 
       duct_area = ducts.duct_surface_area

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7df26538-79de-449c-98e4-26041acc798d</version_id>
-  <version_modified>20200324T175150Z</version_modified>
+  <version_id>16404b65-2cb5-4e8b-9367-49c42d62b139</version_id>
+  <version_modified>20200324T184823Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -459,13 +459,13 @@
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>E841CD36</checksum>
+      <checksum>662B0D0E</checksum>
     </file>
     <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>07326E4A</checksum>
+      <checksum>3551168D</checksum>
     </file>
     <file>
       <version>
@@ -476,7 +476,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4DAC383C</checksum>
+      <checksum>F5879083</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>54bbb00b-01f5-4a50-8ea2-f861c63798f8</version_id>
-  <version_modified>20200323T220238Z</version_modified>
+  <version_id>7df26538-79de-449c-98e4-26041acc798d</version_id>
+  <version_modified>20200324T175150Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -28,20 +28,31 @@
       <default_value>weather</default_value>
     </argument>
     <argument>
-      <name>epw_output_path</name>
-      <display_name>EPW Output File Path</display_name>
-      <description>Absolute/relative path of the output EPW file.</description>
+      <name>output_path</name>
+      <display_name>Path for Output Files</display_name>
+      <description>Absolute/relative path for the output files.</description>
       <type>String</type>
-      <required>false</required>
+      <required>true</required>
       <model_dependent>false</model_dependent>
     </argument>
     <argument>
-      <name>osm_output_path</name>
-      <display_name>OSM Output File Path</display_name>
-      <description>Absolute/relative path of the output OSM file.</description>
-      <type>String</type>
+      <name>debug</name>
+      <display_name>Debug Mode?</display_name>
+      <description>If enabled: 1) Writes in.osm file, 2) Writes in.xml HPXML file with defaults filled, and 3) Generates additional log output. Any files written will be in the output path specified above.</description>
+      <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
     </argument>
   </arguments>
   <outputs/>
@@ -421,12 +432,6 @@
       <checksum>E1E20AAC</checksum>
     </file>
     <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B6779F3D</checksum>
-    </file>
-    <file>
       <filename>hotwater_appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -445,16 +450,22 @@
       <checksum>ACCF116F</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6A9BCBA0</checksum>
-    </file>
-    <file>
       <filename>EPvalidator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>98ED04AE</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>E841CD36</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>07326E4A</checksum>
     </file>
     <file>
       <version>
@@ -465,7 +476,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>D9CAAEEC</checksum>
+      <checksum>4DAC383C</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6c30fca8-6cd6-4a5c-8d03-b19f99437a46</version_id>
-  <version_modified>20200325T010651Z</version_modified>
+  <version_id>19ade733-3f46-4afa-81c2-cf3faa3b3d51</version_id>
+  <version_modified>20200325T044342Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -462,6 +462,12 @@
       <checksum>662B0D0E</checksum>
     </file>
     <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>89ED1530</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -470,13 +476,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F5879083</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>89ED1530</checksum>
+      <checksum>8AA95FCD</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1836,6 +1836,12 @@ class HPXML < Object
           fail "For Window '#{@id}', overhangs distance to bottom (#{@overhangs_distance_to_bottom_of_window}) must be greater than distance to top (#{@overhangs_distance_to_top_of_window})."
         end
       end
+      # TODO: Remove this error when we can support it w/ EnergyPlus
+      if (not @interior_shading_factor_summer.nil?) && (not @interior_shading_factor_winter.nil?)
+        if @interior_shading_factor_summer > @interior_shading_factor_winter
+          fail "SummerShadingCoefficient (#{interior_shading_factor_summer}) must be less than or equal to WinterShadingCoefficient (#{interior_shading_factor_winter}) for window '#{@id}'."
+        end
+      end
 
       return errors
     end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -271,24 +271,14 @@ class HPXML < Object
     return fuel_fracs.key(fuel_fracs.values.max)
   end
 
-  def fraction_of_window_area_operable(default_frac_for_unknown_operable)
+  def fraction_of_window_area_operable()
     # Calculates the fraction of window area that is operable.
-    window_area_total = 0.0
-    window_area_operable = 0.0
-    @windows.each do |window|
-      window_area_total += window.area
-      if window.operable.nil?
-        window_area_operable += (window.area * default_frac_for_unknown_operable)
-      elsif window.operable
-        window_area_operable += window.area
-      end
-    end
+    window_area_total = @windows.map { |w| w.area }.inject(0, :+)
+    window_area_operable = @windows.select { |w| w.operable }.map { |w| w.area }.inject(0, :+)
     if window_area_total <= 0
-      frac_window_area_operable = 0.0
-    else
-      frac_window_area_operable = window_area_operable / window_area_total
+      return 0.0
     end
-    return frac_window_area_operable
+    return window_area_operable / window_area_total
   end
 
   def to_rexml()

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -837,12 +837,14 @@ class Waterheater
 
     if wh_type == HPXML::WaterHeaterTypeCombiStorage
       tank_type = HPXML::WaterHeaterTypeStorage
-      act_vol = calc_storage_tank_actual_vol(vol, nil)
-      a_side = calc_tank_areas(act_vol)[1]
-      standby_loss = get_indirect_standbyloss(standby_loss, act_vol)
+      if standby_loss <= 0
+        fail 'Indirect water heater standby loss is negative, double check TankVolume to be <829 gal or StandbyLoss to be >0.0 F/hr.'
+      end
       if standby_loss > 10.0
         runner.registerWarning('Indirect water heater standby loss is over 10.0 F/hr, double check water heater inputs.')
       end
+      act_vol = calc_storage_tank_actual_vol(vol, nil)
+      a_side = calc_tank_areas(act_vol)[1]
       ua = calc_indirect_ua_with_standbyloss(act_vol, standby_loss, jacket_r, a_side)
     else
       tank_type = HPXML::WaterHeaterTypeTankless
@@ -1208,21 +1210,6 @@ class Waterheater
     surface_area = 2.0 * a_top + a_side # sqft
 
     return surface_area, a_side
-  end
-
-  def self.get_indirect_standbyloss(standby_loss, act_vol)
-    # Tank geometry
-    surface_area = calc_tank_areas(act_vol)[0]
-    if standby_loss.nil? # Swiched to standby_loss equation fit from AHRI database
-      # calculate independent variable SurfaceArea/vol(physically linear to standby_loss/skin_u under test condition) to fit the linear equation from AHRI database
-      sqft_by_gal = surface_area / act_vol # sqft/gal
-      standby_loss = 2.9721 * sqft_by_gal - 0.4732 # linear equation assuming a constant u, F/hr
-    end
-    if standby_loss <= 0
-      fail 'Indirect water heater standby loss is negative, double check TankVolume to be <829 gal or StandbyLoss to be >0.0 F/hr.'
-    end
-
-    return standby_loss
   end
 
   def self.calc_indirect_ua_with_standbyloss(act_vol, standby_loss, jacket_r, a_side)

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -46,10 +46,6 @@ class Waterheater
 
     cap = 100000000.0
 
-    if cd.nil?
-      cd = Waterheater.get_tankless_cycling_derate()
-    end
-
     loop = Waterheater.create_new_loop(model, Constants.PlantLoopDomesticWater, t_set, HPXML::WaterHeaterTypeTankless)
     dhw_map[sys_id] << loop
 

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -35,10 +35,8 @@ def run_workflow(basedir, rundir, hpxml, debug, hourly_outputs)
   args = {}
   args['hpxml_path'] = hpxml
   args['weather_dir'] = 'weather'
-  args['epw_output_path'] = File.join(rundir, 'in.epw')
-  if debug
-    args['osm_output_path'] = File.join(rundir, 'in.osm')
-  end
+  args['output_path'] = rundir
+  args['debug'] = debug
   update_args_hash(measures, measure_subdir, args)
 
   # Add reporting measure to workflow

--- a/workflow/template.osw
+++ b/workflow/template.osw
@@ -6,7 +6,9 @@
   "steps": [
     {
       "arguments": {
-        "hpxml_path": "../workflow/sample_files/base.xml"
+        "hpxml_path": "../workflow/sample_files/base.xml",
+        "output_path": "../workflow/run",
+        "debug": false
       },
       "measure_dir_name": "HPXMLtoOpenStudio"
     },

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -666,7 +666,8 @@ class HPXMLTest < MiniTest::Test
     assert(File.exist? sql_path)
 
     sqlFile = OpenStudio::SqlFile.new(sql_path, false)
-    hpxml = HPXML.new(hpxml_path: hpxml_path)
+    hpxml_defaults_path = File.join(rundir, 'in.xml')
+    hpxml = HPXML.new(hpxml_path: hpxml_defaults_path)
     hpxml.collapse_enclosure_surfaces([:operable])
 
     # Timestep

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -69,32 +69,63 @@ class HPXMLTest < MiniTest::Test
     os_cli = OpenStudio.getOpenStudioCLI
     rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
     xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
-    command = "#{os_cli} #{rb_path} -x #{xml}"
+    command = "#{os_cli} #{rb_path} -x #{xml} --debug"
     system(command, err: File::NULL)
+
+    # Check for output files
     sql_path = File.join(File.dirname(xml), 'run', 'eplusout.sql')
     assert(File.exist? sql_path)
+    csv_output_path = File.join(File.dirname(xml), 'run', 'results_annual.csv')
+    assert(File.exist? csv_output_path)
+
+    # Check for debug files
+    osm_path = File.join(File.dirname(xml), 'run', 'in.osm')
+    assert(File.exist? osm_path)
+    hpxml_defaults_path = File.join(File.dirname(xml), 'run', 'in.xml')
+    assert(File.exist? hpxml_defaults_path)
   end
 
   def test_template_osw
     # Check that simulation works using template.osw
+    require 'json'
+
     os_cli = OpenStudio.getOpenStudioCLI
     osw_path = File.join(File.dirname(__FILE__), '..', 'template.osw')
+
+    # Create derivative OSW for testing
+    osw_path_test = osw_path.gsub('.osw', '_test.osw')
+    FileUtils.cp(osw_path, osw_path_test)
+
+    # Turn on debug mode
+    json = JSON.parse(File.read(osw_path_test), symbolize_names: true)
+    json[:steps][0][:arguments][:debug] = true
+
     if Dir.exist? File.join(File.dirname(__FILE__), '..', '..', 'project')
-      # CI checks out the repo as "project", so need to update the OSW
-      osw_path_ci = osw_path.gsub('.osw', '2.osw')
-      FileUtils.cp(osw_path, osw_path_ci)
-      require 'json'
-      json = JSON.parse(File.read(osw_path_ci), symbolize_names: true)
+      # CI checks out the repo as "project", so update dir name
       json[:steps][0][:measure_dir_name] = 'project'
-      File.open(osw_path_ci, 'w') do |f|
-        f.write(JSON.pretty_generate(json))
-      end
-      osw_path = osw_path_ci
     end
-    command = "#{os_cli} run -w #{osw_path}"
+
+    File.open(osw_path_test, 'w') do |f|
+      f.write(JSON.pretty_generate(json))
+    end
+
+    command = "#{os_cli} run -w #{osw_path_test}"
     system(command, err: File::NULL)
-    sql_path = File.join(File.dirname(osw_path), 'run', 'eplusout.sql')
+
+    # Check for output files
+    sql_path = File.join(File.dirname(osw_path_test), 'run', 'eplusout.sql')
     assert(File.exist? sql_path)
+    csv_output_path = File.join(File.dirname(osw_path_test), 'run', 'results_annual.csv')
+    assert(File.exist? csv_output_path)
+
+    # Check for debug files
+    osm_path = File.join(File.dirname(osw_path_test), 'run', 'in.osm')
+    assert(File.exist? osm_path)
+    hpxml_defaults_path = File.join(File.dirname(osw_path_test), 'run', 'in.xml')
+    assert(File.exist? hpxml_defaults_path)
+
+    # Cleanup
+    File.delete(osw_path_test)
   end
 
   def test_weather_cache
@@ -422,8 +453,8 @@ class HPXMLTest < MiniTest::Test
     args = {}
     args['hpxml_path'] = xml
     args['weather_dir'] = 'weather'
-    args['epw_output_path'] = File.absolute_path(File.join(rundir, 'in.epw'))
-    args['osm_output_path'] = File.absolute_path(File.join(rundir, 'in.osm')) # debug
+    args['output_path'] = File.absolute_path(rundir)
+    args['debug'] = true
     update_args_hash(measures, measure_subdir, args)
 
     # Add reporting measure to workflow


### PR DESCRIPTION
## Pull Request Description

The HPXMLtoOS measure now immediately applies (most) default values to the HPXML object. The new HPXML object w/ default values can be written to a HPXML file (using the new `debug` argument set to true) for inspection.

Also replaces the `epw_output_path` and `osm_output_path` arguments with a single `output_path` argument.

## Checklist

Not all may apply:

- [x] Tests (and test files) have been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
