### PR TITLE
Adobe wall type

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -3114,7 +3114,7 @@ class OSModel
                                    constr_set.drywall_thick_in, constr_set.osb_thick_in,
                                    constr_set.rigid_r, constr_set.exterior_material,
                                    inside_film, outside_film)
-    elsif [HPXML::WallTypeConcrete, HPXML::WallTypeBrick, HPXML::WallTypeStrawBale, HPXML::WallTypeStone, HPXML::WallTypeLog].include? wall_type
+    elsif [HPXML::WallTypeConcrete, HPXML::WallTypeBrick, HPXML::WallTypeAdobe, HPXML::WallTypeStrawBale, HPXML::WallTypeStone, HPXML::WallTypeLog].include? wall_type
       constr_sets = [
         GenericConstructionSet.new(10.0, 0.5, drywall_thick_in, mat_ext_finish), # w/R-10 rigid
         GenericConstructionSet.new(0.0, 0.5, drywall_thick_in, mat_ext_finish),  # Standard
@@ -3128,6 +3128,9 @@ class OSModel
       elsif wall_type == HPXML::WallTypeBrick
         thick_in = 8.0
         base_mat = BaseMaterial.Brick
+      elsif wall_type == HPXML::WallTypeAdobe
+        thick_in = 10.0
+        base_mat = BaseMaterial.Soil
       elsif wall_type == HPXML::WallTypeStrawBale
         thick_in = 23.0
         base_mat = BaseMaterial.StrawBale

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>50b5faf1-2791-4998-99cb-b4b766aadb21</version_id>
-  <version_modified>20200706T171120Z</version_modified>
+  <version_id>772c7194-eb39-46e6-a7cb-392e0ddae041</version_id>
+  <version_modified>20200708T160833Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -391,12 +391,6 @@
       <checksum>FC4DE789</checksum>
     </file>
     <file>
-      <filename>hvac_sizing.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>598BE4EE</checksum>
-    </file>
-    <file>
       <filename>HPXMLDataTypes.xsd</filename>
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
@@ -407,12 +401,6 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>179766A0</checksum>
-    </file>
-    <file>
-      <filename>BaseElements.xsd</filename>
-      <filetype>xsd</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6B0842BB</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
@@ -437,18 +425,6 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>7426D510</checksum>
-    </file>
-    <file>
-      <filename>EPvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>4D06A2B5</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C9BFC94E</checksum>
     </file>
     <file>
       <filename>test_simcontrols.rb</filename>
@@ -541,6 +517,24 @@
       <checksum>0919D764</checksum>
     </file>
     <file>
+      <filename>meta_measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>9E0049EB</checksum>
+    </file>
+    <file>
+      <filename>BaseElements.xsd</filename>
+      <filetype>xsd</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>4A35EEA6</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C5843CD3</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.0.0</identifier>
@@ -549,13 +543,19 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>5DBE9058</checksum>
+      <checksum>F39F78FB</checksum>
     </file>
     <file>
-      <filename>meta_measure.rb</filename>
+      <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>9E0049EB</checksum>
+      <checksum>7CDDC6AE</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3AACC6F0</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/BaseElements.xsd
+++ b/HPXMLtoOpenStudio/resources/BaseElements.xsd
@@ -5139,9 +5139,6 @@
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WallType">
-		<xs:annotation>
-			<xs:documentation>Wall type enumerations are further explained at https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
-		</xs:annotation>
 		<xs:choice>
 			<xs:element name="WoodStud">
 				<xs:complexType>
@@ -5244,6 +5241,14 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="LogWall">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+					<xs:attribute name="dataSource" type="DataSource"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Adobe">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -200,7 +200,7 @@ class EnergyPlusValidator
         'SystemIdentifier' => one, # Required by HPXML schema
         'ExteriorAdjacentTo[text()="outside" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage" or text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]' => one,
         'InteriorAdjacentTo[text()="living space" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage"]' => one,
-        'WallType[WoodStud | DoubleWoodStud | ConcreteMasonryUnit | StructurallyInsulatedPanel | InsulatedConcreteForms | SteelFrame | SolidConcrete | StructuralBrick | StrawBale | Stone | LogWall]' => one,
+        'WallType[WoodStud | DoubleWoodStud | ConcreteMasonryUnit | StructurallyInsulatedPanel | InsulatedConcreteForms | SteelFrame | SolidConcrete | StructuralBrick | StrawBale | Stone | LogWall | Adobe]' => one,
         'Area' => one,
         'Azimuth' => zero_or_one,
         '[not(Siding)] | Siding[text()="wood siding" or text()="vinyl siding" or text()="stucco" or text()="fiber cement siding" or text()="brick veneer" or text()="aluminum siding"]' => one,

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -223,6 +223,7 @@ class HPXML < Object
   UnitsKwhPerYear = 'kWh/year'
   UnitsPercent = 'Percent'
   UnitsThermPerYear = 'therm/year'
+  WallTypeAdobe = 'Adobe'
   WallTypeBrick = 'StructuralBrick'
   WallTypeCMU = 'ConcreteMasonryUnit'
   WallTypeConcrete = 'SolidConcrete'

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -2527,7 +2527,7 @@ class HVACSizing
       # This is an estimate based on Table 4A - Construction Number 13
       wall_group += (wall.insulation_continuous_r_value / 3.0).floor # Group is increased by approximately 1 letter for each R3
 
-    elsif wall_type == HPXML::WallTypeBrick
+    elsif [HPXML::WallTypeBrick, HPXML::WallTypeAdobe].include? wall_type
       # Two Courses Brick
       if wall_ufactor >= (0.218 + 0.179) / 2
         wall_group = 7  # G

--- a/tasks.rb
+++ b/tasks.rb
@@ -1184,7 +1184,8 @@ def set_hpxml_walls(hpxml_file, hpxml)
                   HPXML::WallTypeSteelStud => 8.1,
                   HPXML::WallTypeStone => 5.4,
                   HPXML::WallTypeStrawBale => 58.8,
-                  HPXML::WallTypeBrick => 7.9 }
+                  HPXML::WallTypeBrick => 7.9,
+                  HPXML::WallTypeAdobe => 5.0 }
     siding_types = [[HPXML::SidingTypeAluminum, HPXML::ColorReflective],
                     [HPXML::SidingTypeBrick, HPXML::ColorMediumDark],
                     [HPXML::SidingTypeFiberCement, HPXML::ColorMedium],

--- a/workflow/sample_files/base-enclosure-walltypes.xml
+++ b/workflow/sample_files/base-enclosure-walltypes.xml
@@ -180,7 +180,7 @@
             <WallType>
               <ConcreteMasonryUnit/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>aluminum siding</Siding>
             <Color>reflective</Color>
             <Emittance>0.92</Emittance>
@@ -196,7 +196,7 @@
             <WallType>
               <DoubleWoodStud/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>brick veneer</Siding>
             <Color>medium dark</Color>
             <Emittance>0.92</Emittance>
@@ -212,7 +212,7 @@
             <WallType>
               <InsulatedConcreteForms/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>fiber cement siding</Siding>
             <Color>medium</Color>
             <Emittance>0.92</Emittance>
@@ -228,7 +228,7 @@
             <WallType>
               <LogWall/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>stucco</Siding>
             <Color>light</Color>
             <Emittance>0.92</Emittance>
@@ -244,7 +244,7 @@
             <WallType>
               <StructurallyInsulatedPanel/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>vinyl siding</Siding>
             <Color>dark</Color>
             <Emittance>0.92</Emittance>
@@ -260,7 +260,7 @@
             <WallType>
               <SolidConcrete/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>aluminum siding</Siding>
             <Color>reflective</Color>
             <Emittance>0.92</Emittance>
@@ -276,7 +276,7 @@
             <WallType>
               <SteelFrame/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>brick veneer</Siding>
             <Color>medium dark</Color>
             <Emittance>0.92</Emittance>
@@ -292,7 +292,7 @@
             <WallType>
               <Stone/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>fiber cement siding</Siding>
             <Color>medium</Color>
             <Emittance>0.92</Emittance>
@@ -308,7 +308,7 @@
             <WallType>
               <StrawBale/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>stucco</Siding>
             <Color>light</Color>
             <Emittance>0.92</Emittance>
@@ -324,13 +324,29 @@
             <WallType>
               <StructuralBrick/>
             </WallType>
-            <Area>120.0</Area>
+            <Area>109.0</Area>
             <Siding>vinyl siding</Siding>
             <Color>dark</Color>
             <Emittance>0.92</Emittance>
             <Insulation>
               <SystemIdentifier id='Wall10Insulation'/>
               <AssemblyEffectiveRValue>7.9</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall11'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <Adobe/>
+            </WallType>
+            <Area>109.0</Area>
+            <Siding>aluminum siding</Siding>
+            <Color>reflective</Color>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='Wall11Insulation'/>
+              <AssemblyEffectiveRValue>5.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>


### PR DESCRIPTION
## Pull Request Description

Allow Adobe for `WallType`.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
