### PR TITLE
Increase the Zone Temperature Capacitance Multiplier

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -412,7 +412,7 @@ class OSModel
   end
 
   def self.add_simulation_params(model)
-    SimControls.apply(model, @hpxml.header)
+    SimControls.apply(model, @hpxml.header, @apply_ashrae140_assumptions)
   end
 
   def self.set_zone_volumes(runner, model, spaces)

--- a/HPXMLtoOpenStudio/resources/simcontrols.rb
+++ b/HPXMLtoOpenStudio/resources/simcontrols.rb
@@ -20,6 +20,7 @@ class SimControls
 
     zonecap = model.getZoneCapacitanceMultiplierResearchSpecial
     zonecap.setHumidityCapacityMultiplier(15)
+    zonecap.setTemperatureCapacityMultiplier(3.6)
 
     convlim = model.getConvergenceLimits
     convlim.setMinimumSystemTimestep(0)

--- a/HPXMLtoOpenStudio/resources/simcontrols.rb
+++ b/HPXMLtoOpenStudio/resources/simcontrols.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SimControls
-  def self.apply(model, header)
+  def self.apply(model, header, apply_ashrae140_assumptions)
     sim = model.getSimulationControl
     sim.setRunSimulationforSizingPeriods(false)
 
@@ -20,7 +20,15 @@ class SimControls
 
     zonecap = model.getZoneCapacitanceMultiplierResearchSpecial
     zonecap.setHumidityCapacityMultiplier(15)
+    # temperature capacitance multiplier = 3.6 according to a recent paper:
+    # Kristen S Cetin, Mohammad Hassan Fathollahzadeh, Niraj Kunwar, Huyen Do, Paulo Cesar Tabares-Velasco, Development
+    # and validation of an HVAC on/off controller in EnergyPlus for energy simulation of residential and small commercial
+    # buildings, Energy and Buildings, Volume 183, 2019, Pages 467-483, ISSN 0378-7788,
+    # https://doi.org/10.1016/j.enbuild.2018.11.005.
     zonecap.setTemperatureCapacityMultiplier(3.6)
+    if apply_ashrae140_assumptions
+      zonecap.setTemperatureCapacityMultiplier(1.0)
+    end
 
     convlim = model.getConvergenceLimits
     convlim.setMinimumSystemTimestep(0)


### PR DESCRIPTION
## Pull Request Description

This pull request modifies the zone temperature capacitance multiplier from 1.0 to 3.6 according to a recent paper published in Energy and Buildings.

_Kristen S Cetin, Mohammad Hassan Fathollahzadeh, Niraj Kunwar, Huyen Do, Paulo Cesar Tabares-Velasco, Development and validation of an HVAC on/off controller in EnergyPlus for energy simulation of residential and small commercial buildings, Energy and Buildings, Volume 183, 2019, Pages 467-483, ISSN 0378-7788, https://doi.org/10.1016/j.enbuild.2018.11.005._

Regression:
* base.xml
  * master
    * Electricity: Total (MBtu): 34.17
    * Natural Gas: Total (MBtu): 14.71
  * zone_temp_cap_mult
    * Electricity: Total (MBtu): 34.12
    * Natural Gas: Total (MBtu): 14.73

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
