### PR TITLE
Improve default neighbor height

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -1940,25 +1940,11 @@ class OSModel
   end
 
   def self.add_neighbors(runner, model, length)
-    # Get the max z-value of any model surface
-    default_height = -9e99
-    model.getSpaces.each do |space|
-      z_origin = space.zOrigin
-      space.surfaces.each do |surface|
-        surface.vertices.each do |vertex|
-          surface_z = vertex.z + z_origin
-          next if surface_z < default_height
-
-          default_height = surface_z
-        end
-      end
-    end
-    default_height = UnitConversions.convert(default_height, 'm', 'ft')
     z_origin = 0 # shading surface always starts at grade
 
     shading_surfaces = []
     @hpxml.neighbor_buildings.each do |neighbor_building|
-      height = neighbor_building.height.nil? ? default_height : neighbor_building.height
+      height = neighbor_building.height.nil? ? @walls_top : neighbor_building.height
 
       shading_surface = OpenStudio::Model::ShadingSurface.new(add_wall_polygon(length, height, z_origin, neighbor_building.azimuth), model)
       shading_surface.additionalProperties.setFeature('Azimuth', neighbor_building.azimuth)

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3d99b045-9917-4fe0-ac7c-b330a23559f5</version_id>
-  <version_modified>20200407T001859Z</version_modified>
+  <version_id>e79b92ec-7d46-41ff-b7d2-691e729ff0f9</version_id>
+  <version_modified>20200407T194356Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -476,7 +476,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>1710DE70</checksum>
+      <checksum>42A104B3</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
When the neighbor height is not specified, such that it should mirror the current home, we shouldn't be including roof surfaces in the calculation of the neighbor height since they are pitched (whereas the neighbor shading surface is vertical). Not we just use the walls to determine the height.
