### PR TITLE
Make IECC zone optional

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>1d599d18-813d-4c8e-8659-2ae2a4c76416</version_id>
-  <version_modified>20200408T143034Z</version_modified>
+  <version_id>64ebe448-766f-4ad2-957b-30c138ce4856</version_id>
+  <version_modified>20200408T192839Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -450,18 +450,6 @@
       <checksum>54943094</checksum>
     </file>
     <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>02D857D9</checksum>
-    </file>
-    <file>
-      <filename>EPvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>A455C0DA</checksum>
-    </file>
-    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -477,6 +465,18 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>24CE8483</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>EB9438B5</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>F133BF44</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -49,7 +49,7 @@ class EnergyPlusValidator
         '/HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction' => one, # See [BuildingConstruction]
         '/HPXML/Building/BuildingDetails/BuildingSummary/Site/extension/Neighbors' => zero_or_one, # See [Neighbors]
 
-        '/HPXML/Building/BuildingDetails/ClimateandRiskZones/ClimateZoneIECC' => one, # See [ClimateZone]
+        '/HPXML/Building/BuildingDetails/ClimateandRiskZones/ClimateZoneIECC' => zero_or_one, # See [ClimateZone]
         '/HPXML/Building/BuildingDetails/ClimateandRiskZones/WeatherStation' => one, # See [WeatherStation]
 
         '/HPXML/Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement[HousePressure=50]/BuildingAirLeakage[UnitofMeasure="ACH" or UnitofMeasure="CFM"]/AirLeakage | /HPXML/Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement/extension/ConstantACHnatural' => one, # see [AirInfiltration]

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -1373,6 +1373,12 @@ class Waterheater
       location_hierarchy = [HPXML::LocationBasementConditioned,
                             HPXML::LocationBasementUnconditioned,
                             HPXML::LocationLivingSpace]
+    elsif iecc_zone.nil?
+      location_hierarchy = [HPXML::LocationBasementConditioned,
+                            HPXML::LocationBasementUnconditioned,
+                            HPXML::LocationLivingSpace]
+    else
+      fail "Unexpected IECC climate zone: '#{iecc_zone}'."
     end
     location_hierarchy.each do |space_type|
       if hpxml.has_space_type(space_type)

--- a/docs/source/hpxml_to_openstudio.rst
+++ b/docs/source/hpxml_to_openstudio.rst
@@ -518,7 +518,7 @@ The water heater ``Location`` can be optionally entered; if not provided, a defa
 +====================+============================================================================================+
 | 1-3, excluding 3A  | Garage if present, else Living Space                                                       |
 +--------------------+--------------------------------------------------------------------------------------------+
-| 3A, 4-8            | Conditioned Basement if present, else Unconditioned Basement if present, else Living Space |
+| 3A, 4-8, unknown   | Conditioned Basement if present, else Unconditioned Basement if present, else Living Space |
 +--------------------+--------------------------------------------------------------------------------------------+
 
 The setpoint temperature may be provided as ``HotWaterTemperature``; if not provided, 125°F is assumed.


### PR DESCRIPTION
## Pull Request Description

Changes the IECC zone from a required input to an optional input.

## Checklist

Not all may apply:

- [x] EPvalidator.rb has been updated
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
