### PR TITLE
Minor bugfixes

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -3060,6 +3060,8 @@ class OSModel
       fractions[[lg.location, lg.third_party_certification]] = lg.fration_of_units_in_location
     end
 
+    return if fractions[[HPXML::LocationInterior, HPXML::LightingTypeTierI]].nil? # Not the lighting group(s) we're interested in
+
     int_kwh, ext_kwh, grg_kwh = Lighting.calc_lighting_energy(@eri_version, @cfa, @gfa,
                                                               fractions[[HPXML::LocationInterior, HPXML::LightingTypeTierI]],
                                                               fractions[[HPXML::LocationExterior, HPXML::LightingTypeTierI]],

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>9e3d05a9-769d-4d55-a91b-2d3f352041c0</version_id>
-  <version_modified>20200429T145642Z</version_modified>
+  <version_id>d8707956-d135-4167-8b5b-f69231cc6078</version_id>
+  <version_modified>20200429T150532Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -385,12 +385,6 @@
       <checksum>87AECAD9</checksum>
     </file>
     <file>
-      <filename>hvac_sizing.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>78A9EF9F</checksum>
-    </file>
-    <file>
       <filename>pv.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -478,6 +472,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4CF735E4</checksum>
+    </file>
+    <file>
+      <filename>hvac_sizing.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>A643C1F8</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>d8707956-d135-4167-8b5b-f69231cc6078</version_id>
-  <version_modified>20200429T150532Z</version_modified>
+  <version_id>f4617648-dbc0-4add-a5ff-540fc2bf4b32</version_id>
+  <version_modified>20200429T174350Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -457,17 +457,6 @@
       <checksum>99A4AED4</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>D7F2B990</checksum>
-    </file>
-    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -478,6 +467,17 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>A643C1F8</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>534FAF87</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6060ee70-8c68-4a06-bad1-788ced24a970</version_id>
-  <version_modified>20200428T224003Z</version_modified>
+  <version_id>bc2bc04d-9034-4441-a946-890fdd4b261a</version_id>
+  <version_modified>20200428T234139Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -463,12 +463,6 @@
       <checksum>99A4AED4</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7FEA49BD</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -478,6 +472,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>D7F2B990</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>96E52872</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>bc2bc04d-9034-4441-a946-890fdd4b261a</version_id>
-  <version_modified>20200428T234139Z</version_modified>
+  <version_id>9e3d05a9-769d-4d55-a91b-2d3f352041c0</version_id>
+  <version_modified>20200429T145642Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -477,7 +477,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>96E52872</checksum>
+      <checksum>4CF735E4</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>55c9f72d-2812-49e7-b5ba-ff6bf67d47c4</version_id>
-  <version_modified>20200427T203837Z</version_modified>
+  <version_id>6060ee70-8c68-4a06-bad1-788ced24a970</version_id>
+  <version_modified>20200428T224003Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -433,17 +433,6 @@
       <checksum>6D71A9DC</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>FA5962E7</checksum>
-    </file>
-    <file>
       <filename>constructions.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -478,6 +467,17 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>7FEA49BD</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>D7F2B990</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -4037,6 +4037,17 @@ class HPXML < Object
             end
           end
 
+          # Update attic/foundation idrefs as appropriate
+          @attics.each do |attic|
+            attic.attached_to_roof_idrefs.delete(surf2.id)
+            attic.attached_to_frame_floor_idrefs.delete(surf2.id)
+          end
+          @foundations.each do |foundation|
+            foundation.attached_to_slab_idrefs.delete(surf2.id)
+            foundation.attached_to_frame_floor_idrefs.delete(surf2.id)
+            foundation.attached_to_foundation_wall_idrefs.delete(surf2.id)
+          end
+
           # Remove old surface
           surfaces.delete_at(j)
         end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1276,7 +1276,10 @@ class HPXML < Object
     def delete
       @hpxml_object.roofs.delete(self)
       skylights.reverse_each do |skylight|
-        @hpxml_object.skylights.delete(skylight)
+        skylight.delete
+      end
+      @hpxml_object.attics.each do |attic|
+        attic.attached_to_roof_idrefs.delete(@id)
       end
     end
 
@@ -1485,10 +1488,10 @@ class HPXML < Object
     def delete
       @hpxml_object.walls.delete(self)
       windows.reverse_each do |window|
-        @hpxml_object.windows.delete(window)
+        window.delete
       end
       doors.reverse_each do |door|
-        @hpxml_object.doors.delete(door)
+        door.delete
       end
     end
 
@@ -1616,10 +1619,13 @@ class HPXML < Object
     def delete
       @hpxml_object.foundation_walls.delete(self)
       windows.reverse_each do |window|
-        @hpxml_object.windows.delete(window)
+        window.delete
       end
       doors.reverse_each do |door|
-        @hpxml_object.doors.delete(door)
+        door.delete
+      end
+      @hpxml_object.foundations.each do |foundation|
+        foundation.attached_to_foundation_wall_idrefs.delete(@id)
       end
     end
 
@@ -1750,6 +1756,12 @@ class HPXML < Object
 
     def delete
       @hpxml_object.frame_floors.delete(self)
+      @hpxml_object.attics.each do |attic|
+        attic.attached_to_frame_floor_idrefs.delete(@id)
+      end
+      @hpxml_object.foundations.each do |foundation|
+        foundation.attached_to_frame_floor_idrefs.delete(@id)
+      end
     end
 
     def check_for_errors
@@ -1838,6 +1850,9 @@ class HPXML < Object
 
     def delete
       @hpxml_object.slabs.delete(self)
+      @hpxml_object.foundations.each do |foundation|
+        foundation.attached_to_slab_idrefs.delete(@id)
+      end
     end
 
     def check_for_errors
@@ -2254,6 +2269,10 @@ class HPXML < Object
 
     def delete
       @hpxml_object.heating_systems.delete(self)
+      @hpxml_object.water_heating_systems.each do |water_heating_system|
+        next unless water_heating_system.related_hvac_idref == @id
+        water_heating_system.related_hvac_idref = nil
+      end
     end
 
     def check_for_errors
@@ -2358,6 +2377,10 @@ class HPXML < Object
 
     def delete
       @hpxml_object.cooling_systems.delete(self)
+      @hpxml_object.water_heating_systems.each do |water_heating_system|
+        next unless water_heating_system.related_hvac_idref == @id
+        water_heating_system.related_hvac_idref = nil
+      end
     end
 
     def check_for_errors
@@ -2464,6 +2487,10 @@ class HPXML < Object
 
     def delete
       @hpxml_object.heat_pumps.delete(self)
+      @hpxml_object.water_heating_systems.each do |water_heating_system|
+        next unless water_heating_system.related_hvac_idref == @id
+        water_heating_system.related_hvac_idref = nil
+      end
     end
 
     def check_for_errors
@@ -2700,6 +2727,14 @@ class HPXML < Object
 
     def delete
       @hpxml_object.hvac_distributions.delete(self)
+      (@hpxml_object.heating_systems + @hpxml_object.cooling_systems + @hpxml_object.heat_pumps).each do |hvac|
+        next unless hvac.distribution_system_idref == @id
+        hvac.distribution_system_idref = nil
+      end
+      @hpxml_object.ventilation_fans.each do |ventilation_fan|
+        next unless ventilation_fan.distribution_system_idref == @id
+        ventilation_fan.distribution_system_idref = nil
+      end
     end
 
     def check_for_errors
@@ -2778,7 +2813,6 @@ class HPXML < Object
     def delete
       @hpxml_object.hvac_distributions.each do |hvac_distribution|
         next unless hvac_distribution.duct_leakage_measurements.include? self
-
         hvac_distribution.duct_leakage_measurements.delete(self)
       end
     end
@@ -2832,7 +2866,6 @@ class HPXML < Object
     def delete
       @hpxml_object.hvac_distributions.each do |hvac_distribution|
         next unless hvac_distribution.ducts.include? self
-
         hvac_distribution.ducts.delete(self)
       end
     end
@@ -2996,6 +3029,10 @@ class HPXML < Object
 
     def delete
       @hpxml_object.water_heating_systems.delete(self)
+      @hpxml_object.solar_thermal_systems.each do |solar_thermal_system|
+        next unless solar_thermal_system.water_heating_system_idref == @id
+        solar_thermal_system.water_heating_system_idref = nil
+      end
     end
 
     def check_for_errors
@@ -4019,37 +4056,17 @@ class HPXML < Object
           end
 
           # Update subsurface idrefs as appropriate
-          if [:walls, :foundation_walls].include? surf_type
-            [:windows, :doors].each do |subsurf_type|
-              surf_types[subsurf_type].each do |subsurf, idx|
-                next unless subsurf.wall_idref == surf2.id
-
-                subsurf.wall_idref = surf.id
-              end
-            end
-          elsif [:roofs].include? surf_type
-            [:skylights].each do |subsurf_type|
-              surf_types[subsurf_type].each do |subsurf|
-                next unless subsurf.roof_idref == surf2.id
-
-                subsurf.roof_idref = surf.id
-              end
-            end
+          (@windows + @doors).each do |subsurf|
+            next unless subsurf.wall_idref == surf2.id
+            subsurf.wall_idref = surf.id
           end
-
-          # Update attic/foundation idrefs as appropriate
-          @attics.each do |attic|
-            attic.attached_to_roof_idrefs.delete(surf2.id)
-            attic.attached_to_frame_floor_idrefs.delete(surf2.id)
-          end
-          @foundations.each do |foundation|
-            foundation.attached_to_slab_idrefs.delete(surf2.id)
-            foundation.attached_to_frame_floor_idrefs.delete(surf2.id)
-            foundation.attached_to_foundation_wall_idrefs.delete(surf2.id)
+          @skylights.each do |subsurf|
+            next unless subsurf.roof_idref == surf2.id
+            subsurf.roof_idref = surf.id
           end
 
           # Remove old surface
-          surfaces.delete_at(j)
+          surfaces[j].delete
         end
       end
     end
@@ -4059,7 +4076,6 @@ class HPXML < Object
     (@rim_joists + @walls + @foundation_walls + @frame_floors).reverse_each do |surface|
       next if surface.interior_adjacent_to.nil? || surface.exterior_adjacent_to.nil?
       next unless surface.interior_adjacent_to == surface.exterior_adjacent_to
-
       surface.delete
     end
   end
@@ -4067,7 +4083,6 @@ class HPXML < Object
   def delete_tiny_surfaces()
     (@rim_joists + @walls + @foundation_walls + @frame_floors + @roofs + @windows + @skylights + @doors + @slabs).reverse_each do |surface|
       next if surface.area.nil? || (surface.area > 0.1)
-
       surface.delete
     end
   end

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -3115,9 +3115,9 @@ class HVACSizing
     # Calculated based on Manual J 8th Ed. procedure in section A12-4 (15% decrease due to soil thermal storage)
     u_wall_with_soil = 0.0
     u_wall_without_soil = 0.0
-    wall_height_ft = Geometry.get_surface_height(surface).round
+    wall_height_ft = Geometry.get_surface_height(surface).ceil
     for d in 1..wall_height_ft
-      r_soil = (Math::PI * d / 2.0) / k_soil
+      r_soil = (Math::PI * d / 2.0) / k_soil # FIXME: Should this be (d-wall_height_ag) instead of d?
 
       # Calculate R-wall at this depth
       r_wall = wall_constr_rvalue + Material.AirFilmVertical.rvalue # Base wall construction + interior film

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -27,7 +27,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   # define the arguments that the user will input
-  def arguments(ignore = nil)
+  def arguments(model)
     args = OpenStudio::Measure::OSArgumentVector.new
 
     timeseries_frequency_chs = OpenStudio::StringVector.new
@@ -106,8 +106,15 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     result = OpenStudio::IdfObjectVector.new
 
+    model = runner.lastOpenStudioModel
+    if model.empty?
+      runner.registerError('Cannot find last model.')
+      return false
+    end
+    model = model.get
+
     # use the built-in error checking
-    if !runner.validateUserArguments(arguments, user_arguments)
+    if !runner.validateUserArguments(arguments(model), user_arguments)
       return result
     end
 
@@ -233,8 +240,15 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   def run(runner, user_arguments)
     super(runner, user_arguments)
 
+    model = runner.lastOpenStudioModel
+    if model.empty?
+      runner.registerError('Cannot find OpenStudio model.')
+      return false
+    end
+    @model = model.get
+
     # use the built-in error checking
-    if !runner.validateUserArguments(arguments, user_arguments)
+    if !runner.validateUserArguments(arguments(@model), user_arguments)
       return false
     end
 
@@ -245,14 +259,6 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     include_timeseries_hot_water_uses = runner.getBoolArgumentValue('include_timeseries_hot_water_uses', user_arguments)
     include_timeseries_total_loads = runner.getBoolArgumentValue('include_timeseries_total_loads', user_arguments)
     include_timeseries_component_loads = runner.getBoolArgumentValue('include_timeseries_component_loads', user_arguments)
-
-    # get the last model and sql file
-    model = runner.lastOpenStudioModel
-    if model.empty?
-      runner.registerError('Cannot find OpenStudio model.')
-      return false
-    end
-    @model = model.get
 
     sqlFile = runner.lastEnergyPlusSqlFile
     if sqlFile.empty?

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>b1bde40b-0b71-4f7f-98c7-b559c27199bd</version_id>
-  <version_modified>20200427T163313Z</version_modified>
+  <version_id>dbd2a834-8b13-46da-b481-dc6c2f4d2303</version_id>
+  <version_modified>20200429T154624Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -499,6 +499,12 @@
       <checksum>301A7C10</checksum>
     </file>
     <file>
+      <filename>output_report_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>4C895D3B</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.9.1</identifier>
@@ -507,13 +513,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>2213ED0C</checksum>
-    </file>
-    <file>
-      <filename>output_report_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>4C895D3B</checksum>
+      <checksum>F4E99528</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
- Handle HPXML files with `LightingGroup` elements, but not the ones called out in EPvalidator.
- Fix error if HPXML file has foundation walls < 0.5 ft tall
- Improve HPXML `delete` methods, especially in conjunction with `collapse_enclosure`
- Pass `model` to reporting measure `arguments` method.