### PR TITLE
Rename EnergyPlus class

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>52553c2b-5cdc-4b28-bf5a-1619129cade4</version_id>
-  <version_modified>20200629T232102Z</version_modified>
+  <version_id>5282bfa3-558a-43f4-bab3-f4b85f9af676</version_id>
+  <version_modified>20200630T141629Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -433,64 +433,16 @@
       <checksum>6F263948</checksum>
     </file>
     <file>
-      <filename>misc_loads.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>15069FF8</checksum>
-    </file>
-    <file>
-      <filename>hotwater_appliances.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>8F139D16</checksum>
-    </file>
-    <file>
       <filename>util.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>B31D4F58</checksum>
     </file>
     <file>
-      <filename>test_hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F0A00F0F</checksum>
-    </file>
-    <file>
-      <filename>test_water_heater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>E7DD137C</checksum>
-    </file>
-    <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>CD37CECB</checksum>
-    </file>
-    <file>
-      <filename>test_hotwater_appliance.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>53558AA4</checksum>
-    </file>
-    <file>
-      <filename>energyplus.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>BB599699</checksum>
-    </file>
-    <file>
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>7426D510</checksum>
-    </file>
-    <file>
-      <filename>hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>10645E7C</checksum>
     </file>
     <file>
       <filename>EPvalidator.rb</filename>
@@ -556,6 +508,54 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C0B8ABA</checksum>
+    </file>
+    <file>
+      <filename>misc_loads.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>4E587243</checksum>
+    </file>
+    <file>
+      <filename>hotwater_appliances.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>54D5A2D3</checksum>
+    </file>
+    <file>
+      <filename>test_hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>C3BC236A</checksum>
+    </file>
+    <file>
+      <filename>test_water_heater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2B6B4C0A</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>DD4E96F0</checksum>
+    </file>
+    <file>
+      <filename>test_hotwater_appliance.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>4E349979</checksum>
+    </file>
+    <file>
+      <filename>energyplus.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>0C1B7A80</checksum>
+    </file>
+    <file>
+      <filename>hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>F01E736F</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/energyplus.rb
+++ b/HPXMLtoOpenStudio/resources/energyplus.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EnergyPlus
+class EPlus
   # Constants
   FuelTypeElectricity = 'electricity'
   FuelTypeNaturalGas = 'NaturalGas'

--- a/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
+++ b/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
@@ -617,7 +617,7 @@ class HotWaterAndAppliances
     if fuel_type.nil?
       oe.setFuelType('None')
     else
-      oe.setFuelType(EnergyPlus.input_fuel_map(fuel_type))
+      oe.setFuelType(EPlus.input_fuel_map(fuel_type))
     end
     oe.setSpace(space)
     oe_def.setName(obj_name)

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -118,7 +118,7 @@ class HVAC
         htg_coil.setGasBurnerEfficiency(heating_system.heating_efficiency_afue)
         htg_coil.setParasiticElectricLoad(0)
         htg_coil.setParasiticGasLoad(0)
-        htg_coil.setFuelType(EnergyPlus.input_fuel_map(heating_system.heating_system_fuel))
+        htg_coil.setFuelType(EPlus.input_fuel_map(heating_system.heating_system_fuel))
       end
       htg_coil.setName(obj_name + ' htg coil')
       if not heating_system.heating_capacity.nil?
@@ -999,7 +999,7 @@ class HVAC
 
     boiler = OpenStudio::Model::BoilerHotWater.new(model)
     boiler.setName(obj_name)
-    boiler.setFuelType(EnergyPlus.input_fuel_map(heating_system.heating_system_fuel))
+    boiler.setFuelType(EPlus.input_fuel_map(heating_system.heating_system_fuel))
     if not heating_system.heating_capacity.nil?
       boiler.setNominalCapacity(UnitConversions.convert([heating_system.heating_capacity, Constants.small].max, 'Btu/hr', 'W')) # Used by HVACSizing measure
     end
@@ -1142,7 +1142,7 @@ class HVAC
       htg_coil.setGasBurnerEfficiency(efficiency)
       htg_coil.setParasiticElectricLoad(0.0)
       htg_coil.setParasiticGasLoad(0)
-      htg_coil.setFuelType(EnergyPlus.input_fuel_map(heating_system.heating_system_fuel))
+      htg_coil.setFuelType(EPlus.input_fuel_map(heating_system.heating_system_fuel))
     end
     htg_coil.setName(obj_name + ' htg coil')
     if not heating_system.heating_capacity.nil?
@@ -1614,9 +1614,9 @@ class HVAC
     if htg_object.nil?
       htg_object_sensor = nil
     else
-      var = "Heating Coil #{EnergyPlus.output_fuel_map(EnergyPlus::FuelTypeElectricity)} Energy"
+      var = "Heating Coil #{EPlus.output_fuel_map(EPlus::FuelTypeElectricity)} Energy"
       if htg_object.is_a? OpenStudio::Model::CoilHeatingGas
-        var = "Heating Coil #{EnergyPlus.output_fuel_map(htg_object.fuelType)} Energy"
+        var = "Heating Coil #{EPlus.output_fuel_map(htg_object.fuelType)} Energy"
       elsif htg_object.is_a? OpenStudio::Model::ZoneHVACBaseboardConvectiveWater
         var = 'Baseboard Total Heating Energy'
       end
@@ -1630,9 +1630,9 @@ class HVAC
     if backup_htg_object.nil?
       backup_htg_object_sensor = nil
     else
-      var = "Heating Coil #{EnergyPlus.output_fuel_map(EnergyPlus::FuelTypeElectricity)} Energy"
+      var = "Heating Coil #{EPlus.output_fuel_map(EPlus::FuelTypeElectricity)} Energy"
       if backup_htg_object.is_a? OpenStudio::Model::CoilHeatingGas
-        var = "Heating Coil #{EnergyPlus.output_fuel_map(backup_htg_object.fuelType)} Energy"
+        var = "Heating Coil #{EPlus.output_fuel_map(backup_htg_object.fuelType)} Energy"
       end
 
       backup_htg_object_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, var)
@@ -1763,7 +1763,7 @@ class HVAC
       htg_supp_coil.setGasBurnerEfficiency(efficiency)
       htg_supp_coil.setParasiticElectricLoad(0)
       htg_supp_coil.setParasiticGasLoad(0)
-      htg_supp_coil.setFuelType(EnergyPlus.input_fuel_map(fuel))
+      htg_supp_coil.setFuelType(EPlus.input_fuel_map(fuel))
     end
     htg_supp_coil.setName(obj_name + ' ' + Constants.ObjectNameBackupHeatingCoil)
     if not capacity.nil?
@@ -2945,7 +2945,7 @@ class HVAC
           clg_coil = OpenStudio::Model::CoilCoolingDXMultiSpeed.new(model)
           clg_coil.setApplyPartLoadFractiontoSpeedsGreaterthan1(false)
           clg_coil.setApplyLatentDegradationtoSpeedsGreaterthan1(false)
-          clg_coil.setFuelType(EnergyPlus::FuelTypeElectricity)
+          clg_coil.setFuelType(EPlus::FuelTypeElectricity)
           clg_coil.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
           if not crankcase_temp.nil?
             clg_coil.setMaximumOutdoorDryBulbTemperatureforCrankcaseHeaterOperation(UnitConversions.convert(crankcase_temp, 'F', 'C'))
@@ -3005,7 +3005,7 @@ class HVAC
       else
         if htg_coil.nil?
           htg_coil = OpenStudio::Model::CoilHeatingDXMultiSpeed.new(model)
-          htg_coil.setFuelType(EnergyPlus::FuelTypeElectricity)
+          htg_coil.setFuelType(EPlus::FuelTypeElectricity)
           htg_coil.setApplyPartLoadFractiontoSpeedsGreaterthan1(false)
           htg_coil.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
           if not crankcase_temp.nil?

--- a/HPXMLtoOpenStudio/resources/misc_loads.rb
+++ b/HPXMLtoOpenStudio/resources/misc_loads.rb
@@ -82,7 +82,7 @@ class MiscLoads
     mfl = OpenStudio::Model::OtherEquipment.new(mfl_def)
     mfl.setName(obj_name)
     mfl.setEndUseSubcategory(obj_name)
-    mfl.setFuelType(EnergyPlus.input_fuel_map(fuel_load.fuel_type))
+    mfl.setFuelType(EPlus.input_fuel_map(fuel_load.fuel_type))
     mfl.setSpace(living_space)
     mfl_def.setName(obj_name)
     mfl_def.setDesignLevel(space_design_level)

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -612,7 +612,7 @@ class Waterheater
     storage_tank.setHeater2SetpointTemperatureSchedule(setpoint_schedule_two)
     storage_tank.setHeater2Capacity(0)
     storage_tank.setHeater2Height(0)
-    storage_tank.setHeaterFuelType(EnergyPlus::FuelTypeElectricity)
+    storage_tank.setHeaterFuelType(EPlus::FuelTypeElectricity)
     storage_tank.setHeaterThermalEfficiency(1)
     storage_tank.ambientTemperatureSchedule.get.remove
     set_wh_ambient(loc_space, loc_schedule, model, storage_tank)
@@ -823,12 +823,12 @@ class Waterheater
     tank.setHeater2Capacity(UnitConversions.convert(e_cap, 'kW', 'W'))
     tank.setHeater2Height(h_LE)
     tank.setHeater2DeadbandTemperatureDifference(3.89)
-    tank.setHeaterFuelType(EnergyPlus::FuelTypeElectricity)
+    tank.setHeaterFuelType(EPlus::FuelTypeElectricity)
     tank.setHeaterThermalEfficiency(1)
     tank.setOffCycleParasiticFuelConsumptionRate(parasitics)
-    tank.setOffCycleParasiticFuelType(EnergyPlus::FuelTypeElectricity)
+    tank.setOffCycleParasiticFuelType(EPlus::FuelTypeElectricity)
     tank.setOnCycleParasiticFuelConsumptionRate(parasitics)
-    tank.setOnCycleParasiticFuelType(EnergyPlus::FuelTypeElectricity)
+    tank.setOnCycleParasiticFuelType(EPlus::FuelTypeElectricity)
     tank.setUniformSkinLossCoefficientperUnitAreatoAmbientTemperature(u_tank)
     tank.setAmbientTemperatureSchedule(hpwh_tamb)
     tank.setNumberofNodes(6)
@@ -1279,11 +1279,11 @@ class Waterheater
     # EMS for calculating the EC_adj
 
     # Sensors
-    eplus_fuel = EnergyPlus.input_fuel_map(fuel_type)
-    if eplus_fuel == EnergyPlus::FuelTypeElectricity
-      ep_consumption_name = "#{EnergyPlus.output_fuel_map(eplus_fuel)} Power"
+    eplus_fuel = EPlus.input_fuel_map(fuel_type)
+    if eplus_fuel == EPlus::FuelTypeElectricity
+      ep_consumption_name = "#{EPlus.output_fuel_map(eplus_fuel)} Power"
     else
-      ep_consumption_name = "#{EnergyPlus.output_fuel_map(eplus_fuel)} Rate"
+      ep_consumption_name = "#{EPlus.output_fuel_map(eplus_fuel)} Rate"
     end
     if [HPXML::WaterHeaterTypeCombiStorage, HPXML::WaterHeaterTypeCombiTankless].include? water_heating_system.water_heater_type
       ec_adj_sensor_hx = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Fluid Heat Exchanger Heat Transfer Energy')
@@ -1561,7 +1561,7 @@ class Waterheater
     new_heater = OpenStudio::Model::WaterHeaterMixed.new(model)
     new_heater.setName(name)
     new_heater.setHeaterThermalEfficiency(eta_c) unless eta_c.nil?
-    new_heater.setHeaterFuelType(EnergyPlus.input_fuel_map(fuel)) unless fuel.nil?
+    new_heater.setHeaterFuelType(EPlus.input_fuel_map(fuel)) unless fuel.nil?
     configure_setpoint_schedule(new_heater, t_set_c, model)
     new_heater.setMaximumTemperatureLimit(99.0)
     if [HPXML::WaterHeaterTypeTankless, HPXML::WaterHeaterTypeCombiTankless].include? tank_type
@@ -1586,11 +1586,11 @@ class Waterheater
   end
 
   def self.set_wh_parasitic_parameters(oncycle_p, water_heating_system, water_heater, is_storage)
-    water_heater.setOnCycleParasiticFuelType(EnergyPlus::FuelTypeElectricity)
+    water_heater.setOnCycleParasiticFuelType(EPlus::FuelTypeElectricity)
     water_heater.setOnCycleParasiticHeatFractiontoTank(0)
     water_heater.setOnCycleLossFractiontoThermalZone(1.0)
 
-    water_heater.setOffCycleParasiticFuelType(EnergyPlus::FuelTypeElectricity)
+    water_heater.setOffCycleParasiticFuelType(EPlus::FuelTypeElectricity)
     water_heater.setOffCycleParasiticHeatFractiontoTank(0)
 
     # Set fraction of heat loss from tank to ambient (vs out flue)

--- a/HPXMLtoOpenStudio/tests/test_hotwater_appliance.rb
+++ b/HPXMLtoOpenStudio/tests/test_hotwater_appliance.rb
@@ -354,13 +354,13 @@ class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
 
     cd_fuel_kwh = UnitConversions.convert(17.972, 'therm', 'kWh')
     assert_in_epsilon(cd_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypeOil, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
+    assert_equal(EPlus::FuelTypeOil, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
     assert_in_epsilon(cd_sens_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[0], 0.001)
     assert_in_epsilon(cd_lat_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[1], 0.001)
 
     cook_fuel_kwh = UnitConversions.convert(30.70, 'therm', 'kWh')
     assert_in_epsilon(cook_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypeOil, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
+    assert_equal(EPlus::FuelTypeOil, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
     assert_in_epsilon(cook_sens_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[0], 0.001)
     assert_in_epsilon(cook_lat_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[1], 0.001)
   end
@@ -429,13 +429,13 @@ class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
 
     cd_fuel_kwh = UnitConversions.convert(17.972, 'therm', 'kWh')
     assert_in_epsilon(cd_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypeNaturalGas, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
+    assert_equal(EPlus::FuelTypeNaturalGas, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
     assert_in_epsilon(cd_sens_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[0], 0.001)
     assert_in_epsilon(cd_lat_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[1], 0.001)
 
     cook_fuel_kwh = UnitConversions.convert(30.70, 'therm', 'kWh')
     assert_in_epsilon(cook_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypeNaturalGas, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
+    assert_equal(EPlus::FuelTypeNaturalGas, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
     assert_in_epsilon(cook_sens_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[0], 0.001)
     assert_in_epsilon(cook_lat_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[1], 0.001)
   end
@@ -504,13 +504,13 @@ class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
 
     cd_fuel_kwh = UnitConversions.convert(17.972, 'therm', 'kWh')
     assert_in_epsilon(cd_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypePropane, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
+    assert_equal(EPlus::FuelTypePropane, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
     assert_in_epsilon(cd_sens_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[0], 0.001)
     assert_in_epsilon(cd_lat_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[1], 0.001)
 
     cook_fuel_kwh = UnitConversions.convert(30.70, 'therm', 'kWh')
     assert_in_epsilon(cook_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypePropane, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
+    assert_equal(EPlus::FuelTypePropane, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
     assert_in_epsilon(cook_sens_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[0], 0.001)
     assert_in_epsilon(cook_lat_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[1], 0.001)
   end
@@ -579,13 +579,13 @@ class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
 
     cd_fuel_kwh = UnitConversions.convert(17.972, 'therm', 'kWh')
     assert_in_epsilon(cd_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypeWoodCord, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
+    assert_equal(EPlus::FuelTypeWoodCord, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
     assert_in_epsilon(cd_sens_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[0], 0.001)
     assert_in_epsilon(cd_lat_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[1], 0.001)
 
     cook_fuel_kwh = UnitConversions.convert(30.70, 'therm', 'kWh')
     assert_in_epsilon(cook_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypeWoodCord, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
+    assert_equal(EPlus::FuelTypeWoodCord, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
     assert_in_epsilon(cook_sens_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[0], 0.001)
     assert_in_epsilon(cook_lat_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[1], 0.001)
   end
@@ -654,13 +654,13 @@ class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
 
     cd_fuel_kwh = UnitConversions.convert(17.972, 'therm', 'kWh')
     assert_in_epsilon(cd_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypeCoal, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
+    assert_equal(EPlus::FuelTypeCoal, get_oe_kwh_fuel(model, Constants.ObjectNameClothesDryer)[1], 0.001)
     assert_in_epsilon(cd_sens_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[0], 0.001)
     assert_in_epsilon(cd_lat_frac, get_oe_fractions(model, Constants.ObjectNameClothesDryer)[1], 0.001)
 
     cook_fuel_kwh = UnitConversions.convert(30.70, 'therm', 'kWh')
     assert_in_epsilon(cook_fuel_kwh, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[0], 0.001)
-    assert_equal(EnergyPlus::FuelTypeCoal, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
+    assert_equal(EPlus::FuelTypeCoal, get_oe_kwh_fuel(model, Constants.ObjectNameCookingRange)[1], 0.001)
     assert_in_epsilon(cook_sens_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[0], 0.001)
     assert_in_epsilon(cook_lat_frac, get_oe_fractions(model, Constants.ObjectNameCookingRange)[1], 0.001)
   end

--- a/HPXMLtoOpenStudio/tests/test_hvac.rb
+++ b/HPXMLtoOpenStudio/tests/test_hvac.rb
@@ -105,7 +105,7 @@ class HPXMLtoOpenStudioHVACTest < MiniTest::Test
     htg_coil = model.getCoilHeatingGass[0]
     assert_in_epsilon(afue, htg_coil.gasBurnerEfficiency, 0.01)
     assert_in_epsilon(capacity, htg_coil.nominalCapacity.get, 0.01)
-    assert_equal(EnergyPlus.input_fuel_map(fuel), htg_coil.fuelType)
+    assert_equal(EPlus.input_fuel_map(fuel), htg_coil.fuelType)
   end
 
   def test_furnace_electric
@@ -141,7 +141,7 @@ class HPXMLtoOpenStudioHVACTest < MiniTest::Test
     boiler = model.getBoilerHotWaters[0]
     assert_in_epsilon(afue, boiler.nominalThermalEfficiency, 0.01)
     assert_in_epsilon(capacity, boiler.nominalCapacity.get, 0.01)
-    assert_equal(EnergyPlus.input_fuel_map(fuel), boiler.fuelType)
+    assert_equal(EPlus.input_fuel_map(fuel), boiler.fuelType)
   end
 
   def test_boiler_coal
@@ -160,7 +160,7 @@ class HPXMLtoOpenStudioHVACTest < MiniTest::Test
     boiler = model.getBoilerHotWaters[0]
     assert_in_epsilon(afue, boiler.nominalThermalEfficiency, 0.01)
     assert_in_epsilon(capacity, boiler.nominalCapacity.get, 0.01)
-    assert_equal(EnergyPlus.input_fuel_map(fuel), boiler.fuelType)
+    assert_equal(EPlus.input_fuel_map(fuel), boiler.fuelType)
   end
 
   def test_boiler_electric
@@ -179,7 +179,7 @@ class HPXMLtoOpenStudioHVACTest < MiniTest::Test
     boiler = model.getBoilerHotWaters[0]
     assert_in_epsilon(afue, boiler.nominalThermalEfficiency, 0.01)
     assert_in_epsilon(capacity, boiler.nominalCapacity.get, 0.01)
-    assert_equal(EnergyPlus.input_fuel_map(fuel), boiler.fuelType)
+    assert_equal(EPlus.input_fuel_map(fuel), boiler.fuelType)
   end
 
   def test_electric_resistance
@@ -215,7 +215,7 @@ class HPXMLtoOpenStudioHVACTest < MiniTest::Test
     htg_coil = model.getCoilHeatingGass[0]
     assert_in_epsilon(efficiency, htg_coil.gasBurnerEfficiency, 0.01)
     assert_in_epsilon(capacity, htg_coil.nominalCapacity.get, 0.01)
-    assert_equal(EnergyPlus.input_fuel_map(fuel), htg_coil.fuelType)
+    assert_equal(EPlus.input_fuel_map(fuel), htg_coil.fuelType)
   end
 
   def test_central_air_to_air_heat_pump_1_speed

--- a/HPXMLtoOpenStudio/tests/test_water_heater.rb
+++ b/HPXMLtoOpenStudio/tests/test_water_heater.rb
@@ -24,7 +24,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.95, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(7.88, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 0.773
@@ -53,7 +53,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.95, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(7.88, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 0.773
@@ -82,7 +82,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.95, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(7.88, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 0.773
@@ -111,7 +111,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.95, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(7.88, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 0.773
@@ -140,7 +140,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 1.0
@@ -169,7 +169,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(1.0, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(100000000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = 0.0
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C')
     ther_eff = 0.9108
@@ -198,7 +198,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.327, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 1.0
@@ -227,7 +227,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.95, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(7.88, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 0.773
@@ -255,7 +255,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     loc = HPXML::LocationLivingSpace
@@ -290,7 +290,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     loc = HPXML::LocationLivingSpace
@@ -325,7 +325,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     loc = HPXML::LocationLivingSpace
@@ -361,7 +361,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     loc = HPXML::LocationLivingSpace
@@ -431,7 +431,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     loc = HPXML::LocationLivingSpace
@@ -501,7 +501,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     loc = HPXML::LocationLivingSpace
@@ -571,7 +571,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     loc = HPXML::LocationLivingSpace
@@ -641,7 +641,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     loc = HPXML::LocationLivingSpace
@@ -705,7 +705,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K') * 0.35
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 1.0
@@ -822,7 +822,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     water_heating_system = hpxml.water_heating_systems[0]
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     u =  0.925
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') - 9
     ther_eff = 1.0
@@ -858,7 +858,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # Expected value
     tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3') # convert to actual volume
     cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
-    fuel = EnergyPlus.input_fuel_map(water_heating_system.fuel_type)
+    fuel = EPlus.input_fuel_map(water_heating_system.fuel_type)
     ua = UnitConversions.convert(0.6415, 'Btu/(hr*F)', 'W/K')
     t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
     ther_eff = 1.0

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -1547,12 +1547,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
   def add_object_output_variables(timeseries_frequency)
     hvac_output_vars = [OutputVars.SpaceHeatingElectricity,
-                        OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeNaturalGas),
-                        OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeOil),
-                        OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypePropane),
-                        OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeWoodCord),
-                        OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeWoodPellets),
-                        OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeCoal),
+                        OutputVars.SpaceHeatingFuel(EPlus::FuelTypeNaturalGas),
+                        OutputVars.SpaceHeatingFuel(EPlus::FuelTypeOil),
+                        OutputVars.SpaceHeatingFuel(EPlus::FuelTypePropane),
+                        OutputVars.SpaceHeatingFuel(EPlus::FuelTypeWoodCord),
+                        OutputVars.SpaceHeatingFuel(EPlus::FuelTypeWoodPellets),
+                        OutputVars.SpaceHeatingFuel(EPlus::FuelTypeCoal),
                         OutputVars.SpaceHeatingDFHPPrimaryLoad,
                         OutputVars.SpaceHeatingDFHPBackupLoad,
                         OutputVars.SpaceCoolingElectricity,
@@ -1561,12 +1561,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     dhw_output_vars = [OutputVars.WaterHeatingElectricity,
                        OutputVars.WaterHeatingElectricityRecircPump,
                        OutputVars.WaterHeatingElectricitySolarThermalPump,
-                       OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeNaturalGas),
-                       OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeOil),
-                       OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypePropane),
-                       OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeWoodCord),
-                       OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeWoodPellets),
-                       OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeCoal),
+                       OutputVars.WaterHeatingFuel(EPlus::FuelTypeNaturalGas),
+                       OutputVars.WaterHeatingFuel(EPlus::FuelTypeOil),
+                       OutputVars.WaterHeatingFuel(EPlus::FuelTypePropane),
+                       OutputVars.WaterHeatingFuel(EPlus::FuelTypeWoodCord),
+                       OutputVars.WaterHeatingFuel(EPlus::FuelTypeWoodPellets),
+                       OutputVars.WaterHeatingFuel(EPlus::FuelTypeCoal),
                        OutputVars.WaterHeatingLoad,
                        OutputVars.WaterHeatingLoadTankLosses,
                        OutputVars.WaterHeaterLoadDesuperheater,
@@ -1783,12 +1783,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       return 'kBtu'
     end
 
-    ep_fuel_names = { FT::Gas => EnergyPlus.output_fuel_map(EnergyPlus::FuelTypeNaturalGas),
-                      FT::Oil => EnergyPlus.output_fuel_map(EnergyPlus::FuelTypeOil),
-                      FT::Propane => EnergyPlus.output_fuel_map(EnergyPlus::FuelTypePropane),
-                      FT::WoodCord => EnergyPlus.output_fuel_map(EnergyPlus::FuelTypeWoodCord),
-                      FT::WoodPellets => EnergyPlus.output_fuel_map(EnergyPlus::FuelTypeWoodPellets),
-                      FT::Coal => EnergyPlus.output_fuel_map(EnergyPlus::FuelTypeCoal) }
+    ep_fuel_names = { FT::Gas => EPlus.output_fuel_map(EPlus::FuelTypeNaturalGas),
+                      FT::Oil => EPlus.output_fuel_map(EPlus::FuelTypeOil),
+                      FT::Propane => EPlus.output_fuel_map(EPlus::FuelTypePropane),
+                      FT::WoodCord => EPlus.output_fuel_map(EPlus::FuelTypeWoodCord),
+                      FT::WoodPellets => EPlus.output_fuel_map(EPlus::FuelTypeWoodPellets),
+                      FT::Coal => EPlus.output_fuel_map(EPlus::FuelTypeCoal) }
 
     # Fuels
 
@@ -1845,8 +1845,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       @end_uses[[FT::Elec, EUT::HotTubPump]] = EndUse.new(meter: "#{Constants.ObjectNameMiscHotTubPump}:InteriorEquipment:Electricity")
     end
     @end_uses[[FT::Elec, EUT::PV]] = EndUse.new(meter: 'ElectricityProduced:Facility')
-    @end_uses[[FT::Gas, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeNaturalGas))
-    @end_uses[[FT::Gas, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeNaturalGas))
+    @end_uses[[FT::Gas, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EPlus::FuelTypeNaturalGas))
+    @end_uses[[FT::Gas, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EPlus::FuelTypeNaturalGas))
     @end_uses[[FT::Gas, EUT::ClothesDryer]] = EndUse.new(meter: "#{Constants.ObjectNameClothesDryer}:InteriorEquipment:#{ep_fuel_names[FT::Gas]}")
     @end_uses[[FT::Gas, EUT::RangeOven]] = EndUse.new(meter: "#{Constants.ObjectNameCookingRange}:InteriorEquipment:#{ep_fuel_names[FT::Gas]}")
     if @eri_design.nil? # Skip end uses not used by ERI
@@ -1856,8 +1856,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       @end_uses[[FT::Gas, EUT::Lighting]] = EndUse.new(meter: "#{Constants.ObjectNameMiscLighting}:InteriorEquipment:#{ep_fuel_names[FT::Gas]}")
       @end_uses[[FT::Gas, EUT::Fireplace]] = EndUse.new(meter: "#{Constants.ObjectNameMiscFireplace}:InteriorEquipment:#{ep_fuel_names[FT::Gas]}")
     end
-    @end_uses[[FT::Oil, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeOil))
-    @end_uses[[FT::Oil, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeOil))
+    @end_uses[[FT::Oil, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EPlus::FuelTypeOil))
+    @end_uses[[FT::Oil, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EPlus::FuelTypeOil))
     @end_uses[[FT::Oil, EUT::ClothesDryer]] = EndUse.new(meter: "#{Constants.ObjectNameClothesDryer}:InteriorEquipment:#{ep_fuel_names[FT::Oil]}")
     @end_uses[[FT::Oil, EUT::RangeOven]] = EndUse.new(meter: "#{Constants.ObjectNameCookingRange}:InteriorEquipment:#{ep_fuel_names[FT::Oil]}")
     if @eri_design.nil? # Skip end uses not used by ERI
@@ -1865,8 +1865,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       @end_uses[[FT::Oil, EUT::Lighting]] = EndUse.new(meter: "#{Constants.ObjectNameMiscLighting}:InteriorEquipment:#{ep_fuel_names[FT::Oil]}")
       @end_uses[[FT::Oil, EUT::Fireplace]] = EndUse.new(meter: "#{Constants.ObjectNameMiscFireplace}:InteriorEquipment:#{ep_fuel_names[FT::Oil]}")
     end
-    @end_uses[[FT::Propane, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypePropane))
-    @end_uses[[FT::Propane, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypePropane))
+    @end_uses[[FT::Propane, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EPlus::FuelTypePropane))
+    @end_uses[[FT::Propane, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EPlus::FuelTypePropane))
     @end_uses[[FT::Propane, EUT::ClothesDryer]] = EndUse.new(meter: "#{Constants.ObjectNameClothesDryer}:InteriorEquipment:#{ep_fuel_names[FT::Propane]}")
     @end_uses[[FT::Propane, EUT::RangeOven]] = EndUse.new(meter: "#{Constants.ObjectNameCookingRange}:InteriorEquipment:#{ep_fuel_names[FT::Propane]}")
     if @eri_design.nil? # Skip end uses not used by ERI
@@ -1874,8 +1874,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       @end_uses[[FT::Propane, EUT::Lighting]] = EndUse.new(meter: "#{Constants.ObjectNameMiscLighting}:InteriorEquipment:#{ep_fuel_names[FT::Propane]}")
       @end_uses[[FT::Propane, EUT::Fireplace]] = EndUse.new(meter: "#{Constants.ObjectNameMiscFireplace}:InteriorEquipment:#{ep_fuel_names[FT::Propane]}")
     end
-    @end_uses[[FT::WoodCord, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeWoodCord))
-    @end_uses[[FT::WoodCord, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeWoodCord))
+    @end_uses[[FT::WoodCord, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EPlus::FuelTypeWoodCord))
+    @end_uses[[FT::WoodCord, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EPlus::FuelTypeWoodCord))
     @end_uses[[FT::WoodCord, EUT::ClothesDryer]] = EndUse.new(meter: "#{Constants.ObjectNameClothesDryer}:InteriorEquipment:#{ep_fuel_names[FT::WoodCord]}")
     @end_uses[[FT::WoodCord, EUT::RangeOven]] = EndUse.new(meter: "#{Constants.ObjectNameCookingRange}:InteriorEquipment:#{ep_fuel_names[FT::WoodCord]}")
     if @eri_design.nil? # Skip end uses not used by ERI
@@ -1883,8 +1883,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       @end_uses[[FT::WoodCord, EUT::Lighting]] = EndUse.new(meter: "#{Constants.ObjectNameMiscLighting}:InteriorEquipment:#{ep_fuel_names[FT::WoodCord]}")
       @end_uses[[FT::WoodCord, EUT::Fireplace]] = EndUse.new(meter: "#{Constants.ObjectNameMiscFireplace}:InteriorEquipment:#{ep_fuel_names[FT::WoodCord]}")
     end
-    @end_uses[[FT::WoodPellets, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeWoodPellets))
-    @end_uses[[FT::WoodPellets, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeWoodPellets))
+    @end_uses[[FT::WoodPellets, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EPlus::FuelTypeWoodPellets))
+    @end_uses[[FT::WoodPellets, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EPlus::FuelTypeWoodPellets))
     @end_uses[[FT::WoodPellets, EUT::ClothesDryer]] = EndUse.new(meter: "#{Constants.ObjectNameClothesDryer}:InteriorEquipment:#{ep_fuel_names[FT::WoodPellets]}")
     @end_uses[[FT::WoodPellets, EUT::RangeOven]] = EndUse.new(meter: "#{Constants.ObjectNameCookingRange}:InteriorEquipment:#{ep_fuel_names[FT::WoodPellets]}")
     if @eri_design.nil? # Skip end uses not used by ERI
@@ -1892,8 +1892,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       @end_uses[[FT::WoodPellets, EUT::Lighting]] = EndUse.new(meter: "#{Constants.ObjectNameMiscLighting}:InteriorEquipment:#{ep_fuel_names[FT::WoodPellets]}")
       @end_uses[[FT::WoodPellets, EUT::Fireplace]] = EndUse.new(meter: "#{Constants.ObjectNameMiscFireplace}:InteriorEquipment:#{ep_fuel_names[FT::WoodPellets]}")
     end
-    @end_uses[[FT::Coal, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EnergyPlus::FuelTypeCoal))
-    @end_uses[[FT::Coal, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EnergyPlus::FuelTypeCoal))
+    @end_uses[[FT::Coal, EUT::Heating]] = EndUse.new(variable: OutputVars.SpaceHeatingFuel(EPlus::FuelTypeCoal))
+    @end_uses[[FT::Coal, EUT::HotWater]] = EndUse.new(variable: OutputVars.WaterHeatingFuel(EPlus::FuelTypeCoal))
     @end_uses[[FT::Coal, EUT::ClothesDryer]] = EndUse.new(meter: "#{Constants.ObjectNameClothesDryer}:InteriorEquipment:#{ep_fuel_names[FT::Coal]}")
     @end_uses[[FT::Coal, EUT::RangeOven]] = EndUse.new(meter: "#{Constants.ObjectNameCookingRange}:InteriorEquipment:#{ep_fuel_names[FT::Coal]}")
     if @eri_design.nil? # Skip end uses not used by ERI
@@ -2075,7 +2075,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
 
     def self.SpaceHeatingFuel(fuel)
-      fuel = EnergyPlus.output_fuel_map(fuel)
+      fuel = EPlus.output_fuel_map(fuel)
       return { 'OpenStudio::Model::CoilHeatingGas' => ["Heating Coil #{fuel} Energy"],
                'OpenStudio::Model::ZoneHVACBaseboardConvectiveElectric' => ["Baseboard #{fuel} Energy"],
                'OpenStudio::Model::BoilerHotWater' => ["Boiler #{fuel} Energy"] }
@@ -2117,7 +2117,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
 
     def self.WaterHeatingFuel(fuel)
-      fuel = EnergyPlus.output_fuel_map(fuel)
+      fuel = EPlus.output_fuel_map(fuel)
       return { 'OpenStudio::Model::WaterHeaterMixed' => ["Water Heater #{fuel} Energy"],
                'OpenStudio::Model::WaterHeaterStratified' => ["Water Heater #{fuel} Energy"] }
     end

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>d6817874-b12e-4247-830c-a8450b1753cf</version_id>
-  <version_modified>20200626T234619Z</version_modified>
+  <version_id>b544e6f5-0b91-40f8-b2f6-7b864dec4d6d</version_id>
+  <version_modified>20200630T141629Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -16,7 +16,6 @@
       <display_name>Timeseries Reporting Frequency</display_name>
       <description>The frequency at which to report timeseries output data. Using 'none' will disable timeseries outputs.</description>
       <type>Choice</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>none</default_value>
@@ -42,15 +41,12 @@
           <display_name>monthly</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_fuel_consumptions</name>
       <display_name>Generate Timeseries Output: Fuel Consumptions</display_name>
       <description>Generates timeseries energy consumptions for each fuel type.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -64,15 +60,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_end_use_consumptions</name>
       <display_name>Generate Timeseries Output: End Use Consumptions</display_name>
       <description>Generates timeseries energy consumptions for each end use.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -86,15 +79,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_hot_water_uses</name>
       <display_name>Generate Timeseries Output: Hot Water Uses</display_name>
       <description>Generates timeseries hot water usages for each end use.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -108,15 +98,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_total_loads</name>
       <display_name>Generate Timeseries Output: Total Loads</display_name>
       <description>Generates timeseries heating/cooling loads.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -130,15 +117,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_component_loads</name>
       <display_name>Generate Timeseries Output: Component Loads</display_name>
       <description>Generates timeseries heating/cooling loads disaggregated by component type.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -152,15 +136,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_zone_temperatures</name>
       <display_name>Generate Timeseries Output: Zone Temperatures</display_name>
       <description>Generates timeseries temperatures for each thermal zone.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -174,15 +155,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_airflows</name>
       <display_name>Generate Timeseries Output: Airflows</display_name>
       <description>Generates timeseries airflows.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -196,15 +174,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_weather</name>
       <display_name>Generate Timeseries Output: Weather</display_name>
       <description>Generates timeseries weather data.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -218,8 +193,6 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
   </arguments>
   <outputs>
@@ -227,720 +200,560 @@
       <name>Electricity: Total MBtu</name>
       <display_name>Electricity: Total MBtu</display_name>
       <short_name>Electricity: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Total MBtu</name>
       <display_name>Natural Gas: Total MBtu</display_name>
       <short_name>Natural Gas: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Total MBtu</name>
       <display_name>Fuel Oil: Total MBtu</display_name>
       <short_name>Fuel Oil: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Total MBtu</name>
       <display_name>Propane: Total MBtu</display_name>
       <short_name>Propane: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Total MBtu</name>
       <display_name>Wood Cord: Total MBtu</display_name>
       <short_name>Wood Cord: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Total MBtu</name>
       <display_name>Wood Pellets: Total MBtu</display_name>
       <short_name>Wood Pellets: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Total MBtu</name>
       <display_name>Coal: Total MBtu</display_name>
       <short_name>Coal: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Heating MBtu</name>
       <display_name>Electricity: Heating MBtu</display_name>
       <short_name>Electricity: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Heating Fans/Pumps MBtu</name>
       <display_name>Electricity: Heating Fans/Pumps MBtu</display_name>
       <short_name>Electricity: Heating Fans/Pumps MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Cooling MBtu</name>
       <display_name>Electricity: Cooling MBtu</display_name>
       <short_name>Electricity: Cooling MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Cooling Fans/Pumps MBtu</name>
       <display_name>Electricity: Cooling Fans/Pumps MBtu</display_name>
       <short_name>Electricity: Cooling Fans/Pumps MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Water MBtu</name>
       <display_name>Electricity: Hot Water MBtu</display_name>
       <short_name>Electricity: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Water Recirc Pump MBtu</name>
       <display_name>Electricity: Hot Water Recirc Pump MBtu</display_name>
       <short_name>Electricity: Hot Water Recirc Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Water Solar Thermal Pump MBtu</name>
       <display_name>Electricity: Hot Water Solar Thermal Pump MBtu</display_name>
       <short_name>Electricity: Hot Water Solar Thermal Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Lighting Interior MBtu</name>
       <display_name>Electricity: Lighting Interior MBtu</display_name>
       <short_name>Electricity: Lighting Interior MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Lighting Garage MBtu</name>
       <display_name>Electricity: Lighting Garage MBtu</display_name>
       <short_name>Electricity: Lighting Garage MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Lighting Exterior MBtu</name>
       <display_name>Electricity: Lighting Exterior MBtu</display_name>
       <short_name>Electricity: Lighting Exterior MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Mech Vent MBtu</name>
       <display_name>Electricity: Mech Vent MBtu</display_name>
       <short_name>Electricity: Mech Vent MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Whole House Fan MBtu</name>
       <display_name>Electricity: Whole House Fan MBtu</display_name>
       <short_name>Electricity: Whole House Fan MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Refrigerator MBtu</name>
       <display_name>Electricity: Refrigerator MBtu</display_name>
       <short_name>Electricity: Refrigerator MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Freezer MBtu</name>
       <display_name>Electricity: Freezer MBtu</display_name>
       <short_name>Electricity: Freezer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Dehumidifier MBtu</name>
       <display_name>Electricity: Dehumidifier MBtu</display_name>
       <short_name>Electricity: Dehumidifier MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Dishwasher MBtu</name>
       <display_name>Electricity: Dishwasher MBtu</display_name>
       <short_name>Electricity: Dishwasher MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Clothes Washer MBtu</name>
       <display_name>Electricity: Clothes Washer MBtu</display_name>
       <short_name>Electricity: Clothes Washer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Clothes Dryer MBtu</name>
       <display_name>Electricity: Clothes Dryer MBtu</display_name>
       <short_name>Electricity: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Range/Oven MBtu</name>
       <display_name>Electricity: Range/Oven MBtu</display_name>
       <short_name>Electricity: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Ceiling Fan MBtu</name>
       <display_name>Electricity: Ceiling Fan MBtu</display_name>
       <short_name>Electricity: Ceiling Fan MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Television MBtu</name>
       <display_name>Electricity: Television MBtu</display_name>
       <short_name>Electricity: Television MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Plug Loads MBtu</name>
       <display_name>Electricity: Plug Loads MBtu</display_name>
       <short_name>Electricity: Plug Loads MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Electric Vehicle Charging MBtu</name>
       <display_name>Electricity: Electric Vehicle Charging MBtu</display_name>
       <short_name>Electricity: Electric Vehicle Charging MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Well Pump MBtu</name>
       <display_name>Electricity: Well Pump MBtu</display_name>
       <short_name>Electricity: Well Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Pool Heater MBtu</name>
       <display_name>Electricity: Pool Heater MBtu</display_name>
       <short_name>Electricity: Pool Heater MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Pool Pump MBtu</name>
       <display_name>Electricity: Pool Pump MBtu</display_name>
       <short_name>Electricity: Pool Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Tub Heater MBtu</name>
       <display_name>Electricity: Hot Tub Heater MBtu</display_name>
       <short_name>Electricity: Hot Tub Heater MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Tub Pump MBtu</name>
       <display_name>Electricity: Hot Tub Pump MBtu</display_name>
       <short_name>Electricity: Hot Tub Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: PV MBtu</name>
       <display_name>Electricity: PV MBtu</display_name>
       <short_name>Electricity: PV MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Heating MBtu</name>
       <display_name>Natural Gas: Heating MBtu</display_name>
       <short_name>Natural Gas: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Hot Water MBtu</name>
       <display_name>Natural Gas: Hot Water MBtu</display_name>
       <short_name>Natural Gas: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Clothes Dryer MBtu</name>
       <display_name>Natural Gas: Clothes Dryer MBtu</display_name>
       <short_name>Natural Gas: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Range/Oven MBtu</name>
       <display_name>Natural Gas: Range/Oven MBtu</display_name>
       <short_name>Natural Gas: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Pool Heater MBtu</name>
       <display_name>Natural Gas: Pool Heater MBtu</display_name>
       <short_name>Natural Gas: Pool Heater MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Hot Tub Heater MBtu</name>
       <display_name>Natural Gas: Hot Tub Heater MBtu</display_name>
       <short_name>Natural Gas: Hot Tub Heater MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Grill MBtu</name>
       <display_name>Natural Gas: Grill MBtu</display_name>
       <short_name>Natural Gas: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Lighting MBtu</name>
       <display_name>Natural Gas: Lighting MBtu</display_name>
       <short_name>Natural Gas: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Fireplace MBtu</name>
       <display_name>Natural Gas: Fireplace MBtu</display_name>
       <short_name>Natural Gas: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Heating MBtu</name>
       <display_name>Fuel Oil: Heating MBtu</display_name>
       <short_name>Fuel Oil: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Hot Water MBtu</name>
       <display_name>Fuel Oil: Hot Water MBtu</display_name>
       <short_name>Fuel Oil: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Clothes Dryer MBtu</name>
       <display_name>Fuel Oil: Clothes Dryer MBtu</display_name>
       <short_name>Fuel Oil: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Range/Oven MBtu</name>
       <display_name>Fuel Oil: Range/Oven MBtu</display_name>
       <short_name>Fuel Oil: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Grill MBtu</name>
       <display_name>Fuel Oil: Grill MBtu</display_name>
       <short_name>Fuel Oil: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Lighting MBtu</name>
       <display_name>Fuel Oil: Lighting MBtu</display_name>
       <short_name>Fuel Oil: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Fireplace MBtu</name>
       <display_name>Fuel Oil: Fireplace MBtu</display_name>
       <short_name>Fuel Oil: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Heating MBtu</name>
       <display_name>Propane: Heating MBtu</display_name>
       <short_name>Propane: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Hot Water MBtu</name>
       <display_name>Propane: Hot Water MBtu</display_name>
       <short_name>Propane: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Clothes Dryer MBtu</name>
       <display_name>Propane: Clothes Dryer MBtu</display_name>
       <short_name>Propane: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Range/Oven MBtu</name>
       <display_name>Propane: Range/Oven MBtu</display_name>
       <short_name>Propane: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Grill MBtu</name>
       <display_name>Propane: Grill MBtu</display_name>
       <short_name>Propane: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Lighting MBtu</name>
       <display_name>Propane: Lighting MBtu</display_name>
       <short_name>Propane: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Fireplace MBtu</name>
       <display_name>Propane: Fireplace MBtu</display_name>
       <short_name>Propane: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Heating MBtu</name>
       <display_name>Wood Cord: Heating MBtu</display_name>
       <short_name>Wood Cord: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Hot Water MBtu</name>
       <display_name>Wood Cord: Hot Water MBtu</display_name>
       <short_name>Wood Cord: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Clothes Dryer MBtu</name>
       <display_name>Wood Cord: Clothes Dryer MBtu</display_name>
       <short_name>Wood Cord: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Range/Oven MBtu</name>
       <display_name>Wood Cord: Range/Oven MBtu</display_name>
       <short_name>Wood Cord: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Grill MBtu</name>
       <display_name>Wood Cord: Grill MBtu</display_name>
       <short_name>Wood Cord: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Lighting MBtu</name>
       <display_name>Wood Cord: Lighting MBtu</display_name>
       <short_name>Wood Cord: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Fireplace MBtu</name>
       <display_name>Wood Cord: Fireplace MBtu</display_name>
       <short_name>Wood Cord: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Heating MBtu</name>
       <display_name>Wood Pellets: Heating MBtu</display_name>
       <short_name>Wood Pellets: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Hot Water MBtu</name>
       <display_name>Wood Pellets: Hot Water MBtu</display_name>
       <short_name>Wood Pellets: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Clothes Dryer MBtu</name>
       <display_name>Wood Pellets: Clothes Dryer MBtu</display_name>
       <short_name>Wood Pellets: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Range/Oven MBtu</name>
       <display_name>Wood Pellets: Range/Oven MBtu</display_name>
       <short_name>Wood Pellets: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Grill MBtu</name>
       <display_name>Wood Pellets: Grill MBtu</display_name>
       <short_name>Wood Pellets: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Lighting MBtu</name>
       <display_name>Wood Pellets: Lighting MBtu</display_name>
       <short_name>Wood Pellets: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Fireplace MBtu</name>
       <display_name>Wood Pellets: Fireplace MBtu</display_name>
       <short_name>Wood Pellets: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Heating MBtu</name>
       <display_name>Coal: Heating MBtu</display_name>
       <short_name>Coal: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Hot Water MBtu</name>
       <display_name>Coal: Hot Water MBtu</display_name>
       <short_name>Coal: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Clothes Dryer MBtu</name>
       <display_name>Coal: Clothes Dryer MBtu</display_name>
       <short_name>Coal: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Range/Oven MBtu</name>
       <display_name>Coal: Range/Oven MBtu</display_name>
       <short_name>Coal: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Grill MBtu</name>
       <display_name>Coal: Grill MBtu</display_name>
       <short_name>Coal: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Lighting MBtu</name>
       <display_name>Coal: Lighting MBtu</display_name>
       <short_name>Coal: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Fireplace MBtu</name>
       <display_name>Coal: Fireplace MBtu</display_name>
       <short_name>Coal: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
   </outputs>
@@ -973,6 +786,12 @@
       <checksum>BFBDB9E1</checksum>
     </file>
     <file>
+      <filename>output_report_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>34FC690F</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.9.1</identifier>
@@ -981,14 +800,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>142BEA31</checksum>
-    </file>
-    <file>
-      <filename>output_report_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>34FC690F</checksum>
+      <checksum>E54E4E22</checksum>
     </file>
   </files>
 </measure>
-<error>uninitialized constant SimulationOutputReport::EnergyPlus</error>


### PR DESCRIPTION
## Pull Request Description

Renames the new EnergyPlus class to EPlus to avoid conflicts in some workflows.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
