### PR TITLE
Fix running tests on Windows

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>50b5faf1-2791-4998-99cb-b4b766aadb21</version_id>
-  <version_modified>20200706T171120Z</version_modified>
+  <version_id>9182ea27-c877-4968-bfea-625bebf9b55b</version_id>
+  <version_modified>20200708T171304Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -439,12 +439,6 @@
       <checksum>7426D510</checksum>
     </file>
     <file>
-      <filename>EPvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>4D06A2B5</checksum>
-    </file>
-    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -552,10 +546,16 @@
       <checksum>5DBE9058</checksum>
     </file>
     <file>
+      <filename>EPvalidator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>52A912A0</checksum>
+    </file>
+    <file>
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>9E0049EB</checksum>
+      <checksum>E6D3B53C</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Avoid `IO.sysopen` for capturing stderr, as it results in the file not being closed on Windows, causing errors when running tests.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
