### PR TITLE
Missing HPWH fan energy

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>004404fb-8a4e-43fc-a7d0-253018d7bdb4</version_id>
-  <version_modified>20201030T004842Z</version_modified>
+  <version_id>9da49409-f019-428d-bdeb-65674f1076ad</version_id>
+  <version_modified>20201109T214630Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -418,12 +418,6 @@
       <checksum>942C3E5E</checksum>
     </file>
     <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>85798EEC</checksum>
-    </file>
-    <file>
       <filename>test_water_heater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -505,6 +499,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>E4CE9FD0</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>8CC67A4B</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -145,6 +145,7 @@ class Waterheater
 
     # Fan:OnOff
     fan = setup_hpwh_fan(hpwh, obj_name_hpwh, airflow_rate)
+    dhw_map[water_heating_system.id] << fan
 
     # Amb temp & RH sensors, temp sensor shared across programs
     amb_temp_sensor, amb_rh_sensors = get_loc_temp_rh_sensors(model, obj_name_hpwh, loc_schedule, loc_space, living_zone)

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -2276,7 +2276,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     def self.WaterHeating(fuel)
       return { 'OpenStudio::Model::WaterHeaterMixed' => ["Water Heater #{fuel} Energy", "Water Heater Off Cycle Parasitic #{fuel} Energy", "Water Heater On Cycle Parasitic #{fuel} Energy"],
                'OpenStudio::Model::WaterHeaterStratified' => ["Water Heater #{fuel} Energy", "Water Heater Off Cycle Parasitic #{fuel} Energy", "Water Heater On Cycle Parasitic #{fuel} Energy"],
-               'OpenStudio::Model::CoilWaterHeatingAirToWaterHeatPumpWrapped' => ["Cooling Coil Water Heating #{fuel} Energy"] }
+               'OpenStudio::Model::CoilWaterHeatingAirToWaterHeatPumpWrapped' => ["Cooling Coil Water Heating #{fuel} Energy"],
+               'OpenStudio::Model::FanOnOff' => ["Fan #{fuel} Energy"] }
     end
 
     def self.WaterHeatingLoad

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>3a615bce-d44b-4fb7-a4f5-327ad0877fd4</version_id>
-  <version_modified>20201020T182846Z</version_modified>
+  <version_id>23138be1-8dbf-478b-b687-f7d6d0df8b06</version_id>
+  <version_modified>20201109T214630Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -16,7 +16,6 @@
       <display_name>Timeseries Reporting Frequency</display_name>
       <description>The frequency at which to report timeseries output data. Using 'none' will disable timeseries outputs.</description>
       <type>Choice</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>none</default_value>
@@ -42,15 +41,12 @@
           <display_name>monthly</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_fuel_consumptions</name>
       <display_name>Generate Timeseries Output: Fuel Consumptions</display_name>
       <description>Generates timeseries energy consumptions for each fuel type.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -64,15 +60,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_end_use_consumptions</name>
       <display_name>Generate Timeseries Output: End Use Consumptions</display_name>
       <description>Generates timeseries energy consumptions for each end use.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -86,15 +79,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_hot_water_uses</name>
       <display_name>Generate Timeseries Output: Hot Water Uses</display_name>
       <description>Generates timeseries hot water usages for each end use.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -108,15 +98,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_total_loads</name>
       <display_name>Generate Timeseries Output: Total Loads</display_name>
       <description>Generates timeseries heating/cooling loads.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -130,15 +117,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_component_loads</name>
       <display_name>Generate Timeseries Output: Component Loads</display_name>
       <description>Generates timeseries heating/cooling loads disaggregated by component type.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -152,15 +136,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_zone_temperatures</name>
       <display_name>Generate Timeseries Output: Zone Temperatures</display_name>
       <description>Generates timeseries temperatures for each thermal zone.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -174,15 +155,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_airflows</name>
       <display_name>Generate Timeseries Output: Airflows</display_name>
       <description>Generates timeseries airflows.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -196,15 +174,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_weather</name>
       <display_name>Generate Timeseries Output: Weather</display_name>
       <description>Generates timeseries weather data.</description>
       <type>Boolean</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -218,8 +193,6 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
   </arguments>
   <outputs>
@@ -227,792 +200,616 @@
       <name>Electricity: Total MBtu</name>
       <display_name>Electricity: Total MBtu</display_name>
       <short_name>Electricity: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Total MBtu</name>
       <display_name>Natural Gas: Total MBtu</display_name>
       <short_name>Natural Gas: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Total MBtu</name>
       <display_name>Fuel Oil: Total MBtu</display_name>
       <short_name>Fuel Oil: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Total MBtu</name>
       <display_name>Propane: Total MBtu</display_name>
       <short_name>Propane: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Total MBtu</name>
       <display_name>Wood Cord: Total MBtu</display_name>
       <short_name>Wood Cord: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Total MBtu</name>
       <display_name>Wood Pellets: Total MBtu</display_name>
       <short_name>Wood Pellets: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Total MBtu</name>
       <display_name>Coal: Total MBtu</display_name>
       <short_name>Coal: Total MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Heating MBtu</name>
       <display_name>Electricity: Heating MBtu</display_name>
       <short_name>Electricity: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Heating Fans/Pumps MBtu</name>
       <display_name>Electricity: Heating Fans/Pumps MBtu</display_name>
       <short_name>Electricity: Heating Fans/Pumps MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Cooling MBtu</name>
       <display_name>Electricity: Cooling MBtu</display_name>
       <short_name>Electricity: Cooling MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Cooling Fans/Pumps MBtu</name>
       <display_name>Electricity: Cooling Fans/Pumps MBtu</display_name>
       <short_name>Electricity: Cooling Fans/Pumps MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Water MBtu</name>
       <display_name>Electricity: Hot Water MBtu</display_name>
       <short_name>Electricity: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Water Recirc Pump MBtu</name>
       <display_name>Electricity: Hot Water Recirc Pump MBtu</display_name>
       <short_name>Electricity: Hot Water Recirc Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Water Solar Thermal Pump MBtu</name>
       <display_name>Electricity: Hot Water Solar Thermal Pump MBtu</display_name>
       <short_name>Electricity: Hot Water Solar Thermal Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Lighting Interior MBtu</name>
       <display_name>Electricity: Lighting Interior MBtu</display_name>
       <short_name>Electricity: Lighting Interior MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Lighting Garage MBtu</name>
       <display_name>Electricity: Lighting Garage MBtu</display_name>
       <short_name>Electricity: Lighting Garage MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Lighting Exterior MBtu</name>
       <display_name>Electricity: Lighting Exterior MBtu</display_name>
       <short_name>Electricity: Lighting Exterior MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Mech Vent MBtu</name>
       <display_name>Electricity: Mech Vent MBtu</display_name>
       <short_name>Electricity: Mech Vent MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Mech Vent Preheating MBtu</name>
       <display_name>Electricity: Mech Vent Preheating MBtu</display_name>
       <short_name>Electricity: Mech Vent Preheating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Mech Vent Precooling MBtu</name>
       <display_name>Electricity: Mech Vent Precooling MBtu</display_name>
       <short_name>Electricity: Mech Vent Precooling MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Whole House Fan MBtu</name>
       <display_name>Electricity: Whole House Fan MBtu</display_name>
       <short_name>Electricity: Whole House Fan MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Refrigerator MBtu</name>
       <display_name>Electricity: Refrigerator MBtu</display_name>
       <short_name>Electricity: Refrigerator MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Freezer MBtu</name>
       <display_name>Electricity: Freezer MBtu</display_name>
       <short_name>Electricity: Freezer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Dehumidifier MBtu</name>
       <display_name>Electricity: Dehumidifier MBtu</display_name>
       <short_name>Electricity: Dehumidifier MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Dishwasher MBtu</name>
       <display_name>Electricity: Dishwasher MBtu</display_name>
       <short_name>Electricity: Dishwasher MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Clothes Washer MBtu</name>
       <display_name>Electricity: Clothes Washer MBtu</display_name>
       <short_name>Electricity: Clothes Washer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Clothes Dryer MBtu</name>
       <display_name>Electricity: Clothes Dryer MBtu</display_name>
       <short_name>Electricity: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Range/Oven MBtu</name>
       <display_name>Electricity: Range/Oven MBtu</display_name>
       <short_name>Electricity: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Ceiling Fan MBtu</name>
       <display_name>Electricity: Ceiling Fan MBtu</display_name>
       <short_name>Electricity: Ceiling Fan MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Television MBtu</name>
       <display_name>Electricity: Television MBtu</display_name>
       <short_name>Electricity: Television MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Plug Loads MBtu</name>
       <display_name>Electricity: Plug Loads MBtu</display_name>
       <short_name>Electricity: Plug Loads MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Electric Vehicle Charging MBtu</name>
       <display_name>Electricity: Electric Vehicle Charging MBtu</display_name>
       <short_name>Electricity: Electric Vehicle Charging MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Well Pump MBtu</name>
       <display_name>Electricity: Well Pump MBtu</display_name>
       <short_name>Electricity: Well Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Pool Heater MBtu</name>
       <display_name>Electricity: Pool Heater MBtu</display_name>
       <short_name>Electricity: Pool Heater MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Pool Pump MBtu</name>
       <display_name>Electricity: Pool Pump MBtu</display_name>
       <short_name>Electricity: Pool Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Tub Heater MBtu</name>
       <display_name>Electricity: Hot Tub Heater MBtu</display_name>
       <short_name>Electricity: Hot Tub Heater MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: Hot Tub Pump MBtu</name>
       <display_name>Electricity: Hot Tub Pump MBtu</display_name>
       <short_name>Electricity: Hot Tub Pump MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Electricity: PV MBtu</name>
       <display_name>Electricity: PV MBtu</display_name>
       <short_name>Electricity: PV MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Heating MBtu</name>
       <display_name>Natural Gas: Heating MBtu</display_name>
       <short_name>Natural Gas: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Hot Water MBtu</name>
       <display_name>Natural Gas: Hot Water MBtu</display_name>
       <short_name>Natural Gas: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Clothes Dryer MBtu</name>
       <display_name>Natural Gas: Clothes Dryer MBtu</display_name>
       <short_name>Natural Gas: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Range/Oven MBtu</name>
       <display_name>Natural Gas: Range/Oven MBtu</display_name>
       <short_name>Natural Gas: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Mech Vent Preheating MBtu</name>
       <display_name>Natural Gas: Mech Vent Preheating MBtu</display_name>
       <short_name>Natural Gas: Mech Vent Preheating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Pool Heater MBtu</name>
       <display_name>Natural Gas: Pool Heater MBtu</display_name>
       <short_name>Natural Gas: Pool Heater MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Hot Tub Heater MBtu</name>
       <display_name>Natural Gas: Hot Tub Heater MBtu</display_name>
       <short_name>Natural Gas: Hot Tub Heater MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Grill MBtu</name>
       <display_name>Natural Gas: Grill MBtu</display_name>
       <short_name>Natural Gas: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Lighting MBtu</name>
       <display_name>Natural Gas: Lighting MBtu</display_name>
       <short_name>Natural Gas: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Natural Gas: Fireplace MBtu</name>
       <display_name>Natural Gas: Fireplace MBtu</display_name>
       <short_name>Natural Gas: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Heating MBtu</name>
       <display_name>Fuel Oil: Heating MBtu</display_name>
       <short_name>Fuel Oil: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Hot Water MBtu</name>
       <display_name>Fuel Oil: Hot Water MBtu</display_name>
       <short_name>Fuel Oil: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Clothes Dryer MBtu</name>
       <display_name>Fuel Oil: Clothes Dryer MBtu</display_name>
       <short_name>Fuel Oil: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Range/Oven MBtu</name>
       <display_name>Fuel Oil: Range/Oven MBtu</display_name>
       <short_name>Fuel Oil: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Mech Vent Preheating MBtu</name>
       <display_name>Fuel Oil: Mech Vent Preheating MBtu</display_name>
       <short_name>Fuel Oil: Mech Vent Preheating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Grill MBtu</name>
       <display_name>Fuel Oil: Grill MBtu</display_name>
       <short_name>Fuel Oil: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Lighting MBtu</name>
       <display_name>Fuel Oil: Lighting MBtu</display_name>
       <short_name>Fuel Oil: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Oil: Fireplace MBtu</name>
       <display_name>Fuel Oil: Fireplace MBtu</display_name>
       <short_name>Fuel Oil: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Heating MBtu</name>
       <display_name>Propane: Heating MBtu</display_name>
       <short_name>Propane: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Hot Water MBtu</name>
       <display_name>Propane: Hot Water MBtu</display_name>
       <short_name>Propane: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Clothes Dryer MBtu</name>
       <display_name>Propane: Clothes Dryer MBtu</display_name>
       <short_name>Propane: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Range/Oven MBtu</name>
       <display_name>Propane: Range/Oven MBtu</display_name>
       <short_name>Propane: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Mech Vent Preheating MBtu</name>
       <display_name>Propane: Mech Vent Preheating MBtu</display_name>
       <short_name>Propane: Mech Vent Preheating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Grill MBtu</name>
       <display_name>Propane: Grill MBtu</display_name>
       <short_name>Propane: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Lighting MBtu</name>
       <display_name>Propane: Lighting MBtu</display_name>
       <short_name>Propane: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Propane: Fireplace MBtu</name>
       <display_name>Propane: Fireplace MBtu</display_name>
       <short_name>Propane: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Heating MBtu</name>
       <display_name>Wood Cord: Heating MBtu</display_name>
       <short_name>Wood Cord: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Hot Water MBtu</name>
       <display_name>Wood Cord: Hot Water MBtu</display_name>
       <short_name>Wood Cord: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Clothes Dryer MBtu</name>
       <display_name>Wood Cord: Clothes Dryer MBtu</display_name>
       <short_name>Wood Cord: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Range/Oven MBtu</name>
       <display_name>Wood Cord: Range/Oven MBtu</display_name>
       <short_name>Wood Cord: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Mech Vent Preheating MBtu</name>
       <display_name>Wood Cord: Mech Vent Preheating MBtu</display_name>
       <short_name>Wood Cord: Mech Vent Preheating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Grill MBtu</name>
       <display_name>Wood Cord: Grill MBtu</display_name>
       <short_name>Wood Cord: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Lighting MBtu</name>
       <display_name>Wood Cord: Lighting MBtu</display_name>
       <short_name>Wood Cord: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Cord: Fireplace MBtu</name>
       <display_name>Wood Cord: Fireplace MBtu</display_name>
       <short_name>Wood Cord: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Heating MBtu</name>
       <display_name>Wood Pellets: Heating MBtu</display_name>
       <short_name>Wood Pellets: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Hot Water MBtu</name>
       <display_name>Wood Pellets: Hot Water MBtu</display_name>
       <short_name>Wood Pellets: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Clothes Dryer MBtu</name>
       <display_name>Wood Pellets: Clothes Dryer MBtu</display_name>
       <short_name>Wood Pellets: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Range/Oven MBtu</name>
       <display_name>Wood Pellets: Range/Oven MBtu</display_name>
       <short_name>Wood Pellets: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Mech Vent Preheating MBtu</name>
       <display_name>Wood Pellets: Mech Vent Preheating MBtu</display_name>
       <short_name>Wood Pellets: Mech Vent Preheating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Grill MBtu</name>
       <display_name>Wood Pellets: Grill MBtu</display_name>
       <short_name>Wood Pellets: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Lighting MBtu</name>
       <display_name>Wood Pellets: Lighting MBtu</display_name>
       <short_name>Wood Pellets: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Wood Pellets: Fireplace MBtu</name>
       <display_name>Wood Pellets: Fireplace MBtu</display_name>
       <short_name>Wood Pellets: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Heating MBtu</name>
       <display_name>Coal: Heating MBtu</display_name>
       <short_name>Coal: Heating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Hot Water MBtu</name>
       <display_name>Coal: Hot Water MBtu</display_name>
       <short_name>Coal: Hot Water MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Clothes Dryer MBtu</name>
       <display_name>Coal: Clothes Dryer MBtu</display_name>
       <short_name>Coal: Clothes Dryer MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Range/Oven MBtu</name>
       <display_name>Coal: Range/Oven MBtu</display_name>
       <short_name>Coal: Range/Oven MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Mech Vent Preheating MBtu</name>
       <display_name>Coal: Mech Vent Preheating MBtu</display_name>
       <short_name>Coal: Mech Vent Preheating MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Grill MBtu</name>
       <display_name>Coal: Grill MBtu</display_name>
       <short_name>Coal: Grill MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Lighting MBtu</name>
       <display_name>Coal: Lighting MBtu</display_name>
       <short_name>Coal: Lighting MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Coal: Fireplace MBtu</name>
       <display_name>Coal: Fireplace MBtu</display_name>
       <short_name>Coal: Fireplace MBtu</short_name>
-      <description></description>
       <type>Double</type>
-      <units></units>
       <model_dependent>false</model_dependent>
     </output>
   </outputs>
@@ -1059,8 +856,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3216DA87</checksum>
+      <checksum>58031505</checksum>
     </file>
   </files>
 </measure>
-<error>uninitialized constant SimulationOutputReport::EPlus</error>


### PR DESCRIPTION
## Pull Request Description

Fixes HPWH fan energy not being captured in SimulationOutputReport measure. Typically < 0.1 GJ of annual energy use, so not very important, but can result in the error "Error: Electricity category end uses (X) do not sum to total (X).".

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
