### PR TITLE
Update is_thermal_boundary for Other Heated Space

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3c7c0ccd-fed5-446c-be62-2b81d97dd302</version_id>
-  <version_modified>20200620T022320Z</version_modified>
+  <version_id>d54826d8-449e-4b3d-af72-c098713534f5</version_id>
+  <version_modified>20200623T193639Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -522,16 +522,16 @@
       <checksum>818691B8</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>BC595AAD</checksum>
-    </file>
-    <file>
       <filename>hotwater_appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>0587A09F</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>A3FD7ABA</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -966,7 +966,7 @@ class HPXML < Object
 
   class AirInfiltrationMeasurement < BaseElement
     ATTRS = [:id, :house_pressure, :unit_of_measure, :air_leakage, :effective_leakage_area,
-             :infiltration_volume, :leakiness_description]
+             :infiltration_volume, :leakiness_description, :infiltration_height, :a_ext]
     attr_accessor(*ATTRS)
 
     def check_for_errors
@@ -989,6 +989,9 @@ class HPXML < Object
       end
       XMLHelper.add_element(air_infiltration_measurement, 'EffectiveLeakageArea', to_float(@effective_leakage_area)) unless @effective_leakage_area.nil?
       XMLHelper.add_element(air_infiltration_measurement, 'InfiltrationVolume', to_float(@infiltration_volume)) unless @infiltration_volume.nil?
+      HPXML::add_extension(parent: air_infiltration_measurement,
+                           extensions: { 'InfiltrationHeight' => to_float_or_nil(@infiltration_height),
+                                         'Aext' => to_float_or_nil(@a_ext) })
     end
 
     def from_oga(air_infiltration_measurement)
@@ -1001,6 +1004,8 @@ class HPXML < Object
       @effective_leakage_area = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'EffectiveLeakageArea'))
       @infiltration_volume = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'InfiltrationVolume'))
       @leakiness_description = XMLHelper.get_value(air_infiltration_measurement, 'LeakinessDescription')
+      @infiltration_height = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'extension/InfiltrationHeight'))
+      @a_ext = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'extension/Aext'))
     end
   end
 
@@ -1463,7 +1468,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -1579,7 +1584,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -1714,7 +1719,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -1856,7 +1861,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -1953,7 +1958,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -2088,7 +2093,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(wall)
+      return HPXML::is_thermal_boundary(wall)
     end
 
     def is_exterior_thermal_boundary
@@ -2213,7 +2218,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(roof)
+      return HPXML::is_thermal_boundary(roof)
     end
 
     def is_exterior_thermal_boundary
@@ -2313,7 +2318,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(wall)
+      return HPXML::is_thermal_boundary(wall)
     end
 
     def is_exterior_thermal_boundary
@@ -4718,15 +4723,13 @@ class HPXML < Object
     # Note: Insulated foundation walls of, e.g., unconditioned spaces return false.
     def self.is_adjacent_to_conditioned(adjacent_to)
       if [HPXML::LocationLivingSpace,
-          HPXML::LocationBasementConditioned].include? adjacent_to
+          HPXML::LocationBasementConditioned,
+          HPXML::LocationOtherHousingUnit,
+          HPXML::LocationOtherHeatedSpace].include? adjacent_to
         return true
+      else
+        return false
       end
-
-      return false
-    end
-
-    if surface.exterior_adjacent_to == HPXML::LocationOtherHousingUnit
-      return false # adiabatic
     end
 
     interior_conditioned = is_adjacent_to_conditioned(surface.interior_adjacent_to)


### PR DESCRIPTION
## Pull Request Description

Treat HPXML::LocationOtherHeatedSpace as a conditioned space for HPXML::is_thermal_boundary methods.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
