### PR TITLE
Prevent stacked DHW recirculation systems

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>73f0192e-b20b-4b68-b782-26e8f0865e74</version_id>
-  <version_modified>20201009T184358Z</version_modified>
+  <version_id>a9656667-55a4-4722-b8d4-b7490d2528f1</version_id>
+  <version_modified>20201009T191202Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -498,7 +498,7 @@
       <filename>EPvalidator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
-      <checksum>E2A0CE2C</checksum>
+      <checksum>A8B55E7F</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>03a9a7dd-ca70-47a9-b656-b8109b97f8ae</version_id>
-  <version_modified>20201009T174401Z</version_modified>
+  <version_id>73f0192e-b20b-4b68-b782-26e8f0865e74</version_id>
+  <version_modified>20201009T184358Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -454,12 +454,6 @@
       <checksum>C13E66F3</checksum>
     </file>
     <file>
-      <filename>EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D6248B33</checksum>
-    </file>
-    <file>
       <filename>location.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -499,6 +493,12 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>B85986E1</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>E2A0CE2C</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.xml
@@ -866,6 +866,7 @@
 
   <sch:pattern name='[HotWaterDistributionType=Recirculation]'>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:WaterHeating/h:HotWaterDistribution/h:SystemType/h:Recirculation'>
+      <sch:assert role='ERROR' test='count(../../h:SystemType/h:Standard) = 1'>Expected 1 element(s) for xpath: ../../SystemType/Standard</sch:assert>
       <sch:assert role='ERROR' test='count(h:ControlType[text()="manual demand control" or text()="presence sensor demand control" or text()="temperature" or text()="timer" or text()="no control"]) = 1'>Expected 1 element(s) for xpath: ControlType[text()="manual demand control" or text()="presence sensor demand control" or text()="temperature" or text()="timer" or text()="no control"]</sch:assert>
       <sch:assert role='ERROR' test='count(h:RecirculationPipingLoopLength) &lt;= 1'>Expected 0 or 1 element(s) for xpath: RecirculationPipingLoopLength</sch:assert>
       <sch:assert role='ERROR' test='count(h:BranchPipingLoopLength) &lt;= 1'>Expected 0 or 1 element(s) for xpath: BranchPipingLoopLength</sch:assert>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.xml
@@ -866,7 +866,6 @@
 
   <sch:pattern name='[HotWaterDistributionType=Recirculation]'>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:WaterHeating/h:HotWaterDistribution/h:SystemType/h:Recirculation'>
-      <sch:assert role='ERROR' test='count(../../h:SystemType/h:Standard) = 1'>Expected 1 element(s) for xpath: ../../SystemType/Standard</sch:assert>
       <sch:assert role='ERROR' test='count(h:ControlType[text()="manual demand control" or text()="presence sensor demand control" or text()="temperature" or text()="timer" or text()="no control"]) = 1'>Expected 1 element(s) for xpath: ControlType[text()="manual demand control" or text()="presence sensor demand control" or text()="temperature" or text()="timer" or text()="no control"]</sch:assert>
       <sch:assert role='ERROR' test='count(h:RecirculationPipingLoopLength) &lt;= 1'>Expected 0 or 1 element(s) for xpath: RecirculationPipingLoopLength</sch:assert>
       <sch:assert role='ERROR' test='count(h:BranchPipingLoopLength) &lt;= 1'>Expected 0 or 1 element(s) for xpath: BranchPipingLoopLength</sch:assert>
@@ -877,6 +876,7 @@
   <sch:pattern name='[HotWaterDistributionType=SharedRecirculation]'>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:WaterHeating/h:HotWaterDistribution[h:extension/h:SharedRecirculation]'>
       <sch:assert role='ERROR' test='count(../../../h:BuildingSummary/h:BuildingConstruction[h:ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]) = 1'>Expected 1 element(s) for xpath: ../../../BuildingSummary/BuildingConstruction[ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]</sch:assert>
+      <sch:assert role='ERROR' test='count(h:SystemType/h:Standard) = 1'>Expected 1 element(s) for xpath: SystemType/Standard</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:SharedRecirculation/h:NumberofUnitsServed) = 1'>Expected 1 element(s) for xpath: extension/SharedRecirculation/NumberofUnitsServed</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:SharedRecirculation/h:PumpPower) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/SharedRecirculation/PumpPower</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:SharedRecirculation/h:ControlType[text()="manual demand control" or text()="presence sensor demand control" or text()="timer" or text()="no control"]) = 1'>Expected 1 element(s) for xpath: extension/SharedRecirculation/ControlType[text()="manual demand control" or text()="presence sensor demand control" or text()="timer" or text()="no control"]</sch:assert>

--- a/docs/source/hpxml_to_openstudio.rst
+++ b/docs/source/hpxml_to_openstudio.rst
@@ -913,7 +913,7 @@ For a ``SystemType/Recirculation`` system within the dwelling unit, the followin
 Shared Recirculation
 ~~~~~~~~~~~~~~~~~~~~
 
-In addition to the hot water distribution systems within the dwelling unit, the pump energy use of a shared recirculation system can also be described using the following elements:
+In addition to the hot water distribution systems within the dwelling unit, the pump energy use of a shared recirculation system in an Attached/Multifamily building can also be described using the following elements:
 
 - `extension/SharedRecirculation/NumberofUnitsServed`: Number of dwelling units served by the shared pump.
 - `extension/SharedRecirculation/PumpPower`: Optional. If not provided, the default value will be assumed as shown in the table below. Shared pump power in Watts.
@@ -924,6 +924,9 @@ In addition to the hot water distribution systems within the dwelling unit, the 
   ==================================  ==========================================
   Pump Power [W]                      220 (0.25 HP pump w/ 85% motor efficiency)
   ==================================  ==========================================
+
+Note that when defining a shared recirculation system, the hot water distribution system type within the dwelling unit must be standard (``SystemType/Standard``).
+This is because a stacked recirculation system (i.e., shared recirculation loop plus an additional recirculation system within the dwelling unit) is more likely to indicate input errors than reflect an actual real-world scenario.
 
 Drain Water Heat Recovery
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Description

Stacked hot water recirculation systems (i.e., shared recirculation loop plus an additional recirculation system within the dwelling unit) for attached/multifamily buildings now generate an error. Such inputs are more likely to be erroneous than reflect an actual real-world scenario. When defining a shared recirculation system, the hot water distribution system type within the dwelling unit must now be standard (`SystemType/Standard`).

## Checklist

Not all may apply:

- [x] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
