### PR TITLE
Removes compare-xml gem from build-res-hpxml branch

### DIFF
--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>dec870c1-a37d-4299-8a46-8e054d74b981</version_id>
-  <version_modified>20200319T193507Z</version_modified>
+  <version_id>dc2c8bda-57dc-4eb9-a24b-760cf132054a</version_id>
+  <version_modified>20200324T224035Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -3609,12 +3609,6 @@
   </attributes>
   <files>
     <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>182539AB</checksum>
-    </file>
-    <file>
       <filename>location.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -3625,12 +3619,6 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>D72E55C5</checksum>
-    </file>
-    <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>0A0E0C8E</checksum>
     </file>
     <file>
       <filename>geometry.rb</filename>
@@ -4575,10 +4563,28 @@
       <checksum>E5EF1C3F</checksum>
     </file>
     <file>
+      <filename>base-misc-timestep-10-mins.osw</filename>
+      <filetype>osw</filetype>
+      <usage_type>test</usage_type>
+      <checksum>6A6CDFBB</checksum>
+    </file>
+    <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>932321C5</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1D875154</checksum>
+    </file>
+    <file>
       <filename>build_residential_hpxml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>F2A3D970</checksum>
+      <checksum>F5716E34</checksum>
     </file>
     <file>
       <version>
@@ -4589,13 +4595,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>D7EB5061</checksum>
+      <checksum>4EB85324</checksum>
     </file>
     <file>
-      <filename>base-misc-timestep-10-mins.osw</filename>
-      <filetype>osw</filetype>
-      <usage_type>test</usage_type>
-      <checksum>6A6CDFBB</checksum>
+      <filename>simulation.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>2213959F</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
+++ b/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
@@ -6,7 +6,6 @@ require_relative '../measure.rb'
 require 'fileutils'
 require 'rexml/document'
 require 'rexml/xpath'
-require 'compare-xml'
 require_relative '../../HPXMLtoOpenStudio/resources/meta_measure'
 require_relative '../../HPXMLtoOpenStudio/resources/hpxml'
 
@@ -85,6 +84,7 @@ class BuildResidentialHPXMLTest < MiniTest::Test
   end
 
   def test_invalid_workflows
+    require 'json'
     this_dir = File.dirname(__FILE__)
     measures_dir = File.join(this_dir, '../..')
 
@@ -163,60 +163,43 @@ class BuildResidentialHPXMLTest < MiniTest::Test
         refrigerator.schedules_output_path = nil
         refrigerator.schedules_column_name = nil
       end
-    end
+      hpxml.walls.each do |wall|
+        next unless wall.exterior_adjacent_to == HPXML::LocationOutside
+        next unless [HPXML::LocationAtticUnvented, HPXML::LocationAtticVented].include? wall.interior_adjacent_to
 
-    # Convert to REXML docs
-    hpxml_docs = {}
-    hpxml_objs.each do |version, hpxml|
-      hpxml_docs[version] = hpxml.to_rexml()
-    end
-
-    hpxml_docs = {
-      'Rakefile' => Nokogiri::XML(hpxml_docs['Rakefile'].to_s).remove_namespaces!,
-      'BuildResidentialHPXML' => Nokogiri::XML(hpxml_docs['BuildResidentialHPXML'].to_s).remove_namespaces!
-    }
-
-    opts = { verbose: true }
-    compare_xml = CompareXML.equivalent?(hpxml_docs['Rakefile'], hpxml_docs['BuildResidentialHPXML'], opts)
-    discrepancies = ''
-    compare_xml.each do |discrepancy|
-      unless discrepancy[:node1].nil?
-        next if discrepancy[:node1].attributes.keys.include? 'id'
-        next if discrepancy[:node1].attributes.keys.include? 'idref'
+        wall.area = nil # Attic gable wall areas
+      end
+      hpxml.windows.each do |window|
+        window.overhangs_distance_to_bottom_of_window = nil # Height of windows
       end
 
-      parent_id = 'nil'
-      parent_element = 'nil'
-      if not discrepancy[:node1].nil?
-        parent_element = discrepancy[:node1].name
-        parent = discrepancy[:node1].parent
-        parent_sysid = parent.xpath('SystemIdentifier')
-        if not parent_sysid.empty?
-          parent_id = parent_sysid.attribute('id').to_s
+      # Replace IDs/IDREFs with blank strings
+      HPXML::HPXML_ATTRS.each do |attr|
+        hpxml_obj = hpxml.send(attr)
+        next unless hpxml_obj.is_a? HPXML::BaseArrayElement
+
+        hpxml_obj.each do |obj|
+          obj.class::ATTRS.each do |obj_attr|
+            next unless (obj_attr.to_s == 'id') || obj_attr.to_s.end_with?('_idref')
+
+            obj.send(obj_attr.to_s + '=', '')
+          end
         end
       end
-      parent_text = discrepancy[:diff1]
-
-      next if (parent_id == 'WallAtticGable') && (parent_element == 'Area') # FIXME
-      next if parent_element == 'DistanceToBottomOfWindow' # FIXME
-
-      child_id = 'nil'
-      child_element = 'nil'
-      if not discrepancy[:node2].nil?
-        child_element = discrepancy[:node2].name
-        child = discrepancy[:node2].parent
-        child_sysid = child.xpath('SystemIdentifier')
-        if not child_sysid.empty?
-          child_id = child_sysid.attribute('id').to_s
-        end
-      end
-      child_text = discrepancy[:diff2]
-
-      discrepancies << "(#{parent_id}: #{parent_element}: #{parent_text}) : (#{child_id}: #{child_element}: #{child_text}}\n"
     end
 
-    unless discrepancies.empty?
-      raise discrepancies
+    rakefile_doc = hpxml_objs['Rakefile'].to_rexml
+    measure_doc = hpxml_objs['BuildResidentialHPXML'].to_rexml
+
+    # Write files for inspection?
+    if rakefile_doc.to_s != measure_doc.to_s
+      rakefile_path = File.join(File.dirname(__FILE__), 'test_rakefile.xml')
+      XMLHelper.write_file(rakefile_doc, rakefile_path)
+      measure_path = File.join(File.dirname(__FILE__), 'test_measure.xml')
+      XMLHelper.write_file(measure_doc, measure_path)
+      flunk "ERROR: HPXML files don't match. Wrote #{rakefile_path} and #{measure_path} for inspection."
+    else
+      pass
     end
   end
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,3 @@ gem 'simplecov', '~> 0.17.0'
 gem 'codecov'
 gem 'minitest-reporters'
 gem 'minitest-ci' # For CircleCI Automatic test metadata collection
-gem 'compare-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,6 @@ GEM
       json
       simplecov
       url
-    compare-xml (0.62)
-      nokogiri (~> 1.6)
     docile (1.3.2)
     json (2.2.0)
     mini_portile2 (2.1.0)
@@ -42,7 +40,6 @@ PLATFORMS
 DEPENDENCIES
   ci_reporter_minitest (~> 1.0.0)
   codecov
-  compare-xml
   minitest (~> 5.9)
   minitest-ci
   minitest-reporters

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>644dc35b-c893-40f8-891c-bcda335c6725</version_id>
-  <version_modified>20200321T205852Z</version_modified>
+  <version_id>955dfdfa-e0d1-44c5-b9ac-984a67b4b37a</version_id>
+  <version_modified>20200324T224036Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -451,12 +451,6 @@
       <checksum>363ABD0F</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>98E5F342</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -466,6 +460,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>1E1E9EE3</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C1106F93</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
Branches off of `build-res-hpxml`. Removes compare-xml gem, replaced with simple string comparisons.