### PR TITLE
FrameFloors wrt/ MF space

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -3996,10 +3996,8 @@ class OSModel
     elsif [HPXML::LocationBasementConditioned].include? exterior_adjacent_to
       surface.createAdjacentSurface(create_or_get_space(model, spaces, HPXML::LocationLivingSpace))
       @cond_bsmnt_surfaces << surface
-    elsif [HPXML::LocationOtherHousingUnit, HPXML::LocationOtherHousingUnitAbove, HPXML::LocationOtherHousingUnitBelow].include? exterior_adjacent_to
-      # collapse into one
-      set_surface_otherside_coefficients(surface, HPXML::LocationOtherHousingUnit, model, spaces)
-    elsif [HPXML::LocationOtherHeatedSpace, HPXML::LocationOtherMultifamilyBufferSpace, HPXML::LocationOtherNonFreezingSpace].include? exterior_adjacent_to
+      set_surface_otherside_coefficients(surface, exterior_adjacent_to, model, spaces)
+    elsif [HPXML::LocationOtherHousingUnit, HPXML::LocationOtherHeatedSpace, HPXML::LocationOtherMultifamilyBufferSpace, HPXML::LocationOtherNonFreezingSpace].include? exterior_adjacent_to
       set_surface_otherside_coefficients(surface, exterior_adjacent_to, model, spaces)
     else
       surface.createAdjacentSurface(create_or_get_space(model, spaces, exterior_adjacent_to))

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>4b097a1c-403e-44a1-95d6-13bbccbb3460</version_id>
-  <version_modified>20200512T210518Z</version_modified>
+  <version_id>1e7ce890-cf73-4c35-9f7e-8999a88b7e4b</version_id>
+  <version_modified>20200513T000230Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -451,28 +451,22 @@
       <checksum>4A4B437E</checksum>
     </file>
     <file>
-      <filename>hvac_sizing.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D53AA66B</checksum>
-    </file>
-    <file>
-      <filename>EPvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>41766727</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>879C5357</checksum>
-    </file>
-    <file>
       <filename>airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>8D622991</checksum>
+    </file>
+    <file>
+      <filename>test_airflow.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3204784B</checksum>
+    </file>
+    <file>
+      <filename>hvac_sizing.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C03A6509</checksum>
     </file>
     <file>
       <version>
@@ -483,13 +477,19 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>1E80D659</checksum>
+      <checksum>A2C2E36E</checksum>
     </file>
     <file>
-      <filename>test_airflow.rb</filename>
+      <filename>EPvalidator.rb</filename>
       <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>3204784B</checksum>
+      <usage_type>resource</usage_type>
+      <checksum>7F4E5AC7</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>922A00B7</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -226,11 +226,16 @@ class EnergyPlusValidator
       # [FrameFloor]
       '/HPXML/Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor' => {
         'SystemIdentifier' => one, # Required by HPXML schema
-        'ExteriorAdjacentTo[text()="outside" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage" or text()="other housing unit above" or text()="other housing unit below" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]' => one,
+        'ExteriorAdjacentTo[text()="outside" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage" or text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]' => one, # See [FrameFloorAdjacentToOther]
         'InteriorAdjacentTo[text()="living space" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage"]' => one,
         'Area' => one,
         'Insulation/SystemIdentifier' => one, # Required by HPXML schema
         'Insulation/AssemblyEffectiveRValue' => one,
+      },
+
+      # [FrameFloorAdjacentToOther]
+      '/HPXML/Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor[ExteriorAdjacentTo[text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]]' => {
+        'extension/OtherSpaceAboveOrBelow[text()="above" or text()="below"]' => one,
       },
 
       # [Slab]

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -90,6 +90,8 @@ class HPXML < Object
   FoundationTypeCrawlspaceUnvented = 'UnventedCrawlspace'
   FoundationTypeCrawlspaceVented = 'VentedCrawlspace'
   FoundationTypeSlab = 'SlabOnGrade'
+  FrameFloorOtherSpaceAbove = 'above'
+  FrameFloorOtherSpaceBelow = 'below'
   FuelTypeElectricity = 'electricity'
   FuelTypeNaturalGas = 'natural gas'
   FuelTypeOil = 'fuel oil'
@@ -135,8 +137,6 @@ class HPXML < Object
   LocationLivingSpace = 'living space'
   LocationOtherExterior = 'other exterior'
   LocationOtherHousingUnit = 'other housing unit'
-  LocationOtherHousingUnitAbove = 'other housing unit above'
-  LocationOtherHousingUnitBelow = 'other housing unit below'
   LocationOtherHeatedSpace = 'other heated space'
   LocationOtherMultifamilyBufferSpace = 'other multifamily buffer space'
   LocationOtherNonFreezingSpace = 'other non-freezing space'
@@ -365,7 +365,7 @@ class HPXML < Object
 
         # Update Compartmentalization Boundary areas
         total_area += surface.area
-        if not (surface.exterior_adjacent_to.include?(LocationOtherHousingUnit) || (surface.exterior_adjacent_to == LocationGarage))
+        if not [LocationOtherHousingUnit, LocationGarage].include? surface.exterior_adjacent_to # FIXME: Need to add additional "other" spaces?
           exterior_area += surface.area
         end
       end
@@ -1729,13 +1729,16 @@ class HPXML < Object
 
   class FrameFloor < BaseElement
     ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :area, :insulation_id,
-             :insulation_assembly_r_value, :insulation_cavity_r_value, :insulation_continuous_r_value]
+             :insulation_assembly_r_value, :insulation_cavity_r_value, :insulation_continuous_r_value,
+             :other_space_above_or_below]
     attr_accessor(*ATTRS)
 
     def is_ceiling
       if [LocationAtticVented, LocationAtticUnvented].include? @interior_adjacent_to
         return true
-      elsif [LocationAtticVented, LocationAtticUnvented, LocationOtherHousingUnitAbove].include? @exterior_adjacent_to
+      elsif [LocationAtticVented, LocationAtticUnvented].include? @exterior_adjacent_to
+        return true
+      elsif [LocationOtherHousingUnit, LocationOtherHeatedSpace, LocationOtherMultifamilyBufferSpace, LocationOtherNonFreezingSpace].include?(@exterior_adjacent_to) && (@other_space_above_or_below == FrameFloorOtherSpaceAbove)
         return true
       end
 
@@ -1799,6 +1802,8 @@ class HPXML < Object
         XMLHelper.add_attribute(sys_id, 'id', @id + 'Insulation')
       end
       XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', to_float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+      HPXML::add_extension(parent: frame_floor,
+                           extensions: { 'OtherSpaceAboveOrBelow' => @other_space_above_or_below })
     end
 
     def from_oga(frame_floor)
@@ -1815,6 +1820,7 @@ class HPXML < Object
         @insulation_cavity_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
         @insulation_continuous_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
       end
+      @other_space_above_or_below = XMLHelper.get_value(frame_floor, 'extension/OtherSpaceAboveOrBelow')
     end
   end
 
@@ -4226,7 +4232,7 @@ class HPXML < Object
       return false
     end
 
-    if surface.exterior_adjacent_to.include? HPXML::LocationOtherHousingUnit
+    if surface.exterior_adjacent_to == HPXML::LocationOtherHousingUnit
       return false # adiabatic
     end
 

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -134,7 +134,7 @@ class HVACSizing
     @heat_design_temps[nil] = weather.design.HeatingDrybulb
 
     # MF spaces
-    [HPXML::LocationOtherHousingUnit, HPXML::LocationOtherHousingUnitAbove, HPXML::LocationOtherHousingUnitBelow, HPXML::LocationOtherHeatedSpace, HPXML::LocationOtherMultifamilyBufferSpace, HPXML::LocationOtherNonFreezingSpace].each do |mf_space|
+    [HPXML::LocationOtherHousingUnit, HPXML::LocationOtherHeatedSpace, HPXML::LocationOtherMultifamilyBufferSpace, HPXML::LocationOtherNonFreezingSpace].each do |mf_space|
       @cool_design_temps[mf_space] = get_other_side_temp(mf_space, @cool_setpoint, weather.design.CoolingDrybulb)
       @heat_design_temps[mf_space] = get_other_side_temp(mf_space, @heat_setpoint, weather.design.HeatingDrybulb)
     end
@@ -2651,7 +2651,7 @@ class HVACSizing
       return [(setpoint + oa_db) / 2, 50].max
     elsif adjacent_space_name == HPXML::LocationOtherNonFreezingSpace
       return [oa_db, 40].max
-    elsif [HPXML::LocationOtherHousingUnit, HPXML::LocationOtherHousingUnitAbove, HPXML::LocationOtherHousingUnitBelow].include? adjacent_space_name
+    elsif [HPXML::LocationOtherHousingUnit].include? adjacent_space_name
       return setpoint
     end
   end

--- a/docs/source/hpxml_to_openstudio.rst
+++ b/docs/source/hpxml_to_openstudio.rst
@@ -147,8 +147,6 @@ crawlspace - vented
 crawlspace - unvented     
 garage                    
 other housing unit              Conditioned space of an adjacent attached housing unit.               Same as conditioned space.
-other housing unit above        Conditioned space of an attached housing unit above.                  Same as conditioned space.
-other housing unit below        Conditioned space of an attached housing unit below.                  Same as conditioned space.
 other heated space              Heated multifamily space (e.g., shared laundry or equipment.)         Average of conditioned space and outside; minimum of 68F.
 other multifamily buffer space  Unconditioned multifamily space (e.g., enclosed unheated stairwell).  Average of conditioned space and outside; minimum of 50F.
 other non-freezing space        Non-freezing multifamily space (e.g., parking garage ceiling).        Floats with outside; minimum of 40F.
@@ -241,6 +239,7 @@ Frame Floors
 ************
 
 Any horizontal floor/ceiling surface that is not in contact with the ground (Slab) nor adjacent to ambient conditions above (Roof) should be specified as an ``Enclosure/FrameFloors/FrameFloor``.
+Frame floors in an attached/multifamily building that are adjacent to "other housing unit", "other heated space", "other multifamily buffer space", or "other non-freezing space" must have the ``extension/OtherSpaceAboveOrBelow`` property set to signify whether the other space is "above" or "below".
 
 Frame floors are primarily defined by their ``Insulation/AssemblyEffectiveRValue``.
 

--- a/tasks.rb
+++ b/tasks.rb
@@ -1033,7 +1033,7 @@ def set_hpxml_walls(hpxml_file, hpxml)
                     emittance: 0.92,
                     insulation_assembly_r_value: 4.0)
   elsif ['base-enclosure-attached-multifamily.xml'].include? hpxml_file
-    hpxml.walls.add(id: 'WallUnratedHeatedSpace',
+    hpxml.walls.add(id: 'WallOtherHeatedSpace',
                     exterior_adjacent_to: HPXML::LocationOtherHeatedSpace,
                     interior_adjacent_to: HPXML::LocationLivingSpace,
                     wall_type: 'WoodStud',
@@ -1041,7 +1041,7 @@ def set_hpxml_walls(hpxml_file, hpxml)
                     solar_absorptance: 0.7,
                     emittance: 0.92,
                     insulation_assembly_r_value: 23.0)
-    hpxml.walls.add(id: 'WallMultifamilyBuffer',
+    hpxml.walls.add(id: 'WallOtherMultifamilyBufferSpace',
                     exterior_adjacent_to: HPXML::LocationOtherMultifamilyBufferSpace,
                     interior_adjacent_to: HPXML::LocationLivingSpace,
                     wall_type: 'WoodStud',
@@ -1049,7 +1049,7 @@ def set_hpxml_walls(hpxml_file, hpxml)
                     solar_absorptance: 0.7,
                     emittance: 0.92,
                     insulation_assembly_r_value: 22.3)
-    hpxml.walls.add(id: 'WallNonFreezingSpace',
+    hpxml.walls.add(id: 'WallOtherNonFreezingSpace',
                     exterior_adjacent_to: HPXML::LocationOtherNonFreezingSpace,
                     interior_adjacent_to: HPXML::LocationLivingSpace,
                     wall_type: 'WoodStud',
@@ -1057,7 +1057,7 @@ def set_hpxml_walls(hpxml_file, hpxml)
                     solar_absorptance: 0.7,
                     emittance: 0.92,
                     insulation_assembly_r_value: 23.0)
-    hpxml.walls.add(id: 'WallAdiabatic',
+    hpxml.walls.add(id: 'WallOtherHousingUnit',
                     exterior_adjacent_to: HPXML::LocationOtherHousingUnit,
                     interior_adjacent_to: HPXML::LocationLivingSpace,
                     wall_type: 'WoodStud',
@@ -1163,16 +1163,16 @@ def set_hpxml_walls(hpxml_file, hpxml)
     hpxml.walls[-1].area *= 0.65
     hpxml.walls[-1].insulation_assembly_r_value = 4
     if ['base-enclosure-other-housing-unit.xml'].include? hpxml_file
-      hpxml.walls[-1].id = 'OtherHousingUnitWall'
+      hpxml.walls[-1].id = 'WallOtherHousingUnit'
       hpxml.walls[-1].exterior_adjacent_to = HPXML::LocationOtherHousingUnit
     elsif ['base-enclosure-other-heated-space.xml'].include? hpxml_file
-      hpxml.walls[-1].id = 'OtherHeatedSpaceWall'
+      hpxml.walls[-1].id = 'WallOtherHeatedSpace'
       hpxml.walls[-1].exterior_adjacent_to = HPXML::LocationOtherHeatedSpace
     elsif ['base-enclosure-other-non-freezing-space.xml'].include? hpxml_file
-      hpxml.walls[-1].id = 'OtherNonFreezingSpaceWall'
+      hpxml.walls[-1].id = 'WallOtherNonFreezingSpace'
       hpxml.walls[-1].exterior_adjacent_to = HPXML::LocationOtherNonFreezingSpace
     elsif ['base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
-      hpxml.walls[-1].id = 'OtherMultifamilyBufferSpaceWall'
+      hpxml.walls[-1].id = 'WallOtherMultifamilyBufferSpace'
       hpxml.walls[-1].exterior_adjacent_to = HPXML::LocationOtherMultifamilyBufferSpace
     end
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
@@ -1274,7 +1274,7 @@ def set_hpxml_foundation_walls(hpxml_file, hpxml)
                                 insulation_exterior_distance_to_bottom: 8,
                                 insulation_exterior_r_value: 8.9)
   elsif ['base-enclosure-attached-multifamily.xml'].include? hpxml_file
-    hpxml.foundation_walls.add(id: 'FoundationWall1',
+    hpxml.foundation_walls.add(id: 'FoundationWallOtherNonFreezingSpace',
                                exterior_adjacent_to: HPXML::LocationOtherNonFreezingSpace,
                                interior_adjacent_to: HPXML::LocationBasementConditioned,
                                height: 8,
@@ -1287,7 +1287,7 @@ def set_hpxml_foundation_walls(hpxml_file, hpxml)
                                insulation_exterior_distance_to_top: 0,
                                insulation_exterior_distance_to_bottom: 8,
                                insulation_exterior_r_value: 8.9)
-    hpxml.foundation_walls.add(id: 'FoundationWall2',
+    hpxml.foundation_walls.add(id: 'FoundationWallOtherMultifamilyBufferSpace',
                                exterior_adjacent_to: HPXML::LocationOtherMultifamilyBufferSpace,
                                interior_adjacent_to: HPXML::LocationBasementConditioned,
                                height: 4,
@@ -1300,7 +1300,7 @@ def set_hpxml_foundation_walls(hpxml_file, hpxml)
                                insulation_exterior_distance_to_top: 0,
                                insulation_exterior_distance_to_bottom: 4,
                                insulation_exterior_r_value: 8.9)
-    hpxml.foundation_walls.add(id: 'FoundationWall3',
+    hpxml.foundation_walls.add(id: 'FoundationWallOtherHeatedSpace',
                                exterior_adjacent_to: HPXML::LocationOtherHeatedSpace,
                                interior_adjacent_to: HPXML::LocationBasementConditioned,
                                height: 2,
@@ -1591,44 +1591,45 @@ def set_hpxml_frame_floors(hpxml_file, hpxml)
          'base-enclosure-other-non-freezing-space.xml',
          'base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
     hpxml.frame_floors.clear
-    hpxml.frame_floors.add(id: 'FloorBelowOtherHousingUnit',
-                           exterior_adjacent_to: HPXML::LocationOtherHousingUnitAbove,
-                           interior_adjacent_to: HPXML::LocationLivingSpace,
+    hpxml.frame_floors.add(interior_adjacent_to: HPXML::LocationLivingSpace,
                            area: 1350,
-                           insulation_assembly_r_value: 2.1)
+                           insulation_assembly_r_value: 2.1,
+                           other_space_above_or_below: HPXML::FrameFloorOtherSpaceAbove)
     if ['base-enclosure-other-housing-unit.xml'].include? hpxml_file
-      hpxml.frame_floors << hpxml.frame_floors[0].dup
-      hpxml.frame_floors[1].id = 'FloorAboveOtherHousingUnit'
-      hpxml.frame_floors[1].exterior_adjacent_to = HPXML::LocationOtherHousingUnitBelow
+      hpxml.frame_floors[0].exterior_adjacent_to = HPXML::LocationOtherHousingUnit
+      hpxml.frame_floors[0].id = 'FloorBelowOtherHousingUnit'
     elsif ['base-enclosure-other-heated-space.xml'].include? hpxml_file
-      hpxml.frame_floors << hpxml.frame_floors[0].dup
-      hpxml.frame_floors[1].id = 'FloorOtherHeatedSpace'
-      hpxml.frame_floors[1].exterior_adjacent_to = HPXML::LocationOtherHeatedSpace
+      hpxml.frame_floors[0].exterior_adjacent_to = HPXML::LocationOtherHeatedSpace
+      hpxml.frame_floors[0].id = 'FloorBelowOtherHeatedSpace'
     elsif ['base-enclosure-other-non-freezing-space.xml'].include? hpxml_file
-      hpxml.frame_floors << hpxml.frame_floors[0].dup
-      hpxml.frame_floors[1].id = 'FloorOtherNonFreezingSpace'
-      hpxml.frame_floors[1].exterior_adjacent_to = HPXML::LocationOtherNonFreezingSpace
+      hpxml.frame_floors[0].exterior_adjacent_to = HPXML::LocationOtherNonFreezingSpace
+      hpxml.frame_floors[0].id = 'FloorBelowOtherNonFreezingSpace'
     elsif ['base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
-      hpxml.frame_floors << hpxml.frame_floors[0].dup
-      hpxml.frame_floors[1].id = 'FloorOtherMultifamilyBufferSpace'
-      hpxml.frame_floors[1].exterior_adjacent_to = HPXML::LocationOtherMultifamilyBufferSpace
+      hpxml.frame_floors[0].exterior_adjacent_to = HPXML::LocationOtherMultifamilyBufferSpace
+      hpxml.frame_floors[0].id = 'FloorBelowOtherMultifamilyBufferSpace'
     end
+    hpxml.frame_floors << hpxml.frame_floors[0].dup
+    hpxml.frame_floors[1].id = hpxml.frame_floors[0].id.gsub('Below', 'Above')
+    hpxml.frame_floors[1].other_space_above_or_below = HPXML::FrameFloorOtherSpaceBelow
   elsif ['base-enclosure-attached-multifamily.xml'].include? hpxml_file
-    hpxml.frame_floors.add(id: 'FloorNonFreezingSpace',
+    hpxml.frame_floors.add(id: 'FloorAboveNonFreezingSpace',
                            exterior_adjacent_to: HPXML::LocationOtherNonFreezingSpace,
                            interior_adjacent_to: HPXML::LocationLivingSpace,
                            area: 1000,
-                           insulation_assembly_r_value: 2.1)
-    hpxml.frame_floors.add(id: 'FloorMultifamilyBuffer',
+                           insulation_assembly_r_value: 2.1,
+                           other_space_above_or_below: HPXML::FrameFloorOtherSpaceBelow)
+    hpxml.frame_floors.add(id: 'FloorAboveMultifamilyBuffer',
                            exterior_adjacent_to: HPXML::LocationOtherMultifamilyBufferSpace,
                            interior_adjacent_to: HPXML::LocationLivingSpace,
                            area: 200,
-                           insulation_assembly_r_value: 2.1)
-    hpxml.frame_floors.add(id: 'FloorUnratedHeatedSpace',
+                           insulation_assembly_r_value: 2.1,
+                           other_space_above_or_below: HPXML::FrameFloorOtherSpaceBelow)
+    hpxml.frame_floors.add(id: 'FloorAboveOtherHeatedSpace',
                            exterior_adjacent_to: HPXML::LocationOtherHeatedSpace,
                            interior_adjacent_to: HPXML::LocationLivingSpace,
                            area: 150,
-                           insulation_assembly_r_value: 2.1)
+                           insulation_assembly_r_value: 2.1,
+                           other_space_above_or_below: HPXML::FrameFloorOtherSpaceBelow)
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.frame_floors.size
       hpxml.frame_floors[n - 1].area /= 9.0
@@ -1919,7 +1920,7 @@ def set_hpxml_windows(hpxml_file, hpxml)
                       wall_idref: 'Wall')
   elsif ['invalid_files/attached-multifamily-window-outside-condition.xml'].include? hpxml_file
     hpxml.windows[0].area = 50
-    hpxml.windows[0].wall_idref = 'WallMultifamilyBuffer'
+    hpxml.windows[0].wall_idref = 'WallOtherMultifamilyBufferSpace'
   elsif ['base-enclosure-overhangs.xml'].include? hpxml_file
     hpxml.windows[0].overhangs_depth = 2.5
     hpxml.windows[0].overhangs_distance_to_top_of_window = 0
@@ -2170,22 +2171,22 @@ def set_hpxml_doors(hpxml_file, hpxml)
                     azimuth: 180,
                     r_value: 4.4)
   elsif ['base-enclosure-attached-multifamily.xml'].include? hpxml_file
-    hpxml.doors.add(id: 'DoorOnUnratedHeatedSpace',
-                    wall_idref: 'WallUnratedHeatedSpace',
+    hpxml.doors.add(id: 'DoorOnWallOtherHeatedSpace',
+                    wall_idref: 'WallOtherHeatedSpace',
                     area: 40,
                     azimuth: 0,
                     r_value: 4.4)
-    hpxml.doors.add(id: 'DoorOnNonFreezingFndWall',
-                    wall_idref: 'FoundationWall1',
+    hpxml.doors.add(id: 'DoorOnFoundationWallOtherNonFreezingSpace',
+                    wall_idref: 'FoundationWallOtherNonFreezingSpace',
                     area: 40,
                     azimuth: 0,
                     r_value: 4.4)
-    hpxml.doors.add(id: 'DoorOnOtherUnit',
-                    wall_idref: 'WallAdiabatic',
+    hpxml.doors.add(id: 'DoorOnWallOtherHousingUnit',
+                    wall_idref: 'WallOtherHousingUnit',
                     area: 40,
                     azimuth: 0,
                     r_value: 4.4)
-    hpxml.doors.add(id: 'DoorAttic',
+    hpxml.doors.add(id: 'DoorOnWallAtticLivingWall',
                     wall_idref: 'WallAtticLivingWall',
                     area: 10,
                     azimuth: 0,
@@ -2194,20 +2195,20 @@ def set_hpxml_doors(hpxml_file, hpxml)
          'base-enclosure-other-heated-space.xml',
          'base-enclosure-other-non-freezing-space.xml',
          'base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
-    hpxml.doors.add(id: 'DoorOnOtherHousingUnitWall',
-                    wall_idref: 'OtherHousingUnitWall',
+    hpxml.doors.add(id: 'DoorOnWallOtherHousingUnit',
+                    wall_idref: 'WallOtherHousingUnit',
                     area: 40,
                     azimuth: 0,
                     r_value: 4.4)
     if ['base-enclosure-other-heated-space.xml'].include? hpxml_file
-      hpxml.doors[-1].id = 'DoorOnOtherHeatedSpaceWall'
-      hpxml.doors[-1].wall_idref = 'OtherHeatedSpaceWall'
+      hpxml.doors[-1].id = 'DoorOnWallOtherHeatedSpace'
+      hpxml.doors[-1].wall_idref = 'WallOtherHeatedSpace'
     elsif ['base-enclosure-other-non-freezing-space.xml'].include? hpxml_file
-      hpxml.doors[-1].id = 'DoorOnOtherNonFreezingSpaceWall'
-      hpxml.doors[-1].wall_idref = 'OtherNonFreezingSpaceWall'
+      hpxml.doors[-1].id = 'DoorOnWallOtherNonFreezingSpace'
+      hpxml.doors[-1].wall_idref = 'WallOtherNonFreezingSpace'
     elsif ['base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
-      hpxml.doors[-1].id = 'DoorOnOtherMultifamilyBufferSpaceWall'
-      hpxml.doors[-1].wall_idref = 'OtherMultifamilyBufferSpaceWall'
+      hpxml.doors[-1].id = 'DoorOnWallOtherMultifamilyBufferSpace'
+      hpxml.doors[-1].wall_idref = 'WallOtherMultifamilyBufferSpace'
     end
   elsif ['invalid_files/unattached-door.xml'].include? hpxml_file
     hpxml.doors[0].wall_idref = 'foobar'

--- a/workflow/sample_files/base-enclosure-attached-multifamily.xml
+++ b/workflow/sample_files/base-enclosure-attached-multifamily.xml
@@ -144,7 +144,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallUnratedHeatedSpace'/>
+            <SystemIdentifier id='WallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -154,12 +154,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallUnratedHeatedSpaceInsulation'/>
+              <SystemIdentifier id='WallOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallMultifamilyBuffer'/>
+            <SystemIdentifier id='WallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -169,12 +169,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallMultifamilyBufferInsulation'/>
+              <SystemIdentifier id='WallOtherMultifamilyBufferSpaceInsulation'/>
               <AssemblyEffectiveRValue>22.3</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallNonFreezingSpace'/>
+            <SystemIdentifier id='WallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -184,12 +184,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='WallOtherNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallAdiabatic'/>
+            <SystemIdentifier id='WallOtherHousingUnit'/>
             <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -199,7 +199,7 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallAdiabaticInsulation'/>
+              <SystemIdentifier id='WallOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
@@ -249,7 +249,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall1'/>
+            <SystemIdentifier id='FoundationWallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
@@ -257,7 +257,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall1Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherNonFreezingSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -277,7 +277,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall2'/>
+            <SystemIdentifier id='FoundationWallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>4.0</Height>
@@ -285,7 +285,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>3.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall2Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherMultifamilyBufferSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -305,7 +305,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall3'/>
+            <SystemIdentifier id='FoundationWallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>2.0</Height>
@@ -313,7 +313,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>1.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall3Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherHeatedSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -345,34 +345,43 @@
             </Insulation>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorNonFreezingSpace'/>
+            <SystemIdentifier id='FloorAboveNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1000.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='FloorAboveNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorMultifamilyBuffer'/>
+            <SystemIdentifier id='FloorAboveMultifamilyBuffer'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>200.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorMultifamilyBufferInsulation'/>
+              <SystemIdentifier id='FloorAboveMultifamilyBufferInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorUnratedHeatedSpace'/>
+            <SystemIdentifier id='FloorAboveOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>150.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorUnratedHeatedSpaceInsulation'/>
+              <SystemIdentifier id='FloorAboveOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Slabs>
@@ -478,28 +487,28 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnUnratedHeatedSpace'/>
-            <AttachedToWall idref='WallUnratedHeatedSpace'/>
+            <SystemIdentifier id='DoorOnWallOtherHeatedSpace'/>
+            <AttachedToWall idref='WallOtherHeatedSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnNonFreezingFndWall'/>
-            <AttachedToWall idref='FoundationWall1'/>
+            <SystemIdentifier id='DoorOnFoundationWallOtherNonFreezingSpace'/>
+            <AttachedToWall idref='FoundationWallOtherNonFreezingSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherUnit'/>
-            <AttachedToWall idref='WallAdiabatic'/>
+            <SystemIdentifier id='DoorOnWallOtherHousingUnit'/>
+            <AttachedToWall idref='WallOtherHousingUnit'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorAttic'/>
+            <SystemIdentifier id='DoorOnWallAtticLivingWall'/>
             <AttachedToWall idref='WallAtticLivingWall'/>
             <Area>10.0</Area>
             <Azimuth>0</Azimuth>

--- a/workflow/sample_files/base-enclosure-other-heated-space.xml
+++ b/workflow/sample_files/base-enclosure-other-heated-space.xml
@@ -87,7 +87,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='OtherHeatedSpaceWall'/>
+            <SystemIdentifier id='WallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -97,31 +97,37 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='OtherHeatedSpaceWallInsulation'/>
+              <SystemIdentifier id='WallOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
         </Walls>
         <FrameFloors>
           <FrameFloor>
-            <SystemIdentifier id='FloorBelowOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit above</ExteriorAdjacentTo>
-            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
-            <Area>1350.0</Area>
-            <Insulation>
-              <SystemIdentifier id='FloorBelowOtherHousingUnitInsulation'/>
-              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
-            </Insulation>
-          </FrameFloor>
-          <FrameFloor>
-            <SystemIdentifier id='FloorOtherHeatedSpace'/>
+            <SystemIdentifier id='FloorBelowOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorOtherHeatedSpaceInsulation'/>
+              <SystemIdentifier id='FloorBelowOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>above</OtherSpaceAboveOrBelow>
+            </extension>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorAboveOtherHeatedSpace'/>
+            <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>1350.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorAboveOtherHeatedSpaceInsulation'/>
+              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
+            </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Windows>
@@ -198,8 +204,8 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherHeatedSpaceWall'/>
-            <AttachedToWall idref='OtherHeatedSpaceWall'/>
+            <SystemIdentifier id='DoorOnWallOtherHeatedSpace'/>
+            <AttachedToWall idref='WallOtherHeatedSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>

--- a/workflow/sample_files/base-enclosure-other-housing-unit.xml
+++ b/workflow/sample_files/base-enclosure-other-housing-unit.xml
@@ -87,7 +87,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='OtherHousingUnitWall'/>
+            <SystemIdentifier id='WallOtherHousingUnit'/>
             <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -97,7 +97,7 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='OtherHousingUnitWallInsulation'/>
+              <SystemIdentifier id='WallOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
@@ -105,23 +105,29 @@
         <FrameFloors>
           <FrameFloor>
             <SystemIdentifier id='FloorBelowOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit above</ExteriorAdjacentTo>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
               <SystemIdentifier id='FloorBelowOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>above</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
             <SystemIdentifier id='FloorAboveOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit below</ExteriorAdjacentTo>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
               <SystemIdentifier id='FloorAboveOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Windows>
@@ -198,8 +204,8 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherHousingUnitWall'/>
-            <AttachedToWall idref='OtherHousingUnitWall'/>
+            <SystemIdentifier id='DoorOnWallOtherHousingUnit'/>
+            <AttachedToWall idref='WallOtherHousingUnit'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>

--- a/workflow/sample_files/base-enclosure-other-multifamily-buffer-space.xml
+++ b/workflow/sample_files/base-enclosure-other-multifamily-buffer-space.xml
@@ -87,7 +87,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='OtherMultifamilyBufferSpaceWall'/>
+            <SystemIdentifier id='WallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -97,31 +97,37 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='OtherMultifamilyBufferSpaceWallInsulation'/>
+              <SystemIdentifier id='WallOtherMultifamilyBufferSpaceInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
         </Walls>
         <FrameFloors>
           <FrameFloor>
-            <SystemIdentifier id='FloorBelowOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit above</ExteriorAdjacentTo>
-            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
-            <Area>1350.0</Area>
-            <Insulation>
-              <SystemIdentifier id='FloorBelowOtherHousingUnitInsulation'/>
-              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
-            </Insulation>
-          </FrameFloor>
-          <FrameFloor>
-            <SystemIdentifier id='FloorOtherMultifamilyBufferSpace'/>
+            <SystemIdentifier id='FloorBelowOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorOtherMultifamilyBufferSpaceInsulation'/>
+              <SystemIdentifier id='FloorBelowOtherMultifamilyBufferSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>above</OtherSpaceAboveOrBelow>
+            </extension>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorAboveOtherMultifamilyBufferSpace'/>
+            <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>1350.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorAboveOtherMultifamilyBufferSpaceInsulation'/>
+              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
+            </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Windows>
@@ -198,8 +204,8 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherMultifamilyBufferSpaceWall'/>
-            <AttachedToWall idref='OtherMultifamilyBufferSpaceWall'/>
+            <SystemIdentifier id='DoorOnWallOtherMultifamilyBufferSpace'/>
+            <AttachedToWall idref='WallOtherMultifamilyBufferSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>

--- a/workflow/sample_files/base-enclosure-other-non-freezing-space.xml
+++ b/workflow/sample_files/base-enclosure-other-non-freezing-space.xml
@@ -87,7 +87,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='OtherNonFreezingSpaceWall'/>
+            <SystemIdentifier id='WallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -97,31 +97,37 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='OtherNonFreezingSpaceWallInsulation'/>
+              <SystemIdentifier id='WallOtherNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
         </Walls>
         <FrameFloors>
           <FrameFloor>
-            <SystemIdentifier id='FloorBelowOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit above</ExteriorAdjacentTo>
-            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
-            <Area>1350.0</Area>
-            <Insulation>
-              <SystemIdentifier id='FloorBelowOtherHousingUnitInsulation'/>
-              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
-            </Insulation>
-          </FrameFloor>
-          <FrameFloor>
-            <SystemIdentifier id='FloorOtherNonFreezingSpace'/>
+            <SystemIdentifier id='FloorBelowOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorOtherNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='FloorBelowOtherNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>above</OtherSpaceAboveOrBelow>
+            </extension>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorAboveOtherNonFreezingSpace'/>
+            <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>1350.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorAboveOtherNonFreezingSpaceInsulation'/>
+              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
+            </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Windows>
@@ -198,8 +204,8 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherNonFreezingSpaceWall'/>
-            <AttachedToWall idref='OtherNonFreezingSpaceWall'/>
+            <SystemIdentifier id='DoorOnWallOtherNonFreezingSpace'/>
+            <AttachedToWall idref='WallOtherNonFreezingSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>

--- a/workflow/sample_files/invalid_files/attached-multifamily-window-outside-condition.xml
+++ b/workflow/sample_files/invalid_files/attached-multifamily-window-outside-condition.xml
@@ -144,7 +144,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallUnratedHeatedSpace'/>
+            <SystemIdentifier id='WallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -154,12 +154,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallUnratedHeatedSpaceInsulation'/>
+              <SystemIdentifier id='WallOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallMultifamilyBuffer'/>
+            <SystemIdentifier id='WallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -169,12 +169,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallMultifamilyBufferInsulation'/>
+              <SystemIdentifier id='WallOtherMultifamilyBufferSpaceInsulation'/>
               <AssemblyEffectiveRValue>22.3</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallNonFreezingSpace'/>
+            <SystemIdentifier id='WallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -184,12 +184,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='WallOtherNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallAdiabatic'/>
+            <SystemIdentifier id='WallOtherHousingUnit'/>
             <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -199,7 +199,7 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallAdiabaticInsulation'/>
+              <SystemIdentifier id='WallOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
@@ -249,7 +249,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall1'/>
+            <SystemIdentifier id='FoundationWallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
@@ -257,7 +257,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall1Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherNonFreezingSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -277,7 +277,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall2'/>
+            <SystemIdentifier id='FoundationWallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>4.0</Height>
@@ -285,7 +285,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>3.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall2Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherMultifamilyBufferSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -305,7 +305,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall3'/>
+            <SystemIdentifier id='FoundationWallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>2.0</Height>
@@ -313,7 +313,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>1.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall3Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherHeatedSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -345,34 +345,43 @@
             </Insulation>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorNonFreezingSpace'/>
+            <SystemIdentifier id='FloorAboveNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1000.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='FloorAboveNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorMultifamilyBuffer'/>
+            <SystemIdentifier id='FloorAboveMultifamilyBuffer'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>200.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorMultifamilyBufferInsulation'/>
+              <SystemIdentifier id='FloorAboveMultifamilyBufferInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorUnratedHeatedSpace'/>
+            <SystemIdentifier id='FloorAboveOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>150.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorUnratedHeatedSpaceInsulation'/>
+              <SystemIdentifier id='FloorAboveOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Slabs>
@@ -417,7 +426,7 @@
               <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
             </InteriorShading>
             <FractionOperable>0.67</FractionOperable>
-            <AttachedToWall idref='WallMultifamilyBuffer'/>
+            <AttachedToWall idref='WallOtherMultifamilyBufferSpace'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -478,28 +487,28 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnUnratedHeatedSpace'/>
-            <AttachedToWall idref='WallUnratedHeatedSpace'/>
+            <SystemIdentifier id='DoorOnWallOtherHeatedSpace'/>
+            <AttachedToWall idref='WallOtherHeatedSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnNonFreezingFndWall'/>
-            <AttachedToWall idref='FoundationWall1'/>
+            <SystemIdentifier id='DoorOnFoundationWallOtherNonFreezingSpace'/>
+            <AttachedToWall idref='FoundationWallOtherNonFreezingSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherUnit'/>
-            <AttachedToWall idref='WallAdiabatic'/>
+            <SystemIdentifier id='DoorOnWallOtherHousingUnit'/>
+            <AttachedToWall idref='WallOtherHousingUnit'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorAttic'/>
+            <SystemIdentifier id='DoorOnWallAtticLivingWall'/>
             <AttachedToWall idref='WallAtticLivingWall'/>
             <Area>10.0</Area>
             <Azimuth>0</Azimuth>

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -134,7 +134,7 @@ class HPXMLTest < MiniTest::Test
                                                                               'Expected [1] element(s) but found 0 element(s) for xpath: /HPXML/Building/BuildingDetails/Appliances/Dishwasher: [not(Location)] |',
                                                                               'Expected [1] element(s) but found 0 element(s) for xpath: /HPXML/Building/BuildingDetails/Appliances/Refrigerator: [not(Location)] |',
                                                                               'Expected [1] element(s) but found 0 element(s) for xpath: /HPXML/Building/BuildingDetails/Appliances/CookingRange: [not(Location)] |'],
-                            'attached-multifamily-window-outside-condition.xml' => ["Window 'WindowNorth' cannot be adjacent to 'other multifamily buffer space'. Check parent wall: 'WallMultifamilyBuffer'"],
+                            'attached-multifamily-window-outside-condition.xml' => ["Window 'WindowNorth' cannot be adjacent to 'other multifamily buffer space'. Check parent wall:"],
                             'cfis-with-hydronic-distribution.xml' => ["Attached HVAC distribution system 'HVACDistribution' cannot be hydronic for ventilation fan 'MechanicalVentilation'."],
                             'clothes-dryer-location.xml' => ["ClothesDryer location is 'garage' but building does not have this location specified."],
                             'clothes-washer-location.xml' => ["ClothesWasher location is 'garage' but building does not have this location specified."],


### PR DESCRIPTION
## Pull Request Description

For FrameFloors, removes the "other housing unit above" and "other housing unit below" enumerations. Instead, FrameFloors in MF/attached buildings that are adjacent to any of the "other" space types (i.e., "other housing unit", "other heated space", "other multifamily buffer space", and "other non-freezing space") must now have an `extension/OtherSpaceAboveOrBelow` property set to either "above" or "below".

## Checklist

Not all may apply:

- [x] EPvalidator.rb has been updated
- [x] Tests (and test files) have been updated
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
