### PR TITLE
Allow reporting measure timeseries frequency to be 'none'

### DIFF
--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -31,13 +31,14 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     args = OpenStudio::Measure::OSArgumentVector.new
 
     timeseries_frequency_chs = OpenStudio::StringVector.new
+    timeseries_frequency_chs << 'none'
     reporting_frequency_map.keys.each do |freq|
       timeseries_frequency_chs << freq
     end
     arg = OpenStudio::Measure::OSArgument::makeChoiceArgument('timeseries_frequency', timeseries_frequency_chs, true)
     arg.setDisplayName('Timeseries Reporting Frequency')
     arg.setDescription('The frequency at which to report timeseries output data.')
-    arg.setDefaultValue('hourly')
+    arg.setDefaultValue('none')
     args << arg
 
     arg = OpenStudio::Measure::OSArgument::makeBoolArgument('include_timeseries_zone_temperatures', true)
@@ -177,12 +178,14 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     # Timeseries outputs
 
     timeseries_frequency = runner.getStringArgumentValue('timeseries_frequency', user_arguments)
-    include_timeseries_zone_temperatures = runner.getBoolArgumentValue('include_timeseries_zone_temperatures', user_arguments)
-    include_timeseries_fuel_consumptions = runner.getBoolArgumentValue('include_timeseries_fuel_consumptions', user_arguments)
-    include_timeseries_end_use_consumptions = runner.getBoolArgumentValue('include_timeseries_end_use_consumptions', user_arguments)
-    include_timeseries_hot_water_uses = runner.getBoolArgumentValue('include_timeseries_hot_water_uses', user_arguments)
-    include_timeseries_total_loads = runner.getBoolArgumentValue('include_timeseries_total_loads', user_arguments)
-    include_timeseries_component_loads = runner.getBoolArgumentValue('include_timeseries_component_loads', user_arguments)
+    if timeseries_frequency != 'none'
+      include_timeseries_zone_temperatures = runner.getBoolArgumentValue('include_timeseries_zone_temperatures', user_arguments)
+      include_timeseries_fuel_consumptions = runner.getBoolArgumentValue('include_timeseries_fuel_consumptions', user_arguments)
+      include_timeseries_end_use_consumptions = runner.getBoolArgumentValue('include_timeseries_end_use_consumptions', user_arguments)
+      include_timeseries_hot_water_uses = runner.getBoolArgumentValue('include_timeseries_hot_water_uses', user_arguments)
+      include_timeseries_total_loads = runner.getBoolArgumentValue('include_timeseries_total_loads', user_arguments)
+      include_timeseries_component_loads = runner.getBoolArgumentValue('include_timeseries_component_loads', user_arguments)
+    end
 
     if include_timeseries_fuel_consumptions
       # If fuel uses are selected, we also need to select end uses because
@@ -253,12 +256,14 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
 
     timeseries_frequency = runner.getStringArgumentValue('timeseries_frequency', user_arguments)
-    include_timeseries_zone_temperatures = runner.getBoolArgumentValue('include_timeseries_zone_temperatures', user_arguments)
-    include_timeseries_fuel_consumptions = runner.getBoolArgumentValue('include_timeseries_fuel_consumptions', user_arguments)
-    include_timeseries_end_use_consumptions = runner.getBoolArgumentValue('include_timeseries_end_use_consumptions', user_arguments)
-    include_timeseries_hot_water_uses = runner.getBoolArgumentValue('include_timeseries_hot_water_uses', user_arguments)
-    include_timeseries_total_loads = runner.getBoolArgumentValue('include_timeseries_total_loads', user_arguments)
-    include_timeseries_component_loads = runner.getBoolArgumentValue('include_timeseries_component_loads', user_arguments)
+    if timeseries_frequency != 'none'
+      include_timeseries_zone_temperatures = runner.getBoolArgumentValue('include_timeseries_zone_temperatures', user_arguments)
+      include_timeseries_fuel_consumptions = runner.getBoolArgumentValue('include_timeseries_fuel_consumptions', user_arguments)
+      include_timeseries_end_use_consumptions = runner.getBoolArgumentValue('include_timeseries_end_use_consumptions', user_arguments)
+      include_timeseries_hot_water_uses = runner.getBoolArgumentValue('include_timeseries_hot_water_uses', user_arguments)
+      include_timeseries_total_loads = runner.getBoolArgumentValue('include_timeseries_total_loads', user_arguments)
+      include_timeseries_component_loads = runner.getBoolArgumentValue('include_timeseries_component_loads', user_arguments)
+    end
 
     sqlFile = runner.lastEnergyPlusSqlFile
     if sqlFile.empty?
@@ -847,9 +852,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
                                       include_timeseries_hot_water_uses,
                                       include_timeseries_total_loads,
                                       include_timeseries_component_loads)
+    return if timeseries_frequency == 'none'
+
     # Time column
     if ['timestep', 'hourly', 'daily', 'monthly'].include? timeseries_frequency
-      data = ['Time', '']
+      data = ['Time', nil]
     else
       fail "Unexpected timeseries_frequency: #{timeseries_frequency}."
     end

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -37,7 +37,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
     arg = OpenStudio::Measure::OSArgument::makeChoiceArgument('timeseries_frequency', timeseries_frequency_chs, true)
     arg.setDisplayName('Timeseries Reporting Frequency')
-    arg.setDescription('The frequency at which to report timeseries output data.')
+    arg.setDescription("The frequency at which to report timeseries output data. Using 'none' will disable timeseries outputs.")
     arg.setDefaultValue('none')
     args << arg
 

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>a822fc13-8f6a-4835-9df6-b96c761c0b37</version_id>
-  <version_modified>20200430T151924Z</version_modified>
+  <version_id>b76afe5c-8b5b-494d-a53f-d08fa6f8350c</version_id>
+  <version_modified>20200430T163145Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -14,7 +14,7 @@
     <argument>
       <name>timeseries_frequency</name>
       <display_name>Timeseries Reporting Frequency</display_name>
-      <description>The frequency at which to report timeseries output data.</description>
+      <description>The frequency at which to report timeseries output data. Using 'none' will disable timeseries outputs.</description>
       <type>Choice</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -517,7 +517,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>04B2921A</checksum>
+      <checksum>9301E2AF</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>dbd2a834-8b13-46da-b481-dc6c2f4d2303</version_id>
-  <version_modified>20200429T154624Z</version_modified>
+  <version_id>a822fc13-8f6a-4835-9df6-b96c761c0b37</version_id>
+  <version_modified>20200430T151924Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -18,8 +18,12 @@
       <type>Choice</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value>hourly</default_value>
+      <default_value>none</default_value>
       <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
         <choice>
           <value>timestep</value>
           <display_name>timestep</display_name>
@@ -502,7 +506,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>4C895D3B</checksum>
+      <checksum>1F156299</checksum>
     </file>
     <file>
       <version>
@@ -513,7 +517,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F4E99528</checksum>
+      <checksum>04B2921A</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/tests/output_report_test.rb
+++ b/SimulationOutputReport/tests/output_report_test.rb
@@ -288,6 +288,23 @@ class SimulationOutputReportTest < MiniTest::Test
     assert_equal(expected_annual_rows.sort, actual_annual_rows.sort)
   end
 
+  def test_annual_only2
+    args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
+                  'timeseries_frequency' => 'none',
+                  'include_timeseries_zone_temperatures' => true,
+                  'include_timeseries_fuel_consumptions' => true,
+                  'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
+                  'include_timeseries_total_loads' => true,
+                  'include_timeseries_component_loads' => true }
+    annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
+    assert(File.exist?(annual_csv))
+    assert(!File.exist?(timeseries_csv))
+    expected_annual_rows = AnnualRows
+    actual_annual_rows = File.readlines(annual_csv).map { |x| x.split(',')[0].strip }.select { |x| !x.empty? }
+    assert_equal(expected_annual_rows.sort, actual_annual_rows.sort)
+  end
+
   def test_timeseries_hourly_temperatures
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
                   'timeseries_frequency' => 'hourly',


### PR DESCRIPTION
## Pull Request Description

Allow reporting measure timeseries frequency to be 'none', as an alternative to setting all include_timeseries_foo variables to false.

## Checklist

Not all may apply:

- [x] Tests (and test files) have been updated
- [x] `openstudio tasks.rb update_measures` has been run
