### PR TITLE
Minor code refactors

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f8a70038-32f1-4346-b5b9-6fbac83b5e1a</version_id>
-  <version_modified>20200901T182158Z</version_modified>
+  <version_id>779a6e5f-5dd6-4eda-b219-52811da2e8f7</version_id>
+  <version_modified>20200901T221301Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -457,12 +457,6 @@
       <checksum>DAE60D04</checksum>
     </file>
     <file>
-      <filename>xmlhelper.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>AE298605</checksum>
-    </file>
-    <file>
       <filename>test_airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -534,12 +528,6 @@
       <checksum>4B59EB8A</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>2AB9083A</checksum>
-    </file>
-    <file>
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -568,6 +556,18 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>9D8FA00F</checksum>
+    </file>
+    <file>
+      <filename>xmlhelper.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6CB36D58</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1723AF82</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>779a6e5f-5dd6-4eda-b219-52811da2e8f7</version_id>
-  <version_modified>20200901T221301Z</version_modified>
+  <version_id>6e08ee06-f72d-4e31-98bd-a5972af69f21</version_id>
+  <version_modified>20200901T235831Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -552,12 +552,6 @@
       <checksum>2B46B197</checksum>
     </file>
     <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>9D8FA00F</checksum>
-    </file>
-    <file>
       <filename>xmlhelper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -568,6 +562,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>1723AF82</checksum>
+    </file>
+    <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>AA065D80</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -842,8 +842,7 @@ class HPXML < Object
           XMLHelper.add_element(fuel_types_available, 'Fuel', fuel)
         end
       end
-      HPXML::add_extension(parent: site,
-                           extensions: { 'ShelterCoefficient' => to_float_or_nil(@shelter_coefficient) })
+      XMLHelper.add_extension(site, 'ShelterCoefficient', to_float(@shelter_coefficient)) unless @shelter_coefficient.nil?
     end
 
     def from_oga(hpxml)
@@ -952,9 +951,8 @@ class HPXML < Object
       XMLHelper.add_element(building_construction, 'NumberofBathrooms', to_integer(@number_of_bathrooms)) unless @number_of_bathrooms.nil?
       XMLHelper.add_element(building_construction, 'ConditionedFloorArea', to_float(@conditioned_floor_area)) unless @conditioned_floor_area.nil?
       XMLHelper.add_element(building_construction, 'ConditionedBuildingVolume', to_float(@conditioned_building_volume)) unless @conditioned_building_volume.nil?
-      HPXML::add_extension(parent: building_construction,
-                           extensions: { 'UseOnlyIdealAirSystem' => to_boolean_or_nil(@use_only_ideal_air_system),
-                                         'HasFlueOrChimney' => to_boolean_or_nil(@has_flue_or_chimney) })
+      XMLHelper.add_extension(building_construction, 'UseOnlyIdealAirSystem', to_boolean(@use_only_ideal_air_system)) unless @use_only_ideal_air_system.nil?
+      XMLHelper.add_extension(building_construction, 'HasFlueOrChimney', to_boolean(@has_flue_or_chimney)) unless @has_flue_or_chimney.nil?
     end
 
     def from_oga(hpxml)
@@ -1004,8 +1002,7 @@ class HPXML < Object
         XMLHelper.add_attribute(sys_id, 'id', @weather_station_id)
         XMLHelper.add_element(weather_station, 'Name', @weather_station_name) unless @weather_station_name.nil?
         XMLHelper.add_element(weather_station, 'WMO', @weather_station_wmo) unless @weather_station_wmo.nil?
-        HPXML::add_extension(parent: weather_station,
-                             extensions: { 'EPWFilePath' => @weather_station_epw_filepath })
+        XMLHelper.add_extension(weather_station, 'EPWFilePath', @weather_station_epw_filepath) unless @weather_station_epw_filepath.nil?
       end
     end
 
@@ -1066,9 +1063,8 @@ class HPXML < Object
       end
       XMLHelper.add_element(air_infiltration_measurement, 'EffectiveLeakageArea', to_float(@effective_leakage_area)) unless @effective_leakage_area.nil?
       XMLHelper.add_element(air_infiltration_measurement, 'InfiltrationVolume', to_float(@infiltration_volume)) unless @infiltration_volume.nil?
-      HPXML::add_extension(parent: air_infiltration_measurement,
-                           extensions: { 'InfiltrationHeight' => to_float_or_nil(@infiltration_height),
-                                         'Aext' => to_float_or_nil(@a_ext) })
+      XMLHelper.add_extension(air_infiltration_measurement, 'InfiltrationHeight', to_float(@infiltration_height)) unless @infiltration_height.nil?
+      XMLHelper.add_extension(air_infiltration_measurement, 'Aext', to_float(@a_ext)) unless @a_ext.nil?
     end
 
     def from_oga(air_infiltration_measurement)
@@ -1850,17 +1846,15 @@ class HPXML < Object
         layer = XMLHelper.add_element(insulation, 'Layer')
         XMLHelper.add_element(layer, 'InstallationType', 'continuous - exterior')
         XMLHelper.add_element(layer, 'NominalRValue', to_float(@insulation_exterior_r_value))
-        HPXML::add_extension(parent: layer,
-                             extensions: { 'DistanceToTopOfInsulation' => to_float_or_nil(@insulation_exterior_distance_to_top),
-                                           'DistanceToBottomOfInsulation' => to_float_or_nil(@insulation_exterior_distance_to_bottom) })
+        XMLHelper.add_extension(layer, 'DistanceToTopOfInsulation', to_float(@insulation_exterior_distance_to_top)) unless @insulation_exterior_distance_to_top.nil?
+        XMLHelper.add_extension(layer, 'DistanceToBottomOfInsulation', to_float(@insulation_exterior_distance_to_bottom)) unless @insulation_exterior_distance_to_bottom.nil?
       end
       if not @insulation_interior_r_value.nil?
         layer = XMLHelper.add_element(insulation, 'Layer')
         XMLHelper.add_element(layer, 'InstallationType', 'continuous - interior')
         XMLHelper.add_element(layer, 'NominalRValue', to_float(@insulation_interior_r_value))
-        HPXML::add_extension(parent: layer,
-                             extensions: { 'DistanceToTopOfInsulation' => to_float_or_nil(@insulation_interior_distance_to_top),
-                                           'DistanceToBottomOfInsulation' => to_float_or_nil(@insulation_interior_distance_to_bottom) })
+        XMLHelper.add_extension(layer, 'DistanceToTopOfInsulation', to_float(@insulation_interior_distance_to_top)) unless @insulation_interior_distance_to_top.nil?
+        XMLHelper.add_extension(layer, 'DistanceToBottomOfInsulation', to_float(@insulation_interior_distance_to_bottom)) unless @insulation_interior_distance_to_bottom.nil?
       end
     end
 
@@ -1980,8 +1974,7 @@ class HPXML < Object
         XMLHelper.add_attribute(sys_id, 'id', @id + 'Insulation')
       end
       XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', to_float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
-      HPXML::add_extension(parent: frame_floor,
-                           extensions: { 'OtherSpaceAboveOrBelow' => @other_space_above_or_below })
+      XMLHelper.add_extension(frame_floor, 'OtherSpaceAboveOrBelow', @other_space_above_or_below) unless @other_space_above_or_below.nil?
     end
 
     def from_oga(frame_floor)
@@ -2098,9 +2091,8 @@ class HPXML < Object
       layer = XMLHelper.add_element(insulation, 'Layer')
       XMLHelper.add_element(layer, 'InstallationType', 'continuous')
       XMLHelper.add_element(layer, 'NominalRValue', to_float(@under_slab_insulation_r_value)) unless @under_slab_insulation_r_value.nil?
-      HPXML::add_extension(parent: slab,
-                           extensions: { 'CarpetFraction' => to_float_or_nil(@carpet_fraction),
-                                         'CarpetRValue' => to_float_or_nil(@carpet_r_value) })
+      XMLHelper.add_extension(slab, 'CarpetFraction', to_float(@carpet_fraction)) unless @carpet_fraction.nil?
+      XMLHelper.add_extension(slab, 'CarpetRValue', to_float(@carpet_r_value)) unless @carpet_r_value.nil?
     end
 
     def from_oga(slab)
@@ -2538,15 +2530,12 @@ class HPXML < Object
         XMLHelper.add_element(annual_efficiency, 'Units', efficiency_units)
         XMLHelper.add_element(annual_efficiency, 'Value', to_float(efficiency_value))
       end
-
       XMLHelper.add_element(heating_system, 'FractionHeatLoadServed', to_float(@fraction_heat_load_served)) unless @fraction_heat_load_served.nil?
       XMLHelper.add_element(heating_system, 'ElectricAuxiliaryEnergy', to_float(@electric_auxiliary_energy)) unless @electric_auxiliary_energy.nil?
-      HPXML::add_extension(parent: heating_system,
-                           extensions: { 'HeatingFlowRate' => to_float_or_nil(@heating_cfm),
-                                         'SeedId' => @seed_id,
-                                         'SharedLoopWatts' => to_float_or_nil(@shared_loop_watts),
-                                         'FanCoilWatts' => to_float_or_nil(@fan_coil_watts) })
-
+      XMLHelper.add_extension(heating_system, 'HeatingFlowRate', to_float(@heating_cfm)) unless @heating_cfm.nil?
+      XMLHelper.add_extension(heating_system, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
+      XMLHelper.add_extension(heating_system, 'FanCoilWatts', to_float(@fan_coil_watts)) unless @fan_coil_watts.nil?
+      XMLHelper.add_extension(heating_system, 'SeedId', @seed_id) unless @seed_id.nil?
       if not @wlhp_heating_efficiency_cop.nil?
         wlhp = XMLHelper.create_elements_as_needed(heating_system, ['extension', 'WaterLoopHeatPump'])
         annual_efficiency = XMLHelper.add_element(wlhp, 'AnnualHeatingEfficiency')
@@ -2682,14 +2671,11 @@ class HPXML < Object
         XMLHelper.add_element(annual_efficiency, 'Units', efficiency_units)
         XMLHelper.add_element(annual_efficiency, 'Value', to_float(efficiency_value))
       end
-
       XMLHelper.add_element(cooling_system, 'SensibleHeatFraction', to_float(@cooling_shr)) unless @cooling_shr.nil?
-      HPXML::add_extension(parent: cooling_system,
-                           extensions: { 'CoolingFlowRate' => to_float_or_nil(@cooling_cfm),
-                                         'SeedId' => @seed_id,
-                                         'SharedLoopWatts' => to_float_or_nil(@shared_loop_watts),
-                                         'FanCoilWatts' => to_float_or_nil(@fan_coil_watts) })
-
+      XMLHelper.add_extension(cooling_system, 'CoolingFlowRate', to_float(@cooling_cfm)) unless @cooling_cfm.nil?
+      XMLHelper.add_extension(cooling_system, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
+      XMLHelper.add_extension(cooling_system, 'FanCoilWatts', to_float(@fan_coil_watts)) unless @fan_coil_watts.nil?
+      XMLHelper.add_extension(cooling_system, 'SeedId', @seed_id) unless @seed_id.nil?
       if (not @wlhp_cooling_capacity.nil?) || (not @wlhp_cooling_efficiency_eer.nil?)
         wlhp = XMLHelper.create_elements_as_needed(cooling_system, ['extension', 'WaterLoopHeatPump'])
         XMLHelper.add_element(wlhp, 'CoolingCapacity', to_float(@wlhp_cooling_capacity)) unless @wlhp_cooling_capacity.nil?
@@ -2853,12 +2839,10 @@ class HPXML < Object
         XMLHelper.add_element(annual_efficiency, 'Units', htg_efficiency_units)
         XMLHelper.add_element(annual_efficiency, 'Value', to_float(htg_efficiency_value))
       end
-
-      HPXML::add_extension(parent: heat_pump,
-                           extensions: { 'PumpPowerWattsPerTon' => to_float_or_nil(@pump_watts_per_ton),
-                                         'FanPowerWattsPerCFM' => to_float_or_nil(@fan_watts_per_cfm),
-                                         'SharedLoopWatts' => to_float_or_nil(@shared_loop_watts),
-                                         'SeedId' => @seed_id })
+      XMLHelper.add_extension(heat_pump, 'PumpPowerWattsPerTon', to_float(@pump_watts_per_ton)) unless @pump_watts_per_ton.nil?
+      XMLHelper.add_extension(heat_pump, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm)) unless @fan_watts_per_cfm.nil?
+      XMLHelper.add_extension(heat_pump, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
+      XMLHelper.add_extension(heat_pump, 'SeedId', @seed_id) unless @seed_id.nil?
     end
 
     def from_oga(heat_pump)
@@ -2945,10 +2929,9 @@ class HPXML < Object
       XMLHelper.add_element(hvac_control, 'SetupTempCoolingSeason', to_float(@cooling_setup_temp)) unless @cooling_setup_temp.nil?
       XMLHelper.add_element(hvac_control, 'SetpointTempCoolingSeason', to_float(@cooling_setpoint_temp)) unless @cooling_setpoint_temp.nil?
       XMLHelper.add_element(hvac_control, 'TotalSetupHoursperWeekCooling', to_integer(@cooling_setup_hours_per_week)) unless @cooling_setup_hours_per_week.nil?
-      HPXML::add_extension(parent: hvac_control,
-                           extensions: { 'SetbackStartHourHeating' => to_integer_or_nil(@heating_setback_start_hour),
-                                         'SetupStartHourCooling' => to_integer_or_nil(@cooling_setup_start_hour),
-                                         'CeilingFanSetpointTempCoolingSeasonOffset' => to_float_or_nil(@ceiling_fan_cooling_setpoint_temp_offset) })
+      XMLHelper.add_extension(hvac_control, 'SetbackStartHourHeating', to_integer(@heating_setback_start_hour)) unless @heating_setback_start_hour.nil?
+      XMLHelper.add_extension(hvac_control, 'SetupStartHourCooling', to_integer(@cooling_setup_start_hour)) unless @cooling_setup_start_hour.nil?
+      XMLHelper.add_extension(hvac_control, 'CeilingFanSetpointTempCoolingSeasonOffset', to_float(@ceiling_fan_cooling_setpoint_temp_offset)) unless @ceiling_fan_cooling_setpoint_temp_offset.nil?
     end
 
     def from_oga(hvac_control)
@@ -3087,8 +3070,7 @@ class HPXML < Object
         @duct_leakage_measurements.to_oga(distribution)
         @ducts.to_oga(distribution)
         XMLHelper.add_element(distribution, 'NumberofReturnRegisters', Integer(@number_of_return_registers)) unless @number_of_return_registers.nil?
-        HPXML::add_extension(parent: distribution,
-                             extensions: { 'DuctLeakageTestingExemption' => to_boolean_or_nil(@duct_leakage_testing_exemption) })
+        XMLHelper.add_extension(distribution, 'DuctLeakageTestingExemption', to_boolean(@duct_leakage_testing_exemption)) unless @duct_leakage_testing_exemption.nil?
       end
     end
 
@@ -3346,8 +3328,7 @@ class HPXML < Object
         attached_to_hvac_distribution_system = XMLHelper.add_element(ventilation_fan, 'AttachedToHVACDistributionSystem')
         XMLHelper.add_attribute(attached_to_hvac_distribution_system, 'idref', @distribution_system_idref)
       end
-      HPXML::add_extension(parent: ventilation_fan,
-                           extensions: { 'StartHour' => to_integer_or_nil(@start_hour) })
+      XMLHelper.add_extension(ventilation_fan, 'StartHour', to_integer(@start_hour)) unless @start_hour.nil?
     end
 
     def from_oga(ventilation_fan)
@@ -3638,8 +3619,7 @@ class HPXML < Object
       return if nil?
 
       water_heating = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Systems', 'WaterHeating'])
-      HPXML::add_extension(parent: water_heating,
-                           extensions: { 'WaterFixturesUsageMultiplier' => to_float_or_nil(@water_fixtures_usage_multiplier) })
+      XMLHelper.add_extension(water_heating, 'WaterFixturesUsageMultiplier', to_float(@water_fixtures_usage_multiplier)) unless @water_fixtures_usage_multiplier.nil?
     end
 
     def from_oga(hpxml)
@@ -3780,8 +3760,7 @@ class HPXML < Object
       XMLHelper.add_element(pv_system, 'InverterEfficiency', to_float(@inverter_efficiency)) unless @inverter_efficiency.nil?
       XMLHelper.add_element(pv_system, 'SystemLossesFraction', to_float(@system_losses_fraction)) unless @system_losses_fraction.nil?
       XMLHelper.add_element(pv_system, 'YearModulesManufactured', to_integer(@year_modules_manufactured)) unless @year_modules_manufactured.nil?
-      HPXML::add_extension(parent: pv_system,
-                           extensions: { 'NumberofBedroomsServed' => to_integer_or_nil(@number_of_bedrooms_served) })
+      XMLHelper.add_extension(pv_system, 'NumberofBedroomsServed', to_integer(@number_of_bedrooms_served)) unless @number_of_bedrooms_served.nil?
     end
 
     def from_oga(pv_system)
@@ -3869,8 +3848,7 @@ class HPXML < Object
       XMLHelper.add_element(clothes_washer, 'LabelAnnualGasCost', to_float(@label_annual_gas_cost)) unless @label_annual_gas_cost.nil?
       XMLHelper.add_element(clothes_washer, 'LabelUsage', to_float(@label_usage)) unless @label_usage.nil?
       XMLHelper.add_element(clothes_washer, 'Capacity', to_float(@capacity)) unless @capacity.nil?
-      HPXML::add_extension(parent: clothes_washer,
-                           extensions: { 'UsageMultiplier' => to_float_or_nil(@usage_multiplier) })
+      XMLHelper.add_extension(clothes_washer, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
     end
 
     def from_oga(clothes_washer)
@@ -3937,8 +3915,7 @@ class HPXML < Object
       XMLHelper.add_element(clothes_dryer, 'EnergyFactor', to_float(@energy_factor)) unless @energy_factor.nil?
       XMLHelper.add_element(clothes_dryer, 'CombinedEnergyFactor', to_float(@combined_energy_factor)) unless @combined_energy_factor.nil?
       XMLHelper.add_element(clothes_dryer, 'ControlType', @control_type) unless @control_type.nil?
-      HPXML::add_extension(parent: clothes_dryer,
-                           extensions: { 'UsageMultiplier' => to_float_or_nil(@usage_multiplier) })
+      XMLHelper.add_extension(clothes_dryer, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
     end
 
     def from_oga(clothes_dryer)
@@ -4018,8 +3995,7 @@ class HPXML < Object
       XMLHelper.add_element(dishwasher, 'LabelGasRate', to_float(@label_gas_rate)) unless @label_gas_rate.nil?
       XMLHelper.add_element(dishwasher, 'LabelAnnualGasCost', to_float(@label_annual_gas_cost)) unless @label_annual_gas_cost.nil?
       XMLHelper.add_element(dishwasher, 'LabelUsage', to_float(@label_usage)) unless @label_usage.nil?
-      HPXML::add_extension(parent: dishwasher,
-                           extensions: { 'UsageMultiplier' => to_float_or_nil(@usage_multiplier) })
+      XMLHelper.add_extension(dishwasher, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
     end
 
     def from_oga(dishwasher)
@@ -4090,12 +4066,11 @@ class HPXML < Object
       XMLHelper.add_element(refrigerator, 'Location', @location) unless @location.nil?
       XMLHelper.add_element(refrigerator, 'RatedAnnualkWh', to_float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
       XMLHelper.add_element(refrigerator, 'PrimaryIndicator', to_boolean(@primary_indicator)) unless @primary_indicator.nil?
-      HPXML::add_extension(parent: refrigerator,
-                           extensions: { 'AdjustedAnnualkWh' => to_float_or_nil(@adjusted_annual_kwh),
-                                         'UsageMultiplier' => to_float_or_nil(@usage_multiplier),
-                                         'WeekdayScheduleFractions' => @weekday_fractions,
-                                         'WeekendScheduleFractions' => @weekend_fractions,
-                                         'MonthlyScheduleMultipliers' => @monthly_multipliers })
+      XMLHelper.add_extension(refrigerator, 'AdjustedAnnualkWh', to_float(@adjusted_annual_kwh)) unless @adjusted_annual_kwh.nil?
+      XMLHelper.add_extension(refrigerator, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(refrigerator, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(refrigerator, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(refrigerator, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
     end
 
     def from_oga(refrigerator)
@@ -4150,12 +4125,11 @@ class HPXML < Object
       XMLHelper.add_attribute(sys_id, 'id', @id)
       XMLHelper.add_element(freezer, 'Location', @location) unless @location.nil?
       XMLHelper.add_element(freezer, 'RatedAnnualkWh', to_float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
-      HPXML::add_extension(parent: freezer,
-                           extensions: { 'AdjustedAnnualkWh' => to_float_or_nil(@adjusted_annual_kwh),
-                                         'UsageMultiplier' => to_float_or_nil(@usage_multiplier),
-                                         'WeekdayScheduleFractions' => @weekday_fractions,
-                                         'WeekendScheduleFractions' => @weekend_fractions,
-                                         'MonthlyScheduleMultipliers' => @monthly_multipliers })
+      XMLHelper.add_extension(freezer, 'AdjustedAnnualkWh', to_float(@adjusted_annual_kwh)) unless @adjusted_annual_kwh.nil?
+      XMLHelper.add_extension(freezer, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(freezer, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(freezer, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(freezer, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
     end
 
     def from_oga(freezer)
@@ -4263,11 +4237,10 @@ class HPXML < Object
       XMLHelper.add_element(cooking_range, 'Location', @location) unless @location.nil?
       XMLHelper.add_element(cooking_range, 'FuelType', @fuel_type) unless @fuel_type.nil?
       XMLHelper.add_element(cooking_range, 'IsInduction', to_boolean(@is_induction)) unless @is_induction.nil?
-      HPXML::add_extension(parent: cooking_range,
-                           extensions: { 'UsageMultiplier' => to_float_or_nil(@usage_multiplier),
-                                         'WeekdayScheduleFractions' => @weekday_fractions,
-                                         'WeekendScheduleFractions' => @weekend_fractions,
-                                         'MonthlyScheduleMultipliers' => @monthly_multipliers })
+      XMLHelper.add_extension(cooking_range, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(cooking_range, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(cooking_range, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(cooking_range, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
     end
 
     def from_oga(cooking_range)
@@ -4399,19 +4372,18 @@ class HPXML < Object
       return if nil?
 
       lighting = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Lighting'])
-      HPXML::add_extension(parent: lighting,
-                           extensions: { 'InteriorUsageMultiplier' => to_float_or_nil(@interior_usage_multiplier),
-                                         'GarageUsageMultiplier' => to_float_or_nil(@garage_usage_multiplier),
-                                         'ExteriorUsageMultiplier' => to_float_or_nil(@exterior_usage_multiplier),
-                                         'InteriorWeekdayScheduleFractions' => @interior_weekday_fractions,
-                                         'InteriorWeekendScheduleFractions' => @interior_weekend_fractions,
-                                         'InteriorMonthlyScheduleMultipliers' => @interior_monthly_multipliers,
-                                         'GarageWeekdayScheduleFractions' => @garage_weekday_fractions,
-                                         'GarageWeekendScheduleFractions' => @garage_weekend_fractions,
-                                         'GarageMonthlyScheduleMultipliers' => @garage_monthly_multipliers,
-                                         'ExteriorWeekdayScheduleFractions' => @exterior_weekday_fractions,
-                                         'ExteriorWeekendScheduleFractions' => @exterior_weekend_fractions,
-                                         'ExteriorMonthlyScheduleMultipliers' => @exterior_monthly_multipliers })
+      XMLHelper.add_extension(lighting, 'InteriorUsageMultiplier', to_float(@interior_usage_multiplier)) unless @interior_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'GarageUsageMultiplier', to_float(@garage_usage_multiplier)) unless @garage_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorUsageMultiplier', to_float(@exterior_usage_multiplier)) unless @exterior_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'InteriorWeekdayScheduleFractions', @interior_weekday_fractions) unless @interior_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'InteriorWeekendScheduleFractions', @interior_weekend_fractions) unless @interior_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'InteriorMonthlyScheduleMultipliers', @interior_monthly_multipliers) unless @interior_monthly_multipliers.nil?
+      XMLHelper.add_extension(lighting, 'GarageWeekdayScheduleFractions', @garage_weekday_fractions) unless @garage_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'GarageWeekendScheduleFractions', @garage_weekend_fractions) unless @garage_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'GarageMonthlyScheduleMultipliers', @garage_monthly_multipliers) unless @garage_monthly_multipliers.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorWeekdayScheduleFractions', @exterior_weekday_fractions) unless @exterior_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorWeekendScheduleFractions', @exterior_weekend_fractions) unless @exterior_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorMonthlyScheduleMultipliers', @exterior_monthly_multipliers) unless @exterior_monthly_multipliers.nil?
       if @holiday_exists
         exterior_holiday_lighting = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Lighting', 'extension', 'ExteriorHolidayLighting'])
         if not @holiday_kwh_per_day.nil?
@@ -4559,11 +4531,10 @@ class HPXML < Object
         load = XMLHelper.add_element(pool_pump, 'Load')
         XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
         XMLHelper.add_element(load, 'Value', to_float(@pump_kwh_per_year))
-        HPXML::add_extension(parent: pool_pump,
-                             extensions: { 'UsageMultiplier' => to_float_or_nil(@pump_usage_multiplier),
-                                           'WeekdayScheduleFractions' => @pump_weekday_fractions,
-                                           'WeekendScheduleFractions' => @pump_weekend_fractions,
-                                           'MonthlyScheduleMultipliers' => @pump_monthly_multipliers })
+        XMLHelper.add_extension(pool_pump, 'UsageMultiplier', to_float(@pump_usage_multiplier)) unless @pump_usage_multiplier.nil?
+        XMLHelper.add_extension(pool_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions) unless @pump_weekday_fractions.nil?
+        XMLHelper.add_extension(pool_pump, 'WeekendScheduleFractions', @pump_weekend_fractions) unless @pump_weekend_fractions.nil?
+        XMLHelper.add_extension(pool_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers) unless @pump_monthly_multipliers.nil?
       end
       if not @heater_type.nil?
         heater = XMLHelper.add_element(pool, 'Heater')
@@ -4579,11 +4550,10 @@ class HPXML < Object
           XMLHelper.add_element(load, 'Units', @heater_load_units)
           XMLHelper.add_element(load, 'Value', to_float(@heater_load_value))
         end
-        HPXML::add_extension(parent: heater,
-                             extensions: { 'UsageMultiplier' => to_float_or_nil(@heater_usage_multiplier),
-                                           'WeekdayScheduleFractions' => @heater_weekday_fractions,
-                                           'WeekendScheduleFractions' => @heater_weekend_fractions,
-                                           'MonthlyScheduleMultipliers' => @heater_monthly_multipliers })
+        XMLHelper.add_extension(heater, 'UsageMultiplier', to_float(@heater_usage_multiplier)) unless @heater_usage_multiplier.nil?
+        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions) unless @heater_weekday_fractions.nil?
+        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions) unless @heater_weekend_fractions.nil?
+        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers) unless @heater_monthly_multipliers.nil?
       end
     end
 
@@ -4659,11 +4629,10 @@ class HPXML < Object
         load = XMLHelper.add_element(hot_tub_pump, 'Load')
         XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
         XMLHelper.add_element(load, 'Value', to_float(@pump_kwh_per_year))
-        HPXML::add_extension(parent: hot_tub_pump,
-                             extensions: { 'UsageMultiplier' => to_float_or_nil(@pump_usage_multiplier),
-                                           'WeekdayScheduleFractions' => @pump_weekday_fractions,
-                                           'WeekendScheduleFractions' => @pump_weekend_fractions,
-                                           'MonthlyScheduleMultipliers' => @pump_monthly_multipliers })
+        XMLHelper.add_extension(hot_tub_pump, 'UsageMultiplier', to_float(@pump_usage_multiplier)) unless @pump_usage_multiplier.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions) unless @pump_weekday_fractions.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'WeekendScheduleFractions', @pump_weekend_fractions) unless @pump_weekend_fractions.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers) unless @pump_monthly_multipliers.nil?
       end
       if not @heater_type.nil?
         heater = XMLHelper.add_element(hot_tub, 'Heater')
@@ -4679,11 +4648,10 @@ class HPXML < Object
           XMLHelper.add_element(load, 'Units', @heater_load_units)
           XMLHelper.add_element(load, 'Value', to_float(@heater_load_value))
         end
-        HPXML::add_extension(parent: heater,
-                             extensions: { 'UsageMultiplier' => to_float_or_nil(@heater_usage_multiplier),
-                                           'WeekdayScheduleFractions' => @heater_weekday_fractions,
-                                           'WeekendScheduleFractions' => @heater_weekend_fractions,
-                                           'MonthlyScheduleMultipliers' => @heater_monthly_multipliers })
+        XMLHelper.add_extension(heater, 'UsageMultiplier', to_float(@heater_usage_multiplier)) unless @heater_usage_multiplier.nil?
+        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions) unless @heater_weekday_fractions.nil?
+        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions) unless @heater_weekend_fractions.nil?
+        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers) unless @heater_monthly_multipliers.nil?
       end
     end
 
@@ -4752,13 +4720,12 @@ class HPXML < Object
         XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
         XMLHelper.add_element(load, 'Value', to_float(@kWh_per_year))
       end
-      HPXML::add_extension(parent: plug_load,
-                           extensions: { 'FracSensible' => to_float_or_nil(@frac_sensible),
-                                         'FracLatent' => to_float_or_nil(@frac_latent),
-                                         'UsageMultiplier' => to_float_or_nil(@usage_multiplier),
-                                         'WeekdayScheduleFractions' => @weekday_fractions,
-                                         'WeekendScheduleFractions' => @weekend_fractions,
-                                         'MonthlyScheduleMultipliers' => @monthly_multipliers })
+      XMLHelper.add_extension(plug_load, 'FracSensible', to_float(@frac_sensible)) unless @frac_sensible.nil?
+      XMLHelper.add_extension(plug_load, 'FracLatent', to_float(@frac_latent)) unless @frac_latent.nil?
+      XMLHelper.add_extension(plug_load, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(plug_load, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(plug_load, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(plug_load, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
     end
 
     def from_oga(plug_load)
@@ -4818,13 +4785,12 @@ class HPXML < Object
         XMLHelper.add_element(load, 'Value', to_float(@therm_per_year))
       end
       XMLHelper.add_element(fuel_load, 'FuelType', @fuel_type) unless @fuel_type.nil?
-      HPXML::add_extension(parent: fuel_load,
-                           extensions: { 'FracSensible' => to_float_or_nil(@frac_sensible),
-                                         'FracLatent' => to_float_or_nil(@frac_latent),
-                                         'UsageMultiplier' => to_float_or_nil(@usage_multiplier),
-                                         'WeekdayScheduleFractions' => @weekday_fractions,
-                                         'WeekendScheduleFractions' => @weekend_fractions,
-                                         'MonthlyScheduleMultipliers' => @monthly_multipliers })
+      XMLHelper.add_extension(fuel_load, 'FracSensible', to_float(@frac_sensible)) unless @frac_sensible.nil?
+      XMLHelper.add_extension(fuel_load, 'FracLatent', to_float(@frac_latent)) unless @frac_latent.nil?
+      XMLHelper.add_extension(fuel_load, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(fuel_load, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(fuel_load, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(fuel_load, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
     end
 
     def from_oga(fuel_load)
@@ -5112,21 +5078,6 @@ class HPXML < Object
 
   def self.get_idref(element)
     return XMLHelper.get_attribute_value(element, 'idref')
-  end
-
-  def self.add_extension(parent:,
-                         extensions: {})
-    extension = nil
-    if not extensions.empty?
-      extensions.each do |name, value|
-        next if value.nil?
-
-        extension = XMLHelper.create_elements_as_needed(parent, ['extension'])
-        XMLHelper.add_element(extension, "#{name}", value) unless value.nil?
-      end
-    end
-
-    return extension
   end
 end
 

--- a/HPXMLtoOpenStudio/resources/xmlhelper.rb
+++ b/HPXMLtoOpenStudio/resources/xmlhelper.rb
@@ -12,6 +12,13 @@ class XMLHelper
     return added
   end
 
+  # Adds the child element with 'element_name' to a single extension element and
+  # sets its value. Returns the extension element.
+  def self.add_extension(parent, element_name, value)
+    extension = XMLHelper.create_elements_as_needed(parent, ['extension'])
+    return XMLHelper.add_element(extension, element_name, value)
+  end
+
   # Creates a hierarchy of elements under the parent element based on the supplied
   # list of element names. If a given child element already exists, it is reused.
   # Returns the final element.

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -9,10 +9,14 @@ require_relative '../measure.rb'
 require_relative '../resources/util.rb'
 
 class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
+  ConstantDaySchedule = '0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1'
+  ConstantMonthSchedule = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+
   def before_setup
     @root_path = File.absolute_path(File.join(File.dirname(__FILE__), '..', '..'))
-    @tmp_hpxml_path = File.join(@root_path, 'workflow', 'sample_files', 'tmp.xml')
-    @tmp_output_path = File.join(@root_path, 'workflow', 'sample_files', 'tmp_output')
+    @sample_files_path = File.join(@root_path, 'workflow', 'sample_files')
+    @tmp_hpxml_path = File.join(@sample_files_path, 'tmp.xml')
+    @tmp_output_path = File.join(@sample_files_path, 'tmp_output')
     FileUtils.mkdir_p(@tmp_output_path)
 
     @args_hash = {}
@@ -28,8 +32,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_header
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.header.timestep = 30
     hpxml.header.sim_begin_month = 2
     hpxml.header.sim_begin_day_of_month = 2
@@ -45,13 +48,32 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_header_values(hpxml_default, 30, 2, 2, 11, 11, false, 3, 3, 10, 10)
 
     # Test defaults - DST not in weather file
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.header.timestep = nil
+    hpxml.header.sim_begin_month = nil
+    hpxml.header.sim_begin_day_of_month = nil
+    hpxml.header.sim_end_month = nil
+    hpxml.header.sim_end_day_of_month = nil
+    hpxml.header.dst_enabled = nil
+    hpxml.header.dst_begin_month = nil
+    hpxml.header.dst_begin_day_of_month = nil
+    hpxml.header.dst_end_month = nil
+    hpxml.header.dst_end_day_of_month = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_header_values(hpxml_default, 60, 1, 1, 12, 31, true, 3, 12, 11, 5)
 
     # Test defaults - DST in weather file
-    hpxml = apply_hpxml_defaults('base-location-epw-filepath-AMY-2012.xml')
+    hpxml = _create_hpxml('base-location-epw-filepath-AMY-2012.xml')
+    hpxml.header.timestep = nil
+    hpxml.header.sim_begin_month = nil
+    hpxml.header.sim_begin_day_of_month = nil
+    hpxml.header.sim_end_month = nil
+    hpxml.header.sim_end_day_of_month = nil
+    hpxml.header.dst_enabled = nil
+    hpxml.header.dst_begin_month = nil
+    hpxml.header.dst_begin_day_of_month = nil
+    hpxml.header.dst_end_month = nil
+    hpxml.header.dst_end_day_of_month = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_header_values(hpxml_default, 60, 1, 1, 12, 31, true, 3, 11, 11, 4)
@@ -59,8 +81,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_site
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.site.site_type = HPXML::SiteTypeRural
     hpxml.site.shelter_coefficient = 0.3
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -68,7 +89,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_site_values(hpxml_default, HPXML::SiteTypeRural, 0.3)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.site.site_type = nil
+    hpxml.site.shelter_coefficient = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_site_values(hpxml_default, HPXML::SiteTypeSuburban, 0.5)
@@ -76,15 +98,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_occupancy
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.building_occupancy.number_of_residents = 1
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_occupancy_values(hpxml_default, 1)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.building_occupancy.number_of_residents = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_occupancy_values(hpxml_default, 3)
@@ -92,45 +113,32 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_building_construction
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-enclosure-infil-flue.xml')
+    hpxml.building_construction.number_of_bathrooms = 4.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_building_construction_values(hpxml_default, 21600, false)
+    _test_default_building_construction_values(hpxml_default, 21600, true, 4)
 
     # Test defaults w/ average ceiling height
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.building_construction.conditioned_building_volume = nil
+    hpxml.building_construction.average_ceiling_height = 10
+    hpxml.building_construction.has_flue_or_chimney = nil
+    hpxml.building_construction.number_of_bathrooms = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_building_construction_values(hpxml_default, 27000, false)
-  end
-
-  def test_flue_or_chimney
-    # Test inputs not overridden by defaults
-    hpxml_name = 'base-enclosure-infil-flue.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_building_construction_values(hpxml_default, 21600, true)
-
-    # Test defaults
-    hpxml = apply_hpxml_defaults('base-enclosure-infil-flue.xml')
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_building_construction_values(hpxml_default, 27000, false)
+    _test_default_building_construction_values(hpxml_default, 27000, false, 2)
   end
 
   def test_attics
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-atticroof-vented.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-atticroof-vented.xml')
     hpxml.attics[0].vented_attic_sla = 0.001
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_attic_values(hpxml_default, 0.001)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-atticroof-vented.xml')
+    hpxml.attics[0].vented_attic_sla = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_attic_values(hpxml_default, 1.0 / 300.0)
@@ -138,15 +146,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_foundations
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-foundation-vented-crawlspace.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-foundation-vented-crawlspace.xml')
     hpxml.foundations[0].vented_crawlspace_sla = 0.001
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_foundation_values(hpxml_default, 0.001)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-foundation-vented-crawlspace.xml')
+    hpxml.foundations[0].vented_crawlspace_sla = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_foundation_values(hpxml_default, 1.0 / 150.0)
@@ -154,37 +161,40 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_infiltration
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.air_infiltration_measurements[0].infiltration_volume = 25000
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_infiltration_values(hpxml_default, 25000)
 
     # Test defaults w/ conditioned basement
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.air_infiltration_measurements[0].infiltration_volume = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_infiltration_values(hpxml_default, 2700 * 10)
+    _test_default_infiltration_values(hpxml_default, 2700 * 8)
 
     # Test defaults w/o conditioned basement
-    hpxml = apply_hpxml_defaults('base-foundation-slab.xml')
+    hpxml = _create_hpxml('base-foundation-slab.xml')
+    hpxml.air_infiltration_measurements[0].infiltration_volume = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_infiltration_values(hpxml_default, 1350 * 10)
+    _test_default_infiltration_values(hpxml_default, 1350 * 8)
   end
 
   def test_roofs
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.roofs[0].roof_type = HPXML::RoofTypeMetal
+    hpxml.roofs[0].solar_absorptance = 0.77
+    hpxml.roofs[0].roof_color = HPXML::ColorDark
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_roof_values(hpxml_default, HPXML::RoofTypeMetal, 0.7, HPXML::ColorMedium)
+    _test_default_roof_values(hpxml_default, HPXML::RoofTypeMetal, 0.77, HPXML::ColorDark)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.roofs[0].roof_type = nil
+    hpxml.roofs[0].solar_absorptance = nil
+    hpxml.roofs[0].roof_color = HPXML::ColorLight
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_roof_values(hpxml_default, HPXML::RoofTypeAsphaltShingles, 0.75, HPXML::ColorLight)
@@ -192,15 +202,18 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_walls
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.walls[0].siding = HPXML::SidingTypeFiberCement
+    hpxml.walls[0].solar_absorptance = 0.66
+    hpxml.walls[0].color = HPXML::ColorDark
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_wall_values(hpxml_default, HPXML::SidingTypeFiberCement, 0.7, HPXML::ColorMedium)
+    _test_default_wall_values(hpxml_default, HPXML::SidingTypeFiberCement, 0.66, HPXML::ColorDark)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.walls[0].siding = nil
+    hpxml.walls[0].solar_absorptance = nil
+    hpxml.walls[0].color = HPXML::ColorLight
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_wall_values(hpxml_default, HPXML::SidingTypeWood, 0.5, HPXML::ColorLight)
@@ -208,15 +221,18 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_rim_joists
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.rim_joists[0].siding = HPXML::SidingTypeBrick
+    hpxml.rim_joists[0].solar_absorptance = 0.55
+    hpxml.rim_joists[0].color = HPXML::ColorLight
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeBrick, 0.7, HPXML::ColorMedium)
+    _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeBrick, 0.55, HPXML::ColorLight)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.rim_joists[0].siding = nil
+    hpxml.rim_joists[0].solar_absorptance = nil
+    hpxml.rim_joists[0].color = HPXML::ColorDark
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeWood, 0.95, HPXML::ColorDark)
@@ -224,18 +240,23 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_windows
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-enclosure-windows-interior-shading.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-enclosure-windows-interior-shading.xml')
     hpxml.windows.each do |window|
       window.fraction_operable = 0.5
+      window.interior_shading_factor_summer = 0.66
+      window.interior_shading_factor_winter = 0.77
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     n_windows = hpxml_default.windows.size
-    _test_default_window_values(hpxml_default, [0.7, 0.01, 0.0, 1.0], [0.85, 0.99, 0.5, 1.0], [0.5] * n_windows)
+    _test_default_window_values(hpxml_default, [0.66] * n_windows, [0.77] * n_windows, [0.5] * n_windows)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.windows.each do |window|
+      window.fraction_operable = nil
+      window.interior_shading_factor_summer = nil
+      window.interior_shading_factor_winter = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     n_windows = hpxml_default.windows.size
@@ -244,19 +265,21 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_skylights
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-enclosure-skylights.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-enclosure-skylights.xml')
     hpxml.skylights.each do |skylight|
-      skylight.interior_shading_factor_summer = 0.90
-      skylight.interior_shading_factor_winter = 0.95
+      skylight.interior_shading_factor_summer = 0.66
+      skylight.interior_shading_factor_winter = 0.77
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     n_skylights = hpxml_default.skylights.size
-    _test_default_skylight_values(hpxml_default, [0.90] * n_skylights, [0.95] * n_skylights)
+    _test_default_skylight_values(hpxml_default, [0.66] * n_skylights, [0.77] * n_skylights)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-enclosure-skylights.xml')
+    hpxml.skylights.each do |skylight|
+      skylight.interior_shading_factor_summer = nil
+      skylight.interior_shading_factor_winter = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     n_skylights = hpxml_default.skylights.size
@@ -265,8 +288,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_air_conditioners
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.cooling_systems[0].cooling_shr = 0.88
     hpxml.cooling_systems[0].compressor_type = HPXML::HVACCompressorTypeVariableSpeed
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -274,7 +296,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_air_conditioner_values(hpxml_default, 0.88, HPXML::HVACCompressorTypeVariableSpeed)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.cooling_systems[0].cooling_shr = nil
+    hpxml.cooling_systems[0].compressor_type = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_air_conditioner_values(hpxml_default, 0.73, HPXML::HVACCompressorTypeSingleStage)
@@ -282,8 +305,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_boilers
     # Test inputs not overridden by defaults (in-unit boiler)
-    hpxml_name = 'base-hvac-boiler-gas-only.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-hvac-boiler-gas-only.xml')
     hpxml.heating_systems[0].electric_auxiliary_energy = 99.9
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
@@ -296,8 +318,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_boiler_values(hpxml_default, 170.0)
 
     # Test inputs not overridden by defaults (shared boiler)
-    hpxml_name = 'base-hvac-shared-boiler-only-baseboard.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-hvac-shared-boiler-only-baseboard.xml')
     hpxml.heating_systems[0].shared_loop_watts = nil
     hpxml.heating_systems[0].electric_auxiliary_energy = 99.9
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -313,8 +334,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_ground_source_heat_pumps
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-hvac-ground-to-air-heat-pump.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-hvac-ground-to-air-heat-pump.xml')
     hpxml.heat_pumps[0].pump_watts_per_ton = 9.9
     hpxml.heat_pumps[0].fan_watts_per_cfm = 0.99
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -331,8 +351,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_hvac_distribution
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['attic - unvented']
@@ -343,7 +362,12 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ conditioned basement
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.hvac_distributions.each do |hvac_distribution|
+      hvac_distribution.ducts.each do |duct|
+        duct.duct_location = nil
+        duct.duct_surface_area = nil
+      end
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['basement - conditioned']
@@ -354,7 +378,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ multiple foundations
-    hpxml = apply_hpxml_defaults('base-foundation-multiple.xml')
+    hpxml = _create_hpxml('base-foundation-multiple.xml')
+    hpxml.hvac_distributions.each do |hvac_distribution|
+      hvac_distribution.ducts.each do |duct|
+        duct.duct_location = nil
+        duct.duct_surface_area = nil
+      end
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['basement - unconditioned']
@@ -365,7 +395,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ foundation exposed to ambient
-    hpxml = apply_hpxml_defaults('base-foundation-ambient.xml')
+    hpxml = _create_hpxml('base-foundation-ambient.xml')
+    hpxml.hvac_distributions.each do |hvac_distribution|
+      hvac_distribution.ducts.each do |duct|
+        duct.duct_location = nil
+        duct.duct_surface_area = nil
+      end
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['attic - unvented']
@@ -376,7 +412,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ building/unit adjacent to other housing unit
-    hpxml = apply_hpxml_defaults('base-enclosure-other-housing-unit.xml')
+    hpxml = _create_hpxml('base-enclosure-other-housing-unit.xml')
+    hpxml.hvac_distributions.each do |hvac_distribution|
+      hvac_distribution.ducts.each do |duct|
+        duct.duct_location = nil
+        duct.duct_surface_area = nil
+      end
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['living space']
@@ -387,7 +429,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ 2-story building
-    hpxml = apply_hpxml_defaults('base-enclosure-2stories.xml')
+    hpxml = _create_hpxml('base-enclosure-2stories.xml')
+    hpxml.hvac_distributions.each do |hvac_distribution|
+      hvac_distribution.ducts.each do |duct|
+        duct.duct_location = nil
+        duct.duct_surface_area = nil
+      end
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['basement - conditioned', 'living space']
@@ -398,7 +446,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ 1-story building & multiple HVAC systems
-    hpxml = apply_hpxml_defaults('base-hvac-multiple.xml')
+    hpxml = _create_hpxml('base-hvac-multiple.xml')
+    hpxml.hvac_distributions.each do |hvac_distribution|
+      hvac_distribution.ducts.each do |duct|
+        duct.duct_location = nil
+        duct.duct_surface_area = nil
+      end
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['basement - conditioned', 'basement - conditioned'] * hpxml_default.hvac_distributions.size
@@ -409,8 +463,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ 2-story building & multiple HVAC systems
-    hpxml = apply_hpxml_defaults('base-hvac-multiple.xml')
+    hpxml = _create_hpxml('base-hvac-multiple.xml')
     hpxml.building_construction.number_of_conditioned_floors_above_grade = 2
+    hpxml.hvac_distributions.each do |hvac_distribution|
+      hvac_distribution.ducts.each do |duct|
+        duct.duct_location = nil
+        duct.duct_surface_area = nil
+      end
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['basement - conditioned', 'basement - conditioned', 'living space', 'living space'] * hpxml_default.hvac_distributions.size
@@ -423,8 +483,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_water_heaters
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFA
     hpxml.water_heating_systems.each do |wh|
       wh.is_shared_system = true
@@ -436,81 +495,103 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_water_heater_values(hpxml_default, [true, 15000.0, 40.0, 0.95])
-    _test_default_number_of_bathrooms(hpxml_default, 2.0)
 
     # Test defaults w/ 3-bedroom house & electric storage water heater
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.water_heating_systems.each do |water_heating_system|
+      water_heating_system.is_shared_system = nil
+      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage
+
+      water_heating_system.heating_capacity = nil
+      water_heating_system.tank_volume = nil
+      water_heating_system.recovery_efficiency = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_water_heater_values(hpxml_default, [false, 18766.7, 50.0, 0.98])
-    _test_default_number_of_bathrooms(hpxml_default, 2.0)
 
     # Test defaults w/ 5-bedroom house & electric storage water heater
-    hpxml = apply_hpxml_defaults('base-enclosure-beds-5.xml')
+    hpxml = _create_hpxml('base-enclosure-beds-5.xml')
+    hpxml.water_heating_systems.each do |water_heating_system|
+      water_heating_system.is_shared_system = nil
+      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage
+
+      water_heating_system.heating_capacity = nil
+      water_heating_system.tank_volume = nil
+      water_heating_system.recovery_efficiency = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_water_heater_values(hpxml_default, [false, 18766.7, 66.0, 0.98])
-    _test_default_number_of_bathrooms(hpxml_default, 3.0)
 
     # Test defaults w/ 3-bedroom house & 2 storage water heaters (1 electric and 1 natural gas)
-    hpxml = apply_hpxml_defaults('base-dhw-multiple.xml')
+    hpxml = _create_hpxml('base-dhw-multiple.xml')
+    hpxml.water_heating_systems.each do |water_heating_system|
+      water_heating_system.is_shared_system = nil
+      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage
+
+      water_heating_system.heating_capacity = nil
+      water_heating_system.tank_volume = nil
+      water_heating_system.recovery_efficiency = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_water_heater_values(hpxml_default, [false, 15354.6, 50.0, 0.98],
                                       [false, 36000.0, 40.0, 0.756])
-    _test_default_number_of_bathrooms(hpxml_default, 2.0)
   end
 
   def test_hot_water_distribution
     # Test inputs not overridden by defaults -- standard
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_standard_distribution_values(hpxml_default, 50.0)
 
     # Test inputs not overridden by defaults -- recirculation
-    hpxml_name = 'base-dhw-recirc-demand.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-dhw-recirc-demand.xml')
     hpxml.hot_water_distributions[0].recirculation_pump_power = 65.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_recirc_distribution_values(hpxml_default, 50.0, 50.0, 65.0)
 
     # Test inputs not overridden by defaults -- shared recirculation
-    hpxml_name = 'base-dhw-shared-water-heater-recirc.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-dhw-shared-water-heater-recirc.xml')
     hpxml.hot_water_distributions[0].shared_recirculation_pump_power = 333.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_shared_recirc_distribution_values(hpxml_default, 333.0)
 
     # Test defaults w/ conditioned basement
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml = _create_hpxml('base.xml')
+    hpxml.hot_water_distributions[0].standard_piping_length = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_standard_distribution_values(hpxml_default, 93.48)
 
     # Test defaults w/ unconditioned basement
-    hpxml = apply_hpxml_defaults('base-foundation-unconditioned-basement.xml')
+    hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
+    hpxml.hot_water_distributions[0].standard_piping_length = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_standard_distribution_values(hpxml_default, 88.48)
 
     # Test defaults w/ 2-story building
-    hpxml = apply_hpxml_defaults('base-enclosure-2stories.xml')
+    hpxml = _create_hpxml('base-enclosure-2stories.xml')
+    hpxml.hot_water_distributions[0].standard_piping_length = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_standard_distribution_values(hpxml_default, 103.48)
 
     # Test defaults w/ recirculation & conditioned basement
-    hpxml = apply_hpxml_defaults('base-dhw-recirc-demand.xml')
+    hpxml = _create_hpxml('base-dhw-recirc-demand.xml')
+    hpxml.hot_water_distributions[0].recirculation_piping_length = nil
+    hpxml.hot_water_distributions[0].recirculation_branch_piping_length = nil
+    hpxml.hot_water_distributions[0].recirculation_pump_power = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_recirc_distribution_values(hpxml_default, 166.96, 10.0, 50.0)
 
     # Test defaults w/ recirculation & unconditioned basement
-    hpxml = apply_hpxml_defaults('base-foundation-unconditioned-basement.xml')
+    hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
     hpxml.hot_water_distributions.clear
     hpxml.hot_water_distributions.add(id: 'HotWaterDistribution',
                                       system_type: HPXML::DHWDistTypeRecirc,
@@ -521,7 +602,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_recirc_distribution_values(hpxml_default, 156.96, 10.0, 50.0)
 
     # Test defaults w/ recirculation & 2-story building
-    hpxml = apply_hpxml_defaults('base-enclosure-2stories.xml')
+    hpxml = _create_hpxml('base-enclosure-2stories.xml')
     hpxml.hot_water_distributions.clear
     hpxml.hot_water_distributions.add(id: 'HotWaterDistribution',
                                       system_type: HPXML::DHWDistTypeRecirc,
@@ -532,7 +613,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_recirc_distribution_values(hpxml_default, 186.96, 10.0, 50.0)
 
     # Test defaults w/ shared recirculation
-    hpxml = apply_hpxml_defaults('base-dhw-shared-water-heater-recirc.xml')
+    hpxml = _create_hpxml('base-dhw-shared-water-heater-recirc.xml')
+    hpxml.hot_water_distributions[0].shared_recirculation_pump_power = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_shared_recirc_distribution_values(hpxml_default, 220.0)
@@ -540,38 +622,36 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_water_fixtures
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.water_heating.water_fixtures_usage_multiplier = 2.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_water_fixture_values(hpxml_default, 2.0)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.water_heating.water_fixtures_usage_multiplier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_water_fixture_values(hpxml_default, 1.0)
   end
 
-  def test_solar_thermal_system
+  def test_solar_thermal_systems
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-dhw-solar-direct-flat-plate.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-dhw-solar-direct-flat-plate.xml')
     hpxml.solar_thermal_systems[0].storage_volume = 55.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_solar_thermal_values(hpxml_default, 55.0)
 
     # Test defaults w/ collector area of 40 sqft
-    hpxml = apply_hpxml_defaults('base-dhw-solar-direct-flat-plate.xml')
+    hpxml.solar_thermal_systems[0].storage_volume = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_solar_thermal_values(hpxml_default, 60.0)
 
     # Test defaults w/ collector area of 100 sqft
-    hpxml = apply_hpxml_defaults('base-dhw-solar-direct-flat-plate.xml')
     hpxml.solar_thermal_systems[0].collector_area = 100.0
+    hpxml.solar_thermal_systems[0].storage_volume = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_solar_thermal_values(hpxml_default, 150.0)
@@ -579,25 +659,35 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_ventilation_fans
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-mechvent-bath-kitchen-fans.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-mechvent-bath-kitchen-fans.xml')
     kitchen_fan = hpxml.ventilation_fans.select { |f| f.used_for_local_ventilation && f.fan_location == HPXML::LocationKitchen }[0]
     kitchen_fan.rated_flow_rate = 300
     kitchen_fan.fan_power = 20
     kitchen_fan.start_hour = 12
     kitchen_fan.quantity = 2
+    kitchen_fan.hours_in_operation = 2
     bath_fan = hpxml.ventilation_fans.select { |f| f.used_for_local_ventilation && f.fan_location == HPXML::LocationBath }[0]
     bath_fan.rated_flow_rate = 80
     bath_fan.fan_power = 33
     bath_fan.start_hour = 6
     bath_fan.quantity = 3
+    bath_fan.hours_in_operation = 3
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_kitchen_fan_values(hpxml_default, 2, 300, 1.5, 20, 12)
-    _test_default_bath_fan_values(hpxml_default, 3, 80, 1.5, 33, 6)
+    _test_default_kitchen_fan_values(hpxml_default, 2, 300, 2, 20, 12)
+    _test_default_bath_fan_values(hpxml_default, 3, 80, 3, 33, 6)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-mechvent-bath-kitchen-fans.xml')
+    kitchen_fan.rated_flow_rate = nil
+    kitchen_fan.fan_power = nil
+    kitchen_fan.start_hour = nil
+    kitchen_fan.quantity = nil
+    kitchen_fan.hours_in_operation = nil
+    bath_fan.rated_flow_rate = nil
+    bath_fan.fan_power = nil
+    bath_fan.start_hour = nil
+    bath_fan.quantity = nil
+    bath_fan.hours_in_operation = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_kitchen_fan_values(hpxml_default, 1, 100, 1, 30, 18)
@@ -606,14 +696,16 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_ceiling_fans
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-lighting-ceiling-fans.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-lighting-ceiling-fans.xml')
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_ceiling_fan_values(hpxml_default, 2, 100)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-lighting-ceiling-fans.xml')
+    hpxml.ceiling_fans.each do |ceiling_fan|
+      ceiling_fan.quantity = nil
+      ceiling_fan.efficiency = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_ceiling_fan_values(hpxml_default, 4, 70.4)
@@ -621,32 +713,50 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_pools
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-misc-loads-large-uncommon.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
     pool = hpxml.pools[0]
     pool.heater_load_units = HPXML::UnitsKwhPerYear
     pool.heater_load_value = 1000
     pool.pump_kwh_per_year = 3000
-    pool.heater_weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    pool.heater_weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    pool.heater_monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
-    pool.pump_weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    pool.pump_weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    pool.pump_monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    pool.heater_weekday_fractions = ConstantDaySchedule
+    pool.heater_weekend_fractions = ConstantDaySchedule
+    pool.heater_monthly_multipliers = ConstantMonthSchedule
+    pool.pump_weekday_fractions = ConstantDaySchedule
+    pool.pump_weekend_fractions = ConstantDaySchedule
+    pool.pump_monthly_multipliers = ConstantMonthSchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_pool_heater_values(hpxml_default, HPXML::UnitsKwhPerYear, 1000, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
-    _test_default_pool_pump_values(hpxml_default, 3000, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
+    _test_default_pool_heater_values(hpxml_default, HPXML::UnitsKwhPerYear, 1000, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_pool_pump_values(hpxml_default, 3000, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-misc-loads-large-uncommon.xml')
+    pool = hpxml.pools[0]
+    pool.heater_load_units = nil
+    pool.heater_load_value = nil
+    pool.pump_kwh_per_year = nil
+    pool.heater_weekday_fractions = nil
+    pool.heater_weekend_fractions = nil
+    pool.heater_monthly_multipliers = nil
+    pool.pump_weekday_fractions = nil
+    pool.pump_weekend_fractions = nil
+    pool.pump_monthly_multipliers = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_pool_heater_values(hpxml_default, HPXML::UnitsThermPerYear, 236, '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
     _test_default_pool_pump_values(hpxml_default, 2496, '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
 
     # Test defaults 2
-    hpxml = apply_hpxml_defaults('base-misc-loads-large-uncommon2.xml')
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon2.xml')
+    pool = hpxml.pools[0]
+    pool.heater_load_units = nil
+    pool.heater_load_value = nil
+    pool.pump_kwh_per_year = nil
+    pool.heater_weekday_fractions = nil
+    pool.heater_weekend_fractions = nil
+    pool.heater_monthly_multipliers = nil
+    pool.pump_weekday_fractions = nil
+    pool.pump_weekend_fractions = nil
+    pool.pump_monthly_multipliers = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_pool_heater_values(hpxml_default, nil, nil, nil, nil, nil)
@@ -655,32 +765,50 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_hot_tubs
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-misc-loads-large-uncommon.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
     hot_tub = hpxml.hot_tubs[0]
     hot_tub.heater_load_units = HPXML::UnitsThermPerYear
     hot_tub.heater_load_value = 1000
     hot_tub.pump_kwh_per_year = 3000
-    hot_tub.heater_weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    hot_tub.heater_weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    hot_tub.heater_monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
-    hot_tub.pump_weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    hot_tub.pump_weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    hot_tub.pump_monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    hot_tub.heater_weekday_fractions = ConstantDaySchedule
+    hot_tub.heater_weekend_fractions = ConstantDaySchedule
+    hot_tub.heater_monthly_multipliers = ConstantMonthSchedule
+    hot_tub.pump_weekday_fractions = ConstantDaySchedule
+    hot_tub.pump_weekend_fractions = ConstantDaySchedule
+    hot_tub.pump_monthly_multipliers = ConstantMonthSchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_hot_tub_heater_values(hpxml_default, HPXML::UnitsThermPerYear, 1000, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
-    _test_default_hot_tub_pump_values(hpxml_default, 3000, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
+    _test_default_hot_tub_heater_values(hpxml_default, HPXML::UnitsThermPerYear, 1000, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_hot_tub_pump_values(hpxml_default, 3000, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-misc-loads-large-uncommon.xml')
+    hot_tub = hpxml.hot_tubs[0]
+    hot_tub.heater_load_units = nil
+    hot_tub.heater_load_value = nil
+    hot_tub.pump_kwh_per_year = nil
+    hot_tub.heater_weekday_fractions = nil
+    hot_tub.heater_weekend_fractions = nil
+    hot_tub.heater_monthly_multipliers = nil
+    hot_tub.pump_weekday_fractions = nil
+    hot_tub.pump_weekend_fractions = nil
+    hot_tub.pump_monthly_multipliers = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_hot_tub_heater_values(hpxml_default, HPXML::UnitsKwhPerYear, 1125, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
     _test_default_hot_tub_pump_values(hpxml_default, 1111, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921')
 
     # Test defaults 2
-    hpxml = apply_hpxml_defaults('base-misc-loads-large-uncommon2.xml')
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon2.xml')
+    hot_tub = hpxml.hot_tubs[0]
+    hot_tub.heater_load_units = nil
+    hot_tub.heater_load_value = nil
+    hot_tub.pump_kwh_per_year = nil
+    hot_tub.heater_weekday_fractions = nil
+    hot_tub.heater_weekend_fractions = nil
+    hot_tub.heater_monthly_multipliers = nil
+    hot_tub.pump_weekday_fractions = nil
+    hot_tub.pump_weekend_fractions = nil
+    hot_tub.pump_monthly_multipliers = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_hot_tub_heater_values(hpxml_default, HPXML::UnitsKwhPerYear, 225, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
@@ -689,49 +817,56 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_plug_loads
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-misc-loads-large-uncommon.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
     tv_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeTelevision }[0]
     tv_pl.kWh_per_year = 1000
     tv_pl.frac_sensible = 0.6
     tv_pl.frac_latent = 0.3
     tv_pl.location = HPXML::LocationExterior
-    tv_pl.weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    tv_pl.weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    tv_pl.monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    tv_pl.weekday_fractions = ConstantDaySchedule
+    tv_pl.weekend_fractions = ConstantDaySchedule
+    tv_pl.monthly_multipliers = ConstantMonthSchedule
     other_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeOther }[0]
     other_pl.kWh_per_year = 2000
     other_pl.frac_sensible = 0.5
     other_pl.frac_latent = 0.4
     other_pl.location = HPXML::LocationExterior
-    other_pl.weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    other_pl.weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    other_pl.monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    other_pl.weekday_fractions = ConstantDaySchedule
+    other_pl.weekend_fractions = ConstantDaySchedule
+    other_pl.monthly_multipliers = ConstantMonthSchedule
     veh_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeElectricVehicleCharging }[0]
     veh_pl.kWh_per_year = 4000
     veh_pl.frac_sensible = 0.4
     veh_pl.frac_latent = 0.5
     veh_pl.location = HPXML::LocationInterior
-    veh_pl.weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    veh_pl.weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    veh_pl.monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    veh_pl.weekday_fractions = ConstantDaySchedule
+    veh_pl.weekend_fractions = ConstantDaySchedule
+    veh_pl.monthly_multipliers = ConstantMonthSchedule
     wellpump_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeWellPump }[0]
     wellpump_pl.kWh_per_year = 3000
     wellpump_pl.frac_sensible = 0.3
     wellpump_pl.frac_latent = 0.6
     wellpump_pl.location = HPXML::LocationInterior
-    wellpump_pl.weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    wellpump_pl.weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    wellpump_pl.monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    wellpump_pl.weekday_fractions = ConstantDaySchedule
+    wellpump_pl.weekend_fractions = ConstantDaySchedule
+    wellpump_pl.monthly_multipliers = ConstantMonthSchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeTelevision, 1000, 0.6, 0.3, HPXML::LocationExterior, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeOther, 2000, 0.5, 0.4, HPXML::LocationExterior, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeElectricVehicleCharging, 4000, 0.4, 0.5, HPXML::LocationInterior, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeWellPump, 3000, 0.3, 0.6, HPXML::LocationInterior, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
+    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeTelevision, 1000, 0.6, 0.3, HPXML::LocationExterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeOther, 2000, 0.5, 0.4, HPXML::LocationExterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeElectricVehicleCharging, 4000, 0.4, 0.5, HPXML::LocationInterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeWellPump, 3000, 0.3, 0.6, HPXML::LocationInterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-misc-loads-large-uncommon.xml')
+    hpxml.plug_loads.each do |plug_load|
+      plug_load.kWh_per_year = nil
+      plug_load.frac_sensible = nil
+      plug_load.frac_latent = nil
+      plug_load.location = nil
+      plug_load.weekday_fractions = nil
+      plug_load.weekend_fractions = nil
+      plug_load.monthly_multipliers = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeTelevision, 620, 1.0, 0.0, HPXML::LocationInterior, '0.037, 0.018, 0.009, 0.007, 0.011, 0.018, 0.029, 0.040, 0.049, 0.058, 0.065, 0.072, 0.076, 0.086, 0.091, 0.102, 0.127, 0.156, 0.210, 0.294, 0.363, 0.344, 0.208, 0.090', '0.044, 0.022, 0.012, 0.008, 0.011, 0.014, 0.024, 0.043, 0.071, 0.094, 0.112, 0.123, 0.132, 0.156, 0.178, 0.196, 0.206, 0.213, 0.251, 0.330, 0.388, 0.358, 0.226, 0.103', '1.137, 1.129, 0.961, 0.969, 0.961, 0.993, 0.996, 0.96, 0.993, 0.867, 0.86, 1.137')
@@ -742,40 +877,47 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_fuel_loads
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-misc-loads-large-uncommon.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
     gg_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeGrill }[0]
     gg_fl.therm_per_year = 1000
     gg_fl.frac_sensible = 0.6
     gg_fl.frac_latent = 0.3
     gg_fl.location = HPXML::LocationInterior
-    gg_fl.weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    gg_fl.weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    gg_fl.monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    gg_fl.weekday_fractions = ConstantDaySchedule
+    gg_fl.weekend_fractions = ConstantDaySchedule
+    gg_fl.monthly_multipliers = ConstantMonthSchedule
     gl_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeLighting }[0]
     gl_fl.therm_per_year = 2000
     gl_fl.frac_sensible = 0.5
     gl_fl.frac_latent = 0.4
     gl_fl.location = HPXML::LocationInterior
-    gl_fl.weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    gl_fl.weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    gl_fl.monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    gl_fl.weekday_fractions = ConstantDaySchedule
+    gl_fl.weekend_fractions = ConstantDaySchedule
+    gl_fl.monthly_multipliers = ConstantMonthSchedule
     gf_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeFireplace }[0]
     gf_fl.therm_per_year = 3000
     gf_fl.frac_sensible = 0.4
     gf_fl.frac_latent = 0.5
     gf_fl.location = HPXML::LocationExterior
-    gf_fl.weekday_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    gf_fl.weekend_fractions = '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42'
-    gf_fl.monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+    gf_fl.weekday_fractions = ConstantDaySchedule
+    gf_fl.weekend_fractions = ConstantDaySchedule
+    gf_fl.monthly_multipliers = ConstantMonthSchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeGrill, 1000, 0.6, 0.3, HPXML::LocationInterior, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeLighting, 2000, 0.5, 0.4, HPXML::LocationInterior, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeFireplace, 3000, 0.4, 0.5, HPXML::LocationExterior, '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42, 0.42', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
+    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeGrill, 1000, 0.6, 0.3, HPXML::LocationInterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeLighting, 2000, 0.5, 0.4, HPXML::LocationInterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeFireplace, 3000, 0.4, 0.5, HPXML::LocationExterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-misc-loads-large-uncommon.xml')
+    hpxml.fuel_loads.each do |fuel_load|
+      fuel_load.therm_per_year = nil
+      fuel_load.frac_sensible = nil
+      fuel_load.frac_latent = nil
+      fuel_load.location = nil
+      fuel_load.weekday_fractions = nil
+      fuel_load.weekend_fractions = nil
+      fuel_load.monthly_multipliers = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeGrill, 33, 0.0, 0.0, HPXML::LocationExterior, '0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007', '0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
@@ -783,128 +925,340 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeFireplace, 67, 0.5, 0.1, HPXML::LocationInterior, '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
   end
 
-  def test_appliances
+  def test_clothes_washers
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFA
     hpxml.water_heating_systems[0].is_shared_system = true
     hpxml.water_heating_systems[0].number_of_units_served = 6
     hpxml.water_heating_systems[0].fraction_dhw_load_served = 0
+    hpxml.clothes_washers[0].location = HPXML::LocationBasementConditioned
     hpxml.clothes_washers[0].is_shared_appliance = true
     hpxml.clothes_washers[0].usage_multiplier = 1.5
     hpxml.clothes_washers[0].water_heating_system_idref = hpxml.water_heating_systems[0].id
-    hpxml.clothes_dryers[0].is_shared_appliance = true
-    hpxml.clothes_dryers[0].usage_multiplier = 1.4
-    hpxml.dishwashers[0].is_shared_appliance = true
-    hpxml.dishwashers[0].usage_multiplier = 1.3
-    hpxml.dishwashers[0].water_heating_system_idref = hpxml.water_heating_systems[0].id
-    hpxml.refrigerators[0].usage_multiplier = 1.2
-    hpxml.cooking_ranges[0].is_induction = true
-    hpxml.cooking_ranges[0].usage_multiplier = 1.1
-    hpxml.ovens[0].is_convection = true
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_washer_values(hpxml_default, true, HPXML::LocationLivingSpace, 1.21, 380.0, 0.12, 1.09, 27.0, 3.2, 6.0, 1.5)
-    _test_default_clothes_dryer_values(hpxml_default, true, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 3.73, 1.4)
-    _test_default_dishwasher_values(hpxml_default, true, HPXML::LocationLivingSpace, 307.0, 0.12, 1.09, 22.32, 4.0, 12, 1.3)
-    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 650.0, 1.2, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-    _test_default_cooking_range_values(hpxml_default, HPXML::LocationLivingSpace, true, 1.1, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
-    _test_default_oven_values(hpxml_default, true)
+    _test_default_clothes_washer_values(hpxml_default, true, HPXML::LocationBasementConditioned, 1.21, 380.0, 0.12, 1.09, 27.0, 3.2, 6.0, 1.5)
 
-    # Test defaults w/ appliances
-    hpxml = apply_hpxml_defaults('base-misc-loads-large-uncommon.xml')
+    # Test defaults
+    hpxml.clothes_washers[0].is_shared_appliance = nil
+    hpxml.clothes_washers[0].location = nil
+    hpxml.clothes_washers[0].integrated_modified_energy_factor = nil
+    hpxml.clothes_washers[0].rated_annual_kwh = nil
+    hpxml.clothes_washers[0].label_electric_rate = nil
+    hpxml.clothes_washers[0].label_gas_rate = nil
+    hpxml.clothes_washers[0].label_annual_gas_cost = nil
+    hpxml.clothes_washers[0].capacity = nil
+    hpxml.clothes_washers[0].label_usage = nil
+    hpxml.clothes_washers[0].usage_multiplier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_clothes_washer_values(hpxml_default, false, HPXML::LocationLivingSpace, 1.0, 400.0, 0.12, 1.09, 27.0, 3.0, 6.0, 1.0)
+
+    # Test defaults before 301-2019 Addendum A
+    hpxml = _create_hpxml('base.xml')
+    hpxml.header.eri_calculation_version = '2019'
+    hpxml.clothes_washers[0].is_shared_appliance = nil
+    hpxml.clothes_washers[0].location = nil
+    hpxml.clothes_washers[0].integrated_modified_energy_factor = nil
+    hpxml.clothes_washers[0].rated_annual_kwh = nil
+    hpxml.clothes_washers[0].label_electric_rate = nil
+    hpxml.clothes_washers[0].label_gas_rate = nil
+    hpxml.clothes_washers[0].label_annual_gas_cost = nil
+    hpxml.clothes_washers[0].capacity = nil
+    hpxml.clothes_washers[0].label_usage = nil
+    hpxml.clothes_washers[0].usage_multiplier = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_clothes_washer_values(hpxml_default, false, HPXML::LocationLivingSpace, 0.331, 704.0, 0.08, 0.58, 23.0, 2.874, 6.0, 1.0)
+  end
+
+  def test_clothes_dryers
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFA
+    hpxml.water_heating_systems[0].is_shared_system = true
+    hpxml.water_heating_systems[0].number_of_units_served = 6
+    hpxml.water_heating_systems[0].fraction_dhw_load_served = 0
+    hpxml.clothes_dryers[0].location = HPXML::LocationBasementConditioned
+    hpxml.clothes_dryers[0].is_shared_appliance = true
+    hpxml.clothes_dryers[0].control_type = HPXML::ClothesDryerControlTypeMoisture
+    hpxml.clothes_dryers[0].combined_energy_factor = 3.33
+    hpxml.clothes_dryers[0].usage_multiplier = 1.1
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_clothes_dryer_values(hpxml_default, true, HPXML::LocationBasementConditioned, HPXML::ClothesDryerControlTypeMoisture, 3.33, 1.1)
+
+    # Test defaults w/ electric clothes dryer
+    hpxml.clothes_dryers[0].location = nil
+    hpxml.clothes_dryers[0].is_shared_appliance = false
+    hpxml.clothes_dryers[0].control_type = nil
+    hpxml.clothes_dryers[0].combined_energy_factor = nil
+    hpxml.clothes_dryers[0].usage_multiplier = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
     _test_default_clothes_dryer_values(hpxml_default, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 3.01, 1.0)
-    _test_default_dishwasher_values(hpxml_default, false, HPXML::LocationLivingSpace, 467.0, 0.12, 1.09, 33.12, 4.0, 12, 1.0)
-    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 691.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-    _test_default_extra_refrigerators_values(hpxml_default, HPXML::LocationGarage, 244.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-    _test_default_freezers_values(hpxml_default, HPXML::LocationGarage, 320.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-    _test_default_cooking_range_values(hpxml_default, HPXML::LocationLivingSpace, false, 1.0, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
-    _test_default_oven_values(hpxml_default, false)
 
     # Test defaults w/ gas clothes dryer
-    hpxml = apply_hpxml_defaults('base.xml')
     hpxml.clothes_dryers[0].fuel_type = HPXML::FuelTypeNaturalGas
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_clothes_dryer_values(hpxml_default, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 3.01, 1.0)
 
-    # Test defaults w/ refrigerator in 5-bedroom house
-    hpxml = apply_hpxml_defaults('base-enclosure-beds-5.xml')
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 727.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-
-    # Test defaults w/ appliances before 301-2019 Addendum A
-    hpxml = apply_hpxml_defaults('base.xml')
+    # Test defaults w/ electric clothes dryer before 301-2019 Addendum A
     hpxml.header.eri_calculation_version = '2019'
+    hpxml.clothes_dryers[0].fuel_type = HPXML::FuelTypeElectricity
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_washer_values(hpxml_default, false, HPXML::LocationLivingSpace, 0.331, 704.0, 0.08, 0.58, 23.0, 2.874, 6.0, 1.0)
     _test_default_clothes_dryer_values(hpxml_default, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 2.62, 1.0)
-    _test_default_dishwasher_values(hpxml_default, false, HPXML::LocationLivingSpace, 467.0, 0.12, 1.09, 33.12, 4.0, 12, 1.0)
-    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 691.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-    _test_default_cooking_range_values(hpxml_default, HPXML::LocationLivingSpace, false, 1.0, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
-    _test_default_oven_values(hpxml_default, false)
 
     # Test defaults w/ gas clothes dryer before 301-2019 Addendum A
-    hpxml = apply_hpxml_defaults('base.xml')
-    hpxml.header.eri_calculation_version = '2019'
     hpxml.clothes_dryers[0].fuel_type = HPXML::FuelTypeNaturalGas
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_clothes_dryer_values(hpxml_default, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 2.32, 1.0)
   end
 
+  def test_dishwashers
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFA
+    hpxml.water_heating_systems[0].is_shared_system = true
+    hpxml.water_heating_systems[0].number_of_units_served = 6
+    hpxml.water_heating_systems[0].fraction_dhw_load_served = 0
+    hpxml.dishwashers[0].location = HPXML::LocationBasementConditioned
+    hpxml.dishwashers[0].is_shared_appliance = true
+    hpxml.dishwashers[0].usage_multiplier = 1.3
+    hpxml.dishwashers[0].water_heating_system_idref = hpxml.water_heating_systems[0].id
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_dishwasher_values(hpxml_default, true, HPXML::LocationBasementConditioned, 307.0, 0.12, 1.09, 22.32, 4.0, 12, 1.3)
+
+    # Test defaults
+    hpxml.dishwashers[0].is_shared_appliance = nil
+    hpxml.dishwashers[0].location = nil
+    hpxml.dishwashers[0].rated_annual_kwh = nil
+    hpxml.dishwashers[0].label_electric_rate = nil
+    hpxml.dishwashers[0].label_gas_rate = nil
+    hpxml.dishwashers[0].label_annual_gas_cost = nil
+    hpxml.dishwashers[0].label_usage = nil
+    hpxml.dishwashers[0].place_setting_capacity = nil
+    hpxml.dishwashers[0].usage_multiplier = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_dishwasher_values(hpxml_default, false, HPXML::LocationLivingSpace, 467.0, 0.12, 1.09, 33.12, 4.0, 12, 1.0)
+
+    # Test defaults before 301-2019 Addendum A
+    hpxml.header.eri_calculation_version = '2019'
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_dishwasher_values(hpxml_default, false, HPXML::LocationLivingSpace, 467.0, 0.12, 1.09, 33.12, 4.0, 12, 1.0)
+  end
+
+  def test_refrigerators
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.refrigerators[0].location = HPXML::LocationBasementConditioned
+    hpxml.refrigerators[0].usage_multiplier = 1.2
+    hpxml.refrigerators[0].weekday_fractions = ConstantDaySchedule
+    hpxml.refrigerators[0].weekend_fractions = ConstantDaySchedule
+    hpxml.refrigerators[0].monthly_multipliers = ConstantMonthSchedule
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_refrigerator_values(hpxml_default, HPXML::LocationBasementConditioned, 650.0, 1.2, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    hpxml.refrigerators[0].location = nil
+    hpxml.refrigerators[0].rated_annual_kwh = nil
+    hpxml.refrigerators[0].usage_multiplier = nil
+    hpxml.refrigerators[0].weekday_fractions = nil
+    hpxml.refrigerators[0].weekend_fractions = nil
+    hpxml.refrigerators[0].monthly_multipliers = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 691.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+
+    # Test defaults w/ refrigerator in 5-bedroom house
+    hpxml.building_construction.number_of_bedrooms = 5
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 727.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+
+    # Test defaults before 301-2019 Addendum A
+    hpxml.header.eri_calculation_version = '2019'
+    hpxml.building_construction.number_of_bedrooms = 3
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 691.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+  end
+
+  def test_cooking_ranges
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.cooking_ranges[0].location = HPXML::LocationBasementConditioned
+    hpxml.cooking_ranges[0].is_induction = true
+    hpxml.cooking_ranges[0].usage_multiplier = 1.1
+    hpxml.cooking_ranges[0].weekday_fractions = ConstantDaySchedule
+    hpxml.cooking_ranges[0].weekend_fractions = ConstantDaySchedule
+    hpxml.cooking_ranges[0].monthly_multipliers = ConstantMonthSchedule
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_cooking_range_values(hpxml_default, HPXML::LocationBasementConditioned, true, 1.1, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    hpxml.cooking_ranges[0].location = nil
+    hpxml.cooking_ranges[0].is_induction = nil
+    hpxml.cooking_ranges[0].usage_multiplier = nil
+    hpxml.cooking_ranges[0].weekday_fractions = nil
+    hpxml.cooking_ranges[0].weekend_fractions = nil
+    hpxml.cooking_ranges[0].monthly_multipliers = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_cooking_range_values(hpxml_default, HPXML::LocationLivingSpace, false, 1.0, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
+
+    # Test defaults before 301-2019 Addendum A
+    hpxml.header.eri_calculation_version = '2019'
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_cooking_range_values(hpxml_default, HPXML::LocationLivingSpace, false, 1.0, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
+  end
+
+  def test_ovens
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.ovens[0].is_convection = true
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_oven_values(hpxml_default, true)
+
+    # Test defaults
+    hpxml.ovens[0].is_convection = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_oven_values(hpxml_default, false)
+
+    # Test defaults before 301-2019 Addendum A
+    hpxml.header.eri_calculation_version = '2019'
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_oven_values(hpxml_default, false)
+  end
+
+  def test_extra_refrigerators
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
+    hpxml.refrigerators.each do |refrigerator|
+      refrigerator.location = HPXML::LocationBasementConditioned
+      refrigerator.rated_annual_kwh = 333.0
+      refrigerator.usage_multiplier = 1.5
+      refrigerator.weekday_fractions = ConstantDaySchedule
+      refrigerator.weekend_fractions = ConstantDaySchedule
+      refrigerator.monthly_multipliers = ConstantMonthSchedule
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_extra_refrigerators_values(hpxml_default, HPXML::LocationBasementConditioned, 333.0, 1.5, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    hpxml.refrigerators.each do |refrigerator|
+      refrigerator.location = nil
+      refrigerator.rated_annual_kwh = nil
+      refrigerator.usage_multiplier = nil
+      refrigerator.weekday_fractions = nil
+      refrigerator.weekend_fractions = nil
+      refrigerator.monthly_multipliers = nil
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_extra_refrigerators_values(hpxml_default, HPXML::LocationGarage, 244.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+  end
+
+  def test_freezers
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
+    hpxml.freezers.each do |freezer|
+      freezer.location = HPXML::LocationBasementConditioned
+      freezer.rated_annual_kwh = 333.0
+      freezer.usage_multiplier = 1.5
+      freezer.weekday_fractions = ConstantDaySchedule
+      freezer.weekend_fractions = ConstantDaySchedule
+      freezer.monthly_multipliers = ConstantMonthSchedule
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_freezers_values(hpxml_default, HPXML::LocationBasementConditioned, 333.0, 1.5, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    hpxml.freezers.each do |freezer|
+      freezer.location = nil
+      freezer.rated_annual_kwh = nil
+      freezer.usage_multiplier = nil
+      freezer.weekday_fractions = nil
+      freezer.weekend_fractions = nil
+      freezer.monthly_multipliers = nil
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_freezers_values(hpxml_default, HPXML::LocationGarage, 320.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+  end
+
   def test_lighting
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base.xml')
     hpxml.lighting.interior_usage_multiplier = 2.0
     hpxml.lighting.garage_usage_multiplier = 2.0
     hpxml.lighting.exterior_usage_multiplier = 2.0
-    hpxml.lighting.interior_weekday_fractions = '0.20, 0.20, 0.20, 0.20, 0.20, 0.20, 0.20, 0.70, 0.30, 0.30, 0.30, 0.30, 0.30, 0.30, 0.30, 0.30, 0.70, 0.70, 0.50, 0.50, 0.20, 0.20, 0.20, 0.20'
-    hpxml.lighting.interior_weekend_fractions = '0.20, 0.20, 0.20, 0.20, 0.20, 0.20, 0.20, 0.70, 0.40, 0.40, 0.40, 0.40, 0.40, 0.40, 0.40, 0.40, 0.80, 0.90, 0.70, 0.60, 0.20, 0.20, 0.20, 0.20'
-    hpxml.lighting.interior_monthly_multipliers = '1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0'
-    hpxml.lighting.exterior_weekday_fractions = '0.04, 0.04, 0.04, 0.04, 0.04, 0.03, 0.03, 0.03, 0.03, 0.03, 0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.03, 0.04, 0.06, 0.09, 0.10, 0.09, 0.06'
-    hpxml.lighting.exterior_weekend_fractions = '0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.03, 0.03, 0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.02, 0.03, 0.05, 0.06, 0.08, 0.09, 0.08, 0.05'
-    hpxml.lighting.exterior_monthly_multipliers = '1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1'
-    hpxml.lighting.garage_weekday_fractions = '0.04, 0.04, 0.04, 0.04, 0.04, 0.03, 0.03, 0.03, 0.03, 0.03, 0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.03, 0.04, 0.06, 0.09, 0.10, 0.09, 0.06'
-    hpxml.lighting.garage_weekend_fractions = '0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.03, 0.03, 0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.02, 0.03, 0.05, 0.06, 0.08, 0.09, 0.08, 0.05'
-    hpxml.lighting.garage_monthly_multipliers = '1.2, 1.2, 1.2 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2'
+    hpxml.lighting.interior_weekday_fractions = ConstantDaySchedule
+    hpxml.lighting.interior_weekend_fractions = ConstantDaySchedule
+    hpxml.lighting.interior_monthly_multipliers = ConstantMonthSchedule
+    hpxml.lighting.exterior_weekday_fractions = ConstantDaySchedule
+    hpxml.lighting.exterior_weekend_fractions = ConstantDaySchedule
+    hpxml.lighting.exterior_monthly_multipliers = ConstantMonthSchedule
+    hpxml.lighting.garage_weekday_fractions = ConstantDaySchedule
+    hpxml.lighting.garage_weekend_fractions = ConstantDaySchedule
+    hpxml.lighting.garage_monthly_multipliers = ConstantMonthSchedule
     hpxml.lighting.holiday_exists = true
     hpxml.lighting.holiday_kwh_per_day = 0.7
     hpxml.lighting.holiday_period_begin_month = 11
     hpxml.lighting.holiday_period_begin_day_of_month = 19
     hpxml.lighting.holiday_period_end_month = 12
     hpxml.lighting.holiday_period_end_day_of_month = 31
-    hpxml.lighting.holiday_weekday_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005, 0.050, 0.150, 0.150, 0.250, 0.150, 0.050, 0.020'
-    hpxml.lighting.holiday_weekend_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007, 0.070, 0.170, 0.170, 0.270, 0.170, 0.070, 0.040'
+    hpxml.lighting.holiday_weekday_fractions = ConstantDaySchedule
+    hpxml.lighting.holiday_weekend_fractions = ConstantDaySchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_lighting_values(hpxml_default, 2.0, 2.0, 2.0,
-                                  { int_wk_sch: '0.20, 0.20, 0.20, 0.20, 0.20, 0.20, 0.20, 0.70, 0.30, 0.30, 0.30, 0.30, 0.30, 0.30, 0.30, 0.30, 0.70, 0.70, 0.50, 0.50, 0.20, 0.20, 0.20, 0.20',
-                                    int_wknd_sch: '0.20, 0.20, 0.20, 0.20, 0.20, 0.20, 0.20, 0.70, 0.40, 0.40, 0.40, 0.40, 0.40, 0.40, 0.40, 0.40, 0.80, 0.90, 0.70, 0.60, 0.20, 0.20, 0.20, 0.20',
-                                    int_month_mult: '1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0',
-                                    ext_wk_sch: '0.04, 0.04, 0.04, 0.04, 0.04, 0.03, 0.03, 0.03, 0.03, 0.03, 0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.03, 0.04, 0.06, 0.09, 0.10, 0.09, 0.06',
-                                    ext_wknd_sch: '0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.03, 0.03, 0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.02, 0.03, 0.05, 0.06, 0.08, 0.09, 0.08, 0.05',
-                                    ext_month_mult: '1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1',
-                                    grg_wk_sch: '0.04, 0.04, 0.04, 0.04, 0.04, 0.03, 0.03, 0.03, 0.03, 0.03, 0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.03, 0.04, 0.06, 0.09, 0.10, 0.09, 0.06',
-                                    grg_wknd_sch: '0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.03, 0.03, 0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.02, 0.03, 0.05, 0.06, 0.08, 0.09, 0.08, 0.05',
-                                    grg_month_mult: '1.2, 1.2, 1.2 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2',
+                                  { int_wk_sch: ConstantDaySchedule,
+                                    int_wknd_sch: ConstantDaySchedule,
+                                    int_month_mult: ConstantMonthSchedule,
+                                    ext_wk_sch: ConstantDaySchedule,
+                                    ext_wknd_sch: ConstantDaySchedule,
+                                    ext_month_mult: ConstantMonthSchedule,
+                                    grg_wk_sch: ConstantDaySchedule,
+                                    grg_wknd_sch: ConstantDaySchedule,
+                                    grg_month_mult: ConstantMonthSchedule,
                                     hol_kwh_per_day: 0.7,
                                     hol_begin_month: 11,
                                     hol_begin_day_of_month: 19,
                                     hol_end_month: 12,
                                     hol_end_day_of_month: 31,
-                                    hol_wk_sch: '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005, 0.050, 0.150, 0.150, 0.250, 0.150, 0.050, 0.020',
-                                    hol_wknd_sch: '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007, 0.070, 0.170, 0.170, 0.270, 0.170, 0.070, 0.040' })
+                                    hol_wk_sch: ConstantDaySchedule,
+                                    hol_wknd_sch: ConstantDaySchedule })
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base.xml')
+    hpxml.lighting.interior_usage_multiplier = nil
+    hpxml.lighting.garage_usage_multiplier = nil
+    hpxml.lighting.exterior_usage_multiplier = nil
+    hpxml.lighting.interior_weekday_fractions = nil
+    hpxml.lighting.interior_weekend_fractions = nil
+    hpxml.lighting.interior_monthly_multipliers = nil
+    hpxml.lighting.exterior_weekday_fractions = nil
+    hpxml.lighting.exterior_weekend_fractions = nil
+    hpxml.lighting.exterior_monthly_multipliers = nil
+    hpxml.lighting.garage_weekday_fractions = nil
+    hpxml.lighting.garage_weekend_fractions = nil
+    hpxml.lighting.garage_monthly_multipliers = nil
+    hpxml.lighting.holiday_exists = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_lighting_values(hpxml_default, 1.0, 1.0, 1.0,
@@ -913,7 +1267,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
                                     ext_month_mult: '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248' })
 
     # Test defaults w/ garage
-    hpxml = apply_hpxml_defaults('base-enclosure-garage.xml')
+    hpxml = _create_hpxml('base-enclosure-garage.xml')
+    hpxml.lighting.interior_usage_multiplier = nil
+    hpxml.lighting.garage_usage_multiplier = nil
+    hpxml.lighting.exterior_usage_multiplier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_lighting_values(hpxml_default, 1.0, 1.0, 1.0,
@@ -925,10 +1282,9 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
                                     grg_month_mult: '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248' })
   end
 
-  def test_pv
+  def test_pv_systems
     # Test inputs not overridden by defaults
-    hpxml_name = 'base-pv.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml = _create_hpxml('base-pv.xml')
     hpxml.pv_systems.each do |pv|
       pv.inverter_efficiency = 0.90
       pv.system_losses_fraction = 0.20
@@ -940,7 +1296,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac)
 
     # Test defaults w/o year modules manufactured
-    hpxml = apply_hpxml_defaults('base-pv.xml')
+    hpxml.pv_systems.each do |pv|
+      pv.inverter_efficiency = nil
+      pv.system_losses_fraction = nil
+    end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_interver_efficiency = [0.96, 0.96]
@@ -948,7 +1307,6 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac)
 
     # Test defaults w/ year modules manufactured
-    hpxml = apply_hpxml_defaults('base-pv.xml')
     hpxml.pv_systems.each do |pv|
       pv.year_modules_manufactured = 2010
     end
@@ -1062,9 +1420,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
   end
 
-  def _test_default_building_construction_values(hpxml, building_volume, has_flue_or_chimney)
+  def _test_default_building_construction_values(hpxml, building_volume, has_flue_or_chimney, n_bathrooms)
     assert_equal(building_volume, hpxml.building_construction.conditioned_building_volume)
     assert_equal(has_flue_or_chimney, hpxml.building_construction.has_flue_or_chimney)
+    assert_equal(n_bathrooms, hpxml.building_construction.number_of_bathrooms)
   end
 
   def _test_default_attic_values(hpxml, sla)
@@ -1471,10 +1830,6 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_equal(monthly_mults, fl.monthly_multipliers)
   end
 
-  def _test_default_number_of_bathrooms(hpxml, n_bathrooms)
-    assert_equal(n_bathrooms, hpxml.building_construction.number_of_bathrooms)
-  end
-
   def _test_default_water_heater_values(hpxml, *expected_wh_values)
     storage_water_heaters = hpxml.water_heating_systems.select { |w| w.water_heater_type == HPXML::WaterHeaterTypeStorage }
     assert_equal(expected_wh_values.size, storage_water_heaters.size)
@@ -1487,222 +1842,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
   end
 
-  def apply_hpxml_defaults(hpxml_name)
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
-
-    hpxml.header.timestep = nil
-    hpxml.header.sim_begin_month = nil
-    hpxml.header.sim_begin_day_of_month = nil
-    hpxml.header.sim_end_month = nil
-    hpxml.header.sim_end_day_of_month = nil
-    hpxml.header.dst_enabled = nil
-
-    hpxml.site.site_type = nil
-    hpxml.site.shelter_coefficient = nil
-
-    hpxml.building_construction.conditioned_building_volume = nil
-    hpxml.building_construction.average_ceiling_height = 10
-    hpxml.building_construction.number_of_bathrooms = nil
-    hpxml.building_construction.has_flue_or_chimney = nil
-
-    hpxml.attics.each do |attic|
-      attic.vented_attic_sla = nil
-    end
-
-    hpxml.foundations.each do |foundation|
-      foundation.vented_crawlspace_sla = nil
-    end
-
-    hpxml.air_infiltration_measurements.each do |infil|
-      infil.infiltration_volume = nil
-    end
-
-    hpxml.roofs.each do |roof|
-      roof.roof_type = nil
-      roof.solar_absorptance = nil
-      roof.roof_color = HPXML::ColorLight
-    end
-
-    hpxml.walls.each do |wall|
-      next unless wall.is_exterior
-
-      wall.siding = nil
-      wall.solar_absorptance = nil
-      wall.color = HPXML::ColorLight
-    end
-
-    hpxml.rim_joists.each do |rim_joist|
-      rim_joist.siding = nil
-      rim_joist.solar_absorptance = nil
-      rim_joist.color = HPXML::ColorDark
-    end
-
-    hpxml.windows.each do |window|
-      window.fraction_operable = nil
-      window.interior_shading_factor_summer = nil
-      window.interior_shading_factor_winter = nil
-    end
-
-    hpxml.skylights.each do |skylight|
-      skylight.interior_shading_factor_summer = nil
-      skylight.interior_shading_factor_winter = nil
-    end
-
-    hpxml.hvac_distributions.each do |hvac_distribution|
-      hvac_distribution.ducts.each do |duct|
-        duct.duct_location = nil
-        duct.duct_surface_area = nil
-      end
-    end
-
-    hpxml.water_heating.water_fixtures_usage_multiplier = nil
-
-    hpxml.water_heating_systems.each do |water_heating_system|
-      water_heating_system.is_shared_system = nil
-      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage
-
-      water_heating_system.heating_capacity = nil
-      water_heating_system.tank_volume = nil
-      water_heating_system.recovery_efficiency = nil
-    end
-
-    hot_water_distribution = hpxml.hot_water_distributions[0]
-    hot_water_distribution.standard_piping_length = nil
-    hot_water_distribution.recirculation_piping_length = nil
-    hot_water_distribution.recirculation_branch_piping_length = nil
-    hot_water_distribution.recirculation_pump_power = nil
-    hot_water_distribution.shared_recirculation_pump_power = nil
-
-    hpxml.solar_thermal_systems.each do |solar_thermal_system|
-      solar_thermal_system.storage_volume = nil
-    end
-
-    hpxml.ventilation_fans.each do |vent_fan|
-      next unless vent_fan.used_for_local_ventilation
-
-      vent_fan.quantity = nil
-      vent_fan.rated_flow_rate = nil
-      vent_fan.hours_in_operation = nil
-      vent_fan.fan_power = nil
-      vent_fan.start_hour = nil
-    end
-
-    hpxml.ceiling_fans.each do |ceiling_fan|
-      ceiling_fan.quantity = nil
-      ceiling_fan.efficiency = nil
-    end
-
-    clothes_washer = hpxml.clothes_washers[0]
-    clothes_washer.is_shared_appliance = nil
-    clothes_washer.location = nil
-    clothes_washer.integrated_modified_energy_factor = nil
-    clothes_washer.rated_annual_kwh = nil
-    clothes_washer.label_electric_rate = nil
-    clothes_washer.label_gas_rate = nil
-    clothes_washer.label_annual_gas_cost = nil
-    clothes_washer.capacity = nil
-    clothes_washer.label_usage = nil
-    clothes_washer.usage_multiplier = nil
-
-    clothes_dryer = hpxml.clothes_dryers[0]
-    clothes_dryer.location = nil
-    clothes_dryer.control_type = nil
-    clothes_dryer.combined_energy_factor = nil
-    clothes_dryer.usage_multiplier = nil
-
-    dishwasher = hpxml.dishwashers[0]
-    dishwasher.is_shared_appliance = nil
-    dishwasher.location = nil
-    dishwasher.rated_annual_kwh = nil
-    dishwasher.label_electric_rate = nil
-    dishwasher.label_gas_rate = nil
-    dishwasher.label_annual_gas_cost = nil
-    dishwasher.label_usage = nil
-    dishwasher.place_setting_capacity = nil
-    dishwasher.usage_multiplier = nil
-
-    hpxml.refrigerators.each do |refrigerator|
-      refrigerator.location = nil
-      refrigerator.rated_annual_kwh = nil
-      refrigerator.usage_multiplier = nil
-      refrigerator.weekday_fractions = nil
-      refrigerator.weekend_fractions = nil
-      refrigerator.monthly_multipliers = nil
-    end
-
-    hpxml.freezers.each do |freezer|
-      freezer.location = nil
-      freezer.rated_annual_kwh = nil
-      freezer.usage_multiplier = nil
-      freezer.weekday_fractions = nil
-      freezer.weekend_fractions = nil
-      freezer.monthly_multipliers = nil
-    end
-
-    cooking_range = hpxml.cooking_ranges[0]
-    cooking_range.location = nil
-    cooking_range.is_induction = nil
-    cooking_range.usage_multiplier = nil
-    cooking_range.weekday_fractions = nil
-    cooking_range.weekend_fractions = nil
-    cooking_range.monthly_multipliers = nil
-
-    oven = hpxml.ovens[0]
-    oven.is_convection = nil
-
-    hpxml.pools.each do |pool|
-      pool.heater_load_units = nil
-      pool.heater_load_value = nil
-      pool.pump_kwh_per_year = nil
-      pool.heater_weekday_fractions = nil
-      pool.heater_weekend_fractions = nil
-      pool.heater_monthly_multipliers = nil
-      pool.pump_weekday_fractions = nil
-      pool.pump_weekend_fractions = nil
-      pool.pump_monthly_multipliers = nil
-    end
-
-    hpxml.hot_tubs.each do |hot_tub|
-      hot_tub.heater_load_units = nil
-      hot_tub.heater_load_value = nil
-      hot_tub.pump_kwh_per_year = nil
-      hot_tub.heater_weekday_fractions = nil
-      hot_tub.heater_weekend_fractions = nil
-      hot_tub.heater_monthly_multipliers = nil
-      hot_tub.pump_weekday_fractions = nil
-      hot_tub.pump_weekend_fractions = nil
-      hot_tub.pump_monthly_multipliers = nil
-    end
-
-    hpxml.plug_loads.each do |plug_load|
-      plug_load.kWh_per_year = nil
-      plug_load.frac_sensible = nil
-      plug_load.frac_latent = nil
-      plug_load.location = nil
-      plug_load.weekday_fractions = nil
-      plug_load.weekend_fractions = nil
-      plug_load.monthly_multipliers = nil
-    end
-
-    hpxml.fuel_loads.each do |fuel_load|
-      fuel_load.therm_per_year = nil
-      fuel_load.frac_sensible = nil
-      fuel_load.frac_latent = nil
-      fuel_load.location = nil
-      fuel_load.weekday_fractions = nil
-      fuel_load.weekend_fractions = nil
-      fuel_load.monthly_multipliers = nil
-    end
-
-    hpxml.lighting.interior_usage_multiplier = nil
-    hpxml.lighting.garage_usage_multiplier = nil
-    hpxml.lighting.exterior_usage_multiplier = nil
-
-    hpxml.pv_systems.each do |pv|
-      pv.inverter_efficiency = nil
-      pv.system_losses_fraction = nil
-    end
-
-    return hpxml
+  def _create_hpxml(hpxml_name)
+    return HPXML.new(hpxml_path: File.join(@sample_files_path, hpxml_name))
   end
 end


### PR DESCRIPTION
## Pull Request Description

- Moves `add_extension` method from HPXML class to XMLHelper class and makes the arguments more similar to `add_element` method. Should reduce confusion about use of, e.g., to_boolean_or_nil vs to_boolean.
- Simplify HPXML default tests in test_defaults.rb. Will better ensure that tests are _actually_ checking things.

No CI diffs expected.

## Checklist

Not all may apply:

- [ ] EPvalidator.rb has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
