### PR TITLE
run_simulation.rb exit code

### DIFF
--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -156,6 +156,8 @@ rundir = File.join(options[:output_dir], 'run')
 puts "HPXML: #{options[:hpxml]}"
 success = run_workflow(basedir, rundir, options[:hpxml], options[:debug], timeseries_output_freq, timeseries_outputs)
 
-if success
-  puts "Completed in #{(Time.now - start_time).round(1)} seconds."
+if not success
+  exit! 1
 end
+
+puts "Completed in #{(Time.now - start_time).round(1)} seconds."


### PR DESCRIPTION
## Pull Request Description

`run_simulation.rb` now returns exit code 1 if not successful (i.e., either invalid inputs or simulation fails). Otherwise returns 0 as before.

FYI @nmerket 

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
