### PR TITLE
Remove any existing objects from the model.

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -85,7 +85,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     end
     model.removeObjects(handles)
     unless handles.empty?
-      runner.registerWarning("The model was 'reset'.")
+      runner.registerWarning('The model contains existing objects and is being reset.')
     end
 
     # Check for correct versions of OS

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -78,6 +78,16 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
       return false
     end
 
+    # Tear down the existing model if it exists
+    handles = OpenStudio::UUIDVector.new
+    model.objects.each do |obj|
+      handles << obj.handle
+    end
+    model.removeObjects(handles)
+    unless handles.empty?
+      runner.registerWarning("The model was 'reset'.")
+    end
+
     # Check for correct versions of OS
     os_version = '2.9.1'
     if OpenStudio.openStudioVersion != os_version

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>19ade733-3f46-4afa-81c2-cf3faa3b3d51</version_id>
-  <version_modified>20200325T044342Z</version_modified>
+  <version_id>701cbeaf-b325-4228-8480-f0ef4abd9520</version_id>
+  <version_modified>20200325T152734Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -476,7 +476,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>8AA95FCD</checksum>
+      <checksum>26AFA7E3</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>701cbeaf-b325-4228-8480-f0ef4abd9520</version_id>
-  <version_modified>20200325T152734Z</version_modified>
+  <version_id>62458fab-10ba-4528-9eb0-ebf1aa2b3e39</version_id>
+  <version_modified>20200325T170131Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -476,7 +476,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>26AFA7E3</checksum>
+      <checksum>4383F2DD</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

When BuildResidentialHPXML/HPXMLtoOpenStudio is applied twice (i.e., for an upgrade), then the starting model must be empty.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
