### PR TITLE
test_validation.rb via CLI

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>2a3066df-1cbb-4da9-8532-6f41f40a17ed</version_id>
-  <version_modified>20200909T150408Z</version_modified>
+  <version_id>d76b70ab-0d9d-41c5-a6c1-bb3f8497cf77</version_id>
+  <version_modified>20200915T143313Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -553,12 +553,6 @@
       <checksum>9485FE74</checksum>
     </file>
     <file>
-      <filename>test_validation.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>3921BAE7</checksum>
-    </file>
-    <file>
       <filename>validator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -580,6 +574,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>649DDD2B</checksum>
+    </file>
+    <file>
+      <filename>test_validation.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>0723FC28</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -6,10 +6,16 @@ require 'openstudio/ruleset/ShowRunnerOutput'
 require 'minitest/autorun'
 require 'fileutils'
 require_relative '../measure.rb'
+@@has_schematron_nokogiri_gem = false
 begin
   require 'schematron-nokogiri'
+  @@has_schematron_nokogiri_gem = true
 rescue LoadError
-  fail 'Could not load schematron-nokogiri gem. Try running with "bundle exec ruby ...".'
+  if ENV['CI'] # Ensure we test via schematron-nokogiri on the CI
+    fail 'Could not load schematron-nokogiri gem. Try running with "bundle exec ruby ...".'
+  else
+    puts 'Could not load schematron-nokogiri gem. Proceeding using ruby validation tests only...'
+  end
 end
 
 class HPXMLtoOpenStudioValidationTest < MiniTest::Test
@@ -18,8 +24,11 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
 
     # load the Schematron xml
     @stron_path = File.join(@root_path, 'HPXMLtoOpenStudio', 'resources', 'EPvalidator.xml')
-    # make a Schematron object
-    @stron_doc = SchematronNokogiri::Schema.new Nokogiri::XML File.open(@stron_path)
+
+    if @@has_schematron_nokogiri_gem
+      # make a Schematron object
+      @stron_doc = SchematronNokogiri::Schema.new Nokogiri::XML File.open(@stron_path)
+    end
 
     # Load all HPXMLs
     hpxml_file_dirs = [File.absolute_path(File.join(@root_path, 'workflow', 'sample_files')),
@@ -58,19 +67,21 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
   end
 
   def test_sample_files
+    puts
     puts "Testing #{@hpxml_docs.size} HPXML files..."
     @hpxml_docs.each do |xml, hpxml_doc|
       print '.'
 
       # Test validation
       _test_schema_validation(hpxml_doc, xml)
-      _test_schematron_validation(@stron_doc, hpxml_doc.to_xml)
+      _test_schematron_validation(@stron_doc, hpxml_doc.to_xml) if @@has_schematron_nokogiri_gem
       _test_ruby_validation(hpxml_doc)
     end
     puts
   end
 
   def test_schematron_asserts_by_deletion
+    puts
     puts "Testing #{@expected_assertions_by_deletion.size} Schematron asserts by deletion..."
 
     # Tests by element deletion
@@ -82,12 +93,13 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
 
       # Test validation
       _test_ruby_validation(hpxml_doc, expected_error_msg)
-      _test_schematron_validation(@stron_doc, hpxml_doc.to_xml, expected_error_msg)
+      _test_schematron_validation(@stron_doc, hpxml_doc.to_xml, expected_error_msg) if @@has_schematron_nokogiri_gem
     end
     puts
   end
 
   def test_schematron_asserts_by_addition
+    puts
     puts "Testing #{@expected_assertions_by_addition.size} Schematron asserts by addition..."
 
     # Tests by element addition (i.e. zero_or_one, zero_or_two, etc.)
@@ -112,7 +124,7 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
       (max_number_of_elements_allowed + 1).times { mod_parent_element.children << duplicated }
 
       # Test validation
-      _test_schematron_validation(@stron_doc, hpxml_doc.to_xml, expected_error_msg)
+      _test_schematron_validation(@stron_doc, hpxml_doc.to_xml, expected_error_msg) if @@has_schematron_nokogiri_gem
       _test_ruby_validation(hpxml_doc, expected_error_msg)
     end
     puts


### PR DESCRIPTION
## Pull Request Description

Allow running test_validation.rb via the OS CLI (only ruby tests will run). The CI will continue to run all tests (i.e., including schematron-nokogiri).

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
