### PR TITLE
Change holiday lighting input requirement

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>71a2d590-5e6d-4526-b2f5-255fb9d82df9</version_id>
-  <version_modified>20200717T175119Z</version_modified>
+  <version_id>56152577-6661-4326-b9be-29ecd28f1345</version_id>
+  <version_modified>20200720T163822Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -546,12 +546,6 @@
       <checksum>4708151E</checksum>
     </file>
     <file>
-      <filename>EPvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>38A1E912</checksum>
-    </file>
-    <file>
       <filename>energyplus.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -564,16 +558,22 @@
       <checksum>2C3820DF</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>5B72B234</checksum>
-    </file>
-    <file>
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>8AC20974</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>F30A847E</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3B0A2738</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -833,7 +833,11 @@ class EnergyPlusValidator
 
       ## [ExteriorHolidayLighting]
       '/HPXML/Building/BuildingDetails/Lighting/extension/ExteriorHolidayLighting' => {
-        'Load[Units="kWh/day"]/Value | PeriodBeginMonth | PeriodBeginDayOfMonth | PeriodEndMonth | PeriodEndDayOfMonth | WeekdayScheduleFractions | WeekendScheduleFractions' => zero_or_seven,
+        'Load[Units="kWh/day"]/Value' => zero_or_one,
+        'PeriodBeginMonth | PeriodBeginDayOfMonth' => zero_or_two, # integer
+        'PeriodEndMonth | PeriodEndDayOfMonth' => zero_or_two, # integer
+        'WeekdayScheduleFractions' => zero_or_one,
+        'WeekendScheduleFractions' => zero_or_one,
       },
 
       # [CeilingFan]

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -907,7 +907,7 @@ class HPXMLDefaults
     if hpxml.lighting.exterior_monthly_multipliers.nil?
       hpxml.lighting.exterior_monthly_multipliers = default_exterior_lighting_monthly_multipliers
     end
-    if (hpxml.lighting.holiday_exists == true) 
+    if hpxml.lighting.holiday_exists
       if hpxml.lighting.holiday_kwh_per_day.nil?
         # From LA100 repo (2017)
         if hpxml.building_construction.residential_facility_type == HPXML::ResidentialTypeSFD

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -907,19 +907,29 @@ class HPXMLDefaults
     if hpxml.lighting.exterior_monthly_multipliers.nil?
       hpxml.lighting.exterior_monthly_multipliers = default_exterior_lighting_monthly_multipliers
     end
-    if (hpxml.lighting.holiday_exists == true) && hpxml.lighting.holiday_kwh_per_day.nil?
-      # From LA100 repo (2017)
-      if hpxml.building_construction.residential_facility_type == HPXML::ResidentialTypeSFD
-        hpxml.lighting.holiday_kwh_per_day = 1.1
-      elsif [HPXML::ResidentialTypeApartment, HPXML::ResidentialTypeSFA].include? hpxml.building_construction.residential_facility_type
-        hpxml.lighting.holiday_kwh_per_day = 0.5
+    if (hpxml.lighting.holiday_exists == true) 
+      if hpxml.lighting.holiday_kwh_per_day.nil?
+        # From LA100 repo (2017)
+        if hpxml.building_construction.residential_facility_type == HPXML::ResidentialTypeSFD
+          hpxml.lighting.holiday_kwh_per_day = 1.1
+        else # Multifamily and others
+          hpxml.lighting.holiday_kwh_per_day = 0.55
+        end
       end
-      hpxml.lighting.holiday_period_begin_month = 11
-      hpxml.lighting.holiday_period_begin_day_of_month = 24
-      hpxml.lighting.holiday_period_end_month = 1
-      hpxml.lighting.holiday_period_end_day_of_month = 6
-      hpxml.lighting.holiday_weekday_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
-      hpxml.lighting.holiday_weekend_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
+      if hpxml.lighting.holiday_period_begin_month.nil?
+        hpxml.lighting.holiday_period_begin_month = 11
+        hpxml.lighting.holiday_period_begin_day_of_month = 24
+      end
+      if hpxml.lighting.holiday_period_end_day_of_month.nil?
+        hpxml.lighting.holiday_period_end_month = 1
+        hpxml.lighting.holiday_period_end_day_of_month = 6
+      end
+      if hpxml.lighting.holiday_weekday_fractions.nil?
+        hpxml.lighting.holiday_weekday_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
+      end
+      if hpxml.lighting.holiday_weekend_fractions.nil?
+        hpxml.lighting.holiday_weekend_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
+      end
     end
   end
 

--- a/docs/source/hpxml_to_openstudio.rst
+++ b/docs/source/hpxml_to_openstudio.rst
@@ -1053,10 +1053,8 @@ For the child elements not provided, the following default values will be used.
 Element Name                                   Default Value
 =============================================  ======================================================================================================
 Load[Units='kWh/day']/Value                    1.1 for single-family detached and 0.55 for others
-PeriodBeginMonth                               11  
-PeriodBeginDayOfMonth                          24  
-PeriodEndMonth                                 1  
-PeriodEndDayOfMonth                            6
+PeriodBeginMonth/PeriodBeginDayOfMonth         11/24 (November 24) 
+PeriodEndMonth/PeriodEndDayOfMonth             1/6 (January 6) 
 WeekdayScheduleFractions                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019
 WeekendScheduleFractions                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019
 =============================================  ======================================================================================================

--- a/docs/source/hpxml_to_openstudio.rst
+++ b/docs/source/hpxml_to_openstudio.rst
@@ -1046,13 +1046,13 @@ Garage lighting values are ignored if the building has no garage.
 Optional ``extension/InteriorUsageMultiplier``, ``extension/ExteriorUsageMultiplier``, and ``extension/GarageUsageMultiplier`` can be provided that scales energy usage; if not provided, they are assumed to be 1.0.
 
 An optional ``extension/ExteriorHolidayLighting`` can also be provided to define additional exterior holiday lighting; if not provided, none will be modeled. 
-If provided, child elements ``Load[Units='kWh/day']/Value``, ``PeriodBeginMonth``, ``PeriodBeginDayOfMonth``, ``PeriodEndMonth``, ``PeriodEndDayOfMonth``, ``WeekdayScheduleFractions``, and ``WeekendScheduleFractions`` can be optionally provided. 
-If the complete set of child elements is not provided, the following default values will be used.
+If provided, child elements ``Load[Units='kWh/day']/Value``, ``PeriodBeginMonth``/``PeriodBeginDayOfMonth``, ``PeriodEndMonth``/``PeriodEndDayOfMonth``, ``WeekdayScheduleFractions``, and ``WeekendScheduleFractions`` can be optionally provided. 
+For the child elements not provided, the following default values will be used.
 
 =============================================  ======================================================================================================
 Element Name                                   Default Value
 =============================================  ======================================================================================================
-Load[Units='kWh/day']/Value                    1.1 for SFD; 0.5 for SFA or MF  
+Load[Units='kWh/day']/Value                    1.1 for single-family detached and 0.55 for others
 PeriodBeginMonth                               11  
 PeriodBeginDayOfMonth                          24  
 PeriodEndMonth                                 1  


### PR DESCRIPTION
## Pull Request Description

Change holiday lighting input requirement

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
