### PR TITLE
BuildResidentialHPXML measure: Use OpenStudio::EpwFile

### DIFF
--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>0a0583de-1588-4b05-b4d6-0ac16a01033c</version_id>
-  <version_modified>20200928T154201Z</version_modified>
+  <version_id>ffaac6c8-8724-49cb-88d3-f813ad9befa0</version_id>
+  <version_modified>20200928T195947Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -18,15 +18,6 @@
       <type>String</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
-    </argument>
-    <argument>
-      <name>weather_dir</name>
-      <display_name>Weather Directory</display_name>
-      <description>Absolute/relative path of the weather directory.</description>
-      <type>String</type>
-      <required>true</required>
-      <model_dependent>false</model_dependent>
-      <default_value>weather</default_value>
     </argument>
     <argument>
       <name>software_program_used</name>
@@ -146,7 +137,7 @@
     <argument>
       <name>weather_station_epw_filepath</name>
       <display_name>EnergyPlus Weather (EPW) Filepath</display_name>
-      <description>Name of the EPW file.</description>
+      <description>Path of the EPW file.</description>
       <type>String</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -6274,1042 +6265,1048 @@
       <checksum>0ABBC934</checksum>
     </file>
     <file>
-      <filename>location.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1833FBD3</checksum>
-    </file>
-    <file>
       <filename>build_residential_hpxml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>6C06E9F8</checksum>
     </file>
     <file>
+      <filename>location.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>2951BCAF</checksum>
+    </file>
+    <file>
       <filename>base-hvac-dual-fuel-mini-split-heat-pump-ducted.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>7249E3C9</checksum>
+      <checksum>D4907EAE</checksum>
     </file>
     <file>
       <filename>base-hvac-mini-split-heat-pump-ducted.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>7C053873</checksum>
+      <checksum>C1FCA3CF</checksum>
     </file>
     <file>
       <filename>base-hvac-mini-split-heat-pump-ducted-heating-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>75C8D426</checksum>
+      <checksum>317EE70D</checksum>
     </file>
     <file>
       <filename>base-multifamily.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>85B0B90B</checksum>
+      <checksum>7B12E1CE</checksum>
     </file>
     <file>
       <filename>base.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>DCEDDD76</checksum>
+      <checksum>C82A8E83</checksum>
     </file>
     <file>
       <filename>base-appliances-none.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A94D5412</checksum>
+      <checksum>6B55164A</checksum>
     </file>
     <file>
       <filename>base-single-family-attached.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9F42BB61</checksum>
+      <checksum>62BBA314</checksum>
     </file>
     <file>
       <filename>base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8E3E5BA</checksum>
+      <checksum>278DD13E</checksum>
     </file>
     <file>
       <filename>base-mechvent-cfis.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>54C9E6C4</checksum>
+      <checksum>3BB5BB99</checksum>
     </file>
     <file>
       <filename>base-dhw-indirect-outside.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>8BC32D38</checksum>
+      <checksum>EB2EF519</checksum>
     </file>
     <file>
       <filename>base-dhw-jacket-electric.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A91E917B</checksum>
+      <checksum>662A382B</checksum>
     </file>
     <file>
       <filename>base-dhw-low-flow-fixtures.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>DA2B6F57</checksum>
+      <checksum>29C566CA</checksum>
     </file>
     <file>
       <filename>base-dhw-recirc-demand.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>6474A82C</checksum>
+      <checksum>BB15049F</checksum>
     </file>
     <file>
       <filename>base-dhw-recirc-manual.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>4F588034</checksum>
+      <checksum>E70EDD1C</checksum>
     </file>
     <file>
       <filename>base-dhw-recirc-nocontrol.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>6C93EBA7</checksum>
+      <checksum>E84248C8</checksum>
     </file>
     <file>
       <filename>base-dhw-recirc-temperature.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>1C0B1CBA</checksum>
+      <checksum>2A17F7B5</checksum>
     </file>
     <file>
       <filename>base-dhw-recirc-timer.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>C950143B</checksum>
+      <checksum>09FAC7B0</checksum>
     </file>
     <file>
       <filename>base-dhw-solar-fraction.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A74FDF6A</checksum>
+      <checksum>32C4CB94</checksum>
     </file>
     <file>
       <filename>base-dhw-uef.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A2C8EFA5</checksum>
+      <checksum>891255B8</checksum>
     </file>
     <file>
       <filename>base-enclosure-infil-cfm50.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>FFB6FB91</checksum>
+      <checksum>C6CCE2A5</checksum>
     </file>
     <file>
       <filename>base-foundation-conditioned-basement-slab-insulation.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>203F9BFF</checksum>
+      <checksum>3AD1768B</checksum>
     </file>
     <file>
       <filename>base-hvac-boiler-gas-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>6D6682EF</checksum>
+      <checksum>C0520473</checksum>
     </file>
     <file>
       <filename>base-hvac-boiler-oil-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>89AA2DEA</checksum>
+      <checksum>0177CF3E</checksum>
     </file>
     <file>
       <filename>base-hvac-boiler-propane-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>765FFAEC</checksum>
+      <checksum>2205C638</checksum>
     </file>
     <file>
       <filename>base-hvac-boiler-wood-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A5637ED1</checksum>
+      <checksum>D103081A</checksum>
     </file>
     <file>
       <filename>base-hvac-central-ac-only-1-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>5EE3D5F8</checksum>
+      <checksum>2140423B</checksum>
     </file>
     <file>
       <filename>base-hvac-ducts-leakage-percent.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>312EAE85</checksum>
+      <checksum>25D8BD1C</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-elec-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>667E06ED</checksum>
+      <checksum>C5578D87</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-gas-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>7768000E</checksum>
+      <checksum>27679C09</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-oil-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>5ACFEAEC</checksum>
+      <checksum>091BE412</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-propane-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>FB93480C</checksum>
+      <checksum>4D43BD45</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-wood-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A677B569</checksum>
+      <checksum>2025253B</checksum>
     </file>
     <file>
       <filename>base-hvac-none.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>DD5158C3</checksum>
+      <checksum>58EFABE9</checksum>
     </file>
     <file>
       <filename>base-hvac-programmable-thermostat.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>67A9F598</checksum>
+      <checksum>FD1EFB3D</checksum>
     </file>
     <file>
       <filename>base-hvac-setpoints.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>6DDCA156</checksum>
+      <checksum>B478E65A</checksum>
     </file>
     <file>
       <filename>base-location-baltimore-md.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC8E5CA8</checksum>
+      <checksum>C8D1794A</checksum>
     </file>
     <file>
       <filename>base-location-duluth-mn.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>35FD7F1B</checksum>
+      <checksum>41C0DD29</checksum>
     </file>
     <file>
       <filename>base-mechvent-balanced.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>2FA66CA4</checksum>
+      <checksum>08FB653B</checksum>
     </file>
     <file>
       <filename>base-mechvent-erv.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A902D929</checksum>
+      <checksum>7A6EE0FC</checksum>
     </file>
     <file>
       <filename>base-mechvent-exhaust.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>2C216698</checksum>
+      <checksum>0271CD3A</checksum>
     </file>
     <file>
       <filename>base-mechvent-hrv.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>B463D576</checksum>
+      <checksum>0EC6FE1A</checksum>
     </file>
     <file>
       <filename>base-mechvent-supply.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>26A0EF70</checksum>
+      <checksum>0782FD3D</checksum>
     </file>
     <file>
       <filename>base-hvac-air-to-air-heat-pump-1-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>EC08ED39</checksum>
+      <checksum>E5DB0A44</checksum>
     </file>
     <file>
       <filename>base-mechvent-erv-atre-asre.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>945F6161</checksum>
+      <checksum>6DE029EF</checksum>
     </file>
     <file>
       <filename>base-enclosure-windows-none.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>85570793</checksum>
+      <checksum>54BEEDD2</checksum>
     </file>
     <file>
       <filename>base-dhw-indirect-standbyloss.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>DE52E67F</checksum>
+      <checksum>FAAD10CE</checksum>
     </file>
     <file>
       <filename>base-dhw-indirect.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>661D57E1</checksum>
+      <checksum>49F079E9</checksum>
     </file>
     <file>
       <filename>base-dhw-jacket-indirect.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>621251EE</checksum>
+      <checksum>919592DF</checksum>
     </file>
     <file>
       <filename>base-hvac-undersized.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>517D7853</checksum>
+      <checksum>AE0DA295</checksum>
     </file>
     <file>
       <filename>base-atticroof-unvented-insulated-roof.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>F023310D</checksum>
+      <checksum>C5210D3B</checksum>
     </file>
     <file>
       <filename>base-pv.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>3E403207</checksum>
+      <checksum>B46787C7</checksum>
     </file>
     <file>
       <filename>base-mechvent-hrv-asre.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>56A7B588</checksum>
+      <checksum>7B2C554C</checksum>
     </file>
     <file>
       <filename>base-enclosure-overhangs.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>68182A4E</checksum>
+      <checksum>9815F099</checksum>
     </file>
     <file>
       <filename>base-atticroof-vented.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>BC8C2FD3</checksum>
+      <checksum>266738F9</checksum>
     </file>
     <file>
       <filename>base-dhw-dwhr.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>7EF87C71</checksum>
+      <checksum>7880E72C</checksum>
     </file>
     <file>
       <filename>base-enclosure-beds-4.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>70347EEE</checksum>
+      <checksum>FB9A3519</checksum>
     </file>
     <file>
       <filename>base-foundation-ambient.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>F32D3F8B</checksum>
+      <checksum>86EB3252</checksum>
     </file>
     <file>
       <filename>base-foundation-vented-crawlspace.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>D2B200CA</checksum>
+      <checksum>7ABFC23F</checksum>
     </file>
     <file>
       <filename>base-foundation-unvented-crawlspace.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>269A5503</checksum>
+      <checksum>06768418</checksum>
     </file>
     <file>
       <filename>base-hvac-central-ac-plus-air-to-air-heat-pump-heating.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>7D298B93</checksum>
+      <checksum>B6B01C03</checksum>
     </file>
     <file>
       <filename>base-hvac-air-to-air-heat-pump-2-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>ED8CF613</checksum>
+      <checksum>D1D7407C</checksum>
     </file>
     <file>
       <filename>base-hvac-central-ac-only-2-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>96A1D051</checksum>
+      <checksum>C12F7B60</checksum>
     </file>
     <file>
       <filename>base-hvac-air-to-air-heat-pump-var-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>BF15A2B2</checksum>
+      <checksum>D0DA095B</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-gas-central-ac-2-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>AB75C54D</checksum>
+      <checksum>08F8E604</checksum>
     </file>
     <file>
       <filename>base-hvac-central-ac-only-var-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>EE56C56C</checksum>
+      <checksum>12DB9D9E</checksum>
     </file>
     <file>
       <filename>base-hvac-evap-cooler-furnace-gas.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>35E745FB</checksum>
+      <checksum>3826F361</checksum>
     </file>
     <file>
       <filename>base-hvac-evap-cooler-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A4CF3B9E</checksum>
+      <checksum>780B1B1A</checksum>
     </file>
     <file>
       <filename>base-hvac-evap-cooler-only-ducted.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>4A732552</checksum>
+      <checksum>4552DB5A</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-gas-central-ac-var-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>D0FB5DE4</checksum>
+      <checksum>FEA057B6</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-gas-room-ac.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>40BE1669</checksum>
+      <checksum>1BC59957</checksum>
     </file>
     <file>
       <filename>base-hvac-room-ac-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>C5C8E945</checksum>
+      <checksum>3EAF7EBA</checksum>
     </file>
     <file>
       <filename>base-mechvent-cfis-evap-cooler-only-ducted.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>2FD607D1</checksum>
+      <checksum>B5A7E831</checksum>
     </file>
     <file>
       <filename>base-atticroof-flat.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>FE05F9C1</checksum>
+      <checksum>C4D5C7EA</checksum>
     </file>
     <file>
       <filename>extra-dhw-solar-latitude.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9319750B</checksum>
+      <checksum>1FE2B561</checksum>
     </file>
     <file>
       <filename>extra-pv-roofpitch.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>36F5EE38</checksum>
+      <checksum>18A34055</checksum>
     </file>
     <file>
       <filename>extra-auto.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>AC982503</checksum>
+      <checksum>9B55F3F7</checksum>
     </file>
     <file>
       <filename>base-hvac-boiler-elec-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A3CD8426</checksum>
+      <checksum>AD0F33E0</checksum>
     </file>
     <file>
       <filename>base-hvac-stove-oil-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>3A2653A5</checksum>
+      <checksum>8881C530</checksum>
     </file>
     <file>
       <filename>base-hvac-wall-furnace-elec-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>D979A477</checksum>
+      <checksum>D3C95A9F</checksum>
     </file>
     <file>
       <filename>base-hvac-stove-wood-pellets-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>3A730A51</checksum>
+      <checksum>AC259F52</checksum>
     </file>
     <file>
       <filename>base-mechvent-bath-kitchen-fans.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>5D173734</checksum>
+      <checksum>099E88E1</checksum>
     </file>
     <file>
       <filename>base-misc-neighbor-shading.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>39291637</checksum>
+      <checksum>F67A10F6</checksum>
     </file>
     <file>
       <filename>base-dhw-indirect-with-solar-fraction.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9062BC59</checksum>
+      <checksum>699BB252</checksum>
     </file>
     <file>
       <filename>base-location-epw-filepath-AMY-2012.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>7128E4EB</checksum>
+      <checksum>09904E59</checksum>
     </file>
     <file>
       <filename>base-location-epw-filepath.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A2ABAE6F</checksum>
+      <checksum>CA85F304</checksum>
     </file>
     <file>
       <filename>base-dhw-combi-tankless-outside.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>372A40C8</checksum>
+      <checksum>EA3FA6DA</checksum>
     </file>
     <file>
       <filename>base-dhw-combi-tankless.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>133D0115</checksum>
+      <checksum>BF1FBDDB</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-heat-pump-outside.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>BFB106D1</checksum>
+      <checksum>A93DFBCA</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-heat-pump-with-solar-fraction.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>D77AC515</checksum>
+      <checksum>57B6283B</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-heat-pump.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>57B6E197</checksum>
+      <checksum>7BA1F7F0</checksum>
     </file>
     <file>
       <filename>base-dhw-jacket-hpwh.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>01147FF0</checksum>
+      <checksum>B441819A</checksum>
     </file>
     <file>
       <filename>base-dhw-jacket-gas.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>60C5AB24</checksum>
+      <checksum>65700A1D</checksum>
     </file>
     <file>
       <filename>base-dhw-solar-direct-evacuated-tube.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B6C88B1</checksum>
+      <checksum>53C3DCFE</checksum>
     </file>
     <file>
       <filename>base-dhw-solar-direct-flat-plate.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>DAE57472</checksum>
+      <checksum>E8C48E73</checksum>
     </file>
     <file>
       <filename>base-dhw-solar-direct-ics.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>8334C084</checksum>
+      <checksum>BBDC00E2</checksum>
     </file>
     <file>
       <filename>base-dhw-solar-indirect-flat-plate.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>6B907A04</checksum>
+      <checksum>54C205AE</checksum>
     </file>
     <file>
       <filename>base-dhw-solar-thermosyphon-flat-plate.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>ADB3E9B9</checksum>
+      <checksum>4F42A5AB</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-heat-pump-with-solar.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>F42D1D18</checksum>
+      <checksum>E6172A74</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-gas-outside.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9A963B83</checksum>
+      <checksum>281D0080</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-gas.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>BDBEB522</checksum>
+      <checksum>D1454EAC</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-oil.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1A8188C</checksum>
+      <checksum>7FA5A63B</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-wood.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>C9AF888E</checksum>
+      <checksum>5790381C</checksum>
     </file>
     <file>
       <filename>base-dhw-tankless-gas-with-solar.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>02851AD9</checksum>
+      <checksum>D4B5B857</checksum>
     </file>
     <file>
       <filename>base-dhw-tankless-electric.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>CA1B21B2</checksum>
+      <checksum>0F8C1FD8</checksum>
     </file>
     <file>
       <filename>base-dhw-tankless-gas-with-solar-fraction.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>810753F4</checksum>
+      <checksum>9909DA87</checksum>
     </file>
     <file>
       <filename>base-dhw-tankless-propane.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>B36397B0</checksum>
+      <checksum>B8A93461</checksum>
     </file>
     <file>
       <filename>base-dhw-tankless-gas.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>E9D17BD7</checksum>
+      <checksum>BB8D9F7E</checksum>
     </file>
     <file>
       <filename>base-hvac-room-ac-only-33percent.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9E7A6DB7</checksum>
+      <checksum>C5D13B89</checksum>
     </file>
     <file>
       <filename>base-hvac-furnace-elec-central-ac-1-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>6E9AA0E3</checksum>
+      <checksum>E5B76FEE</checksum>
     </file>
     <file>
       <filename>base-enclosure-infil-natural-ach.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>D6DC18D1</checksum>
+      <checksum>DA9A7606</checksum>
     </file>
     <file>
       <filename>base-foundation-unconditioned-basement.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>82DF21F3</checksum>
+      <checksum>9398ECD1</checksum>
     </file>
     <file>
       <filename>base-hvac-floor-furnace-propane-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>AFD790AB</checksum>
+      <checksum>FCBA5AA6</checksum>
     </file>
     <file>
       <filename>base-enclosure-2stories-garage.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>183C8232</checksum>
+      <checksum>43A29AA5</checksum>
     </file>
     <file>
       <filename>base-enclosure-2stories.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>228FCB68</checksum>
+      <checksum>23F38967</checksum>
     </file>
     <file>
       <filename>base-foundation-slab.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9F11C50B</checksum>
+      <checksum>41F6ADF4</checksum>
     </file>
     <file>
       <filename>extra-second-refrigerator.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>E4F34EC2</checksum>
+      <checksum>ECA8B629</checksum>
     </file>
     <file>
       <filename>base-enclosure-garage.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>91D64833</checksum>
+      <checksum>945FF487</checksum>
     </file>
     <file>
       <filename>base-dhw-tank-coal.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>0AF14D78</checksum>
+      <checksum>37A0B465</checksum>
     </file>
     <file>
       <filename>base-hvac-boiler-coal-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>965C1CED</checksum>
+      <checksum>894E64B5</checksum>
     </file>
     <file>
       <filename>base-hvac-elec-resistance-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>1D7303DA</checksum>
+      <checksum>6686622C</checksum>
     </file>
     <file>
       <filename>base-simcontrol-timestep-10-mins.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>F0BBF067</checksum>
+      <checksum>66549442</checksum>
     </file>
     <file>
       <filename>base-simcontrol-daylight-saving-custom.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>6391030C</checksum>
+      <checksum>9E15E826</checksum>
     </file>
     <file>
       <filename>base-simcontrol-daylight-saving-disabled.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>85432208</checksum>
+      <checksum>E7301820</checksum>
     </file>
     <file>
       <filename>extra-second-heating-system-fireplace.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>BB768142</checksum>
+      <checksum>0A9AF574</checksum>
     </file>
     <file>
       <filename>extra-second-heating-system-portable-heater.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>2F6D6FC9</checksum>
+      <checksum>2D03C056</checksum>
     </file>
     <file>
       <filename>base-hvac-mini-split-air-conditioner-only-ducted.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>8F89F7CC</checksum>
+      <checksum>8E66E299</checksum>
     </file>
     <file>
       <filename>base-hvac-mini-split-air-conditioner-only-ductless.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>1DCD05CA</checksum>
+      <checksum>F0C79417</checksum>
     </file>
     <file>
       <filename>base-lighting-ceiling-fans.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>AF956C2E</checksum>
+      <checksum>223EB216</checksum>
     </file>
     <file>
       <filename>base-lighting-detailed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>30BCFCC5</checksum>
+      <checksum>1C2A906C</checksum>
     </file>
     <file>
       <filename>base-mechvent-whole-house-fan.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>03668040</checksum>
+      <checksum>EE5344E5</checksum>
     </file>
     <file>
       <filename>base-misc-loads-large-uncommon.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>605EEFB9</checksum>
+      <checksum>E54C6C87</checksum>
     </file>
     <file>
       <filename>base-misc-loads-large-uncommon2.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>0EF438D2</checksum>
+      <checksum>99E35E9D</checksum>
     </file>
     <file>
       <filename>base-dhw-none.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>3CB22C03</checksum>
+      <checksum>5A1B7D3C</checksum>
     </file>
     <file>
       <filename>base-enclosure-infil-flue.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>B5797AA2</checksum>
+      <checksum>DCEC452E</checksum>
     </file>
     <file>
       <filename>extra-dhw-shared-water-heater.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>768B8790</checksum>
+      <checksum>76348284</checksum>
     </file>
     <file>
       <filename>base-enclosure-infil-ach-house-pressure.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>683E368D</checksum>
+      <checksum>E3F7C52F</checksum>
     </file>
     <file>
       <filename>base-enclosure-infil-cfm-house-pressure.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>C67A24D6</checksum>
+      <checksum>55573B23</checksum>
     </file>
     <file>
       <filename>extra-pv-shared.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9DC7F1CA</checksum>
+      <checksum>6161AB1A</checksum>
     </file>
     <file>
       <filename>base-dhw-tankless-electric-outside.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>28E5EC6F</checksum>
+      <checksum>EED19042</checksum>
     </file>
     <file>
       <filename>base-enclosure-beds-5.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A61E603C</checksum>
+      <checksum>B2F298FC</checksum>
     </file>
     <file>
       <filename>base-enclosure-beds-1.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>5753F3E3</checksum>
+      <checksum>C3DDE75E</checksum>
     </file>
     <file>
       <filename>base-enclosure-beds-2.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>D68273FB</checksum>
+      <checksum>DC5CC3EE</checksum>
     </file>
     <file>
       <filename>base-hvac-boiler-gas-central-ac-1-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>FF55D023</checksum>
+      <checksum>357F836A</checksum>
     </file>
     <file>
       <filename>base-hvac-fireplace-wood-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>67593420</checksum>
+      <checksum>0764F2A6</checksum>
     </file>
     <file>
       <filename>base-hvac-ground-to-air-heat-pump.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>B026B611</checksum>
+      <checksum>F7E7909C</checksum>
     </file>
     <file>
       <filename>base-hvac-fixed-heater-gas-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>5AB1A11D</checksum>
+      <checksum>0497DBAA</checksum>
     </file>
     <file>
       <filename>base-hvac-portable-heater-gas-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>48012774</checksum>
+      <checksum>A98FBB55</checksum>
     </file>
     <file>
       <filename>base-misc-usage-multiplier.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BA9B789</checksum>
+      <checksum>45BFAE6B</checksum>
     </file>
     <file>
       <filename>base-simcontrol-runperiod-1-month.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A1A0AA64</checksum>
+      <checksum>52DA1A9C</checksum>
     </file>
     <file>
       <filename>extra-enclosure-garage-partially-protruded.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>F14FE826</checksum>
+      <checksum>26D3CFB1</checksum>
     </file>
     <file>
       <filename>base-atticroof-radiant-barrier.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>BC05D395</checksum>
+      <checksum>45D8BCFC</checksum>
     </file>
     <file>
       <filename>base-location-miami-fl.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9293C71F</checksum>
+      <checksum>A467621E</checksum>
     </file>
     <file>
       <filename>base-appliances-dehumidifier-ief.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>82A6F8AA</checksum>
+      <checksum>42E31647</checksum>
     </file>
     <file>
       <filename>base-appliances-dehumidifier.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>C4EE2227</checksum>
+      <checksum>1E282B77</checksum>
     </file>
     <file>
       <filename>base-location-dallas-tx.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>51001ABD</checksum>
+      <checksum>F2E55AED</checksum>
     </file>
     <file>
       <filename>base-appliances-dehumidifier-50percent.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>83BA717C</checksum>
+      <checksum>497AC2A7</checksum>
     </file>
     <file>
       <filename>base-foundation-unconditioned-basement-assembly-r.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>745F3C0A</checksum>
+      <checksum>0D880F72</checksum>
     </file>
     <file>
       <filename>base-foundation-unconditioned-basement-wall-insulation.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>FB3475E4</checksum>
+      <checksum>D361C0ED</checksum>
     </file>
     <file>
       <filename>base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>6973768F</checksum>
+      <checksum>5253B8D5</checksum>
     </file>
     <file>
       <filename>base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>988DC72D</checksum>
+      <checksum>EC3C2D3B</checksum>
     </file>
     <file>
       <filename>base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>42F81CA0</checksum>
+      <checksum>9C00F74B</checksum>
     </file>
     <file>
       <filename>base-hvac-mini-split-heat-pump-ducted-cooling-only.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>8108EBDE</checksum>
+      <checksum>9C89844B</checksum>
     </file>
     <file>
       <filename>base-hvac-mini-split-heat-pump-ductless.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>8A274C82</checksum>
+      <checksum>8AF86716</checksum>
     </file>
     <file>
       <filename>extra-mechvent-shared-preconditioning.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>A9A3CE45</checksum>
+      <checksum>2E458BE7</checksum>
     </file>
     <file>
       <filename>extra-mechvent-shared.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>B853049D</checksum>
+      <checksum>E391F54D</checksum>
     </file>
     <file>
       <filename>base-appliances-coal.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>3C5869EE</checksum>
+      <checksum>F9AF0BFC</checksum>
     </file>
     <file>
       <filename>base-appliances-gas.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>44579799</checksum>
+      <checksum>B8AB0B6A</checksum>
     </file>
     <file>
       <filename>base-appliances-modified.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>E464A243</checksum>
+      <checksum>BAFE95D0</checksum>
     </file>
     <file>
       <filename>base-appliances-oil.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>D6D9AB2D</checksum>
+      <checksum>88CEBC4F</checksum>
     </file>
     <file>
       <filename>base-appliances-propane.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>EB84925E</checksum>
+      <checksum>A367B4A6</checksum>
     </file>
     <file>
       <filename>base-appliances-wood.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
-      <checksum>9BC91FA3</checksum>
+      <checksum>39838144</checksum>
+    </file>
+    <file>
+      <filename>base-misc-defaults.osw</filename>
+      <filetype>osw</filetype>
+      <usage_type>test</usage_type>
+      <checksum>5F14793E</checksum>
     </file>
     <file>
       <version>
@@ -7320,25 +7317,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0EE1BE55</checksum>
-    </file>
-    <file>
-      <filename>base-misc-defaults.osw</filename>
-      <filetype>osw</filetype>
-      <usage_type>test</usage_type>
-      <checksum>EC3A442A</checksum>
-    </file>
-    <file>
-      <filename>test_measure.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>2B020881</checksum>
-    </file>
-    <file>
-      <filename>test_rakefile.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>DA2FBD91</checksum>
+      <checksum>3BC1BF88</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/resources/location.rb
+++ b/BuildResidentialHPXML/resources/location.rb
@@ -16,7 +16,7 @@ class Location
 
     require 'csv'
     CSV.foreach(zones_csv) do |row|
-      return row[6].to_s if row[0].to_s == wmo.to_s
+      return row[6].to_s if row[0].to_s == wmo
     end
 
     return

--- a/BuildResidentialHPXML/tests/base-appliances-coal.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-coal.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-dehumidifier-50percent.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-dehumidifier-50percent.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_TX_Dallas-Fort.Worth.Intl.AP.722590_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-dehumidifier-ief.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-dehumidifier-ief.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_TX_Dallas-Fort.Worth.Intl.AP.722590_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-dehumidifier.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-dehumidifier.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_TX_Dallas-Fort.Worth.Intl.AP.722590_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-gas.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-gas.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-modified.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-modified.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-none.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-none.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-oil.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-oil.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-propane.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-propane.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-appliances-wood.osw
+++ b/BuildResidentialHPXML/tests/base-appliances-wood.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-atticroof-flat.osw
+++ b/BuildResidentialHPXML/tests/base-atticroof-flat.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-atticroof-radiant-barrier.osw
+++ b/BuildResidentialHPXML/tests/base-atticroof-radiant-barrier.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_TX_Dallas-Fort.Worth.Intl.AP.722590_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-atticroof-unvented-insulated-roof.osw
+++ b/BuildResidentialHPXML/tests/base-atticroof-unvented-insulated-roof.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-atticroof-vented.osw
+++ b/BuildResidentialHPXML/tests/base-atticroof-vented.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-combi-tankless-outside.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-combi-tankless-outside.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "space-heating boiler with tankless coil",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-combi-tankless.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-combi-tankless.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "space-heating boiler with tankless coil",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-dwhr.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-dwhr.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-indirect-outside.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-indirect-outside.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "space-heating boiler with storage tank",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-indirect-standbyloss.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-indirect-standbyloss.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 1.0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "space-heating boiler with storage tank",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-indirect-with-solar-fraction.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-indirect-with-solar-fraction.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "space-heating boiler with storage tank",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-indirect.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-indirect.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "space-heating boiler with storage tank",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-jacket-electric.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-jacket-electric.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-jacket-gas.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-jacket-gas.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-jacket-hpwh.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-jacket-hpwh.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "80",
         "water_heater_type": "heat pump water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-jacket-indirect.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-jacket-indirect.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "space-heating boiler with storage tank",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-low-flow-fixtures.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-low-flow-fixtures.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-none.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-none.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "none",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-recirc-demand.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-recirc-demand.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-recirc-manual.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-recirc-manual.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-recirc-nocontrol.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-recirc-nocontrol.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-recirc-temperature.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-recirc-temperature.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-recirc-timer.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-recirc-timer.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-solar-direct-evacuated-tube.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-solar-direct-evacuated-tube.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-solar-direct-flat-plate.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-solar-direct-flat-plate.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-solar-direct-ics.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-solar-direct-ics.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-solar-fraction.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-solar-fraction.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-solar-indirect-flat-plate.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-solar-indirect-flat-plate.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-solar-thermosyphon-flat-plate.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-solar-thermosyphon-flat-plate.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-coal.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-coal.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-gas-outside.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-gas-outside.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-gas.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-gas.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-heat-pump-outside.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-heat-pump-outside.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "80",
         "water_heater_type": "heat pump water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-heat-pump-with-solar-fraction.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-heat-pump-with-solar-fraction.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "80",
         "water_heater_type": "heat pump water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-heat-pump-with-solar.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-heat-pump-with-solar.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "80",
         "water_heater_type": "heat pump water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-heat-pump.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-heat-pump.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "80",
         "water_heater_type": "heat pump water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-oil.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-oil.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tank-wood.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tank-wood.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "50",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tankless-electric-outside.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tankless-electric-outside.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "instantaneous water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tankless-electric.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tankless-electric.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "instantaneous water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tankless-gas-with-solar-fraction.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tankless-gas-with-solar-fraction.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "instantaneous water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tankless-gas-with-solar.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tankless-gas-with-solar.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "instantaneous water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tankless-gas.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tankless-gas.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "instantaneous water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-tankless-propane.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-tankless-propane.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "instantaneous water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-dhw-uef.osw
+++ b/BuildResidentialHPXML/tests/base-dhw-uef.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-2stories-garage.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-2stories-garage.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-2stories.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-2stories.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-beds-1.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-beds-1.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-beds-2.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-beds-2.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-beds-4.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-beds-4.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-beds-5.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-beds-5.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-garage.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-garage.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-infil-ach-house-pressure.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-infil-ach-house-pressure.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-infil-cfm-house-pressure.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-infil-cfm-house-pressure.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-infil-cfm50.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-infil-cfm50.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-infil-flue.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-infil-flue.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-infil-natural-ach.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-infil-natural-ach.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-overhangs.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-overhangs.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-enclosure-windows-none.osw
+++ b/BuildResidentialHPXML/tests/base-enclosure-windows-none.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-foundation-ambient.osw
+++ b/BuildResidentialHPXML/tests/base-foundation-ambient.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-foundation-conditioned-basement-slab-insulation.osw
+++ b/BuildResidentialHPXML/tests/base-foundation-conditioned-basement-slab-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-foundation-slab.osw
+++ b/BuildResidentialHPXML/tests/base-foundation-slab.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-foundation-unconditioned-basement-assembly-r.osw
+++ b/BuildResidentialHPXML/tests/base-foundation-unconditioned-basement-assembly-r.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-foundation-unconditioned-basement-wall-insulation.osw
+++ b/BuildResidentialHPXML/tests/base-foundation-unconditioned-basement-wall-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-foundation-unconditioned-basement.osw
+++ b/BuildResidentialHPXML/tests/base-foundation-unconditioned-basement.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-foundation-unvented-crawlspace.osw
+++ b/BuildResidentialHPXML/tests/base-foundation-unvented-crawlspace.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-foundation-vented-crawlspace.osw
+++ b/BuildResidentialHPXML/tests/base-foundation-vented-crawlspace.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-air-to-air-heat-pump-1-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-air-to-air-heat-pump-1-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-air-to-air-heat-pump-2-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-air-to-air-heat-pump-2-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-air-to-air-heat-pump-var-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-air-to-air-heat-pump-var-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-boiler-coal-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-boiler-coal-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-boiler-elec-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-boiler-elec-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-boiler-gas-central-ac-1-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-boiler-gas-central-ac-1-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-boiler-gas-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-boiler-gas-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-boiler-oil-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-boiler-oil-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-boiler-propane-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-boiler-propane-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-boiler-wood-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-boiler-wood-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-central-ac-only-1-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-central-ac-only-1-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-central-ac-only-2-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-central-ac-only-2-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-central-ac-only-var-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-central-ac-only-var-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-dual-fuel-mini-split-heat-pump-ducted.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-dual-fuel-mini-split-heat-pump-ducted.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-ducts-leakage-percent.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-ducts-leakage-percent.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-elec-resistance-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-elec-resistance-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-evap-cooler-furnace-gas.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-evap-cooler-furnace-gas.osw
@@ -391,7 +391,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-evap-cooler-only-ducted.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-evap-cooler-only-ducted.osw
@@ -391,7 +391,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-evap-cooler-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-evap-cooler-only.osw
@@ -391,7 +391,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-fireplace-wood-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-fireplace-wood-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-fixed-heater-gas-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-fixed-heater-gas-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-floor-furnace-propane-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-floor-furnace-propane-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-elec-central-ac-1-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-elec-central-ac-1-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-elec-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-elec-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-gas-central-ac-2-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-gas-central-ac-2-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-gas-central-ac-var-speed.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-gas-central-ac-var-speed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-gas-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-gas-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-gas-room-ac.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-gas-room-ac.osw
@@ -392,7 +392,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-oil-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-oil-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-propane-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-propane-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-furnace-wood-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-furnace-wood-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-ground-to-air-heat-pump.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-ground-to-air-heat-pump.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-mini-split-air-conditioner-only-ducted.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-mini-split-air-conditioner-only-ducted.osw
@@ -392,7 +392,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-mini-split-air-conditioner-only-ductless.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-mini-split-air-conditioner-only-ductless.osw
@@ -392,7 +392,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-mini-split-heat-pump-ducted-cooling-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-mini-split-heat-pump-ducted-cooling-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-mini-split-heat-pump-ducted-heating-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-mini-split-heat-pump-ducted-heating-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-mini-split-heat-pump-ducted.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-mini-split-heat-pump-ducted.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-mini-split-heat-pump-ductless.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-mini-split-heat-pump-ductless.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-none.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-none.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-portable-heater-gas-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-portable-heater-gas-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-programmable-thermostat.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-programmable-thermostat.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-room-ac-only-33percent.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-room-ac-only-33percent.osw
@@ -392,7 +392,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-room-ac-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-room-ac-only.osw
@@ -392,7 +392,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-setpoints.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-setpoints.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-stove-oil-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-stove-oil-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-stove-wood-pellets-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-stove-wood-pellets-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-undersized.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-undersized.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-hvac-wall-furnace-elec-only.osw
+++ b/BuildResidentialHPXML/tests/base-hvac-wall-furnace-elec-only.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-lighting-ceiling-fans.osw
+++ b/BuildResidentialHPXML/tests/base-lighting-ceiling-fans.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-lighting-detailed.osw
+++ b/BuildResidentialHPXML/tests/base-lighting-detailed.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-location-baltimore-md.osw
+++ b/BuildResidentialHPXML/tests/base-location-baltimore-md.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_MD_Baltimore-Washington.Intl.AP.724060_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-location-dallas-tx.osw
+++ b/BuildResidentialHPXML/tests/base-location-dallas-tx.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_TX_Dallas-Fort.Worth.Intl.AP.722590_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-location-duluth-mn.osw
+++ b/BuildResidentialHPXML/tests/base-location-duluth-mn.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_MN_Duluth.Intl.AP.727450_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-location-epw-filepath-AMY-2012.osw
+++ b/BuildResidentialHPXML/tests/base-location-epw-filepath-AMY-2012.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "US_CO_Boulder_AMY_2012.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-location-epw-filepath.osw
+++ b/BuildResidentialHPXML/tests/base-location-epw-filepath.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-location-miami-fl.osw
+++ b/BuildResidentialHPXML/tests/base-location-miami-fl.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_FL_Miami.Intl.AP.722020_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-balanced.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-balanced.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-bath-kitchen-fans.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-bath-kitchen-fans.osw
@@ -403,7 +403,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-cfis-evap-cooler-only-ducted.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-cfis-evap-cooler-only-ducted.osw
@@ -391,7 +391,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-cfis.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-cfis.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-erv-atre-asre.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-erv-atre-asre.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-erv.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-erv.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-exhaust.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-exhaust.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-hrv-asre.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-hrv-asre.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-hrv.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-hrv.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-supply.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-supply.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-mechvent-whole-house-fan.osw
+++ b/BuildResidentialHPXML/tests/base-mechvent-whole-house-fan.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-misc-defaults.osw
+++ b/BuildResidentialHPXML/tests/base-misc-defaults.osw
@@ -383,7 +383,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-misc-loads-large-uncommon.osw
+++ b/BuildResidentialHPXML/tests/base-misc-loads-large-uncommon.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-misc-loads-large-uncommon2.osw
+++ b/BuildResidentialHPXML/tests/base-misc-loads-large-uncommon2.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-misc-neighbor-shading.osw
+++ b/BuildResidentialHPXML/tests/base-misc-neighbor-shading.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-misc-usage-multiplier.osw
+++ b/BuildResidentialHPXML/tests/base-misc-usage-multiplier.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-multifamily.osw
+++ b/BuildResidentialHPXML/tests/base-multifamily.osw
@@ -396,7 +396,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-pv.osw
+++ b/BuildResidentialHPXML/tests/base-pv.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-simcontrol-daylight-saving-custom.osw
+++ b/BuildResidentialHPXML/tests/base-simcontrol-daylight-saving-custom.osw
@@ -398,7 +398,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-simcontrol-daylight-saving-disabled.osw
+++ b/BuildResidentialHPXML/tests/base-simcontrol-daylight-saving-disabled.osw
@@ -394,7 +394,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-simcontrol-runperiod-1-month.osw
+++ b/BuildResidentialHPXML/tests/base-simcontrol-runperiod-1-month.osw
@@ -397,7 +397,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-simcontrol-timestep-10-mins.osw
+++ b/BuildResidentialHPXML/tests/base-simcontrol-timestep-10-mins.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base-single-family-attached.osw
+++ b/BuildResidentialHPXML/tests/base-single-family-attached.osw
@@ -395,7 +395,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/base.osw
+++ b/BuildResidentialHPXML/tests/base.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-auto.osw
+++ b/BuildResidentialHPXML/tests/extra-auto.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "auto",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-dhw-shared-water-heater.osw
+++ b/BuildResidentialHPXML/tests/extra-dhw-shared-water-heater.osw
@@ -395,7 +395,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-dhw-solar-latitude.osw
+++ b/BuildResidentialHPXML/tests/extra-dhw-solar-latitude.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-enclosure-garage-partially-protruded.osw
+++ b/BuildResidentialHPXML/tests/extra-enclosure-garage-partially-protruded.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-mechvent-shared-preconditioning.osw
+++ b/BuildResidentialHPXML/tests/extra-mechvent-shared-preconditioning.osw
@@ -403,7 +403,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-mechvent-shared.osw
+++ b/BuildResidentialHPXML/tests/extra-mechvent-shared.osw
@@ -397,7 +397,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-pv-roofpitch.osw
+++ b/BuildResidentialHPXML/tests/extra-pv-roofpitch.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-pv-shared.osw
+++ b/BuildResidentialHPXML/tests/extra-pv-shared.osw
@@ -396,7 +396,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-second-heating-system-fireplace.osw
+++ b/BuildResidentialHPXML/tests/extra-second-heating-system-fireplace.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-second-heating-system-portable-heater.osw
+++ b/BuildResidentialHPXML/tests/extra-second-heating-system-portable-heater.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/extra-second-refrigerator.osw
+++ b/BuildResidentialHPXML/tests/extra-second-refrigerator.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/conditioned-attic-with-floor-insulation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/conditioned-attic-with-floor-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/conditioned-basement-with-ceiling-insulation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/conditioned-basement-with-ceiling-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/cooling-system-and-heat-pump.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/cooling-system-and-heat-pump.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/dhw-indirect-without-boiler.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/dhw-indirect-without-boiler.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "space-heating boiler with storage tank",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/ducts-location-and-areas-not-same-type.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/ducts-location-and-areas-not-same-type.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/heating-system-and-heat-pump.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/heating-system-and-heat-pump.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/multifamily-bottom-crawlspace-zero-foundation-height.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/multifamily-bottom-crawlspace-zero-foundation-height.osw
@@ -396,7 +396,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/multifamily-bottom-slab-non-zero-foundation-height.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/multifamily-bottom-slab-non-zero-foundation-height.osw
@@ -396,7 +396,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/multifamily-no-building-orientation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/multifamily-no-building-orientation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/non-electric-heat-pump-water-heater.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/non-electric-heat-pump-water-heater.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "heat pump water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/non-integer-ceiling-fan-quantity.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/non-integer-ceiling-fan-quantity.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/non-integer-geometry-num-bathrooms.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/non-integer-geometry-num-bathrooms.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/second-heating-system-serves-majority-heat.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/second-heating-system-serves-majority-heat.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/single-family-attached-ambient.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/single-family-attached-ambient.osw
@@ -395,7 +395,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/single-family-attached-no-building-orientation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/single-family-attached-no-building-orientation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/single-family-detached-finished-basement-zero-foundation-height.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/single-family-detached-finished-basement-zero-foundation-height.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/single-family-detached-slab-non-zero-foundation-height.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/single-family-detached-slab-non-zero-foundation-height.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/slab-non-zero-foundation-height-above-grade.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/slab-non-zero-foundation-height-above-grade.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/unconditioned-basement-with-wall-and-ceiling-insulation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/unconditioned-basement-with-wall-and-ceiling-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/unvented-attic-with-floor-and-roof-insulation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/unvented-attic-with-floor-and-roof-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/unvented-crawlspace-with-wall-and-ceiling-insulation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/unvented-crawlspace-with-wall-and-ceiling-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/vented-attic-with-floor-and-roof-insulation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/vented-attic-with-floor-and-roof-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/BuildResidentialHPXML/tests/invalid_files/vented-crawlspace-with-wall-and-ceiling-insulation.osw
+++ b/BuildResidentialHPXML/tests/invalid_files/vented-crawlspace-with-wall-and-ceiling-insulation.osw
@@ -393,7 +393,6 @@
         "water_heater_standby_loss": 0,
         "water_heater_tank_volume": "40",
         "water_heater_type": "storage water heater",
-        "weather_dir": "weather",
         "weather_station_epw_filepath": "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
         "whole_house_fan_flow_rate": 4500,
         "whole_house_fan_power": 300,

--- a/tasks.rb
+++ b/tasks.rb
@@ -328,7 +328,6 @@ def get_values(osw_file, step)
   step.setArgument('hpxml_path', "../BuildResidentialHPXML/tests/built_residential_hpxml/#{File.basename(osw_file, '.*')}.xml")
 
   if ['base.osw'].include? osw_file
-    step.setArgument('weather_dir', 'weather')
     step.setArgument('simulation_control_timestep', '60')
     step.setArgument('weather_station_epw_filepath', 'USA_CO_Denver.Intl.AP.725650_TMY3.epw')
     step.setArgument('site_type', HPXML::SiteTypeSuburban)


### PR DESCRIPTION
## Pull Request Description

Remove creation of weather object/cache; use OpenStudio::EpwFile instead.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
