### PR TITLE
Suppress "Cannot find current Workflow Step" warning

### DIFF
--- a/HPXMLtoOpenStudio/resources/meta_measure.rb
+++ b/HPXMLtoOpenStudio/resources/meta_measure.rb
@@ -19,7 +19,7 @@ def apply_measures(measures_dir, measures, runner, model, show_measure_calls = t
         print_measure_call(args, measure_subdir, runner)
       end
 
-      if not run_measure(model, measure, argument_map, runner, measure_subdir)
+      if not run_measure(model, measure, argument_map, runner)
         return false
       end
     end
@@ -150,24 +150,15 @@ def get_argument_map(model, measure, provided_args, lookup_file, measure_name, r
   return argument_map
 end
 
-def run_measure(model, measure, argument_map, runner, measure_subdir)
+def run_measure(model, measure, argument_map, runner)
   require 'openstudio'
   begin
     # run the measure
-    super_class_name = measure.class.superclass.name.to_s
-
-    measure_type = super_class_name.split('::')[-1]
-    model_measure = OpenStudio::MeasureType.new(measure_type)
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new(measure_subdir))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner_child = OpenStudio::Measure::OSRunner.new(workflow_json)
+    runner_child = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
     if model.instance_of? OpenStudio::Workspace
       runner_child.setLastOpenStudioModel(runner.lastOpenStudioModel.get)
     end
-    if super_class_name == 'OpenStudio::Measure::ReportingMeasure'
+    if measure.class.superclass.name.to_s == 'OpenStudio::Measure::ReportingMeasure'
       runner_child.setLastOpenStudioModel(model)
       runner_child.setLastEnergyPlusSqlFilePath(runner.lastEnergyPlusSqlFile.get.path)
       measure.run(runner_child, argument_map)

--- a/HPXMLtoOpenStudio/tests/test_airflow.rb
+++ b/HPXMLtoOpenStudio/tests/test_airflow.rb
@@ -332,7 +332,13 @@ class HPXMLtoOpenStudioAirflowTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_airflow.rb
+++ b/HPXMLtoOpenStudio/tests/test_airflow.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioAirflowTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -332,13 +339,7 @@ class HPXMLtoOpenStudioAirflowTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -355,8 +356,8 @@ class HPXMLtoOpenStudioAirflowTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def before_setup
     @root_path = File.absolute_path(File.join(File.dirname(__FILE__), '..', '..'))
     @tmp_hpxml_path = File.join(@root_path, 'workflow', 'sample_files', 'tmp.xml')
@@ -797,13 +804,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -820,8 +821,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -797,7 +797,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_hotwater_appliance.rb
+++ b/HPXMLtoOpenStudio/tests/test_hotwater_appliance.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -669,13 +676,7 @@ class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -692,8 +693,8 @@ class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_hotwater_appliance.rb
+++ b/HPXMLtoOpenStudio/tests/test_hotwater_appliance.rb
@@ -669,7 +669,13 @@ class HPXMLtoOpenStudioHotWaterApplianceTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_hvac.rb
+++ b/HPXMLtoOpenStudio/tests/test_hvac.rb
@@ -401,7 +401,13 @@ class HPXMLtoOpenStudioHVACTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_hvac.rb
+++ b/HPXMLtoOpenStudio/tests/test_hvac.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioHVACTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -401,13 +408,7 @@ class HPXMLtoOpenStudioHVACTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -424,8 +425,8 @@ class HPXMLtoOpenStudioHVACTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_lighting.rb
+++ b/HPXMLtoOpenStudio/tests/test_lighting.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioLightingTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -67,13 +74,7 @@ class HPXMLtoOpenStudioLightingTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -90,8 +91,8 @@ class HPXMLtoOpenStudioLightingTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_lighting.rb
+++ b/HPXMLtoOpenStudio/tests/test_lighting.rb
@@ -67,7 +67,13 @@ class HPXMLtoOpenStudioLightingTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_location.rb
+++ b/HPXMLtoOpenStudio/tests/test_location.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioLocationTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -62,13 +69,7 @@ class HPXMLtoOpenStudioLocationTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -85,8 +86,8 @@ class HPXMLtoOpenStudioLocationTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_location.rb
+++ b/HPXMLtoOpenStudio/tests/test_location.rb
@@ -62,7 +62,13 @@ class HPXMLtoOpenStudioLocationTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_miscloads.rb
+++ b/HPXMLtoOpenStudio/tests/test_miscloads.rb
@@ -195,7 +195,13 @@ class HPXMLtoOpenStudioMiscLoadsTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_miscloads.rb
+++ b/HPXMLtoOpenStudio/tests/test_miscloads.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioMiscLoadsTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -195,13 +202,7 @@ class HPXMLtoOpenStudioMiscLoadsTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -218,8 +219,8 @@ class HPXMLtoOpenStudioMiscLoadsTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_pv.rb
+++ b/HPXMLtoOpenStudio/tests/test_pv.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioPVTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -54,13 +61,7 @@ class HPXMLtoOpenStudioPVTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -77,8 +78,8 @@ class HPXMLtoOpenStudioPVTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_pv.rb
+++ b/HPXMLtoOpenStudio/tests/test_pv.rb
@@ -54,7 +54,13 @@ class HPXMLtoOpenStudioPVTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_simcontrols.rb
+++ b/HPXMLtoOpenStudio/tests/test_simcontrols.rb
@@ -9,6 +9,13 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioSimControlsTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -66,13 +73,7 @@ class HPXMLtoOpenStudioSimControlsTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -89,8 +90,8 @@ class HPXMLtoOpenStudioSimControlsTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'

--- a/HPXMLtoOpenStudio/tests/test_simcontrols.rb
+++ b/HPXMLtoOpenStudio/tests/test_simcontrols.rb
@@ -66,7 +66,13 @@ class HPXMLtoOpenStudioSimControlsTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_water_heater.rb
+++ b/HPXMLtoOpenStudio/tests/test_water_heater.rb
@@ -881,7 +881,13 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+    measure_steps = OpenStudio::MeasureStepVector.new
+    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+    workflow_json = OpenStudio::WorkflowJSON.new
+    workflow_json.setMeasureSteps(model_measure, measure_steps)
+
+    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
     model = OpenStudio::Model::Model.new
 
     # get arguments

--- a/HPXMLtoOpenStudio/tests/test_water_heater.rb
+++ b/HPXMLtoOpenStudio/tests/test_water_heater.rb
@@ -10,6 +10,13 @@ require_relative '../resources/util.rb'
 require_relative '../resources/waterheater.rb'
 
 class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
+  model_measure = OpenStudio::MeasureType.new('ModelMeasure')
+  measure_steps = OpenStudio::MeasureStepVector.new
+  measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
+  workflow_json = OpenStudio::WorkflowJSON.new
+  workflow_json.setMeasureSteps(model_measure, measure_steps)
+  @@runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+
   def sample_files_dir
     return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
   end
@@ -881,13 +888,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     # create an instance of the measure
     measure = HPXMLtoOpenStudio.new
 
-    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
-    measure_steps = OpenStudio::MeasureStepVector.new
-    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
-    workflow_json = OpenStudio::WorkflowJSON.new
-    workflow_json.setMeasureSteps(model_measure, measure_steps)
-
-    runner = OpenStudio::Measure::OSRunner.new(workflow_json)
+    @@runner.reset # otherwise you get "Step already started"
     model = OpenStudio::Model::Model.new
 
     # get arguments
@@ -904,8 +905,8 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
     end
 
     # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result
+    measure.run(model, @@runner, argument_map)
+    result = @@runner.result
 
     # show the output
     show_output(result) unless result.value.valueName == 'Success'


### PR DESCRIPTION
## Pull Request Description

Instead of modifying the OpenStudio SDK, this approach creates a workflow with the current measure, e.g.:
```
    model_measure = OpenStudio::MeasureType.new('ModelMeasure')
    measure_steps = OpenStudio::MeasureStepVector.new
    measure_steps.push(OpenStudio::MeasureStep.new('HPXMLtoOpenStudio'))
    workflow_json = OpenStudio::WorkflowJSON.new
    workflow_json.setMeasureSteps(model_measure, measure_steps)
```

For reference, see https://github.com/NREL/OpenStudio/issues/3578.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
