### PR TITLE
Switch to OpenStudio.getOpenStudioCLI

### DIFF
--- a/tasks.rb
+++ b/tasks.rb
@@ -5354,7 +5354,7 @@ if ARGV[0].to_sym == :create_release_zips
   if not ENV['CI']
     # Run ASHRAE 140 files
     puts 'Running ASHRAE 140 tests (this will take a minute)...'
-    command = 'openstudio workflow/tests/hpxml_translator_test.rb --name=test_ashrae_140 > log.txt'
+    command = "#{OpenStudio.getOpenStudioCLI} workflow/tests/hpxml_translator_test.rb --name=test_ashrae_140 > log.txt"
     system(command)
     results_csv_path = 'workflow/tests/results/results_ashrae_140.csv'
     if not File.exist? results_csv_path

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -269,7 +269,7 @@ class HPXMLTest < MiniTest::Test
   def test_release_zips
     # Check release zips successfully created
     top_dir = File.join(@this_dir, '..', '..')
-    command = "openstudio #{File.join(top_dir, 'tasks.rb')} create_release_zips"
+    command = "#{OpenStudio.getOpenStudioCLI} #{File.join(top_dir, 'tasks.rb')} create_release_zips"
     system(command)
     assert_equal(2, Dir["#{top_dir}/*.zip"].size)
 
@@ -277,7 +277,7 @@ class HPXMLTest < MiniTest::Test
     Dir["#{top_dir}/OpenStudio-HPXML*.zip"].each do |zip|
       unzip_file = OpenStudio::UnzipFile.new(zip)
       unzip_file.extractAllFiles(OpenStudio::toPath(top_dir))
-      command = 'openstudio OpenStudio-HPXML/workflow/run_simulation.rb -x OpenStudio-HPXML/workflow/sample_files/base.xml'
+      command = "#{OpenStudio.getOpenStudioCLI} OpenStudio-HPXML/workflow/run_simulation.rb -x OpenStudio-HPXML/workflow/sample_files/base.xml"
       system(command)
       assert(File.exist? 'OpenStudio-HPXML/workflow/sample_files/run/results_annual.csv')
       File.delete(zip)


### PR DESCRIPTION
## Pull Request Description

Minor change. Replaces hardcoded "openstudio" with OpenStudio.getOpenStudioCLI.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
