### PR TITLE
Allow monthly timeseries outputs

### DIFF
--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -313,6 +313,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     elsif timeseries_frequency == 'daily'
       timeseries_size /= 3600
       timeseries_size /= 24
+    elsif timeseries_frequency == 'monthly'
+      timeseries_size = run_period.getEndMonth - run_period.getBeginMonth + 1
     elsif timeseries_frequency == 'timestep'
       timeseries_size /= 3600
       timeseries_size *= @model.getTimestep.numberOfTimestepsPerHour
@@ -797,6 +799,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       data = ['Hour', '#']
     elsif timeseries_frequency == 'daily'
       data = ['Day', '#']
+    elsif timeseries_frequency == 'monthly'
+      data = ['Month', '#']
     elsif timeseries_frequency == 'timestep'
       data = ['Timestep', '#']
     else
@@ -1761,6 +1765,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       'timestep' => 'Zone Timestep',
       'hourly' => 'Hourly',
       'daily' => 'Daily',
+      'monthly' => 'Monthly',
     }
   end
 

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -1181,8 +1181,10 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     values = values.get
     values += [0.0] * @timeseries_size if values.size == 0
     if (key_values_list.size == 1) && (key_values_list[0] == 'EMS')
-      # Shift all values by 1 timestep due to EMS reporting lag
-      return values[1..-1] + [values[-1]]
+      if (timeseries_frequency.downcase == 'timestep' || (timeseries_frequency.downcase == 'hourly' && @model.getTimestep.numberOfTimestepsPerHour == 1))
+        # Shift all values by 1 timestep due to EMS reporting lag
+        return values[1..-1] + [values[-1]]
+      end
     end
 
     return values

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>39bfa5c1-bb15-4880-ad22-57f041cb2020</version_id>
-  <version_modified>20200414T200853Z</version_modified>
+  <version_id>14855243-d710-48ed-a600-e7bbb5b51146</version_id>
+  <version_modified>20200414T205748Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -472,6 +472,12 @@
       <checksum>80167322</checksum>
     </file>
     <file>
+      <filename>output_report_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>88088CD4</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.9.1</identifier>
@@ -480,13 +486,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F47F36C4</checksum>
-    </file>
-    <file>
-      <filename>output_report_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>88088CD4</checksum>
+      <checksum>F9F0C597</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>cc544bfd-f6e4-4412-ba63-deba7b313520</version_id>
-  <version_modified>20200403T200946Z</version_modified>
+  <version_id>39bfa5c1-bb15-4880-ad22-57f041cb2020</version_id>
+  <version_modified>20200414T200853Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -30,6 +30,10 @@
         <choice>
           <value>daily</value>
           <display_name>daily</display_name>
+        </choice>
+        <choice>
+          <value>monthly</value>
+          <display_name>monthly</display_name>
         </choice>
       </choices>
     </argument>
@@ -476,13 +480,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>AEE07569</checksum>
+      <checksum>F47F36C4</checksum>
     </file>
     <file>
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>15EE06DB</checksum>
+      <checksum>88088CD4</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/tests/output_report_test.rb
+++ b/SimulationOutputReport/tests/output_report_test.rb
@@ -392,6 +392,23 @@ class SimulationOutputReportTest < MiniTest::Test
     assert_equal(365, File.readlines(timeseries_csv).size - 2)
   end
 
+  def test_timeseries_monthly_ALL
+    args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
+                  'timeseries_frequency' => 'monthly',
+                  'include_timeseries_zone_temperatures' => true,
+                  'include_timeseries_fuel_consumptions' => true,
+                  'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_total_loads' => true,
+                  'include_timeseries_component_loads' => true }
+    annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
+    assert(File.exist?(annual_csv))
+    assert(File.exist?(timeseries_csv))
+    expected_timeseries_cols = ['Month'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
+    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
+    assert_equal(12, File.readlines(timeseries_csv).size - 2)
+  end
+
   def test_timeseries_timestep_ALL_60min
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
                   'timeseries_frequency' => 'timestep',
@@ -458,6 +475,23 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31, File.readlines(timeseries_csv).size - 2)
+  end
+
+  def test_timeseries_monthly_ALL_runperiod_Jan
+    args_hash = { 'hpxml_path' => '../workflow/sample_files/base-misc-runperiod-1-month.xml',
+                  'timeseries_frequency' => 'monthly',
+                  'include_timeseries_zone_temperatures' => true,
+                  'include_timeseries_fuel_consumptions' => true,
+                  'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_total_loads' => true,
+                  'include_timeseries_component_loads' => true }
+    annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
+    assert(File.exist?(annual_csv))
+    assert(File.exist?(timeseries_csv))
+    expected_timeseries_cols = ['Month'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
+    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
+    assert_equal(1, File.readlines(timeseries_csv).size - 2)
   end
 
   def test_timeseries_timestep_ALL_60min_runperiod_Jan


### PR DESCRIPTION
## Pull Request Description

Adds ability to request monthly timeseries output from the reporting measure.

## Checklist

Not all may apply:

- [x] Tests (and test files) have been updated
- [x] `openstudio tasks.rb update_measures` has been run
