### PR TITLE
Allow no space in setpoint arrays

### DIFF
--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -1350,10 +1350,10 @@ class HVAC
       htg_weekend_setpoints = htg_weekday_setpoints.dup
     else
       # 24-hr weekday/weekend heating setpoint schedules
-      htg_weekday_setpoints = hvac_control.weekday_heating_setpoints.split(', ').map { |i| Float(i) }
+      htg_weekday_setpoints = hvac_control.weekday_heating_setpoints.split(',').map { |i| Float(i) }
       htg_weekday_setpoints = [htg_weekday_setpoints] * 12
 
-      htg_weekend_setpoints = hvac_control.weekend_heating_setpoints.split(', ').map { |i| Float(i) }
+      htg_weekend_setpoints = hvac_control.weekend_heating_setpoints.split(',').map { |i| Float(i) }
       htg_weekend_setpoints = [htg_weekend_setpoints] * 12
     end
 
@@ -1376,10 +1376,10 @@ class HVAC
       clg_weekend_setpoints = clg_weekday_setpoints.dup
     else
       # 24-hr weekday/weekend cooling setpoint schedules
-      clg_weekday_setpoints = hvac_control.weekday_cooling_setpoints.split(', ').map { |i| Float(i) }
+      clg_weekday_setpoints = hvac_control.weekday_cooling_setpoints.split(',').map { |i| Float(i) }
       clg_weekday_setpoints = [clg_weekday_setpoints] * 12
 
-      clg_weekend_setpoints = hvac_control.weekend_cooling_setpoints.split(', ').map { |i| Float(i) }
+      clg_weekend_setpoints = hvac_control.weekend_cooling_setpoints.split(',').map { |i| Float(i) }
       clg_weekend_setpoints = [clg_weekend_setpoints] * 12
     end
 


### PR DESCRIPTION
## Pull Request Description

Small fix to allow, e.g., "1,2,3,4" instead of only "1, 2, 3, 4".

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
