### PR TITLE
Tankless water heater performance adjustment

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -586,7 +586,7 @@ class OSModel
         water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(@eri_version)
       end
       if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless) && water_heating_system.performance_adjustment.nil?
-        water_heating_system.performance_adjustment = Waterheater.get_tankless_cycling_derate()
+        water_heating_system.performance_adjustment = Waterheater.get_tankless_performance_adjustment()
       end
       if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeCombiStorage) && water_heating_system.standby_loss.nil?
         # Use equation fit from AHRI database
@@ -2455,7 +2455,7 @@ class OSModel
 
         elsif wh_type == HPXML::WaterHeaterTypeTankless
 
-          cycling_derate = water_heating_system.performance_adjustment
+          cycling_derate = 1.0 - water_heating_system.performance_adjustment
 
           Waterheater.apply_tankless(model, loc_space, loc_schedule, fuel, ef, cycling_derate,
                                      setpoint_temp, ec_adj, @nbeds, @dhw_map,

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -586,7 +586,7 @@ class OSModel
         water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(@eri_version)
       end
       if water_heating_system.performance_adjustment.nil?
-        water_heating_system.performance_adjustment = Waterheater.get_default_performance_adjustment()
+        water_heating_system.performance_adjustment = Waterheater.get_default_performance_adjustment(water_heating_system)
       end
       if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeCombiStorage) && water_heating_system.standby_loss.nil?
         # Use equation fit from AHRI database

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -585,8 +585,8 @@ class OSModel
       if water_heating_system.temperature.nil?
         water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(@eri_version)
       end
-      if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless) && water_heating_system.performance_adjustment.nil?
-        water_heating_system.performance_adjustment = Waterheater.get_tankless_performance_adjustment()
+      if water_heating_system.performance_adjustment.nil?
+        water_heating_system.performance_adjustment = Waterheater.get_default_performance_adjustment()
       end
       if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeCombiStorage) && water_heating_system.standby_loss.nil?
         # Use equation fit from AHRI database
@@ -2455,9 +2455,9 @@ class OSModel
 
         elsif wh_type == HPXML::WaterHeaterTypeTankless
 
-          cycling_derate = 1.0 - water_heating_system.performance_adjustment
+          performance_adjustment = water_heating_system.performance_adjustment
 
-          Waterheater.apply_tankless(model, loc_space, loc_schedule, fuel, ef, cycling_derate,
+          Waterheater.apply_tankless(model, loc_space, loc_schedule, fuel, ef, performance_adjustment,
                                      setpoint_temp, ec_adj, @nbeds, @dhw_map,
                                      sys_id, desuperheater_clg_coil, solar_fraction)
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>dac04c4e-6999-4f14-8813-e441481abaad</version_id>
-  <version_modified>20200514T223406Z</version_modified>
+  <version_id>cf8d4923-4e03-45b2-ada5-94ae69007247</version_id>
+  <version_modified>20200514T231021Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -478,7 +478,7 @@
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>69375D36</checksum>
+      <checksum>91EAD611</checksum>
     </file>
     <file>
       <version>
@@ -489,7 +489,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>31F887FF</checksum>
+      <checksum>4F85305A</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>cf8d4923-4e03-45b2-ada5-94ae69007247</version_id>
-  <version_modified>20200514T231021Z</version_modified>
+  <version_id>ea5cf47d-fe8a-469e-806e-52958fefc403</version_id>
+  <version_modified>20200514T233533Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -478,7 +478,7 @@
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>91EAD611</checksum>
+      <checksum>364DBB7E</checksum>
     </file>
     <file>
       <version>
@@ -489,7 +489,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4F85305A</checksum>
+      <checksum>9260E271</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>13323397-0155-4b62-a629-71694df7719a</version_id>
-  <version_modified>20200513T194127Z</version_modified>
+  <version_id>dac04c4e-6999-4f14-8813-e441481abaad</version_id>
+  <version_modified>20200514T223406Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -325,12 +325,6 @@
       <checksum>15FA9595</checksum>
     </file>
     <file>
-      <filename>BaseElements.xsd</filename>
-      <filetype>xsd</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>CE0F105B</checksum>
-    </file>
-    <file>
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -445,12 +439,6 @@
       <checksum>3426AF5E</checksum>
     </file>
     <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>BDCFB48D</checksum>
-    </file>
-    <file>
       <filename>hotwater_appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -469,17 +457,6 @@
       <checksum>AA162D27</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>FA27B272</checksum>
-    </file>
-    <file>
       <filename>EPvalidator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -490,6 +467,29 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>61D6CFEC</checksum>
+    </file>
+    <file>
+      <filename>BaseElements.xsd</filename>
+      <filetype>xsd</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>76A93C0E</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>69375D36</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>31F887FF</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/BaseElements.xsd
+++ b/HPXMLtoOpenStudio/resources/BaseElements.xsd
@@ -1466,7 +1466,11 @@
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
+									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+										<xs:annotation>
+											<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
@@ -3107,7 +3111,11 @@
 			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
-			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
+			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+				<xs:annotation>
+					<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>
@@ -4602,7 +4610,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" name="FractionOperable" type="Fraction">
 				<xs:annotation>
-					<xs:documentation>If the Window/Skylight element represents a single window/skylight, the value should be 0 or 1, otherwise the fraction of area that is operable.</xs:documentation>
+					<xs:documentation>The fraction of windows/skylights that are operable. If the Window/Skylight element represents a single window/skylight, the value should be 0 or 1.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -1241,8 +1241,8 @@ class Waterheater
     end
   end
 
-  def self.get_tankless_cycling_derate()
-    return 0.08
+  def self.get_tankless_performance_adjustment()
+    return 0.92
   end
 
   def self.get_default_location(hpxml, iecc_zone)

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -1241,7 +1241,7 @@ class Waterheater
     end
   end
 
-  def self.get_default_performance_adjustment()
+  def self.get_default_performance_adjustment(water_heating_system)
     return unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless
 
     return 0.92 # Applies to EF

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -19,7 +19,7 @@ class Waterheater
     new_manager.addToNode(loop.supplyOutletNode)
 
     act_vol = calc_storage_tank_actual_vol(vol, fuel_type)
-    u, ua, eta_c = calc_tank_UA(act_vol, fuel_type, ef, re, cap, HPXML::WaterHeaterTypeStorage, 0, jacket_r, solar_fraction)
+    u, ua, eta_c = calc_tank_UA(act_vol, fuel_type, ef, re, cap, HPXML::WaterHeaterTypeStorage, 1.0, jacket_r, solar_fraction)
     new_heater = create_new_heater(name: Constants.ObjectNameWaterHeater, cap: cap, fuel: fuel_type, act_vol: act_vol, t_set: t_set, loc_space: loc_space, loc_schedule: loc_schedule, wh_type: HPXML::WaterHeaterTypeStorage, model: model, ua: ua, eta_c: eta_c, oncycle_p: 0.0, ef: ef)
     set_parasitic_power_for_storage_wh(water_heater: new_heater)
     dhw_map[sys_id] << new_heater
@@ -35,7 +35,7 @@ class Waterheater
     end
   end
 
-  def self.apply_tankless(model, loc_space, loc_schedule, fuel_type, ef, cd,
+  def self.apply_tankless(model, loc_space, loc_schedule, fuel_type, ef, performance_adjustment,
                           t_set, ec_adj, nbeds, dhw_map, sys_id,
                           desuperheater_clg_coil, solar_fraction)
 
@@ -51,7 +51,7 @@ class Waterheater
     new_manager.addToNode(loop.supplyOutletNode)
 
     act_vol = 1.0
-    u, ua, eta_c = calc_tank_UA(act_vol, fuel_type, ef, nil, cap, HPXML::WaterHeaterTypeTankless, cd, nil, solar_fraction)
+    u, ua, eta_c = calc_tank_UA(act_vol, fuel_type, ef, nil, cap, HPXML::WaterHeaterTypeTankless, performance_adjustment, nil, solar_fraction)
     new_heater = create_new_heater(name: Constants.ObjectNameWaterHeater, cap: cap, fuel: fuel_type, act_vol: act_vol, t_set: t_set, loc_space: loc_space, loc_schedule: loc_schedule, wh_type: HPXML::WaterHeaterTypeTankless, model: model, ua: ua, eta_c: eta_c, ef: ef)
     set_parasitic_power_for_tankless_wh(nbeds: nbeds, water_heater: new_heater)
     dhw_map[sys_id] << new_heater
@@ -1241,8 +1241,10 @@ class Waterheater
     end
   end
 
-  def self.get_tankless_performance_adjustment()
-    return 0.92
+  def self.get_default_performance_adjustment()
+    return unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeTankless
+
+    return 0.92 # Applies to EF
   end
 
   def self.get_default_location(hpxml, iecc_zone)
@@ -1295,12 +1297,12 @@ class Waterheater
     return act_vol
   end
 
-  def self.calc_tank_UA(act_vol, fuel, ef, re, pow, wh_type, cyc_derate, jacket_r, solar_fraction)
+  def self.calc_tank_UA(act_vol, fuel, ef, re, pow, wh_type, performance_adjustment, jacket_r, solar_fraction)
     # Calculates the U value, UA of the tank and conversion efficiency (eta_c)
     # based on the Energy Factor and recovery efficiency of the tank
     # Source: Burch and Erickson 2004 - http://www.nrel.gov/docs/gen/fy04/36035.pdf
     if wh_type == HPXML::WaterHeaterTypeTankless
-      eta_c = ef * (1.0 - cyc_derate)
+      eta_c = ef * performance_adjustment
       ua = 0.0
       surface_area = 1.0
     else

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -1254,8 +1254,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       value = dhw_system.energy_factor
       wh_type = dhw_system.water_heater_type
       if wh_type == HPXML::WaterHeaterTypeTankless
-        cycling_derate = dhw_system.performance_adjustment
-        value_adj = 1.0 - cycling_derate
+        value_adj = dhw_system.performance_adjustment
       else
         value_adj = 1.0
       end

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>942ddcb7-c078-4c2f-88f9-197d05ce120d</version_id>
-  <version_modified>20200513T213715Z</version_modified>
+  <version_id>c240e371-0b7f-430f-b6af-4d3ddf9840ed</version_id>
+  <version_modified>20200514T223406Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -555,7 +555,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>70FE8D1E</checksum>
+      <checksum>D363F057</checksum>
     </file>
   </files>
 </measure>

--- a/docs/source/hpxml_to_openstudio.rst
+++ b/docs/source/hpxml_to_openstudio.rst
@@ -547,7 +547,7 @@ EnergyFactor  RecoveryEfficiency (default)
 ============  ======================================
 
 For tankless water heaters, a performance adjustment due to cycling inefficiencies can be provided.
-If not provided, a value of 0.92 (92%) will be assumed to apply to its rated performance.
+If not provided, a default value of 0.92 (92%) will apply to the Energy Factor.
 
 For combi boiler systems, the ``RelatedHVACSystem`` must point to a ``HeatingSystem`` of type "Boiler".
 For combi boiler systems with a storage tank, the storage tank losses (deg-F/hr) can be entered as ``StandbyLoss``; if not provided, a default value based on the `AHRI Directory of Certified Product Performance <https://www.ahridirectory.org>`_ will be calculated.

--- a/docs/source/hpxml_to_openstudio.rst
+++ b/docs/source/hpxml_to_openstudio.rst
@@ -525,15 +525,15 @@ Inputs including ``WaterHeaterType`` and ``FractionDHWLoadServed`` must be provi
 
 Depending on the type of water heater specified, additional elements are required/available:
 
-========================================  ===================================  ===========  ==========  ===============  ==================  =================  =========================================  ==============================
-WaterHeaterType                           UniformEnergyFactor or EnergyFactor  FuelType     TankVolume  HeatingCapacity  RecoveryEfficiency  UsesDesuperheater  WaterHeaterInsulation/Jacket/JacketRValue  RelatedHVACSystem
-========================================  ===================================  ===========  ==========  ===============  ==================  =================  =========================================  ==============================
-storage water heater                      required                             <any>        <optional>  <optional>       <optional>          <optional>         <optional>                                 required if uses desuperheater
-instantaneous water heater                required                             <any>                                                         <optional>                                                    required if uses desuperheater
-heat pump water heater                    required                             electricity  required                                         <optional>         <optional>                                 required if uses desuperheater
-space-heating boiler with storage tank                                                      required                                                            <optional>                                 required
-space-heating boiler with tankless coil                                                                                                                                                                    required
-========================================  ===================================  ===========  ==========  ===============  ==================  =================  =========================================  ==============================
+========================================  ===================================  ===========  ==========  ===============  ==================  ===================== =================  =========================================  ==============================
+WaterHeaterType                           UniformEnergyFactor or EnergyFactor  FuelType     TankVolume  HeatingCapacity  RecoveryEfficiency  PerformanceAdjustment UsesDesuperheater  WaterHeaterInsulation/Jacket/JacketRValue  RelatedHVACSystem
+========================================  ===================================  ===========  ==========  ===============  ==================  ===================== =================  =========================================  ==============================
+storage water heater                      required                             <any>        <optional>  <optional>       <optional>                                <optional>         <optional>                                 required if uses desuperheater
+instantaneous water heater                required                             <any>                                                         <optional>            <optional>                                                    required if uses desuperheater
+heat pump water heater                    required                             electricity  required                                                               <optional>         <optional>                                 required if uses desuperheater
+space-heating boiler with storage tank                                                      required                                                                                  <optional>                                 required
+space-heating boiler with tankless coil                                                                                                                                                                                          required
+========================================  ===================================  ===========  ==========  ===============  ==================  ===================== =================  =========================================  ==============================
 
 For storage water heaters, the tank volume in gallons, heating capacity in Btuh, and recovery efficiency can be optionally provided.
 If not provided, default values for the tank volume and heating capacity will be assumed based on Table 8 in the `2014 Building America House Simulation Protocols <https://www.energy.gov/sites/prod/files/2014/03/f13/house_simulation_protocols_2014.pdf#page=22&zoom=100,93,333>`_ 
@@ -546,8 +546,8 @@ EnergyFactor  RecoveryEfficiency (default)
 < 0.75        0.252117 * EF + 0.607997
 ============  ======================================
 
-For tankless water heaters, an annual energy derate due to cycling inefficiencies can be provided.
-If not provided, a value of 0.08 (8%) will be assumed.
+For tankless water heaters, a performance adjustment due to cycling inefficiencies can be provided.
+If not provided, a value of 0.92 (92%) will be assumed to apply to its rated performance.
 
 For combi boiler systems, the ``RelatedHVACSystem`` must point to a ``HeatingSystem`` of type "Boiler".
 For combi boiler systems with a storage tank, the storage tank losses (deg-F/hr) can be entered as ``StandbyLoss``; if not provided, a default value based on the `AHRI Directory of Certified Product Performance <https://www.ahridirectory.org>`_ will be calculated.


### PR DESCRIPTION
## Pull Request Description

Converts `PerformanceAdjustment` from a derate (e.g., 0.08) to a multiplier (e.g., 0.92) for tankless systems. No CI diffs expected.

## Checklist

Not all may apply:

- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
