### PR TITLE
Usage multipliers

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -327,7 +327,7 @@ class OSModel
     @dhw_map = {}  # mapping between HPXML Water Heating systems and model objects
     @cond_bsmnt_surfaces = [] # list of surfaces in conditioned basement, used for modification of some surface properties, eg. solar absorptance, view factor, etc.
 
-    # Default misc
+    # Default high-level parameters
     @hpxml.header.timestep = 60 if @hpxml.header.timestep.nil?
     @hpxml.header.begin_month = 1 if @hpxml.header.begin_month.nil?
     @hpxml.header.begin_day_of_month = 1 if @hpxml.header.begin_day_of_month.nil?
@@ -340,7 +340,7 @@ class OSModel
     end
     @cvolume = @hpxml.building_construction.conditioned_building_volume
 
-    # Default attic/crawlspace ventilation rate
+    # Default attics/foundations
     if @hpxml.has_space_type(HPXML::LocationAtticVented)
       @hpxml.attics.each do |attic|
         next unless attic.attic_type == HPXML::AtticTypeVented
@@ -358,7 +358,7 @@ class OSModel
       end
     end
 
-    # Default infiltration volume
+    # Default infiltration
     measurements = []
     infilvolume = nil
     @hpxml.air_infiltration_measurements.each do |measurement|
@@ -379,7 +379,7 @@ class OSModel
       @infil_volume = infilvolume
     end
 
-    # Default window interior shading
+    # Default windows
     default_shade_summer, default_shade_winter = Constructions.get_default_interior_shading_factors()
     @hpxml.windows.each do |window|
       if window.interior_shading_factor_summer.nil?
@@ -388,13 +388,9 @@ class OSModel
       if window.interior_shading_factor_winter.nil?
         window.interior_shading_factor_winter = default_shade_winter
       end
-    end
-
-    # Default window fraction operable
-    @hpxml.windows.each do |window|
-      next unless window.fraction_operable.nil?
-
-      window.fraction_operable = Airflow.get_default_fraction_of_operable_window_area()
+      if window.fraction_operable.nil?
+        window.fraction_operable = Airflow.get_default_fraction_of_operable_window_area()
+      end
     end
     @frac_window_area_operable = @hpxml.fraction_of_window_area_operable()
 
@@ -445,40 +441,29 @@ class OSModel
     # TODO: Default HeatingCapacity17F
     # TODO: Default Electric Auxiliary Energy (EAE; requires autosized HVAC capacity)
 
-    # Default hot water temperature
+    # Default water heaters
     @hpxml.water_heating_systems.each do |water_heating_system|
-      next unless water_heating_system.temperature.nil?
-      water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(@eri_version)
-    end
-
-    # Default tankless water heater cycle derate (performance adjustment)
-    @hpxml.water_heating_systems.each do |water_heating_system|
-      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless
-      next unless water_heating_system.performance_adjustment.nil?
-      water_heating_system.performance_adjustment = Waterheater.get_tankless_cycling_derate()
-    end
-
-    # Default indirect water heater standby loss
-    @hpxml.water_heating_systems.each do |water_heating_system|
-      next unless [HPXML::WaterHeaterTypeCombiStorage].include? water_heating_system.water_heater_type
-      next unless water_heating_system.standby_loss.nil?
-      # Use equation fit from AHRI database
-      # calculate independent variable SurfaceArea/vol(physically linear to standby_loss/skin_u under test condition) to fit the linear equation from AHRI database
-      act_vol = Waterheater.calc_storage_tank_actual_vol(water_heating_system.tank_volume, nil)
-      surface_area = Waterheater.calc_tank_areas(act_vol)[0]
-      sqft_by_gal = surface_area / act_vol # sqft/gal
-      water_heating_system.standby_loss = (2.9721 * sqft_by_gal - 0.4732).round(3) # linear equation assuming a constant u, F/hr
-    end
-
-    # Default water heater location based on Building America climate zone
-    @hpxml.water_heating_systems.each do |water_heating_system|
+      if water_heating_system.temperature.nil?
+        water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(@eri_version)
+      end
+      if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless) && water_heating_system.performance_adjustment.nil?
+        water_heating_system.performance_adjustment = Waterheater.get_tankless_cycling_derate()
+      end
+      if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeCombiStorage) && water_heating_system.standby_loss.nil?
+        # Use equation fit from AHRI database
+        # calculate independent variable SurfaceArea/vol(physically linear to standby_loss/skin_u under test condition) to fit the linear equation from AHRI database
+        act_vol = Waterheater.calc_storage_tank_actual_vol(water_heating_system.tank_volume, nil)
+        surface_area = Waterheater.calc_tank_areas(act_vol)[0]
+        sqft_by_gal = surface_area / act_vol # sqft/gal
+        water_heating_system.standby_loss = (2.9721 * sqft_by_gal - 0.4732).round(3) # linear equation assuming a constant u, F/hr
+      end
       if water_heating_system.location.nil?
         water_heating_system.location = Waterheater.get_default_location(@hpxml, @hpxml.climate_and_risk_zones.iecc_zone)
       end
     end
 
-    # Default water heater piping length
-    if @hpxml.water_heating_systems.size > 0
+    # Default hot water distribution
+    if @hpxml.hot_water_distributions.size > 0
       hot_water_distribution = @hpxml.hot_water_distributions[0]
       if hot_water_distribution.system_type == HPXML::DHWDistTypeStandard
         if hot_water_distribution.standard_piping_length.nil?
@@ -487,7 +472,12 @@ class OSModel
       end
     end
 
-    # Default ceiling fans efficiency/quantity
+    # Default water fixtures
+    if @hpxml.water_heating.water_fixtures_usage_multiplier.nil?
+      @hpxml.water_heating.water_fixtures_usage_multiplier = 1.0
+    end
+
+    # Default ceiling fans
     if @hpxml.ceiling_fans.size > 0
       ceiling_fan = @hpxml.ceiling_fans[0]
       if ceiling_fan.efficiency.nil?
@@ -499,7 +489,7 @@ class OSModel
       end
     end
 
-    # Default plug loads kwh/year, frac sensible/latent
+    # Default plug loads
     @hpxml.plug_loads.each do |plug_load|
       if plug_load.plug_load_type == HPXML::PlugLoadTypeOther
         default_annual_kwh, default_sens_frac, default_lat_frac = MiscLoads.get_residual_mels_default_values(@cfa)
@@ -518,6 +508,9 @@ class OSModel
           plug_load.kWh_per_year = default_annual_kwh
         end
       end
+      if plug_load.usage_multiplier.nil?
+        plug_load.usage_multiplier = 1.0
+      end
     end
 
     # Default plug load schedules
@@ -531,7 +524,7 @@ class OSModel
       @hpxml.misc_loads_schedule.monthly_multipliers = '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248'
     end
 
-    # Default clothes washer location, rated annual kWh, label electric rate, label gas rate, label annual gas cost, capacity, and modified energy factor
+    # Default clothes washer
     if @hpxml.clothes_washers.size > 0
       clothes_washer = @hpxml.clothes_washers[0]
       if clothes_washer.location.nil?
@@ -547,9 +540,12 @@ class OSModel
         clothes_washer.capacity = default_values[:capacity]
         clothes_washer.label_usage = default_values[:label_usage]
       end
+      if clothes_washer.usage_multiplier.nil?
+        clothes_washer.usage_multiplier = 1.0
+      end
     end
 
-    # Default clothes dryer location, control type, and energy factor
+    # Default clothes dryer
     if @hpxml.clothes_dryers.size > 0
       clothes_dryer = @hpxml.clothes_dryers[0]
       if clothes_dryer.location.nil?
@@ -560,9 +556,12 @@ class OSModel
         clothes_dryer.control_type = default_values[:control_type]
         clothes_dryer.combined_energy_factor = default_values[:combined_energy_factor]
       end
+      if clothes_dryer.usage_multiplier.nil?
+        clothes_dryer.usage_multiplier = 1.0
+      end
     end
 
-    # Default dishwasher place setting capacity and energy factor
+    # Default dishwasher
     if @hpxml.dishwashers.size > 0
       dishwasher = @hpxml.dishwashers[0]
       if dishwasher.place_setting_capacity.nil?
@@ -574,9 +573,12 @@ class OSModel
         dishwasher.label_usage = default_values[:label_usage]
         dishwasher.place_setting_capacity = default_values[:place_setting_capacity]
       end
+      if dishwasher.usage_multiplier.nil?
+        dishwasher.usage_multiplier = 1.0
+      end
     end
 
-    # Default refrigerator location and adjusted annual kWh
+    # Default refrigerator
     if @hpxml.refrigerators.size > 0
       refrigerator = @hpxml.refrigerators[0]
       if refrigerator.location.nil?
@@ -586,18 +588,24 @@ class OSModel
         default_values = HotWaterAndAppliances.get_refrigerator_default_values(@nbeds)
         refrigerator.rated_annual_kwh = default_values[:rated_annual_kwh]
       end
+      if refrigerator.usage_multiplier.nil?
+        refrigerator.usage_multiplier = 1.0
+      end
     end
 
-    # Default cooking range/oven type
+    # Default cooking range
     if @hpxml.cooking_ranges.size > 0
       cooking_range = @hpxml.cooking_ranges[0]
       if cooking_range.is_induction.nil?
         default_values = HotWaterAndAppliances.get_range_oven_default_values()
         cooking_range.is_induction = default_values[:is_induction]
       end
+      if cooking_range.usage_multiplier.nil?
+        cooking_range.usage_multiplier = 1.0
+      end
     end
 
-    # Default oven type
+    # Default oven
     if @hpxml.ovens.size > 0
       oven = @hpxml.ovens[0]
       if oven.is_convection.nil?
@@ -606,7 +614,12 @@ class OSModel
       end
     end
 
-    # Default PV systems inverter efficiency and system loss fraction
+    # Default lighting
+    if @hpxml.lighting.usage_multiplier.nil?
+      @hpxml.lighting.usage_multiplier = 1.0
+    end
+
+    # Default PV systems
     @hpxml.pv_systems.each do |pv_system|
       if pv_system.inverter_efficiency.nil?
         pv_system.inverter_efficiency = PV.get_default_inv_eff()
@@ -2164,17 +2177,14 @@ class OSModel
     end
 
     # Fixtures
-    has_low_flow_fixtures = false
+    fixtures_usage_multiplier = @hpxml.water_heating.water_fixtures_usage_multiplier
+    fixtures_all_low_flow = false
     if @hpxml.water_heating_systems.size > 0
-      low_flow_fixtures_list = []
+      fixtures_all_low_flow = true # default
       @hpxml.water_fixtures.each do |water_fixture|
         next unless [HPXML::WaterFixtureTypeShowerhead, HPXML::WaterFixtureTypeFaucet].include? water_fixture.water_fixture_type
 
-        low_flow_fixtures_list << water_fixture.low_flow
-      end
-      low_flow_fixtures_list.uniq!
-      if (low_flow_fixtures_list.size == 1) && low_flow_fixtures_list[0]
-        has_low_flow_fixtures = true
+        fixtures_all_low_flow = false if not water_fixture.low_flow
       end
     end
 
@@ -2317,13 +2327,12 @@ class OSModel
                                 @cfa, @nbeds, @ncfl, @has_uncond_bsmnt, avg_setpoint_temp,
                                 clothes_washer, cw_space, clothes_dryer, cd_space,
                                 dishwasher, refrigerator, rf_space, cooking_range, oven,
-                                has_low_flow_fixtures, dist_type, pipe_r,
-                                std_pipe_length, recirc_loop_length,
+                                fixtures_all_low_flow, fixtures_usage_multiplier,
+                                dist_type, pipe_r, std_pipe_length, recirc_loop_length,
                                 recirc_branch_length, recirc_control_type,
                                 recirc_pump_power, dwhr_present,
                                 dwhr_facilities_connected, dwhr_is_equal_flow,
-                                dwhr_efficiency, dhw_loop_fracs, @eri_version,
-                                @dhw_map, @hpxml_path)
+                                dwhr_efficiency, dhw_loop_fracs, @eri_version, @dhw_map)
 
     if @hpxml.solar_thermal_systems.size > 0
       solar_thermal_system = @hpxml.solar_thermal_systems[0]
@@ -2909,33 +2918,17 @@ class OSModel
 
   def self.add_mels(runner, model, spaces)
     # Misc
-    misc_annual_kwh = 0
-    misc_sens_frac = nil
-    misc_lat_frac = nil
-    misc_weekday_sch = nil
-    misc_weekend_sch = nil
-    misc_monthly_sch = nil
+    plug_load_misc = nil
+    plug_load_tv = nil
     @hpxml.plug_loads.each do |plug_load|
-      next unless plug_load.plug_load_type == HPXML::PlugLoadTypeOther
-
-      misc_annual_kwh = plug_load.kWh_per_year
-      misc_sens_frac = plug_load.frac_sensible
-      misc_lat_frac = plug_load.frac_latent
-      misc_weekday_sch = @hpxml.misc_loads_schedule.weekday_fractions
-      misc_weekend_sch = @hpxml.misc_loads_schedule.weekend_fractions
-      misc_monthly_sch = @hpxml.misc_loads_schedule.monthly_multipliers
+      if plug_load.plug_load_type == HPXML::PlugLoadTypeOther
+        plug_load_misc = plug_load
+      elsif plug_load.plug_load_type == HPXML::PlugLoadTypeTelevision
+        plug_load_tv = plug_load
+      end
     end
 
-    # Television
-    tv_annual_kwh = 0
-    @hpxml.plug_loads.each do |plug_load|
-      next unless plug_load.plug_load_type == HPXML::PlugLoadTypeTelevision
-
-      tv_annual_kwh = plug_load.kWh_per_year
-    end
-
-    MiscLoads.apply_plug(model, misc_annual_kwh, misc_sens_frac, misc_lat_frac,
-                         misc_weekday_sch, misc_weekend_sch, misc_monthly_sch, tv_annual_kwh,
+    MiscLoads.apply_plug(model, plug_load_misc, plug_load_tv, @hpxml.misc_loads_schedule,
                          @cfa, @living_space)
   end
 
@@ -2953,7 +2946,8 @@ class OSModel
                                                               fractions[[HPXML::LocationGarage, HPXML::LightingTypeTierI]],
                                                               fractions[[HPXML::LocationInterior, HPXML::LightingTypeTierII]],
                                                               fractions[[HPXML::LocationExterior, HPXML::LightingTypeTierII]],
-                                                              fractions[[HPXML::LocationGarage, HPXML::LightingTypeTierII]])
+                                                              fractions[[HPXML::LocationGarage, HPXML::LightingTypeTierII]],
+                                                              @hpxml.lighting.usage_multiplier)
 
     garage_space = spaces[HPXML::LocationGarage]
     Lighting.apply(model, weather, int_kwh, grg_kwh, ext_kwh, @cfa, @gfa,

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>ed9197be-9f8d-429c-9041-bdcb7253845e</version_id>
-  <version_modified>20200410T163021Z</version_modified>
+  <version_id>32a9b530-583b-4ddd-a8bb-1e3d3324d735</version_id>
+  <version_modified>20200410T205524Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -390,12 +390,6 @@
       <checksum>ACCF116F</checksum>
     </file>
     <file>
-      <filename>lighting.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>59386D80</checksum>
-    </file>
-    <file>
       <filename>HPXMLDataTypes.xsd</filename>
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
@@ -406,12 +400,6 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>8B5F0A97</checksum>
-    </file>
-    <file>
-      <filename>misc_loads.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>8A303FFD</checksum>
     </file>
     <file>
       <filename>constructions.rb</filename>
@@ -432,24 +420,6 @@
       <checksum>EB9438B5</checksum>
     </file>
     <file>
-      <filename>hotwater_appliances.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1565597E</checksum>
-    </file>
-    <file>
-      <filename>BaseElements.xsd</filename>
-      <filetype>xsd</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>04DDCF5B</checksum>
-    </file>
-    <file>
-      <filename>EPvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>59D78BF2</checksum>
-    </file>
-    <file>
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -462,10 +432,28 @@
       <checksum>9FC9A661</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
+      <filename>lighting.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>7B9F4BAE</checksum>
+      <checksum>226E206B</checksum>
+    </file>
+    <file>
+      <filename>misc_loads.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6AB64ECB</checksum>
+    </file>
+    <file>
+      <filename>BaseElements.xsd</filename>
+      <filetype>xsd</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>06222F98</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>4BB70205</checksum>
     </file>
     <file>
       <version>
@@ -476,7 +464,19 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>836E3E98</checksum>
+      <checksum>7668D215</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>0D11F615</checksum>
+    </file>
+    <file>
+      <filename>hotwater_appliances.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>D9C13D5F</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/BaseElements.xsd
+++ b/HPXMLtoOpenStudio/resources/BaseElements.xsd
@@ -1742,6 +1742,7 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -591,6 +591,7 @@ class EnergyPlusValidator
         'SystemIdentifier' => one, # Required by HPXML schema
         'WaterFixtureType[text()="shower head" or text()="faucet"]' => one, # Required by HPXML schema
         'LowFlow' => one,
+        '../extension/WaterFixturesUsageMultiplier' => zero_or_one,
       },
 
       # [SolarThermalSystem]
@@ -631,6 +632,7 @@ class EnergyPlusValidator
         '[not(Location)] | Location[text()="living space" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="garage"]' => one,
         'ModifiedEnergyFactor | IntegratedModifiedEnergyFactor' => zero_or_one,
         'ModifiedEnergyFactor | IntegratedModifiedEnergyFactor | RatedAnnualkWh | LabelElectricRate | LabelGasRate | LabelAnnualGasCost | LabelUsage | Capacity' => zero_or_seven,
+        'extension/UsageMultiplier' => zero_or_one,
       },
 
       # [ClothesDryer]
@@ -640,6 +642,7 @@ class EnergyPlusValidator
         'FuelType[text()="natural gas" or text()="fuel oil" or text()="propane" or text()="electricity" or text()="wood"]' => one,
         'EnergyFactor | CombinedEnergyFactor' => zero_or_one,
         'EnergyFactor | CombinedEnergyFactor | ControlType' => zero_or_two,
+        'extension/UsageMultiplier' => zero_or_one,
       },
 
       # [Dishwasher]
@@ -647,6 +650,7 @@ class EnergyPlusValidator
         'SystemIdentifier' => one, # Required by HPXML schema
         'RatedAnnualkWh | EnergyFactor' => zero_or_one,
         'RatedAnnualkWh | EnergyFactor | LabelElectricRate | LabelGasRate | LabelAnnualGasCost | LabelUsage | PlaceSettingCapacity' => zero_or_six,
+        'extension/UsageMultiplier' => zero_or_one,
       },
 
       # [Refrigerator]
@@ -654,6 +658,7 @@ class EnergyPlusValidator
         'SystemIdentifier' => one, # Required by HPXML schema
         '[not(Location)] | Location[text()="living space" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="garage"]' => one,
         'RatedAnnualkWh | extension/AdjustedAnnualkWh' => zero_or_more,
+        'extension/UsageMultiplier' => zero_or_one,
       },
 
       # [CookingRange]
@@ -661,12 +666,14 @@ class EnergyPlusValidator
         'SystemIdentifier' => one, # Required by HPXML schema
         'FuelType[text()="natural gas" or text()="fuel oil" or text()="propane" or text()="electricity" or text()="wood"]' => one,
         'IsInduction' => zero_or_one,
+        'extension/UsageMultiplier' => zero_or_one,
         '../Oven/IsConvection' => zero_or_one,
       },
 
       # [Lighting]
       '/HPXML/Building/BuildingDetails/Lighting' => {
         'LightingGroup[(ThirdPartyCertification="ERI Tier I" or ThirdPartyCertification="ERI Tier II") and (Location="interior" or Location="exterior" or Location="garage")]' => zero_or_six, # See [LightingGroup]
+        'extension/UsageMultiplier' => zero_or_one,
       },
 
       ## [LightingGroup]
@@ -688,6 +695,7 @@ class EnergyPlusValidator
         'Load[Units="kWh/year"]/Value' => zero_or_one, # Uses ERI Reference Home if not provided
         'extension/FracSensible' => zero_or_one, # Uses ERI Reference Home if not provided
         'extension/FracLatent' => zero_or_one, # Uses ERI Reference Home if not provided
+        'extension/UsageMultiplier' => zero_or_one,
         '../extension/WeekdayScheduleFractions' => zero_or_one, # Uses ERI Reference Home if not provided
         '../extension/WeekendScheduleFractions' => zero_or_one, # Uses ERI Reference Home if not provided
         '../extension/MonthlyScheduleMultipliers' => zero_or_one, # Uses ERI Reference Home if not provided
@@ -697,6 +705,7 @@ class EnergyPlusValidator
       '/HPXML/Building/BuildingDetails/MiscLoads/PlugLoad[PlugLoadType="TV other"]' => {
         'SystemIdentifier' => one, # Required by HPXML schema
         'Load[Units="kWh/year"]/Value' => zero_or_one, # Uses ERI Reference Home if not provided
+        'extension/UsageMultiplier' => zero_or_one,
         '../extension/WeekdayScheduleFractions' => zero_or_one, # Uses ERI Reference Home if not provided
         '../extension/WeekendScheduleFractions' => zero_or_one, # Uses ERI Reference Home if not provided
         '../extension/MonthlyScheduleMultipliers' => zero_or_one, # Uses ERI Reference Home if not provided

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -48,9 +48,9 @@ class HPXML < Object
                  :roofs, :rim_joists, :walls, :foundation_walls, :frame_floors, :slabs, :windows,
                  :skylights, :doors, :heating_systems, :cooling_systems, :heat_pumps, :hvac_controls,
                  :hvac_distributions, :ventilation_fans, :water_heating_systems, :hot_water_distributions,
-                 :water_fixtures, :solar_thermal_systems, :pv_systems, :clothes_washers, :clothes_dryers,
-                 :dishwashers, :refrigerators, :cooking_ranges, :ovens, :lighting_groups, :ceiling_fans,
-                 :plug_loads, :misc_loads_schedule]
+                 :water_fixtures, :water_heating, :solar_thermal_systems, :pv_systems, :clothes_washers,
+                 :clothes_dryers, :dishwashers, :refrigerators, :cooking_ranges, :ovens, :lighting_groups,
+                 :lighting, :ceiling_fans, :plug_loads, :misc_loads_schedule]
   attr_reader(*HPXML_ATTRS, :doc)
 
   # Constants
@@ -315,6 +315,7 @@ class HPXML < Object
     @water_heating_systems.to_rexml(@doc)
     @hot_water_distributions.to_rexml(@doc)
     @water_fixtures.to_rexml(@doc)
+    @water_heating.to_rexml(@doc)
     @solar_thermal_systems.to_rexml(@doc)
     @pv_systems.to_rexml(@doc)
     @clothes_washers.to_rexml(@doc)
@@ -324,6 +325,7 @@ class HPXML < Object
     @cooking_ranges.to_rexml(@doc)
     @ovens.to_rexml(@doc)
     @lighting_groups.to_rexml(@doc)
+    @lighting.to_rexml(@doc)
     @ceiling_fans.to_rexml(@doc)
     @plug_loads.to_rexml(@doc)
     @misc_loads_schedule.to_rexml(@doc)
@@ -358,6 +360,7 @@ class HPXML < Object
     @water_heating_systems = WaterHeatingSystems.new(self, hpxml)
     @hot_water_distributions = HotWaterDistributions.new(self, hpxml)
     @water_fixtures = WaterFixtures.new(self, hpxml)
+    @water_heating = WaterHeating.new(self, hpxml)
     @solar_thermal_systems = SolarThermalSystems.new(self, hpxml)
     @pv_systems = PVSystems.new(self, hpxml)
     @clothes_washers = ClothesWashers.new(self, hpxml)
@@ -367,6 +370,7 @@ class HPXML < Object
     @cooking_ranges = CookingRanges.new(self, hpxml)
     @ovens = Ovens.new(self, hpxml)
     @lighting_groups = LightingGroups.new(self, hpxml)
+    @lighting = Lighting.new(self, hpxml)
     @ceiling_fans = CeilingFans.new(self, hpxml)
     @plug_loads = PlugLoads.new(self, hpxml)
     @misc_loads_schedule = MiscLoadsSchedule.new(self, hpxml)
@@ -3066,6 +3070,33 @@ class HPXML < Object
     end
   end
 
+  class WaterHeating < BaseElement
+    ATTRS = [:water_fixtures_usage_multiplier]
+    attr_accessor(*ATTRS)
+
+    def check_for_errors
+      errors = []
+      return errors
+    end
+
+    def to_rexml(doc)
+      return if nil?
+
+      water_heating = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Systems', 'WaterHeating'])
+      HPXML::add_extension(parent: water_heating,
+                           extensions: { 'WaterFixturesUsageMultiplier' => HPXML::to_float_or_nil(@water_fixtures_usage_multiplier) })
+    end
+
+    def from_rexml(hpxml)
+      return if hpxml.nil?
+
+      water_heating = hpxml.elements['Building/BuildingDetails/Systems/WaterHeating']
+      return if water_heating.nil?
+
+      @water_fixtures_usage_multiplier = HPXML::to_float_or_nil(XMLHelper.get_value(water_heating, 'extension/WaterFixturesUsageMultiplier'))
+    end
+  end
+
   class SolarThermalSystems < BaseArrayElement
     def add(**kwargs)
       self << SolarThermalSystem.new(@hpxml_object, **kwargs)
@@ -3230,7 +3261,7 @@ class HPXML < Object
   class ClothesWasher < BaseElement
     ATTRS = [:id, :location, :modified_energy_factor, :integrated_modified_energy_factor,
              :rated_annual_kwh, :label_electric_rate, :label_gas_rate, :label_annual_gas_cost,
-             :capacity, :label_usage]
+             :capacity, :label_usage, :usage_multiplier]
     attr_accessor(*ATTRS)
 
     def delete
@@ -3258,6 +3289,8 @@ class HPXML < Object
       XMLHelper.add_element(clothes_washer, 'LabelAnnualGasCost', Float(@label_annual_gas_cost)) unless @label_annual_gas_cost.nil?
       XMLHelper.add_element(clothes_washer, 'LabelUsage', Float(@label_usage)) unless @label_usage.nil?
       XMLHelper.add_element(clothes_washer, 'Capacity', Float(@capacity)) unless @capacity.nil?
+      HPXML::add_extension(parent: clothes_washer,
+                           extensions: { 'UsageMultiplier' => HPXML::to_float_or_nil(@usage_multiplier) })
     end
 
     def from_rexml(clothes_washer)
@@ -3273,6 +3306,7 @@ class HPXML < Object
       @label_annual_gas_cost = HPXML::to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelAnnualGasCost'))
       @label_usage = HPXML::to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelUsage'))
       @capacity = HPXML::to_float_or_nil(XMLHelper.get_value(clothes_washer, 'Capacity'))
+      @usage_multiplier = HPXML::to_float_or_nil(XMLHelper.get_value(clothes_washer, 'extension/UsageMultiplier'))
     end
   end
 
@@ -3291,7 +3325,8 @@ class HPXML < Object
   end
 
   class ClothesDryer < BaseElement
-    ATTRS = [:id, :location, :fuel_type, :energy_factor, :combined_energy_factor, :control_type]
+    ATTRS = [:id, :location, :fuel_type, :energy_factor, :combined_energy_factor, :control_type,
+             :usage_multiplier]
     attr_accessor(*ATTRS)
 
     def delete
@@ -3315,6 +3350,8 @@ class HPXML < Object
       XMLHelper.add_element(clothes_dryer, 'EnergyFactor', Float(@energy_factor)) unless @energy_factor.nil?
       XMLHelper.add_element(clothes_dryer, 'CombinedEnergyFactor', Float(@combined_energy_factor)) unless @combined_energy_factor.nil?
       XMLHelper.add_element(clothes_dryer, 'ControlType', @control_type) unless @control_type.nil?
+      HPXML::add_extension(parent: clothes_dryer,
+                           extensions: { 'UsageMultiplier' => HPXML::to_float_or_nil(@usage_multiplier) })
     end
 
     def from_rexml(clothes_dryer)
@@ -3326,6 +3363,7 @@ class HPXML < Object
       @energy_factor = HPXML::to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'EnergyFactor'))
       @combined_energy_factor = HPXML::to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'CombinedEnergyFactor'))
       @control_type = XMLHelper.get_value(clothes_dryer, 'ControlType')
+      @usage_multiplier = HPXML::to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'extension/UsageMultiplier'))
     end
   end
 
@@ -3346,7 +3384,7 @@ class HPXML < Object
   class Dishwasher < BaseElement
     ATTRS = [:id, :energy_factor, :rated_annual_kwh, :place_setting_capacity,
              :label_electric_rate, :label_gas_rate, :label_annual_gas_cost,
-             :label_usage]
+             :label_usage, :usage_multiplier]
     attr_accessor(*ATTRS)
 
     def delete
@@ -3372,6 +3410,8 @@ class HPXML < Object
       XMLHelper.add_element(dishwasher, 'LabelGasRate', Float(@label_gas_rate)) unless @label_gas_rate.nil?
       XMLHelper.add_element(dishwasher, 'LabelAnnualGasCost', Float(@label_annual_gas_cost)) unless @label_annual_gas_cost.nil?
       XMLHelper.add_element(dishwasher, 'LabelUsage', Float(@label_usage)) unless @label_usage.nil?
+      HPXML::add_extension(parent: dishwasher,
+                           extensions: { 'UsageMultiplier' => HPXML::to_float_or_nil(@usage_multiplier) })
     end
 
     def from_rexml(dishwasher)
@@ -3385,6 +3425,7 @@ class HPXML < Object
       @label_gas_rate = HPXML::to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelGasRate'))
       @label_annual_gas_cost = HPXML::to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelAnnualGasCost'))
       @label_usage = HPXML::to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelUsage'))
+      @usage_multiplier = HPXML::to_float_or_nil(XMLHelper.get_value(dishwasher, 'extension/UsageMultiplier'))
     end
   end
 
@@ -3403,7 +3444,7 @@ class HPXML < Object
   end
 
   class Refrigerator < BaseElement
-    ATTRS = [:id, :location, :rated_annual_kwh, :adjusted_annual_kwh]
+    ATTRS = [:id, :location, :rated_annual_kwh, :adjusted_annual_kwh, :usage_multiplier]
     attr_accessor(*ATTRS)
 
     def delete
@@ -3425,7 +3466,8 @@ class HPXML < Object
       XMLHelper.add_element(refrigerator, 'Location', @location) unless @location.nil?
       XMLHelper.add_element(refrigerator, 'RatedAnnualkWh', Float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
       HPXML::add_extension(parent: refrigerator,
-                           extensions: { 'AdjustedAnnualkWh' => HPXML::to_float_or_nil(@adjusted_annual_kwh) })
+                           extensions: { 'AdjustedAnnualkWh' => HPXML::to_float_or_nil(@adjusted_annual_kwh),
+                                         'UsageMultiplier' => HPXML::to_float_or_nil(@usage_multiplier) })
     end
 
     def from_rexml(refrigerator)
@@ -3435,6 +3477,7 @@ class HPXML < Object
       @location = XMLHelper.get_value(refrigerator, 'Location')
       @rated_annual_kwh = HPXML::to_float_or_nil(XMLHelper.get_value(refrigerator, 'RatedAnnualkWh'))
       @adjusted_annual_kwh = HPXML::to_float_or_nil(XMLHelper.get_value(refrigerator, 'extension/AdjustedAnnualkWh'))
+      @usage_multiplier = HPXML::to_float_or_nil(XMLHelper.get_value(refrigerator, 'extension/UsageMultiplier'))
     end
   end
 
@@ -3453,7 +3496,7 @@ class HPXML < Object
   end
 
   class CookingRange < BaseElement
-    ATTRS = [:id, :fuel_type, :is_induction]
+    ATTRS = [:id, :fuel_type, :is_induction, :usage_multiplier]
     attr_accessor(*ATTRS)
 
     def delete
@@ -3474,6 +3517,8 @@ class HPXML < Object
       XMLHelper.add_attribute(sys_id, 'id', @id)
       XMLHelper.add_element(cooking_range, 'FuelType', @fuel_type) unless @fuel_type.nil?
       XMLHelper.add_element(cooking_range, 'IsInduction', Boolean(@is_induction)) unless @is_induction.nil?
+      HPXML::add_extension(parent: cooking_range,
+                           extensions: { 'UsageMultiplier' => HPXML::to_float_or_nil(@usage_multiplier) })
     end
 
     def from_rexml(cooking_range)
@@ -3482,6 +3527,7 @@ class HPXML < Object
       @id = HPXML::get_id(cooking_range)
       @fuel_type = XMLHelper.get_value(cooking_range, 'FuelType')
       @is_induction = HPXML::to_bool_or_nil(XMLHelper.get_value(cooking_range, 'IsInduction'))
+      @usage_multiplier = HPXML::to_float_or_nil(XMLHelper.get_value(cooking_range, 'extension/UsageMultiplier'))
     end
   end
 
@@ -3579,6 +3625,33 @@ class HPXML < Object
     end
   end
 
+  class Lighting < BaseElement
+    ATTRS = [:usage_multiplier]
+    attr_accessor(*ATTRS)
+
+    def check_for_errors
+      errors = []
+      return errors
+    end
+
+    def to_rexml(doc)
+      return if nil?
+
+      lighting = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Lighting'])
+      HPXML::add_extension(parent: lighting,
+                           extensions: { 'UsageMultiplier' => HPXML::to_float_or_nil(@usage_multiplier) })
+    end
+
+    def from_rexml(hpxml)
+      return if hpxml.nil?
+
+      lighting = hpxml.elements['Building/BuildingDetails/Lighting']
+      return if lighting.nil?
+
+      @usage_multiplier = HPXML::to_float_or_nil(XMLHelper.get_value(lighting, 'extension/UsageMultiplier'))
+    end
+  end
+
   class CeilingFans < BaseArrayElement
     def add(**kwargs)
       self << CeilingFan.new(@hpxml_object, **kwargs)
@@ -3643,7 +3716,7 @@ class HPXML < Object
   end
 
   class PlugLoad < BaseElement
-    ATTRS = [:id, :plug_load_type, :kWh_per_year, :frac_sensible, :frac_latent]
+    ATTRS = [:id, :plug_load_type, :kWh_per_year, :frac_sensible, :frac_latent, :usage_multiplier]
     attr_accessor(*ATTRS)
 
     def delete
@@ -3670,7 +3743,8 @@ class HPXML < Object
       end
       HPXML::add_extension(parent: plug_load,
                            extensions: { 'FracSensible' => HPXML::to_float_or_nil(@frac_sensible),
-                                         'FracLatent' => HPXML::to_float_or_nil(@frac_latent) })
+                                         'FracLatent' => HPXML::to_float_or_nil(@frac_latent),
+                                         'UsageMultiplier' => HPXML::to_float_or_nil(@usage_multiplier) })
     end
 
     def from_rexml(plug_load)
@@ -3679,6 +3753,7 @@ class HPXML < Object
       @kWh_per_year = HPXML::to_float_or_nil(XMLHelper.get_value(plug_load, "Load[Units='kWh/year']/Value"))
       @frac_sensible = HPXML::to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/FracSensible'))
       @frac_latent = HPXML::to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/FracLatent'))
+      @usage_multiplier = HPXML::to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/UsageMultiplier'))
     end
   end
 

--- a/HPXMLtoOpenStudio/resources/lighting.rb
+++ b/HPXMLtoOpenStudio/resources/lighting.rb
@@ -189,7 +189,7 @@ class Lighting
     return fFI_int, fFI_ext, fFI_grg, fFII_int, fFII_ext, fFII_grg
   end
 
-  def self.calc_lighting_energy(eri_version, cfa, gfa, fFI_int, fFI_ext, fFI_grg, fFII_int, fFII_ext, fFII_grg)
+  def self.calc_lighting_energy(eri_version, cfa, gfa, fFI_int, fFI_ext, fFI_grg, fFII_int, fFII_ext, fFII_grg, usage_multiplier = 1.0)
     if Constants.ERIVersions.index(eri_version) >= Constants.ERIVersions.index('2014ADEG')
       # ANSI/RESNET/ICC 301-2014 Addendum G-2018, Solid State Lighting
       int_kwh = 0.9 / 0.925 * (455.0 + 0.8 * cfa) * ((1.0 - fFII_int - fFI_int) + fFI_int * 15.0 / 60.0 + fFII_int * 15.0 / 90.0) + 0.1 * (455.0 + 0.8 * cfa) # Eq 4.2-2)
@@ -206,6 +206,11 @@ class Lighting
         grg_kwh = 100.0 * (1.0 - (fFI_grg + fFII_grg)) + 25.0 * (fFI_grg + fFII_grg) # Eq 4.2-4
       end
     end
+
+    int_kwh *= usage_multiplier
+    ext_kwh *= usage_multiplier
+    grg_kwh *= usage_multiplier
+
     return int_kwh, ext_kwh, grg_kwh
   end
 end

--- a/HPXMLtoOpenStudio/resources/misc_loads.rb
+++ b/HPXMLtoOpenStudio/resources/misc_loads.rb
@@ -3,11 +3,22 @@ require_relative 'unit_conversions'
 require_relative 'schedules'
 
 class MiscLoads
-  def self.apply_plug(model, misc_kwh, sens_frac, lat_frac,
-                      weekday_sch, weekend_sch, monthly_sch, tv_kwh, cfa,
+  def self.apply_plug(model, plug_load_misc, plug_load_tv, schedule, cfa,
                       living_space)
 
-    return if misc_kwh + tv_kwh == 0
+    misc_kwh = 0
+    if not plug_load_misc.nil?
+      misc_kwh = plug_load_misc.kWh_per_year * plug_load_misc.usage_multiplier
+    end
+    tv_kwh = 0
+    if not plug_load_tv.nil?
+      tv_kwh = plug_load_tv.kWh_per_year * plug_load_tv.usage_multiplier
+    end
+
+    return if misc_kwh + tv_kwh <= 0
+
+    sens_frac = plug_load_misc.frac_sensible
+    lat_frac = plug_load_misc.frac_latent
 
     # check for valid inputs
     if (sens_frac < 0) || (sens_frac > 1)
@@ -21,7 +32,7 @@ class MiscLoads
     end
 
     # Create schedule
-    sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameMiscPlugLoads + ' schedule', weekday_sch, weekend_sch, monthly_sch, 1.0, 1.0, true, true, Constants.ScheduleTypeLimitsFraction)
+    sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameMiscPlugLoads + ' schedule', schedule.weekday_fractions, schedule.weekend_fractions, schedule.monthly_multipliers, 1.0, 1.0, true, true, Constants.ScheduleTypeLimitsFraction)
 
     # Misc plug loads
     if misc_kwh > 0

--- a/docs/source/hpxml_to_openstudio.rst
+++ b/docs/source/hpxml_to_openstudio.rst
@@ -587,6 +587,8 @@ Water fixtures should be entered as ``Systems/WaterHeating/WaterFixture`` elemen
 Each fixture must have ``WaterFixtureType`` and ``LowFlow`` elements provided.
 Fixtures should be specified as low flow if they are <= 2.0 gpm.
 
+A ``WaterHeating/extension/WaterFixturesUsageMultiplier`` can also be optionally provided that scales hot water usage; if not provided, it is assumed to be 1.0.
+
 Solar Thermal
 *************
 
@@ -664,6 +666,8 @@ This equation is based on the `Interpretation on ANSI/RESNET 301-2014 Clothes Wa
 
 .. math:: IntegratedModifiedEnergyFactor = \frac{ModifiedEnergyFactor - 0.503}{0.95}
 
+An ``extension/UsageMultiplier`` can also be optionally provided that scales energy and hot water usage; if not provided, it is assumed to be 1.0.
+
 Clothes Dryer
 *************
 
@@ -685,6 +689,8 @@ If ``EnergyFactor`` is provided instead of ``CombinedEnergyFactor``, it will be 
 This equation is based on the `Interpretation on ANSI/RESNET/ICC 301-2014 Clothes Dryer CEF <https://www.resnet.us/wp-content/uploads/No.-301-2014-10-Section-4.2.2.5.2.8-Clothes-Dryer-CEF-Rating.pdf>`_.
 
 .. math:: CombinedEnergyFactor = \frac{EnergyFactor}{1.15}
+
+An ``extension/UsageMultiplier`` can also be optionally provided that scales energy usage; if not provided, it is assumed to be 1.0.
 
 Dishwasher
 **********
@@ -711,6 +717,8 @@ This equation is based on `ANSI/RESNET/ICC 301-2014 <https://codes.iccsafe.org/c
 
 .. math:: RatedAnnualkWh = \frac{215.0}{EnergyFactor}
 
+An ``extension/UsageMultiplier`` can also be optionally provided that scales energy and hot water usage; if not provided, it is assumed to be 1.0.
+
 Refrigerator
 ************
 
@@ -722,6 +730,8 @@ If neither are provided, ``RatedAnnualkWh`` will be defaulted to represent a sta
 This equation is based on `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
 
 .. math:: RatedAnnualkWh = 637.0 + 18.0 \cdot Number of bedrooms
+
+An ``extension/UsageMultiplier`` can also be optionally provided that scales energy usage; if not provided, it is assumed to be 1.0.
 
 Cooking Range/Oven
 ******************
@@ -740,6 +750,8 @@ IsInduction    false
 IsConvection   false
 =============  ==============
 
+An ``extension/UsageMultiplier`` can also be optionally provided that scales energy usage; if not provided, it is assumed to be 1.0.
+
 Lighting
 ~~~~~~~~
 
@@ -754,6 +766,8 @@ If the fractions sum to less than 1, the remainder is assumed to be incandescent
 Garage lighting values are ignored if the building has no garage.
 
 To model a building without any lighting, all six ``Lighting/LightingGroup`` elements must be excluded.
+
+A ``Lighting/extension/UsageMultiplier`` can also be optionally provided that scales energy usage; if not provided, it is assumed to be 1.0.
 
 Ceiling Fans
 ~~~~~~~~~~~~
@@ -770,6 +784,8 @@ Plug Loads
 Plug loads can be provided by entering ``MiscLoads/PlugLoad`` elements; if not provided, plug loads will not be modeled.
 Currently only plug loads specified with ``PlugLoadType='other'`` and ``PlugLoadType='TV other'`` are recognized.
 The annual energy consumption (``Load[Units='kWh/year']/Value``) can be provided, otherwise default assumptions based on the plug load type are used.
+
+An ``extension/UsageMultiplier`` can also be optionally provided that scales energy usage; if not provided, it is assumed to be 1.0.
 
 Validating & Debugging Errors
 -----------------------------

--- a/tasks.rb
+++ b/tasks.rb
@@ -231,6 +231,7 @@ def create_hpxmls
     'base-misc-lighting-none.xml' => 'base.xml',
     'base-misc-timestep-10-mins.xml' => 'base.xml',
     'base-misc-runperiod-1-month.xml' => 'base.xml',
+    'base-misc-usage-multiplier.xml' => 'base.xml',
     'base-misc-whole-house-fan.xml' => 'base.xml',
     'base-pv.xml' => 'base.xml',
     'base-site-neighbors.xml' => 'base.xml',
@@ -2879,6 +2880,8 @@ def set_hpxml_water_fixtures(hpxml_file, hpxml)
     hpxml.water_fixtures[1].low_flow = true
   elsif ['base-dhw-none.xml'].include? hpxml_file
     hpxml.water_fixtures.clear()
+  elsif ['base-misc-usage-multiplier.xml'].include? hpxml_file
+    hpxml.water_heating.water_fixtures_usage_multiplier = 0.9
   end
 end
 
@@ -3028,6 +3031,8 @@ def set_hpxml_clothes_washer(hpxml_file, hpxml)
     hpxml.clothes_washers[0].label_annual_gas_cost = nil
     hpxml.clothes_washers[0].capacity = nil
     hpxml.clothes_washers[0].label_usage = nil
+  elsif ['base-misc-usage-multiplier.xml'].include? hpxml_file
+    hpxml.clothes_washers[0].usage_multiplier = 0.9
   end
 end
 
@@ -3084,6 +3089,8 @@ def set_hpxml_clothes_dryer(hpxml_file, hpxml)
     hpxml.clothes_dryers[0].energy_factor = nil
     hpxml.clothes_dryers[0].combined_energy_factor = nil
     hpxml.clothes_dryers[0].control_type = nil
+  elsif ['base-misc-usage-multiplier.xml'].include? hpxml_file
+    hpxml.clothes_dryers[0].usage_multiplier = 0.9
   end
 end
 
@@ -3109,6 +3116,8 @@ def set_hpxml_dishwasher(hpxml_file, hpxml)
     hpxml.dishwashers[0].label_annual_gas_cost = nil
     hpxml.dishwashers[0].place_setting_capacity = nil
     hpxml.dishwashers[0].label_usage = nil
+  elsif ['base-misc-usage-multiplier.xml'].include? hpxml_file
+    hpxml.dishwashers[0].usage_multiplier = 0.9
   end
 end
 
@@ -3134,6 +3143,8 @@ def set_hpxml_refrigerator(hpxml_file, hpxml)
     hpxml.refrigerators[0].location = nil
     hpxml.refrigerators[0].rated_annual_kwh = nil
     hpxml.refrigerators[0].adjusted_annual_kwh = nil
+  elsif ['base-misc-usage-multiplier.xml'].include? hpxml_file
+    hpxml.refrigerators[0].usage_multiplier = 0.9
   end
 end
 
@@ -3157,6 +3168,8 @@ def set_hpxml_cooking_range(hpxml_file, hpxml)
     hpxml.cooking_ranges[0].is_induction = false
   elsif ['base-misc-defaults.xml'].include? hpxml_file
     hpxml.cooking_ranges[0].is_induction = nil
+  elsif ['base-misc-usage-multiplier.xml'].include? hpxml_file
+    hpxml.cooking_ranges[0].usage_multiplier = 0.9
   end
 end
 
@@ -3201,6 +3214,8 @@ def set_hpxml_lighting(hpxml_file, hpxml)
     hpxml.lighting_groups.clear()
   elsif ['invalid_files/lighting-fractions.xml'].include? hpxml_file
     hpxml.lighting_groups[0].fration_of_units_in_location = 0.8
+  elsif ['base-misc-usage-multiplier.xml'].include? hpxml_file
+    hpxml.lighting.usage_multiplier = 0.9
   end
 end
 
@@ -3222,6 +3237,10 @@ def set_hpxml_plug_loads(hpxml_file, hpxml)
                          plug_load_type: HPXML::PlugLoadTypeOther)
     hpxml.plug_loads.add(id: 'PlugLoadMisc2',
                          plug_load_type: HPXML::PlugLoadTypeTelevision)
+  elsif ['base-misc-usage-multiplier.xml'].include? hpxml_file
+    hpxml.plug_loads.each do |plug_load|
+      plug_load.usage_multiplier = 0.9
+    end
   end
   if ['base-misc-defaults.xml'].include? hpxml_file
     hpxml.plug_loads.each do |plug_load|

--- a/workflow/sample_files/base-misc-usage-multiplier.xml
+++ b/workflow/sample_files/base-misc-usage-multiplier.xml
@@ -1,0 +1,538 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<HPXML xmlns='http://hpxmlonline.com/2019/10' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://hpxmlonline.com/2019/10' schemaVersion='3.0'>
+  <XMLTransactionHeaderInformation>
+    <XMLType>HPXML</XMLType>
+    <XMLGeneratedBy>Rakefile</XMLGeneratedBy>
+    <CreatedDateAndTime>2000-01-01T00:00:00-07:00</CreatedDateAndTime>
+    <Transaction>create</Transaction>
+  </XMLTransactionHeaderInformation>
+  <SoftwareInfo>
+    <extension>
+      <SimulationControl>
+        <Timestep>60</Timestep>
+      </SimulationControl>
+    </extension>
+  </SoftwareInfo>
+  <Building>
+    <BuildingID id='MyBuilding'/>
+    <ProjectStatus>
+      <EventType>proposed workscope</EventType>
+    </ProjectStatus>
+    <BuildingDetails>
+      <BuildingSummary>
+        <Site>
+          <FuelTypesAvailable>
+            <Fuel>electricity</Fuel>
+            <Fuel>natural gas</Fuel>
+          </FuelTypesAvailable>
+        </Site>
+        <BuildingOccupancy>
+          <NumberofResidents>3.0</NumberofResidents>
+        </BuildingOccupancy>
+        <BuildingConstruction>
+          <ResidentialFacilityType>single-family detached</ResidentialFacilityType>
+          <NumberofConditionedFloors>2</NumberofConditionedFloors>
+          <NumberofConditionedFloorsAboveGrade>1</NumberofConditionedFloorsAboveGrade>
+          <NumberofBedrooms>3</NumberofBedrooms>
+          <ConditionedFloorArea>2700.0</ConditionedFloorArea>
+          <ConditionedBuildingVolume>21600.0</ConditionedBuildingVolume>
+        </BuildingConstruction>
+      </BuildingSummary>
+      <ClimateandRiskZones>
+        <ClimateZoneIECC>
+          <Year>2006</Year>
+          <ClimateZone>5B</ClimateZone>
+        </ClimateZoneIECC>
+        <WeatherStation>
+          <SystemIdentifier id='WeatherStation'/>
+          <Name>Denver, CO</Name>
+          <WMO>725650</WMO>
+        </WeatherStation>
+      </ClimateandRiskZones>
+      <Enclosure>
+        <AirInfiltration>
+          <AirInfiltrationMeasurement>
+            <SystemIdentifier id='InfiltrationMeasurement'/>
+            <HousePressure>50.0</HousePressure>
+            <BuildingAirLeakage>
+              <UnitofMeasure>ACH</UnitofMeasure>
+              <AirLeakage>3.0</AirLeakage>
+            </BuildingAirLeakage>
+            <InfiltrationVolume>21600.0</InfiltrationVolume>
+          </AirInfiltrationMeasurement>
+        </AirInfiltration>
+        <Attics>
+          <Attic>
+            <SystemIdentifier id='UnventedAttic'/>
+            <AtticType>
+              <Attic>
+                <Vented>false</Vented>
+              </Attic>
+            </AtticType>
+            <WithinInfiltrationVolume>false</WithinInfiltrationVolume>
+          </Attic>
+        </Attics>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='ConditionedBasement'/>
+            <FoundationType>
+              <Basement>
+                <Conditioned>true</Conditioned>
+              </Basement>
+            </FoundationType>
+          </Foundation>
+        </Foundations>
+        <Roofs>
+          <Roof>
+            <SystemIdentifier id='Roof'/>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <Area>1510.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='RoofInsulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+        </Roofs>
+        <RimJoists>
+          <RimJoist>
+            <SystemIdentifier id='RimJoistFoundation'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>116.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoistFoundationInsulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+        </RimJoists>
+        <Walls>
+          <Wall>
+            <SystemIdentifier id='Wall'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1200.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallInsulation'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='WallAtticGable'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - unvented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>290.0</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='WallAtticGableInsulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+        </Walls>
+        <FoundationWalls>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>1200.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <Insulation>
+              <SystemIdentifier id='FoundationWallInsulation'/>
+              <Layer>
+                <InstallationType>continuous - exterior</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+                <extension>
+                  <DistanceToTopOfInsulation>0.0</DistanceToTopOfInsulation>
+                  <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+                </extension>
+              </Layer>
+              <Layer>
+                <InstallationType>continuous - interior</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+                <extension>
+                  <DistanceToTopOfInsulation>0.0</DistanceToTopOfInsulation>
+                  <DistanceToBottomOfInsulation>0.0</DistanceToBottomOfInsulation>
+                </extension>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+        </FoundationWalls>
+        <FrameFloors>
+          <FrameFloor>
+            <SystemIdentifier id='FloorBelowAttic'/>
+            <ExteriorAdjacentTo>attic - unvented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>1350.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorBelowAtticInsulation'/>
+              <AssemblyEffectiveRValue>39.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+        </FrameFloors>
+        <Slabs>
+          <Slab>
+            <SystemIdentifier id='Slab'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>1350.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>150.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='SlabPerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='SlabUnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+        </Slabs>
+        <Windows>
+          <Window>
+            <SystemIdentifier id='WindowNorth'/>
+            <Area>108.0</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <InteriorShading>
+              <SystemIdentifier id='WindowNorthInteriorShading'/>
+              <SummerShadingCoefficient>0.7</SummerShadingCoefficient>
+              <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
+            </InteriorShading>
+            <FractionOperable>0.33</FractionOperable>
+            <AttachedToWall idref='Wall'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowSouth'/>
+            <Area>108.0</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <InteriorShading>
+              <SystemIdentifier id='WindowSouthInteriorShading'/>
+              <SummerShadingCoefficient>0.7</SummerShadingCoefficient>
+              <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
+            </InteriorShading>
+            <FractionOperable>0.33</FractionOperable>
+            <AttachedToWall idref='Wall'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowEast'/>
+            <Area>72.0</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <InteriorShading>
+              <SystemIdentifier id='WindowEastInteriorShading'/>
+              <SummerShadingCoefficient>0.7</SummerShadingCoefficient>
+              <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
+            </InteriorShading>
+            <FractionOperable>0.33</FractionOperable>
+            <AttachedToWall idref='Wall'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='WindowWest'/>
+            <Area>72.0</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.33</UFactor>
+            <SHGC>0.45</SHGC>
+            <InteriorShading>
+              <SystemIdentifier id='WindowWestInteriorShading'/>
+              <SummerShadingCoefficient>0.7</SummerShadingCoefficient>
+              <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
+            </InteriorShading>
+            <FractionOperable>0.33</FractionOperable>
+            <AttachedToWall idref='Wall'/>
+          </Window>
+        </Windows>
+        <Doors>
+          <Door>
+            <SystemIdentifier id='DoorNorth'/>
+            <AttachedToWall idref='Wall'/>
+            <Area>40.0</Area>
+            <Azimuth>0</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+          <Door>
+            <SystemIdentifier id='DoorSouth'/>
+            <AttachedToWall idref='Wall'/>
+            <Area>40.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+        </Doors>
+      </Enclosure>
+      <Systems>
+        <HVAC>
+          <HVACPlant>
+            <HeatingSystem>
+              <SystemIdentifier id='HeatingSystem'/>
+              <DistributionSystem idref='HVACDistribution'/>
+              <HeatingSystemType>
+                <Furnace/>
+              </HeatingSystemType>
+              <HeatingSystemFuel>natural gas</HeatingSystemFuel>
+              <HeatingCapacity>64000.0</HeatingCapacity>
+              <AnnualHeatingEfficiency>
+                <Units>AFUE</Units>
+                <Value>0.92</Value>
+              </AnnualHeatingEfficiency>
+              <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
+            </HeatingSystem>
+            <CoolingSystem>
+              <SystemIdentifier id='CoolingSystem'/>
+              <DistributionSystem idref='HVACDistribution'/>
+              <CoolingSystemType>central air conditioner</CoolingSystemType>
+              <CoolingSystemFuel>electricity</CoolingSystemFuel>
+              <CoolingCapacity>48000.0</CoolingCapacity>
+              <CompressorType>single stage</CompressorType>
+              <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
+              <AnnualCoolingEfficiency>
+                <Units>SEER</Units>
+                <Value>13.0</Value>
+              </AnnualCoolingEfficiency>
+              <SensibleHeatFraction>0.73</SensibleHeatFraction>
+            </CoolingSystem>
+          </HVACPlant>
+          <HVACControl>
+            <SystemIdentifier id='HVACControl'/>
+            <ControlType>manual thermostat</ControlType>
+            <SetpointTempHeatingSeason>68.0</SetpointTempHeatingSeason>
+            <SetpointTempCoolingSeason>78.0</SetpointTempCoolingSeason>
+          </HVACControl>
+          <HVACDistribution>
+            <SystemIdentifier id='HVACDistribution'/>
+            <DistributionSystemType>
+              <AirDistribution>
+                <DuctLeakageMeasurement>
+                  <DuctType>supply</DuctType>
+                  <DuctLeakage>
+                    <Units>CFM25</Units>
+                    <Value>75.0</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <DuctLeakageMeasurement>
+                  <DuctType>return</DuctType>
+                  <DuctLeakage>
+                    <Units>CFM25</Units>
+                    <Value>25.0</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <Ducts>
+                  <DuctType>supply</DuctType>
+                  <DuctInsulationRValue>4.0</DuctInsulationRValue>
+                  <DuctLocation>attic - unvented</DuctLocation>
+                  <DuctSurfaceArea>150.0</DuctSurfaceArea>
+                </Ducts>
+                <Ducts>
+                  <DuctType>return</DuctType>
+                  <DuctInsulationRValue>0.0</DuctInsulationRValue>
+                  <DuctLocation>attic - unvented</DuctLocation>
+                  <DuctSurfaceArea>50.0</DuctSurfaceArea>
+                </Ducts>
+              </AirDistribution>
+            </DistributionSystemType>
+          </HVACDistribution>
+        </HVAC>
+        <WaterHeating>
+          <WaterHeatingSystem>
+            <SystemIdentifier id='WaterHeater'/>
+            <FuelType>electricity</FuelType>
+            <WaterHeaterType>storage water heater</WaterHeaterType>
+            <Location>living space</Location>
+            <TankVolume>40.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <HeatingCapacity>18767.0</HeatingCapacity>
+            <EnergyFactor>0.95</EnergyFactor>
+            <HotWaterTemperature>125.0</HotWaterTemperature>
+          </WaterHeatingSystem>
+          <HotWaterDistribution>
+            <SystemIdentifier id='HotWaterDstribution'/>
+            <SystemType>
+              <Standard>
+                <PipingLength>50.0</PipingLength>
+              </Standard>
+            </SystemType>
+            <PipeInsulation>
+              <PipeRValue>0.0</PipeRValue>
+            </PipeInsulation>
+          </HotWaterDistribution>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture'/>
+            <WaterFixtureType>shower head</WaterFixtureType>
+            <LowFlow>true</LowFlow>
+          </WaterFixture>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture2'/>
+            <WaterFixtureType>faucet</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+          <extension>
+            <WaterFixturesUsageMultiplier>0.9</WaterFixturesUsageMultiplier>
+          </extension>
+        </WaterHeating>
+      </Systems>
+      <Appliances>
+        <ClothesWasher>
+          <SystemIdentifier id='ClothesWasher'/>
+          <Location>living space</Location>
+          <IntegratedModifiedEnergyFactor>1.21</IntegratedModifiedEnergyFactor>
+          <RatedAnnualkWh>380.0</RatedAnnualkWh>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>27.0</LabelAnnualGasCost>
+          <LabelUsage>6.0</LabelUsage>
+          <Capacity>3.2</Capacity>
+          <extension>
+            <UsageMultiplier>0.9</UsageMultiplier>
+          </extension>
+        </ClothesWasher>
+        <ClothesDryer>
+          <SystemIdentifier id='ClothesDryer'/>
+          <Location>living space</Location>
+          <FuelType>electricity</FuelType>
+          <CombinedEnergyFactor>3.73</CombinedEnergyFactor>
+          <ControlType>timer</ControlType>
+          <extension>
+            <UsageMultiplier>0.9</UsageMultiplier>
+          </extension>
+        </ClothesDryer>
+        <Dishwasher>
+          <SystemIdentifier id='Dishwasher'/>
+          <RatedAnnualkWh>307.0</RatedAnnualkWh>
+          <PlaceSettingCapacity>12</PlaceSettingCapacity>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>22.32</LabelAnnualGasCost>
+          <LabelUsage>4.0</LabelUsage>
+          <extension>
+            <UsageMultiplier>0.9</UsageMultiplier>
+          </extension>
+        </Dishwasher>
+        <Refrigerator>
+          <SystemIdentifier id='Refrigerator'/>
+          <Location>living space</Location>
+          <RatedAnnualkWh>650.0</RatedAnnualkWh>
+          <extension>
+            <UsageMultiplier>0.9</UsageMultiplier>
+          </extension>
+        </Refrigerator>
+        <CookingRange>
+          <SystemIdentifier id='Range'/>
+          <FuelType>electricity</FuelType>
+          <IsInduction>false</IsInduction>
+          <extension>
+            <UsageMultiplier>0.9</UsageMultiplier>
+          </extension>
+        </CookingRange>
+        <Oven>
+          <SystemIdentifier id='Oven'/>
+          <IsConvection>false</IsConvection>
+        </Oven>
+      </Appliances>
+      <Lighting>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierI_Interior'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.5</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier I</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierI_Exterior'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.5</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier I</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierI_Garage'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.5</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier I</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierII_Interior'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.25</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier II</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierII_Exterior'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.25</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier II</ThirdPartyCertification>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='Lighting_TierII_Garage'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.25</FractionofUnitsInLocation>
+          <ThirdPartyCertification>ERI Tier II</ThirdPartyCertification>
+        </LightingGroup>
+        <extension>
+          <UsageMultiplier>0.9</UsageMultiplier>
+        </extension>
+      </Lighting>
+      <MiscLoads>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoadMisc'/>
+          <PlugLoadType>other</PlugLoadType>
+          <Load>
+            <Units>kWh/year</Units>
+            <Value>2457.0</Value>
+          </Load>
+          <extension>
+            <FracSensible>0.855</FracSensible>
+            <FracLatent>0.045</FracLatent>
+            <UsageMultiplier>0.9</UsageMultiplier>
+          </extension>
+        </PlugLoad>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoadMisc2'/>
+          <PlugLoadType>TV other</PlugLoadType>
+          <Load>
+            <Units>kWh/year</Units>
+            <Value>620.0</Value>
+          </Load>
+          <extension>
+            <FracSensible>1.0</FracSensible>
+            <FracLatent>0.0</FracLatent>
+            <UsageMultiplier>0.9</UsageMultiplier>
+          </extension>
+        </PlugLoad>
+        <extension>
+          <WeekdayScheduleFractions>0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05</WeekdayScheduleFractions>
+          <WeekendScheduleFractions>0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05</WeekendScheduleFractions>
+          <MonthlyScheduleMultipliers>1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248</MonthlyScheduleMultipliers>
+        </extension>
+      </MiscLoads>
+    </BuildingDetails>
+  </Building>
+</HPXML>


### PR DESCRIPTION
## Pull Request Description

Adds optional `UsageMultiplier` inputs for appliances, plug loads, lighting, and water fixtures. Can be used to, e.g., reflect high/low usage occupants. Affects energy and/or hot water usage as appropriate. See base-misc-usage-multiplier.xml for an example.

## Checklist

Not all may apply:

- [x] EPvalidator.rb has been updated
- [x] Tests (and test files) have been updated
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
