### PR TITLE
Conditioned ducts LtO warning

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>4ef3a41e-6866-4416-8c15-d4e824686255</version_id>
-  <version_modified>20200528T201045Z</version_modified>
+  <version_id>4922c645-5017-4d39-afb5-d5170942456c</version_id>
+  <version_modified>20200529T124613Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -505,6 +505,12 @@
       <checksum>4D5E34BB</checksum>
     </file>
     <file>
+      <filename>hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>40B78609</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.0.0</identifier>
@@ -513,13 +519,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>45DE5769</checksum>
-    </file>
-    <file>
-      <filename>hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>40B78609</checksum>
+      <checksum>CE3CA445</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Closes #402. Adds a warning if a HVACDistribution system has ducts entirely within conditioned space and non-zero leakage to the outside.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
