### PR TITLE
Allow more defaults (i.e., optional inputs)

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3f94ab09-3e57-4c47-8022-4d80e3c9f2d3</version_id>
-  <version_modified>20201125T012852Z</version_modified>
+  <version_id>5d35ef22-f9a1-41eb-93e6-6e3c011a5ed4</version_id>
+  <version_modified>20201125T031901Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -435,12 +435,6 @@
       <checksum>A461F4D4</checksum>
     </file>
     <file>
-      <filename>hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>9B116EBF</checksum>
-    </file>
-    <file>
       <filename>simcontrols.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -501,10 +495,16 @@
       <checksum>6209C52E</checksum>
     </file>
     <file>
+      <filename>hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>FCCE7AC0</checksum>
+    </file>
+    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>778E2866</checksum>
+      <checksum>FEEDB395</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f4f7e0ff-69c1-4647-b3a3-00ecfe637a1c</version_id>
-  <version_modified>20201124T025714Z</version_modified>
+  <version_id>c6a4327e-5ed7-4aa8-b4b2-19c1e405a9da</version_id>
+  <version_modified>20201124T225339Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -412,12 +412,6 @@
       <checksum>CCB83C02</checksum>
     </file>
     <file>
-      <filename>xmlhelper.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>942C3E5E</checksum>
-    </file>
-    <file>
       <filename>test_water_heater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -466,12 +460,6 @@
       <checksum>8CC67A4B</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C5F3F911</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -489,22 +477,34 @@
       <checksum>9B116EBF</checksum>
     </file>
     <file>
+      <filename>xmlhelper.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>66DB2D3A</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>B9C656DA</checksum>
+    </file>
+    <file>
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>775F2623</checksum>
+      <checksum>5714066F</checksum>
     </file>
     <file>
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>41A3F9F0</checksum>
+      <checksum>6A8A946E</checksum>
     </file>
     <file>
       <filename>EPvalidator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
-      <checksum>6245E3AF</checksum>
+      <checksum>1CD5B114</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7634786f-825a-4049-aa18-64b8dbe61a9f</version_id>
-  <version_modified>20201125T001320Z</version_modified>
+  <version_id>fe2183f3-b75d-4938-a9b0-d7b155480d0e</version_id>
+  <version_modified>20201125T011044Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -483,18 +483,6 @@
       <checksum>CFF8A021</checksum>
     </file>
     <file>
-      <filename>xmlhelper.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>4E02A097</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>37A886DC</checksum>
-    </file>
-    <file>
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -505,6 +493,18 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>D32C25FD</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3369DB62</checksum>
+    </file>
+    <file>
+      <filename>xmlhelper.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1932CF82</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>fe2183f3-b75d-4938-a9b0-d7b155480d0e</version_id>
-  <version_modified>20201125T011044Z</version_modified>
+  <version_id>3f94ab09-3e57-4c47-8022-4d80e3c9f2d3</version_id>
+  <version_modified>20201125T012852Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -441,12 +441,6 @@
       <checksum>9B116EBF</checksum>
     </file>
     <file>
-      <filename>EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1CD5B114</checksum>
-    </file>
-    <file>
       <filename>simcontrols.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -483,28 +477,34 @@
       <checksum>CFF8A021</checksum>
     </file>
     <file>
+      <filename>xmlhelper.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1932CF82</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6CB567F1</checksum>
+    </file>
+    <file>
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>C8B497D6</checksum>
+      <checksum>6A7652CD</checksum>
     </file>
     <file>
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>D32C25FD</checksum>
+      <checksum>6209C52E</checksum>
     </file>
     <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>3369DB62</checksum>
-    </file>
-    <file>
-      <filename>xmlhelper.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1932CF82</checksum>
+      <checksum>778E2866</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>c6a4327e-5ed7-4aa8-b4b2-19c1e405a9da</version_id>
-  <version_modified>20201124T225339Z</version_modified>
+  <version_id>7634786f-825a-4049-aa18-64b8dbe61a9f</version_id>
+  <version_modified>20201125T001320Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -98,12 +98,6 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>6F263948</checksum>
-    </file>
-    <file>
-      <filename>simcontrols.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>68F83651</checksum>
     </file>
     <file>
       <filename>util.rb</filename>
@@ -280,24 +274,6 @@
       <checksum>6BF095D2</checksum>
     </file>
     <file>
-      <filename>lighting.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>F405FA57</checksum>
-    </file>
-    <file>
-      <filename>test_location.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>E4C51989</checksum>
-    </file>
-    <file>
-      <filename>test_simcontrols.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>5127F8D4</checksum>
-    </file>
-    <file>
       <filename>energyplus.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -364,12 +340,6 @@
       <checksum>1A6416EF</checksum>
     </file>
     <file>
-      <filename>schedules.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1F108CF8</checksum>
-    </file>
-    <file>
       <filename>BaseElements.xsd</filename>
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
@@ -380,12 +350,6 @@
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
       <checksum>C13E66F3</checksum>
-    </file>
-    <file>
-      <filename>location.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>AF3AF52D</checksum>
     </file>
     <file>
       <filename>hotwater_appliances.rb</filename>
@@ -477,34 +441,70 @@
       <checksum>9B116EBF</checksum>
     </file>
     <file>
+      <filename>EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1CD5B114</checksum>
+    </file>
+    <file>
+      <filename>simcontrols.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1164C9B8</checksum>
+    </file>
+    <file>
+      <filename>lighting.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>4E69B40E</checksum>
+    </file>
+    <file>
+      <filename>test_location.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>983025AE</checksum>
+    </file>
+    <file>
+      <filename>test_simcontrols.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>5CEBAA1B</checksum>
+    </file>
+    <file>
+      <filename>schedules.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C2B5A5E7</checksum>
+    </file>
+    <file>
+      <filename>location.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>CFF8A021</checksum>
+    </file>
+    <file>
       <filename>xmlhelper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>66DB2D3A</checksum>
+      <checksum>4E02A097</checksum>
     </file>
     <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B9C656DA</checksum>
+      <checksum>37A886DC</checksum>
     </file>
     <file>
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>5714066F</checksum>
+      <checksum>C8B497D6</checksum>
     </file>
     <file>
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>6A8A946E</checksum>
-    </file>
-    <file>
-      <filename>EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1CD5B114</checksum>
+      <checksum>D32C25FD</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>a5a17100-1ab8-4d14-8897-9694389cc08c</version_id>
-  <version_modified>20201120T215241Z</version_modified>
+  <version_id>f4f7e0ff-69c1-4647-b3a3-00ecfe637a1c</version_id>
+  <version_modified>20201124T025714Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -430,18 +430,6 @@
       <checksum>BF4566BB</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>0B363A53</checksum>
-    </file>
-    <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>466F5D83</checksum>
-    </file>
-    <file>
       <filename>version.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -478,12 +466,6 @@
       <checksum>8CC67A4B</checksum>
     </file>
     <file>
-      <filename>EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>F701C8BC</checksum>
-    </file>
-    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -505,6 +487,24 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>9B116EBF</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>775F2623</checksum>
+    </file>
+    <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>41A3F9F0</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6245E3AF</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.xml
@@ -1003,9 +1003,9 @@
       <sch:assert role='ERROR' test='count(h:IsSharedSystem) &lt;= 1'>Expected 0 or 1 element(s) for xpath: IsSharedSystem</sch:assert> <!-- See [PVSystemType=Shared] -->
       <sch:assert role='ERROR' test='count(h:Location) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Location</sch:assert>
       <sch:assert role='ERROR' test='h:Location[text()="ground" or text()="roof"] or not(h:Location)'>Expected Location to be 'ground' or 'roof'</sch:assert>
-      <sch:assert role='ERROR' test='count(h:ModuleType) &lt= 1'>Expected 0 or 1 element(s) for xpath: ModuleType</sch:assert>
+      <sch:assert role='ERROR' test='count(h:ModuleType) &lt;= 1'>Expected 0 or 1 element(s) for xpath: ModuleType</sch:assert>
       <sch:assert role='ERROR' test='h:ModuleType[text()="standard" or text()="premium" or text()="thin film"] or not(h:ModuleType)'>Expected ModuleType to be 'standard' or 'premium' or 'thin film'</sch:assert>
-      <sch:assert role='ERROR' test='count(h:Tracking) &lt= 1'>Expected 0 or 1 element(s) for xpath: Tracking</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Tracking) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Tracking</sch:assert>
       <sch:assert role='ERROR' test='h:Tracking[text()="fixed" or text()="1-axis" or text()="1-axis backtracked" or text()="2-axis"] or not(h:Tracking)'>Expected Tracking to be 'fixed' or '1-axis' or '1-axis backtracked' or '2-axis'</sch:assert>
       <sch:assert role='ERROR' test='count(h:ArrayAzimuth) = 1'>Expected 1 element(s) for xpath: ArrayAzimuth</sch:assert>
       <sch:assert role='ERROR' test='count(h:ArrayTilt) = 1'>Expected 1 element(s) for xpath: ArrayTilt</sch:assert>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.xml
@@ -194,9 +194,9 @@
       <sch:assert role='ERROR' test='count(h:RoofType) &lt;= 1'>Expected 0 or 1 element(s) for xpath: RoofType</sch:assert>
       <sch:assert role='ERROR' test='h:RoofType[text()="asphalt or fiberglass shingles" or text()="wood shingles or shakes" or text()="slate or tile shingles" or text()="metal surfacing"] or not(h:RoofType)'>Expected RoofType to be 'asphalt or fiberglass shingles' or 'wood shingles or shakes' or 'slate or tile shingles' or 'metal surfacing'</sch:assert>
       <sch:assert role='ERROR' test='count(h:SolarAbsorptance) + count(h:RoofColor) &gt;= 1'>Expected 1 or more element(s) for xpath: SolarAbsorptance | RoofColor</sch:assert>
-      <sch:assert role='ERROR' test='count(h:Emittance) = 1'>Expected 1 element(s) for xpath: Emittance</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Emittance) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Emittance</sch:assert>
       <sch:assert role='ERROR' test='count(h:Pitch) = 1'>Expected 1 element(s) for xpath: Pitch</sch:assert>
-      <sch:assert role='ERROR' test='count(h:RadiantBarrier) = 1'>Expected 1 element(s) for xpath: RadiantBarrier</sch:assert> <!-- See [RadiantBarrier] -->
+      <sch:assert role='ERROR' test='count(h:RadiantBarrier) &lt;= 1'>Expected 0 or 1 element(s) for xpath: RadiantBarrier</sch:assert> <!-- See [RadiantBarrier] -->
       <sch:assert role='ERROR' test='count(h:Insulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: Insulation/SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/AssemblyEffectiveRValue</sch:assert>
     </sch:rule>
@@ -227,7 +227,7 @@
       <sch:assert role='ERROR' test='count(h:Siding) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Siding</sch:assert>
       <sch:assert role='ERROR' test='h:Siding[text()="wood siding" or text()="vinyl siding" or text()="stucco" or text()="fiber cement siding" or text()="brick veneer" or text()="aluminum siding"] or not(h:Siding)'>Expected Siding to be 'wood siding' or 'vinyl siding' or 'stucco' or 'fiber cement siding' or 'brick veneer' or 'aluminum siding'</sch:assert>
       <sch:assert role='ERROR' test='count(h:SolarAbsorptance) + count(h:Color) &gt;= 1'>Expected 1 or more element(s) for xpath: SolarAbsorptance | Color</sch:assert>
-      <sch:assert role='ERROR' test='count(h:Emittance) = 1'>Expected 1 element(s) for xpath: Emittance</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Emittance) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Emittance</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: Insulation/SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/AssemblyEffectiveRValue</sch:assert>
     </sch:rule>
@@ -245,7 +245,7 @@
       <sch:assert role='ERROR' test='count(h:Siding) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Siding</sch:assert> <!-- See [Siding] -->
       <sch:assert role='ERROR' test='h:Siding[text()="wood siding" or text()="vinyl siding" or text()="stucco" or text()="fiber cement siding" or text()="brick veneer" or text()="aluminum siding"] or not(h:Siding)'>Expected Siding to be 'wood siding' or 'vinyl siding' or 'stucco' or 'fiber cement siding' or 'brick veneer' or 'aluminum siding'</sch:assert>
       <sch:assert role='ERROR' test='count(h:SolarAbsorptance) + count(h:Color) &gt;= 1'>Expected 1 or more element(s) for xpath: SolarAbsorptance | Color</sch:assert>
-      <sch:assert role='ERROR' test='count(h:Emittance) = 1'>Expected 1 element(s) for xpath: Emittance</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Emittance) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Emittance</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: Insulation/SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/AssemblyEffectiveRValue</sch:assert>
     </sch:rule>
@@ -261,7 +261,7 @@
       <sch:assert role='ERROR' test='count(h:Height) = 1'>Expected 1 element(s) for xpath: Height</sch:assert>
       <sch:assert role='ERROR' test='count(h:Area) = 1'>Expected 1 element(s) for xpath: Area</sch:assert>
       <sch:assert role='ERROR' test='count(h:Azimuth) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Azimuth</sch:assert>
-      <sch:assert role='ERROR' test='count(h:Thickness) = 1'>Expected 1 element(s) for xpath: Thickness</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Thickness) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Thickness</sch:assert>
       <sch:assert role='ERROR' test='count(h:DepthBelowGrade) = 1'>Expected 1 element(s) for xpath: DepthBelowGrade</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: Insulation/SystemIdentifier</sch:assert>
       <!-- Insulation: either specify interior and exterior layers OR assembly R-value: -->
@@ -309,7 +309,7 @@
       <sch:assert role='ERROR' test='count(h:InteriorAdjacentTo) = 1'>Expected 1 element(s) for xpath: InteriorAdjacentTo</sch:assert> <!-- See [SlabInteriorAdjacentTo] -->
       <sch:assert role='ERROR' test='h:InteriorAdjacentTo[text()="living space" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage"] or not(h:InteriorAdjacentTo)'>Expected InteriorAdjacentTo to be 'living space' or 'basement - conditioned' or 'basement - unconditioned' or 'crawlspace - vented' or 'crawlspace - unvented' or 'garage'</sch:assert>
       <sch:assert role='ERROR' test='count(h:Area) = 1'>Expected 1 element(s) for xpath: Area</sch:assert>
-      <sch:assert role='ERROR' test='count(h:Thickness) = 1'>Expected 1 element(s) for xpath: Thickness</sch:assert> <!-- Use zero for dirt floor -->
+      <sch:assert role='ERROR' test='count(h:Thickness) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Thickness</sch:assert> <!-- Use zero for dirt floor -->
       <sch:assert role='ERROR' test='count(h:ExposedPerimeter) = 1'>Expected 1 element(s) for xpath: ExposedPerimeter</sch:assert>
       <sch:assert role='ERROR' test='count(h:PerimeterInsulationDepth) = 1'>Expected 1 element(s) for xpath: PerimeterInsulationDepth</sch:assert>
       <sch:assert role='ERROR' test='count(h:UnderSlabInsulationWidth) + count(h:UnderSlabInsulationSpansEntireSlab[text()="true"]) = 1'>Expected 1 element(s) for xpath: UnderSlabInsulationWidth | UnderSlabInsulationSpansEntireSlab[text()="true"]</sch:assert>
@@ -318,8 +318,8 @@
       <sch:assert role='ERROR' test='count(h:PerimeterInsulation/h:Layer[h:InstallationType="continuous"]/h:NominalRValue) = 1'>Expected 1 element(s) for xpath: PerimeterInsulation/Layer[InstallationType="continuous"]/NominalRValue</sch:assert>
       <sch:assert role='ERROR' test='count(h:UnderSlabInsulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: UnderSlabInsulation/SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:UnderSlabInsulation/h:Layer[h:InstallationType="continuous"]/h:NominalRValue) = 1'>Expected 1 element(s) for xpath: UnderSlabInsulation/Layer[InstallationType="continuous"]/NominalRValue</sch:assert>
-      <sch:assert role='ERROR' test='count(h:extension/h:CarpetFraction) = 1'>Expected 1 element(s) for xpath: extension/CarpetFraction</sch:assert> <!-- 0 - 1 -->
-      <sch:assert role='ERROR' test='count(h:extension/h:CarpetRValue) = 1'>Expected 1 element(s) for xpath: extension/CarpetRValue</sch:assert>
+      <sch:assert role='ERROR' test='count(h:extension/h:CarpetFraction) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/CarpetFraction</sch:assert> <!-- 0 - 1 -->
+      <sch:assert role='ERROR' test='count(h:extension/h:CarpetRValue) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/CarpetRValue</sch:assert>
     </sch:rule>
   </sch:pattern>
 
@@ -687,14 +687,14 @@
   <sch:pattern name='[HVACControlType=HeatingSetback]'>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:HVAC/h:HVACControl[h:SetbackTempHeatingSeason]'>
       <sch:assert role='ERROR' test='count(h:TotalSetbackHoursperWeekHeating) = 1'>Expected 1 element(s) for xpath: TotalSetbackHoursperWeekHeating</sch:assert>
-      <sch:assert role='ERROR' test='count(h:extension/h:SetbackStartHourHeating) = 1'>Expected 1 element(s) for xpath: extension/SetbackStartHourHeating</sch:assert> <!-- 0 = midnight. 12 = noon -->
+      <sch:assert role='ERROR' test='count(h:extension/h:SetbackStartHourHeating) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/SetbackStartHourHeating</sch:assert> <!-- 0 = midnight. 12 = noon -->
     </sch:rule>
   </sch:pattern>
 
   <sch:pattern name='[HVACControlType=CoolingSetup]'>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:HVAC/h:HVACControl[h:SetupTempCoolingSeason]'>
       <sch:assert role='ERROR' test='count(h:TotalSetupHoursperWeekCooling) = 1'>Expected 1 element(s) for xpath: TotalSetupHoursperWeekCooling</sch:assert>
-      <sch:assert role='ERROR' test='count(h:extension/h:SetupStartHourCooling) = 1'>Expected 1 element(s) for xpath: extension/SetupStartHourCooling</sch:assert> <!-- 0 = midnight. 12 = noon -->
+      <sch:assert role='ERROR' test='count(h:extension/h:SetupStartHourCooling) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/SetupStartHourCooling</sch:assert> <!-- 0 = midnight. 12 = noon -->
     </sch:rule>
   </sch:pattern>
 
@@ -758,7 +758,7 @@
       <sch:assert role='ERROR' test='count(h:FanType) = 1'>Expected 1 element(s) for xpath: FanType</sch:assert> <!-- See [MechanicalVentilationType=HRV] or [MechanicalVentilationType=ERV] or [MechanicalVentilationType=CFIS] -->
       <sch:assert role='ERROR' test='h:FanType[text()="energy recovery ventilator" or text()="heat recovery ventilator" or text()="exhaust only" or text()="supply only" or text()="balanced" or text()="central fan integrated supply"] or not(h:FanType)'>Expected FanType to be 'energy recovery ventilator' or 'heat recovery ventilator' or 'exhaust only' or 'supply only' or 'balanced' or 'central fan integrated supply'</sch:assert>
       <sch:assert role='ERROR' test='count(h:TestedFlowRate) + count(h:RatedFlowRate) &gt;= 1'>Expected 1 or more element(s) for xpath: TestedFlowRate | RatedFlowRate</sch:assert>
-      <sch:assert role='ERROR' test='count(h:HoursInOperation) = 1'>Expected 1 element(s) for xpath: HoursInOperation</sch:assert>
+      <sch:assert role='ERROR' test='count(h:HoursInOperation) &lt;= 1'>Expected 0 or 1 element(s) for xpath: HoursInOperation</sch:assert>
       <sch:assert role='ERROR' test='count(h:FanPower) = 1'>Expected 1 element(s) for xpath: FanPower</sch:assert>
     </sch:rule>
   </sch:pattern>
@@ -1001,11 +1001,11 @@
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:Photovoltaics/h:PVSystem'>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:IsSharedSystem) &lt;= 1'>Expected 0 or 1 element(s) for xpath: IsSharedSystem</sch:assert> <!-- See [PVSystemType=Shared] -->
-      <sch:assert role='ERROR' test='count(h:Location) = 1'>Expected 1 element(s) for xpath: Location</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Location) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Location</sch:assert>
       <sch:assert role='ERROR' test='h:Location[text()="ground" or text()="roof"] or not(h:Location)'>Expected Location to be 'ground' or 'roof'</sch:assert>
-      <sch:assert role='ERROR' test='count(h:ModuleType) = 1'>Expected 1 element(s) for xpath: ModuleType</sch:assert>
+      <sch:assert role='ERROR' test='count(h:ModuleType) &lt= 1'>Expected 0 or 1 element(s) for xpath: ModuleType</sch:assert>
       <sch:assert role='ERROR' test='h:ModuleType[text()="standard" or text()="premium" or text()="thin film"] or not(h:ModuleType)'>Expected ModuleType to be 'standard' or 'premium' or 'thin film'</sch:assert>
-      <sch:assert role='ERROR' test='count(h:Tracking) = 1'>Expected 1 element(s) for xpath: Tracking</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Tracking) &lt= 1'>Expected 0 or 1 element(s) for xpath: Tracking</sch:assert>
       <sch:assert role='ERROR' test='h:Tracking[text()="fixed" or text()="1-axis" or text()="1-axis backtracked" or text()="2-axis"] or not(h:Tracking)'>Expected Tracking to be 'fixed' or '1-axis' or '1-axis backtracked' or '2-axis'</sch:assert>
       <sch:assert role='ERROR' test='count(h:ArrayAzimuth) = 1'>Expected 1 element(s) for xpath: ArrayAzimuth</sch:assert>
       <sch:assert role='ERROR' test='count(h:ArrayTilt) = 1'>Expected 1 element(s) for xpath: ArrayTilt</sch:assert>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.xml
@@ -145,7 +145,7 @@
       <sch:assert role='ERROR' test='count(h:NumberofBedrooms) = 1'>Expected 1 element(s) for xpath: NumberofBedrooms</sch:assert>
       <sch:assert role='ERROR' test='count(h:NumberofBathrooms) &lt;= 1'>Expected 0 or 1 element(s) for xpath: NumberofBathrooms</sch:assert>
       <sch:assert role='ERROR' test='count(h:ConditionedFloorArea) = 1'>Expected 1 element(s) for xpath: ConditionedFloorArea</sch:assert>
-      <sch:assert role='ERROR' test='count(h:ConditionedBuildingVolume) + count(h:AverageCeilingHeight) &gt;= 1'>Expected 1 or more element(s) for xpath: ConditionedBuildingVolume | AverageCeilingHeight</sch:assert>
+      <sch:assert role='ERROR' test='count(h:ConditionedBuildingVolume) + count(h:AverageCeilingHeight) &gt;= 0'>Expected 0 or more element(s) for xpath: ConditionedBuildingVolume | AverageCeilingHeight</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:HasFlueOrChimney) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/HasFlueOrChimney</sch:assert>
     </sch:rule>
   </sch:pattern>
@@ -915,7 +915,7 @@
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:WaterHeating/h:HotWaterDistribution'>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:SystemType/h:Standard) + count(h:SystemType/h:Recirculation) = 1'>Expected 1 element(s) for xpath: SystemType/Standard | SystemType/Recirculation</sch:assert> <!-- See [HotWaterDistributionType=Standard] or [HotWaterDistributionType=Recirculation] -->
-      <sch:assert role='ERROR' test='count(h:PipeInsulation/h:PipeRValue) = 1'>Expected 1 element(s) for xpath: PipeInsulation/PipeRValue</sch:assert>
+      <sch:assert role='ERROR' test='count(h:PipeInsulation/h:PipeRValue) &lt;= 1'>Expected 0 or 1 element(s) for xpath: PipeInsulation/PipeRValue</sch:assert>
       <sch:assert role='ERROR' test='count(h:DrainWaterHeatRecovery) &lt;= 1'>Expected 0 or 1 element(s) for xpath: DrainWaterHeatRecovery</sch:assert> <!-- See [DrainWaterHeatRecovery] -->
       <sch:assert role='ERROR' test='count(h:extension/h:SharedRecirculation) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/SharedRecirculation</sch:assert> <!-- See [HotWaterDistributionType=SharedRecirculation] --> 
     </sch:rule>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -597,6 +597,19 @@ class HPXML < Object
     def initialize(hpxml_object, oga_element = nil, **kwargs)
       @hpxml_object = hpxml_object
       @additional_properties = AdditionalProperties.new
+
+      # Automatically add :foo_isdefaulted attributes to class
+      self.class::ATTRS.each do |attribute|
+        next if attribute.to_s.end_with? '_isdefaulted'
+
+        attr = "#{attribute}_isdefaulted".to_sym
+        next if self.class::ATTRS.include? attr
+
+        # Add attribute to ATTRS and class
+        self.class::ATTRS << attr
+        create_attr(attr.to_s) # From https://stackoverflow.com/a/4082937
+      end
+
       if not oga_element.nil?
         # Set values from HPXML Oga element
         from_oga(oga_element)
@@ -606,6 +619,15 @@ class HPXML < Object
           send(k.to_s + '=', v)
         end
       end
+    end
+
+    def create_method(name, &block)
+      self.class.send(:define_method, name, &block)
+    end
+
+    def create_attr(name)
+      create_method("#{name}=".to_sym) { |val| instance_variable_set('@' + name, val) }
+      create_method(name.to_sym) { instance_variable_get('@' + name) }
     end
 
     def to_h
@@ -636,6 +658,7 @@ class HPXML < Object
     def initialize(hpxml_object, oga_element = nil)
       @hpxml_object = hpxml_object
       @additional_properties = AdditionalProperties.new
+
       if not oga_element.nil?
         # Set values from HPXML Oga element
         from_oga(oga_element)
@@ -772,26 +795,26 @@ class HPXML < Object
       if (not @timestep.nil?) || (not @sim_begin_month.nil?) || (not @sim_begin_day_of_month.nil?) || (not @sim_end_month.nil?) || (not @sim_end_day_of_month.nil?) || (not @dst_enabled.nil?) || (not @dst_begin_month.nil?) || (not @dst_begin_day_of_month.nil?) || (not @dst_end_month.nil?) || (not @dst_end_day_of_month.nil?)
         extension = XMLHelper.create_elements_as_needed(software_info, ['extension'])
         simulation_control = XMLHelper.add_element(extension, 'SimulationControl')
-        XMLHelper.add_element(simulation_control, 'Timestep', to_integer(@timestep)) unless @timestep.nil?
-        XMLHelper.add_element(simulation_control, 'BeginMonth', to_integer(@sim_begin_month)) unless @sim_begin_month.nil?
-        XMLHelper.add_element(simulation_control, 'BeginDayOfMonth', to_integer(@sim_begin_day_of_month)) unless @sim_begin_day_of_month.nil?
-        XMLHelper.add_element(simulation_control, 'EndMonth', to_integer(@sim_end_month)) unless @sim_end_month.nil?
-        XMLHelper.add_element(simulation_control, 'EndDayOfMonth', to_integer(@sim_end_day_of_month)) unless @sim_end_day_of_month.nil?
-        XMLHelper.add_element(simulation_control, 'CalendarYear', to_integer(@sim_calendar_year)) unless @sim_calendar_year.nil?
+        XMLHelper.add_element(simulation_control, 'Timestep', to_integer(@timestep), @timestep_isdefaulted) unless @timestep.nil?
+        XMLHelper.add_element(simulation_control, 'BeginMonth', to_integer(@sim_begin_month), @sim_begin_month_isdefaulted) unless @sim_begin_month.nil?
+        XMLHelper.add_element(simulation_control, 'BeginDayOfMonth', to_integer(@sim_begin_day_of_month), @sim_begin_day_of_month_isdefaulted) unless @sim_begin_day_of_month.nil?
+        XMLHelper.add_element(simulation_control, 'EndMonth', to_integer(@sim_end_month), @sim_end_month_isdefaulted) unless @sim_end_month.nil?
+        XMLHelper.add_element(simulation_control, 'EndDayOfMonth', to_integer(@sim_end_day_of_month), @sim_end_day_of_month_isdefaulted) unless @sim_end_day_of_month.nil?
+        XMLHelper.add_element(simulation_control, 'CalendarYear', to_integer(@sim_calendar_year), @sim_calendar_year_isdefaulted) unless @sim_calendar_year.nil?
         if (not @dst_enabled.nil?) || (not @dst_begin_month.nil?) || (not @dst_begin_day_of_month.nil?) || (not @dst_end_month.nil?) || (not @dst_end_day_of_month.nil?)
           daylight_saving = XMLHelper.add_element(simulation_control, 'DaylightSaving')
-          XMLHelper.add_element(daylight_saving, 'Enabled', to_boolean(@dst_enabled)) unless @dst_enabled.nil?
-          XMLHelper.add_element(daylight_saving, 'BeginMonth', to_integer(@dst_begin_month)) unless @dst_begin_month.nil?
-          XMLHelper.add_element(daylight_saving, 'BeginDayOfMonth', to_integer(@dst_begin_day_of_month)) unless @dst_begin_day_of_month.nil?
-          XMLHelper.add_element(daylight_saving, 'EndMonth', to_integer(@dst_end_month)) unless @dst_end_month.nil?
-          XMLHelper.add_element(daylight_saving, 'EndDayOfMonth', to_integer(@dst_end_day_of_month)) unless @dst_end_day_of_month.nil?
+          XMLHelper.add_element(daylight_saving, 'Enabled', to_boolean(@dst_enabled), @dst_enabled_isdefaulted) unless @dst_enabled.nil?
+          XMLHelper.add_element(daylight_saving, 'BeginMonth', to_integer(@dst_begin_month), @dst_begin_month_isdefaulted) unless @dst_begin_month.nil?
+          XMLHelper.add_element(daylight_saving, 'BeginDayOfMonth', to_integer(@dst_begin_day_of_month), @dst_begin_day_of_month_isdefaulted) unless @dst_begin_day_of_month.nil?
+          XMLHelper.add_element(daylight_saving, 'EndMonth', to_integer(@dst_end_month), @dst_end_month_isdefaulted) unless @dst_end_month.nil?
+          XMLHelper.add_element(daylight_saving, 'EndDayOfMonth', to_integer(@dst_end_day_of_month), @dst_end_day_of_month_isdefaulted) unless @dst_end_day_of_month.nil?
         end
       end
       if (not @use_max_load_for_heat_pumps.nil?) || (not @allow_increased_fixed_capacities.nil?)
         extension = XMLHelper.create_elements_as_needed(software_info, ['extension'])
         hvac_sizing_control = XMLHelper.add_element(extension, 'HVACSizingControl')
-        XMLHelper.add_element(hvac_sizing_control, 'UseMaxLoadForHeatPumps', to_boolean(@use_max_load_for_heat_pumps)) unless @use_max_load_for_heat_pumps.nil?
-        XMLHelper.add_element(hvac_sizing_control, 'AllowIncreasedFixedCapacities', to_boolean(@allow_increased_fixed_capacities)) unless @allow_increased_fixed_capacities.nil?
+        XMLHelper.add_element(hvac_sizing_control, 'UseMaxLoadForHeatPumps', to_boolean(@use_max_load_for_heat_pumps), @use_max_load_for_heat_pumps_isdefaulted) unless @use_max_load_for_heat_pumps.nil?
+        XMLHelper.add_element(hvac_sizing_control, 'AllowIncreasedFixedCapacities', to_boolean(@allow_increased_fixed_capacities), @allow_increased_fixed_capacities_isdefaulted) unless @allow_increased_fixed_capacities.nil?
       end
 
       building = XMLHelper.add_element(hpxml, 'Building')
@@ -820,19 +843,32 @@ class HPXML < Object
       @eri_calculation_version = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ERICalculation/Version')
       @eri_design = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ERICalculation/Design')
       @timestep = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/Timestep'))
+      @timestep_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/Timestep') unless @timestep.nil?
       @sim_begin_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginMonth'))
+      @sim_begin_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginMonth') unless @sim_begin_month.nil?
       @sim_begin_day_of_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginDayOfMonth'))
+      @sim_begin_day_of_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginDayOfMonth') unless @sim_begin_day_of_month.nil?
       @sim_end_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/EndMonth'))
+      @sim_end_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/EndMonth') unless @sim_end_month.nil?
       @sim_end_day_of_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/EndDayOfMonth'))
+      @sim_end_day_of_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/EndDayOfMonth') unless @sim_end_day_of_month.nil?
       @sim_calendar_year = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/CalendarYear'))
+      @sim_calendar_year_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/CalendarYear') unless @sim_calendar_year.nil?
       @dst_enabled = to_boolean_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/Enabled'))
+      @dst_enabled_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/Enabled') unless @dst_enabled.nil?
       @dst_begin_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginMonth'))
+      @dst_begin_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginMonth') unless @dst_begin_month.nil?
       @dst_begin_day_of_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginDayOfMonth'))
+      @dst_begin_day_of_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginDayOfMonth') unless @dst_begin_day_of_month.nil?
       @dst_end_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndMonth'))
+      @dst_end_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndMonth') unless @dst_end_month.nil?
       @dst_end_day_of_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndDayOfMonth'))
+      @dst_end_day_of_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndDayOfMonth') unless @dst_end_day_of_month.nil?
       @apply_ashrae140_assumptions = to_boolean_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ApplyASHRAE140Assumptions'))
       @use_max_load_for_heat_pumps = to_boolean_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/HVACSizingControl/UseMaxLoadForHeatPumps'))
+      @use_max_load_for_heat_pumps_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/HVACSizingControl/UseMaxLoadForHeatPumps') unless @use_max_load_for_heat_pumps.nil?
       @allow_increased_fixed_capacities = to_boolean_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/HVACSizingControl/AllowIncreasedFixedCapacities'))
+      @allow_increased_fixed_capacities_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/HVACSizingControl/AllowIncreasedFixedCapacities') unless @allow_increased_fixed_capacities.nil?
       @building_id = HPXML::get_id(hpxml, 'Building/BuildingID')
       @event_type = XMLHelper.get_value(hpxml, 'Building/ProjectStatus/EventType')
       @state_code = XMLHelper.get_value(hpxml, 'Building/Site/Address/StateCode')
@@ -852,7 +888,7 @@ class HPXML < Object
       return if nil?
 
       site = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'BuildingSummary', 'Site'])
-      XMLHelper.add_element(site, 'SiteType', @site_type) unless @site_type.nil?
+      XMLHelper.add_element(site, 'SiteType', @site_type, @site_type_isdefaulted) unless @site_type.nil?
       XMLHelper.add_element(site, 'Surroundings', @surroundings) unless @surroundings.nil?
       XMLHelper.add_element(site, 'OrientationOfFrontOfHome', @orientation_of_front_of_home) unless @orientation_of_front_of_home.nil?
       if (not @fuels.nil?) && (not @fuels.empty?)
@@ -861,7 +897,7 @@ class HPXML < Object
           XMLHelper.add_element(fuel_types_available, 'Fuel', fuel)
         end
       end
-      XMLHelper.add_extension(site, 'ShelterCoefficient', to_float(@shelter_coefficient)) unless @shelter_coefficient.nil?
+      XMLHelper.add_extension(site, 'ShelterCoefficient', to_float(@shelter_coefficient), shelter_coefficient_isdefaulted) unless @shelter_coefficient.nil?
     end
 
     def from_oga(hpxml)
@@ -871,10 +907,12 @@ class HPXML < Object
       return if site.nil?
 
       @site_type = XMLHelper.get_value(site, 'SiteType')
+      @site_type_isdefaulted = get_software_defaulted(site, 'SiteType') unless @site_type.nil?
       @surroundings = XMLHelper.get_value(site, 'Surroundings')
       @orientation_of_front_of_home = XMLHelper.get_value(site, 'OrientationOfFrontOfHome')
       @fuels = XMLHelper.get_values(site, 'FuelTypesAvailable/Fuel')
       @shelter_coefficient = to_float_or_nil(XMLHelper.get_value(site, 'extension/ShelterCoefficient'))
+      @shelter_coefficient_isdefaulted = get_software_defaulted(site, 'extension/ShelterCoefficient') unless @shelter_coefficient.nil?
     end
   end
 
@@ -933,7 +971,7 @@ class HPXML < Object
       return if nil?
 
       building_occupancy = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'BuildingSummary', 'BuildingOccupancy'])
-      XMLHelper.add_element(building_occupancy, 'NumberofResidents', to_float(@number_of_residents)) unless @number_of_residents.nil?
+      XMLHelper.add_element(building_occupancy, 'NumberofResidents', to_float(@number_of_residents), @number_of_residents_isdefaulted) unless @number_of_residents.nil?
     end
 
     def from_oga(hpxml)
@@ -943,6 +981,7 @@ class HPXML < Object
       return if building_occupancy.nil?
 
       @number_of_residents = to_float_or_nil(XMLHelper.get_value(building_occupancy, 'NumberofResidents'))
+      @number_of_residents_isdefaulted = get_software_defaulted(building_occupancy, 'NumberofResidents') unless @number_of_residents.nil?
     end
   end
 
@@ -967,11 +1006,11 @@ class HPXML < Object
       XMLHelper.add_element(building_construction, 'NumberofConditionedFloorsAboveGrade', to_integer(@number_of_conditioned_floors_above_grade)) unless @number_of_conditioned_floors_above_grade.nil?
       XMLHelper.add_element(building_construction, 'AverageCeilingHeight', to_float(@average_ceiling_height)) unless @average_ceiling_height.nil?
       XMLHelper.add_element(building_construction, 'NumberofBedrooms', to_integer(@number_of_bedrooms)) unless @number_of_bedrooms.nil?
-      XMLHelper.add_element(building_construction, 'NumberofBathrooms', to_integer(@number_of_bathrooms)) unless @number_of_bathrooms.nil?
+      XMLHelper.add_element(building_construction, 'NumberofBathrooms', to_integer(@number_of_bathrooms), @number_of_bathrooms_isdefaulted) unless @number_of_bathrooms.nil?
       XMLHelper.add_element(building_construction, 'ConditionedFloorArea', to_float(@conditioned_floor_area)) unless @conditioned_floor_area.nil?
-      XMLHelper.add_element(building_construction, 'ConditionedBuildingVolume', to_float(@conditioned_building_volume)) unless @conditioned_building_volume.nil?
+      XMLHelper.add_element(building_construction, 'ConditionedBuildingVolume', to_float(@conditioned_building_volume), @conditioned_building_volume_isdefaulted) unless @conditioned_building_volume.nil?
       XMLHelper.add_extension(building_construction, 'UseOnlyIdealAirSystem', to_boolean(@use_only_ideal_air_system)) unless @use_only_ideal_air_system.nil?
-      XMLHelper.add_extension(building_construction, 'HasFlueOrChimney', to_boolean(@has_flue_or_chimney)) unless @has_flue_or_chimney.nil?
+      XMLHelper.add_extension(building_construction, 'HasFlueOrChimney', to_boolean(@has_flue_or_chimney), @has_flue_or_chimney_isdefaulted) unless @has_flue_or_chimney.nil?
     end
 
     def from_oga(hpxml)
@@ -986,11 +1025,14 @@ class HPXML < Object
       @average_ceiling_height = to_float_or_nil(XMLHelper.get_value(building_construction, 'AverageCeilingHeight'))
       @number_of_bedrooms = to_integer_or_nil(XMLHelper.get_value(building_construction, 'NumberofBedrooms'))
       @number_of_bathrooms = to_integer_or_nil(XMLHelper.get_value(building_construction, 'NumberofBathrooms'))
+      @number_of_bathrooms_isdefaulted = get_software_defaulted(building_construction, 'NumberofBathrooms') unless @number_of_bathrooms.nil?
       @conditioned_floor_area = to_float_or_nil(XMLHelper.get_value(building_construction, 'ConditionedFloorArea'))
       @conditioned_building_volume = to_float_or_nil(XMLHelper.get_value(building_construction, 'ConditionedBuildingVolume'))
+      @conditioned_building_volume_isdefaulted = get_software_defaulted(building_construction, 'ConditionedBuildingVolume') unless @conditioned_building_volume.nil?
       @use_only_ideal_air_system = to_boolean_or_nil(XMLHelper.get_value(building_construction, 'extension/UseOnlyIdealAirSystem'))
       @residential_facility_type = XMLHelper.get_value(building_construction, 'ResidentialFacilityType')
       @has_flue_or_chimney = to_boolean_or_nil(XMLHelper.get_value(building_construction, 'extension/HasFlueOrChimney'))
+      @has_flue_or_chimney_isdefaulted = get_software_defaulted(building_construction, 'extension/HasFlueOrChimney') unless @has_flue_or_chimney.nil?
     end
   end
 
@@ -1081,7 +1123,7 @@ class HPXML < Object
         XMLHelper.add_element(building_air_leakage, 'AirLeakage', to_float(@air_leakage))
       end
       XMLHelper.add_element(air_infiltration_measurement, 'EffectiveLeakageArea', to_float(@effective_leakage_area)) unless @effective_leakage_area.nil?
-      XMLHelper.add_element(air_infiltration_measurement, 'InfiltrationVolume', to_float(@infiltration_volume)) unless @infiltration_volume.nil?
+      XMLHelper.add_element(air_infiltration_measurement, 'InfiltrationVolume', to_float(@infiltration_volume), @infiltration_volume_isdefaulted) unless @infiltration_volume.nil?
       XMLHelper.add_extension(air_infiltration_measurement, 'InfiltrationHeight', to_float(@infiltration_height)) unless @infiltration_height.nil?
       XMLHelper.add_extension(air_infiltration_measurement, 'Aext', to_float(@a_ext)) unless @a_ext.nil?
     end
@@ -1095,6 +1137,7 @@ class HPXML < Object
       @air_leakage = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'BuildingAirLeakage/AirLeakage'))
       @effective_leakage_area = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'EffectiveLeakageArea'))
       @infiltration_volume = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'InfiltrationVolume'))
+      @infiltration_volume_isdefaulted = get_software_defaulted(air_infiltration_measurement, 'InfiltrationVolume') unless @infiltration_volume.nil?
       @leakiness_description = XMLHelper.get_value(air_infiltration_measurement, 'LeakinessDescription')
       @infiltration_height = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'extension/InfiltrationHeight'))
       @a_ext = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'extension/Aext'))
@@ -1186,7 +1229,7 @@ class HPXML < Object
           if not @vented_attic_sla.nil?
             ventilation_rate = XMLHelper.add_element(attic, 'VentilationRate')
             XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsSLA)
-            XMLHelper.add_element(ventilation_rate, 'Value', to_float(@vented_attic_sla))
+            XMLHelper.add_element(ventilation_rate, 'Value', to_float(@vented_attic_sla), @vented_attic_sla_isdefaulted)
           elsif not @vented_attic_ach.nil?
             ventilation_rate = XMLHelper.add_element(attic, 'VentilationRate')
             XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsACHNatural)
@@ -1221,6 +1264,7 @@ class HPXML < Object
       end
       if @attic_type == AtticTypeVented
         @vented_attic_sla = to_float_or_nil(XMLHelper.get_value(attic, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value"))
+        @vented_attic_sla_isdefaulted = get_software_defaulted(attic, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value") unless @vented_attic_sla.nil?
         @vented_attic_ach = to_float_or_nil(XMLHelper.get_value(attic, "VentilationRate[UnitofMeasure='#{UnitsACHNatural}']/Value"))
       end
       @within_infiltration_volume = to_boolean_or_nil(XMLHelper.get_value(attic, 'WithinInfiltrationVolume'))
@@ -1354,7 +1398,7 @@ class HPXML < Object
           if not @vented_crawlspace_sla.nil?
             ventilation_rate = XMLHelper.add_element(foundation, 'VentilationRate')
             XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsSLA)
-            XMLHelper.add_element(ventilation_rate, 'Value', to_float(@vented_crawlspace_sla))
+            XMLHelper.add_element(ventilation_rate, 'Value', to_float(@vented_crawlspace_sla), @vented_crawlspace_sla_isdefaulted)
           end
         elsif @foundation_type == FoundationTypeCrawlspaceUnvented
           crawlspace = XMLHelper.add_element(foundation_type_e, 'Crawlspace')
@@ -1384,7 +1428,8 @@ class HPXML < Object
         @foundation_type = FoundationTypeAmbient
       end
       if @foundation_type == FoundationTypeCrawlspaceVented
-        @vented_crawlspace_sla = to_float_or_nil(XMLHelper.get_value(foundation, "VentilationRate[UnitofMeasure='SLA']/Value"))
+        @vented_crawlspace_sla = to_float_or_nil(XMLHelper.get_value(foundation, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value"))
+        @vented_crawlspace_sla_isdefaulted = get_software_defaulted(foundation, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value") unless @vented_crawlspace_sla.nil?
       end
       @within_infiltration_volume = to_boolean_or_nil(XMLHelper.get_value(foundation, 'WithinInfiltrationVolume'))
       @attached_to_slab_idrefs = []
@@ -1486,12 +1531,12 @@ class HPXML < Object
       XMLHelper.add_element(roof, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
       XMLHelper.add_element(roof, 'Area', to_float(@area)) unless @area.nil?
       XMLHelper.add_element(roof, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(roof, 'RoofType', @roof_type) unless @roof_type.nil?
-      XMLHelper.add_element(roof, 'RoofColor', @roof_color) unless @roof_color.nil?
-      XMLHelper.add_element(roof, 'SolarAbsorptance', to_float(@solar_absorptance)) unless @solar_absorptance.nil?
-      XMLHelper.add_element(roof, 'Emittance', to_float(@emittance)) unless @emittance.nil?
+      XMLHelper.add_element(roof, 'RoofType', @roof_type, @roof_type_isdefaulted) unless @roof_type.nil?
+      XMLHelper.add_element(roof, 'RoofColor', @roof_color, @roof_color_isdefaulted) unless @roof_color.nil?
+      XMLHelper.add_element(roof, 'SolarAbsorptance', to_float(@solar_absorptance), @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
+      XMLHelper.add_element(roof, 'Emittance', to_float(@emittance), @emittance_isdefaulted) unless @emittance.nil?
       XMLHelper.add_element(roof, 'Pitch', to_float(@pitch)) unless @pitch.nil?
-      XMLHelper.add_element(roof, 'RadiantBarrier', to_boolean(@radiant_barrier)) unless @radiant_barrier.nil?
+      XMLHelper.add_element(roof, 'RadiantBarrier', to_boolean(@radiant_barrier), @radiant_barrier_isdefaulted) unless @radiant_barrier.nil?
       XMLHelper.add_element(roof, 'RadiantBarrierGrade', to_integer(@radiant_barrier_grade)) unless @radiant_barrier_grade.nil?
       insulation = XMLHelper.add_element(roof, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
@@ -1511,11 +1556,16 @@ class HPXML < Object
       @area = to_float_or_nil(XMLHelper.get_value(roof, 'Area'))
       @azimuth = to_integer_or_nil(XMLHelper.get_value(roof, 'Azimuth'))
       @roof_type = XMLHelper.get_value(roof, 'RoofType')
+      @roof_type_isdefaulted = get_software_defaulted(roof, 'RoofType') unless @roof_type.nil?
       @roof_color = XMLHelper.get_value(roof, 'RoofColor')
+      @roof_color_isdefaulted = get_software_defaulted(roof, 'RoofColor') unless @roof_color.nil?
       @solar_absorptance = to_float_or_nil(XMLHelper.get_value(roof, 'SolarAbsorptance'))
+      @solar_absorptance_isdefaulted = get_software_defaulted(roof, 'SolarAbsorptance') unless @solar_absorptance.nil?
       @emittance = to_float_or_nil(XMLHelper.get_value(roof, 'Emittance'))
+      @emittance_isdefaulted = get_software_defaulted(roof, 'Emittance') unless @emittance.nil?
       @pitch = to_float_or_nil(XMLHelper.get_value(roof, 'Pitch'))
       @radiant_barrier = to_boolean_or_nil(XMLHelper.get_value(roof, 'RadiantBarrier'))
+      @radiant_barrier_isdefaulted = get_software_defaulted(roof, 'RadiantBarrier') unless @radiant_barrier.nil?
       @radiant_barrier_grade = to_integer_or_nil(XMLHelper.get_value(roof, 'RadiantBarrierGrade'))
       insulation = XMLHelper.get_element(roof, 'Insulation')
       if not insulation.nil?
@@ -1591,10 +1641,10 @@ class HPXML < Object
       XMLHelper.add_element(rim_joist, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
       XMLHelper.add_element(rim_joist, 'Area', to_float(@area)) unless @area.nil?
       XMLHelper.add_element(rim_joist, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(rim_joist, 'Siding', @siding) unless @siding.nil?
-      XMLHelper.add_element(rim_joist, 'Color', @color) unless @color.nil?
-      XMLHelper.add_element(rim_joist, 'SolarAbsorptance', to_float(@solar_absorptance)) unless @solar_absorptance.nil?
-      XMLHelper.add_element(rim_joist, 'Emittance', to_float(@emittance)) unless @emittance.nil?
+      XMLHelper.add_element(rim_joist, 'Siding', @siding, @siding_isdefaulted) unless @siding.nil?
+      XMLHelper.add_element(rim_joist, 'Color', @color, @color_isdefaulted) unless @color.nil?
+      XMLHelper.add_element(rim_joist, 'SolarAbsorptance', to_float(@solar_absorptance), @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
+      XMLHelper.add_element(rim_joist, 'Emittance', to_float(@emittance), @emittance_isdefaulted) unless @emittance.nil?
       insulation = XMLHelper.add_element(rim_joist, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @insulation_id.nil?
@@ -1614,9 +1664,13 @@ class HPXML < Object
       @area = to_float_or_nil(XMLHelper.get_value(rim_joist, 'Area'))
       @azimuth = to_integer_or_nil(XMLHelper.get_value(rim_joist, 'Azimuth'))
       @siding = XMLHelper.get_value(rim_joist, 'Siding')
+      @siding_isdefaulted = get_software_defaulted(rim_joist, 'Siding') unless @siding.nil?
       @color = XMLHelper.get_value(rim_joist, 'Color')
+      @color_isdefaulted = get_software_defaulted(rim_joist, 'Color') unless @color.nil?
       @solar_absorptance = to_float_or_nil(XMLHelper.get_value(rim_joist, 'SolarAbsorptance'))
+      @solar_absorptance_isdefaulted = get_software_defaulted(rim_joist, 'SolarAbsorptance') unless @solar_absorptance.nil?
       @emittance = to_float_or_nil(XMLHelper.get_value(rim_joist, 'Emittance'))
+      @emittance_isdefaulted = get_software_defaulted(rim_joist, 'Emittance') unless @emittance.nil?
       insulation = XMLHelper.get_element(rim_joist, 'Insulation')
       if not insulation.nil?
         @insulation_id = HPXML::get_id(insulation)
@@ -1723,10 +1777,10 @@ class HPXML < Object
       end
       XMLHelper.add_element(wall, 'Area', to_float(@area)) unless @area.nil?
       XMLHelper.add_element(wall, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(wall, 'Siding', @siding) unless @siding.nil?
-      XMLHelper.add_element(wall, 'Color', @color) unless @color.nil?
-      XMLHelper.add_element(wall, 'SolarAbsorptance', to_float(@solar_absorptance)) unless @solar_absorptance.nil?
-      XMLHelper.add_element(wall, 'Emittance', to_float(@emittance)) unless @emittance.nil?
+      XMLHelper.add_element(wall, 'Siding', @siding, @siding_isdefaulted) unless @siding.nil?
+      XMLHelper.add_element(wall, 'Color', @color, @color_isdefaulted) unless @color.nil?
+      XMLHelper.add_element(wall, 'SolarAbsorptance', to_float(@solar_absorptance), @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
+      XMLHelper.add_element(wall, 'Emittance', to_float(@emittance), @emittance_isdefaulted) unless @emittance.nil?
       insulation = XMLHelper.add_element(wall, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @insulation_id.nil?
@@ -1749,9 +1803,13 @@ class HPXML < Object
       @orientation = XMLHelper.get_value(wall, 'Orientation')
       @azimuth = to_integer_or_nil(XMLHelper.get_value(wall, 'Azimuth'))
       @siding = XMLHelper.get_value(wall, 'Siding')
+      @siding_isdefaulted = get_software_defaulted(wall, 'Siding') unless @siding.nil?
       @color = XMLHelper.get_value(wall, 'Color')
+      @color_isdefaulted = get_software_defaulted(wall, 'Color') unless @color.nil?
       @solar_absorptance = to_float_or_nil(XMLHelper.get_value(wall, 'SolarAbsorptance'))
+      @solar_absorptance_isdefaulted = get_software_defaulted(wall, 'SolarAbsorptance') unless @solar_absorptance.nil?
       @emittance = to_float_or_nil(XMLHelper.get_value(wall, 'Emittance'))
+      @emittance_isdefaulted = get_software_defaulted(wall, 'Emittance') unless @emittance.nil?
       insulation = XMLHelper.get_element(wall, 'Insulation')
       if not insulation.nil?
         @insulation_id = HPXML::get_id(insulation)
@@ -1863,7 +1921,7 @@ class HPXML < Object
       XMLHelper.add_element(foundation_wall, 'Height', to_float(@height)) unless @height.nil?
       XMLHelper.add_element(foundation_wall, 'Area', to_float(@area)) unless @area.nil?
       XMLHelper.add_element(foundation_wall, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(foundation_wall, 'Thickness', to_float(@thickness)) unless @thickness.nil?
+      XMLHelper.add_element(foundation_wall, 'Thickness', to_float(@thickness), @thickness_isdefaulted) unless @thickness.nil?
       XMLHelper.add_element(foundation_wall, 'DepthBelowGrade', to_float(@depth_below_grade)) unless @depth_below_grade.nil?
       insulation = XMLHelper.add_element(foundation_wall, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
@@ -1899,6 +1957,7 @@ class HPXML < Object
       @area = to_float_or_nil(XMLHelper.get_value(foundation_wall, 'Area'))
       @azimuth = to_integer_or_nil(XMLHelper.get_value(foundation_wall, 'Azimuth'))
       @thickness = to_float_or_nil(XMLHelper.get_value(foundation_wall, 'Thickness'))
+      @thickness_isdefaulted = get_software_defaulted(foundation_wall, 'Thickness') unless @thickness.nil?
       @depth_below_grade = to_float_or_nil(XMLHelper.get_value(foundation_wall, 'DepthBelowGrade'))
       insulation = XMLHelper.get_element(foundation_wall, 'Insulation')
       if not insulation.nil?
@@ -2100,7 +2159,7 @@ class HPXML < Object
       XMLHelper.add_attribute(sys_id, 'id', @id)
       XMLHelper.add_element(slab, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
       XMLHelper.add_element(slab, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(slab, 'Thickness', to_float(@thickness)) unless @thickness.nil?
+      XMLHelper.add_element(slab, 'Thickness', to_float(@thickness), @thickness_isdefaulted) unless @thickness.nil?
       XMLHelper.add_element(slab, 'ExposedPerimeter', to_float(@exposed_perimeter)) unless @exposed_perimeter.nil?
       XMLHelper.add_element(slab, 'PerimeterInsulationDepth', to_float(@perimeter_insulation_depth)) unless @perimeter_insulation_depth.nil?
       XMLHelper.add_element(slab, 'UnderSlabInsulationWidth', to_float(@under_slab_insulation_width)) unless @under_slab_insulation_width.nil?
@@ -2126,8 +2185,8 @@ class HPXML < Object
       layer = XMLHelper.add_element(insulation, 'Layer')
       XMLHelper.add_element(layer, 'InstallationType', 'continuous')
       XMLHelper.add_element(layer, 'NominalRValue', to_float(@under_slab_insulation_r_value)) unless @under_slab_insulation_r_value.nil?
-      XMLHelper.add_extension(slab, 'CarpetFraction', to_float(@carpet_fraction)) unless @carpet_fraction.nil?
-      XMLHelper.add_extension(slab, 'CarpetRValue', to_float(@carpet_r_value)) unless @carpet_r_value.nil?
+      XMLHelper.add_extension(slab, 'CarpetFraction', to_float(@carpet_fraction), @carpet_fraction_isdefaulted) unless @carpet_fraction.nil?
+      XMLHelper.add_extension(slab, 'CarpetRValue', to_float(@carpet_r_value), @carpet_r_value_isdefaulted) unless @carpet_r_value.nil?
     end
 
     def from_oga(slab)
@@ -2137,13 +2196,16 @@ class HPXML < Object
       @interior_adjacent_to = XMLHelper.get_value(slab, 'InteriorAdjacentTo')
       @area = to_float_or_nil(XMLHelper.get_value(slab, 'Area'))
       @thickness = to_float_or_nil(XMLHelper.get_value(slab, 'Thickness'))
+      @thickness_isdefaulted = get_software_defaulted(slab, 'Thickness') unless @thickness.nil?
       @exposed_perimeter = to_float_or_nil(XMLHelper.get_value(slab, 'ExposedPerimeter'))
       @perimeter_insulation_depth = to_float_or_nil(XMLHelper.get_value(slab, 'PerimeterInsulationDepth'))
       @under_slab_insulation_width = to_float_or_nil(XMLHelper.get_value(slab, 'UnderSlabInsulationWidth'))
       @under_slab_insulation_spans_entire_slab = to_boolean_or_nil(XMLHelper.get_value(slab, 'UnderSlabInsulationSpansEntireSlab'))
       @depth_below_grade = to_float_or_nil(XMLHelper.get_value(slab, 'DepthBelowGrade'))
       @carpet_fraction = to_float_or_nil(XMLHelper.get_value(slab, 'extension/CarpetFraction'))
+      @carpet_fraction_isdefaulted = get_software_defaulted(slab, 'extension/CarpetFraction') unless @carpet_fraction.nil?
       @carpet_r_value = to_float_or_nil(XMLHelper.get_value(slab, 'extension/CarpetRValue'))
+      @carpet_r_value_isdefaulted = get_software_defaulted(slab, 'extension/CarpetRValue') unless @carpet_r_value.nil?
       perimeter_insulation = XMLHelper.get_element(slab, 'PerimeterInsulation')
       if not perimeter_insulation.nil?
         @perimeter_insulation_id = HPXML::get_id(perimeter_insulation)
@@ -2237,8 +2299,8 @@ class HPXML < Object
         interior_shading = XMLHelper.add_element(window, 'InteriorShading')
         sys_id = XMLHelper.add_element(interior_shading, 'SystemIdentifier')
         XMLHelper.add_attribute(sys_id, 'id', "#{id}InteriorShading")
-        XMLHelper.add_element(interior_shading, 'SummerShadingCoefficient', to_float(@interior_shading_factor_summer)) unless @interior_shading_factor_summer.nil?
-        XMLHelper.add_element(interior_shading, 'WinterShadingCoefficient', to_float(@interior_shading_factor_winter)) unless @interior_shading_factor_winter.nil?
+        XMLHelper.add_element(interior_shading, 'SummerShadingCoefficient', to_float(@interior_shading_factor_summer), @interior_shading_factor_summer_isdefaulted) unless @interior_shading_factor_summer.nil?
+        XMLHelper.add_element(interior_shading, 'WinterShadingCoefficient', to_float(@interior_shading_factor_winter), @interior_shading_factor_winter_isdefaulted) unless @interior_shading_factor_winter.nil?
       end
       if (not @overhangs_depth.nil?) || (not @overhangs_distance_to_top_of_window.nil?) || (not @overhangs_distance_to_bottom_of_window.nil?)
         overhangs = XMLHelper.add_element(window, 'Overhangs')
@@ -2246,7 +2308,7 @@ class HPXML < Object
         XMLHelper.add_element(overhangs, 'DistanceToTopOfWindow', to_float(@overhangs_distance_to_top_of_window)) unless @overhangs_distance_to_top_of_window.nil?
         XMLHelper.add_element(overhangs, 'DistanceToBottomOfWindow', to_float(@overhangs_distance_to_bottom_of_window)) unless @overhangs_distance_to_bottom_of_window.nil?
       end
-      XMLHelper.add_element(window, 'FractionOperable', to_float(@fraction_operable)) unless @fraction_operable.nil?
+      XMLHelper.add_element(window, 'FractionOperable', to_float(@fraction_operable), @fraction_operable_isdefaulted) unless @fraction_operable.nil?
       if not @wall_idref.nil?
         attached_to_wall = XMLHelper.add_element(window, 'AttachedToWall')
         XMLHelper.add_attribute(attached_to_wall, 'idref', @wall_idref)
@@ -2268,12 +2330,15 @@ class HPXML < Object
       @ufactor = to_float_or_nil(XMLHelper.get_value(window, 'UFactor'))
       @shgc = to_float_or_nil(XMLHelper.get_value(window, 'SHGC'))
       @interior_shading_factor_summer = to_float_or_nil(XMLHelper.get_value(window, 'InteriorShading/SummerShadingCoefficient'))
+      @interior_shading_factor_summer_isdefaulted = get_software_defaulted(window, 'InteriorShading/SummerShadingCoefficient') unless @interior_shading_factor_summer.nil?
       @interior_shading_factor_winter = to_float_or_nil(XMLHelper.get_value(window, 'InteriorShading/WinterShadingCoefficient'))
+      @interior_shading_factor_winter_isdefaulted = get_software_defaulted(window, 'InteriorShading/WinterShadingCoefficient') unless @interior_shading_factor_winter.nil?
       @exterior_shading = XMLHelper.get_value(window, 'ExteriorShading/Type')
       @overhangs_depth = to_float_or_nil(XMLHelper.get_value(window, 'Overhangs/Depth'))
       @overhangs_distance_to_top_of_window = to_float_or_nil(XMLHelper.get_value(window, 'Overhangs/DistanceToTopOfWindow'))
       @overhangs_distance_to_bottom_of_window = to_float_or_nil(XMLHelper.get_value(window, 'Overhangs/DistanceToBottomOfWindow'))
       @fraction_operable = to_float_or_nil(XMLHelper.get_value(window, 'FractionOperable'))
+      @fraction_operable_isdefaulted = get_software_defaulted(window, 'FractionOperable') unless @fraction_operable.nil?
       @wall_idref = HPXML::get_idref(XMLHelper.get_element(window, 'AttachedToWall'))
     end
   end
@@ -2350,8 +2415,8 @@ class HPXML < Object
         interior_shading = XMLHelper.add_element(skylight, 'InteriorShading')
         sys_id = XMLHelper.add_element(interior_shading, 'SystemIdentifier')
         XMLHelper.add_attribute(sys_id, 'id', "#{id}InteriorShading")
-        XMLHelper.add_element(interior_shading, 'SummerShadingCoefficient', to_float(@interior_shading_factor_summer)) unless @interior_shading_factor_summer.nil?
-        XMLHelper.add_element(interior_shading, 'WinterShadingCoefficient', to_float(@interior_shading_factor_winter)) unless @interior_shading_factor_winter.nil?
+        XMLHelper.add_element(interior_shading, 'SummerShadingCoefficient', to_float(@interior_shading_factor_summer), @interior_shading_factor_summer_isdefaulted) unless @interior_shading_factor_summer.nil?
+        XMLHelper.add_element(interior_shading, 'WinterShadingCoefficient', to_float(@interior_shading_factor_winter), @interior_shading_factor_winter_isdefaulted) unless @interior_shading_factor_winter.nil?
       end
       if not @roof_idref.nil?
         attached_to_roof = XMLHelper.add_element(skylight, 'AttachedToRoof')
@@ -2374,7 +2439,9 @@ class HPXML < Object
       @ufactor = to_float_or_nil(XMLHelper.get_value(skylight, 'UFactor'))
       @shgc = to_float_or_nil(XMLHelper.get_value(skylight, 'SHGC'))
       @interior_shading_factor_summer = to_float_or_nil(XMLHelper.get_value(skylight, 'InteriorShading/SummerShadingCoefficient'))
+      @interior_shading_factor_summer_isdefaulted = get_software_defaulted(skylight, 'InteriorShading/SummerShadingCoefficient') unless @interior_shading_factor_summer.nil?
       @interior_shading_factor_winter = to_float_or_nil(XMLHelper.get_value(skylight, 'InteriorShading/WinterShadingCoefficient'))
+      @interior_shading_factor_winter_isdefaulted = get_software_defaulted(skylight, 'InteriorShading/WinterShadingCoefficient') unless @interior_shading_factor_winter.nil?
       @exterior_shading = XMLHelper.get_value(skylight, 'ExteriorShading/Type')
       @roof_idref = HPXML::get_idref(XMLHelper.get_element(skylight, 'AttachedToRoof'))
     end
@@ -2561,11 +2628,11 @@ class HPXML < Object
         XMLHelper.add_element(annual_efficiency, 'Value', to_float(efficiency_value))
       end
       XMLHelper.add_element(heating_system, 'FractionHeatLoadServed', to_float(@fraction_heat_load_served)) unless @fraction_heat_load_served.nil?
-      XMLHelper.add_element(heating_system, 'ElectricAuxiliaryEnergy', to_float(@electric_auxiliary_energy)) unless @electric_auxiliary_energy.nil?
+      XMLHelper.add_element(heating_system, 'ElectricAuxiliaryEnergy', to_float(@electric_auxiliary_energy), @electric_auxiliary_energy_isdefaulted) unless @electric_auxiliary_energy.nil?
       XMLHelper.add_extension(heating_system, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
       XMLHelper.add_extension(heating_system, 'FanCoilWatts', to_float(@fan_coil_watts)) unless @fan_coil_watts.nil?
-      XMLHelper.add_extension(heating_system, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm)) unless @fan_watts_per_cfm.nil?
-      XMLHelper.add_extension(heating_system, 'FanPowerWatts', to_float(@fan_watts)) unless @fan_watts.nil?
+      XMLHelper.add_extension(heating_system, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm), @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
+      XMLHelper.add_extension(heating_system, 'FanPowerWatts', to_float(@fan_watts), @fan_watts_isdefaulted) unless @fan_watts.nil?
       XMLHelper.add_extension(heating_system, 'SeedId', @seed_id) unless @seed_id.nil?
       if not @wlhp_heating_efficiency_cop.nil?
         wlhp = XMLHelper.create_elements_as_needed(heating_system, ['extension', 'WaterLoopHeatPump'])
@@ -2593,10 +2660,13 @@ class HPXML < Object
       end
       @fraction_heat_load_served = to_float_or_nil(XMLHelper.get_value(heating_system, 'FractionHeatLoadServed'))
       @electric_auxiliary_energy = to_float_or_nil(XMLHelper.get_value(heating_system, 'ElectricAuxiliaryEnergy'))
+      @electric_auxiliary_energy_isdefaulted = get_software_defaulted(heating_system, 'ElectricAuxiliaryEnergy') unless @electric_auxiliary_energy.nil?
       @energy_star = XMLHelper.get_values(heating_system, 'ThirdPartyCertification').include?('Energy Star')
       @seed_id = XMLHelper.get_value(heating_system, 'extension/SeedId')
       @fan_watts_per_cfm = to_float_or_nil(XMLHelper.get_value(heating_system, 'extension/FanPowerWattsPerCFM'))
+      @fan_watts_per_cfm_isdefaulted = get_software_defaulted(heating_system, 'extension/FanPowerWattsPerCFM') unless @fan_watts_per_cfm.nil?
       @fan_watts = to_float_or_nil(XMLHelper.get_value(heating_system, 'extension/FanPowerWatts'))
+      @fan_watts_isdefaulted = get_software_defaulted(heating_system, 'extension/FanPowerWatts') unless @fan_watts.nil?
       @shared_loop_watts = to_float_or_nil(XMLHelper.get_value(heating_system, 'extension/SharedLoopWatts'))
       @fan_coil_watts = to_float_or_nil(XMLHelper.get_value(heating_system, 'extension/FanCoilWatts'))
       @wlhp_heating_efficiency_cop = to_float_or_nil(XMLHelper.get_value(heating_system, "extension/WaterLoopHeatPump/AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value"))
@@ -2683,7 +2753,7 @@ class HPXML < Object
       XMLHelper.add_element(cooling_system, 'CoolingSystemType', @cooling_system_type) unless @cooling_system_type.nil?
       XMLHelper.add_element(cooling_system, 'CoolingSystemFuel', @cooling_system_fuel) unless @cooling_system_fuel.nil?
       XMLHelper.add_element(cooling_system, 'CoolingCapacity', to_float(@cooling_capacity)) unless @cooling_capacity.nil?
-      XMLHelper.add_element(cooling_system, 'CompressorType', @compressor_type) unless @compressor_type.nil?
+      XMLHelper.add_element(cooling_system, 'CompressorType', @compressor_type, @compressor_type_isdefaulted) unless @compressor_type.nil?
       XMLHelper.add_element(cooling_system, 'FractionCoolLoadServed', to_float(@fraction_cool_load_served)) unless @fraction_cool_load_served.nil?
 
       efficiency_units = nil
@@ -2703,8 +2773,8 @@ class HPXML < Object
         XMLHelper.add_element(annual_efficiency, 'Units', efficiency_units)
         XMLHelper.add_element(annual_efficiency, 'Value', to_float(efficiency_value))
       end
-      XMLHelper.add_element(cooling_system, 'SensibleHeatFraction', to_float(@cooling_shr)) unless @cooling_shr.nil?
-      XMLHelper.add_extension(cooling_system, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm)) unless @fan_watts_per_cfm.nil?
+      XMLHelper.add_element(cooling_system, 'SensibleHeatFraction', to_float(@cooling_shr), @cooling_shr_isdefaulted) unless @cooling_shr.nil?
+      XMLHelper.add_extension(cooling_system, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm), @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
       XMLHelper.add_extension(cooling_system, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
       XMLHelper.add_extension(cooling_system, 'FanCoilWatts', to_float(@fan_coil_watts)) unless @fan_coil_watts.nil?
       XMLHelper.add_extension(cooling_system, 'SeedId', @seed_id) unless @seed_id.nil?
@@ -2731,6 +2801,7 @@ class HPXML < Object
       @cooling_system_fuel = XMLHelper.get_value(cooling_system, 'CoolingSystemFuel')
       @cooling_capacity = to_float_or_nil(XMLHelper.get_value(cooling_system, 'CoolingCapacity'))
       @compressor_type = XMLHelper.get_value(cooling_system, 'CompressorType')
+      @compressor_type_isdefaulted = get_software_defaulted(cooling_system, 'CompressorType') unless @compressor_type.nil?
       @fraction_cool_load_served = to_float_or_nil(XMLHelper.get_value(cooling_system, 'FractionCoolLoadServed'))
       if [HVACTypeCentralAirConditioner, HVACTypeMiniSplitAirConditioner].include? @cooling_system_type
         @cooling_efficiency_seer = to_float_or_nil(XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsSEER}']/Value"))
@@ -2740,9 +2811,11 @@ class HPXML < Object
         @cooling_efficiency_kw_per_ton = to_float_or_nil(XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsKwPerTon}']/Value"))
       end
       @cooling_shr = to_float_or_nil(XMLHelper.get_value(cooling_system, 'SensibleHeatFraction'))
+      @cooling_shr_isdefaulted = get_software_defaulted(cooling_system, 'SensibleHeatFraction') unless @cooling_shr.nil?
       @energy_star = XMLHelper.get_values(cooling_system, 'ThirdPartyCertification').include?('Energy Star')
       @seed_id = XMLHelper.get_value(cooling_system, 'extension/SeedId')
       @fan_watts_per_cfm = to_float_or_nil(XMLHelper.get_value(cooling_system, 'extension/FanPowerWattsPerCFM'))
+      @fan_watts_per_cfm_isdefaulted = get_software_defaulted(cooling_system, 'extension/FanPowerWattsPerCFM') unless @fan_watts_per_cfm.nil?
       @shared_loop_watts = to_float_or_nil(XMLHelper.get_value(cooling_system, 'extension/SharedLoopWatts'))
       @fan_coil_watts = to_float_or_nil(XMLHelper.get_value(cooling_system, 'extension/FanCoilWatts'))
       @wlhp_cooling_capacity = to_float_or_nil(XMLHelper.get_value(cooling_system, 'extension/WaterLoopHeatPump/CoolingCapacity'))
@@ -2827,8 +2900,8 @@ class HPXML < Object
       XMLHelper.add_element(heat_pump, 'HeatingCapacity', to_float(@heating_capacity)) unless @heating_capacity.nil?
       XMLHelper.add_element(heat_pump, 'HeatingCapacity17F', to_float(@heating_capacity_17F)) unless @heating_capacity_17F.nil?
       XMLHelper.add_element(heat_pump, 'CoolingCapacity', to_float(@cooling_capacity)) unless @cooling_capacity.nil?
-      XMLHelper.add_element(heat_pump, 'CompressorType', @compressor_type) unless @compressor_type.nil?
-      XMLHelper.add_element(heat_pump, 'CoolingSensibleHeatFraction', to_float(@cooling_shr)) unless @cooling_shr.nil?
+      XMLHelper.add_element(heat_pump, 'CompressorType', @compressor_type, @compressor_type_isdefaulted) unless @compressor_type.nil?
+      XMLHelper.add_element(heat_pump, 'CoolingSensibleHeatFraction', to_float(@cooling_shr), @cooling_shr_isdefaulted) unless @cooling_shr.nil?
       if not @backup_heating_fuel.nil?
         XMLHelper.add_element(heat_pump, 'BackupSystemFuel', @backup_heating_fuel)
         efficiencies = { 'Percent' => @backup_heating_efficiency_percent,
@@ -2871,8 +2944,8 @@ class HPXML < Object
         XMLHelper.add_element(annual_efficiency, 'Units', htg_efficiency_units)
         XMLHelper.add_element(annual_efficiency, 'Value', to_float(htg_efficiency_value))
       end
-      XMLHelper.add_extension(heat_pump, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm)) unless @fan_watts_per_cfm.nil?
-      XMLHelper.add_extension(heat_pump, 'PumpPowerWattsPerTon', to_float(@pump_watts_per_ton)) unless @pump_watts_per_ton.nil?
+      XMLHelper.add_extension(heat_pump, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm), @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
+      XMLHelper.add_extension(heat_pump, 'PumpPowerWattsPerTon', to_float(@pump_watts_per_ton), @pump_watts_per_ton_isdefaulted) unless @pump_watts_per_ton.nil?
       XMLHelper.add_extension(heat_pump, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
       XMLHelper.add_extension(heat_pump, 'SeedId', @seed_id) unless @seed_id.nil?
     end
@@ -2891,7 +2964,9 @@ class HPXML < Object
       @heating_capacity_17F = to_float_or_nil(XMLHelper.get_value(heat_pump, 'HeatingCapacity17F'))
       @cooling_capacity = to_float_or_nil(XMLHelper.get_value(heat_pump, 'CoolingCapacity'))
       @compressor_type = XMLHelper.get_value(heat_pump, 'CompressorType')
+      @compressor_type_isdefaulted = get_software_defaulted(heat_pump, 'CompressorType') unless @compressor_type.nil?
       @cooling_shr = to_float_or_nil(XMLHelper.get_value(heat_pump, 'CoolingSensibleHeatFraction'))
+      @cooling_shr_isdefaulted = get_software_defaulted(heat_pump, 'CoolingSensibleHeatFraction') unless @cooling_shr.nil?
       @backup_heating_fuel = XMLHelper.get_value(heat_pump, 'BackupSystemFuel')
       @backup_heating_capacity = to_float_or_nil(XMLHelper.get_value(heat_pump, 'BackupHeatingCapacity'))
       @backup_heating_efficiency_percent = to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='Percent']/Value"))
@@ -2911,7 +2986,9 @@ class HPXML < Object
       end
       @energy_star = XMLHelper.get_values(heat_pump, 'ThirdPartyCertification').include?('Energy Star')
       @pump_watts_per_ton = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/PumpPowerWattsPerTon'))
+      @pump_watts_per_ton_isdefaulted = get_software_defaulted(heat_pump, 'extension/PumpPowerWattsPerTon') unless @pump_watts_per_ton.nil?
       @fan_watts_per_cfm = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/FanPowerWattsPerCFM'))
+      @fan_watts_per_cfm_isdefaulted = get_software_defaulted(heat_pump, 'extension/FanPowerWattsPerCFM') unless @fan_watts_per_cfm.nil?
       @seed_id = XMLHelper.get_value(heat_pump, 'extension/SeedId')
       @shared_loop_watts = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/SharedLoopWatts'))
     end
@@ -2963,8 +3040,8 @@ class HPXML < Object
       XMLHelper.add_element(hvac_control, 'SetupTempCoolingSeason', to_float(@cooling_setup_temp)) unless @cooling_setup_temp.nil?
       XMLHelper.add_element(hvac_control, 'SetpointTempCoolingSeason', to_float(@cooling_setpoint_temp)) unless @cooling_setpoint_temp.nil?
       XMLHelper.add_element(hvac_control, 'TotalSetupHoursperWeekCooling', to_integer(@cooling_setup_hours_per_week)) unless @cooling_setup_hours_per_week.nil?
-      XMLHelper.add_extension(hvac_control, 'SetbackStartHourHeating', to_integer(@heating_setback_start_hour)) unless @heating_setback_start_hour.nil?
-      XMLHelper.add_extension(hvac_control, 'SetupStartHourCooling', to_integer(@cooling_setup_start_hour)) unless @cooling_setup_start_hour.nil?
+      XMLHelper.add_extension(hvac_control, 'SetbackStartHourHeating', to_integer(@heating_setback_start_hour), @heating_setback_start_hour_isdefaulted) unless @heating_setback_start_hour.nil?
+      XMLHelper.add_extension(hvac_control, 'SetupStartHourCooling', to_integer(@cooling_setup_start_hour), @cooling_setup_start_hour_isdefaulted) unless @cooling_setup_start_hour.nil?
       XMLHelper.add_extension(hvac_control, 'CeilingFanSetpointTempCoolingSeasonOffset', to_float(@ceiling_fan_cooling_setpoint_temp_offset)) unless @ceiling_fan_cooling_setpoint_temp_offset.nil?
       XMLHelper.add_extension(hvac_control, 'WeekdaySetpointTempsHeatingSeason', @weekday_heating_setpoints) unless @weekday_heating_setpoints.nil?
       XMLHelper.add_extension(hvac_control, 'WeekendSetpointTempsHeatingSeason', @weekend_heating_setpoints) unless @weekend_heating_setpoints.nil?
@@ -2981,10 +3058,12 @@ class HPXML < Object
       @heating_setback_temp = to_float_or_nil(XMLHelper.get_value(hvac_control, 'SetbackTempHeatingSeason'))
       @heating_setback_hours_per_week = to_integer_or_nil(XMLHelper.get_value(hvac_control, 'TotalSetbackHoursperWeekHeating'))
       @heating_setback_start_hour = to_integer_or_nil(XMLHelper.get_value(hvac_control, 'extension/SetbackStartHourHeating'))
+      @heating_setback_start_hour_isdefaulted = get_software_defaulted(hvac_control, 'extension/SetbackStartHourHeating') unless @heating_setback_start_hour.nil?
       @cooling_setpoint_temp = to_float_or_nil(XMLHelper.get_value(hvac_control, 'SetpointTempCoolingSeason'))
       @cooling_setup_temp = to_float_or_nil(XMLHelper.get_value(hvac_control, 'SetupTempCoolingSeason'))
       @cooling_setup_hours_per_week = to_integer_or_nil(XMLHelper.get_value(hvac_control, 'TotalSetupHoursperWeekCooling'))
       @cooling_setup_start_hour = to_integer_or_nil(XMLHelper.get_value(hvac_control, 'extension/SetupStartHourCooling'))
+      @cooling_setup_start_hour_isdefaulted = get_software_defaulted(hvac_control, 'extension/SetupStartHourCooling') unless @cooling_setup_start_hour.nil?
       @ceiling_fan_cooling_setpoint_temp_offset = to_float_or_nil(XMLHelper.get_value(hvac_control, 'extension/CeilingFanSetpointTempCoolingSeasonOffset'))
       @weekday_heating_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekdaySetpointTempsHeatingSeason')
       @weekend_heating_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekendSetpointTempsHeatingSeason')
@@ -3111,7 +3190,7 @@ class HPXML < Object
         end
         @duct_leakage_measurements.to_oga(distribution)
         @ducts.to_oga(distribution)
-        XMLHelper.add_element(distribution, 'NumberofReturnRegisters', Integer(@number_of_return_registers)) unless @number_of_return_registers.nil?
+        XMLHelper.add_element(distribution, 'NumberofReturnRegisters', Integer(@number_of_return_registers), @number_of_return_registers_isdefaulted) unless @number_of_return_registers.nil?
         XMLHelper.add_extension(distribution, 'DuctLeakageToOutsideTestingExemption', to_boolean(@duct_leakage_to_outside_testing_exemption)) unless @duct_leakage_to_outside_testing_exemption.nil?
       end
     end
@@ -3143,6 +3222,7 @@ class HPXML < Object
         distribution = air_distribution
         distribution = hydronic_and_air_distribution if distribution.nil?
         @number_of_return_registers = to_integer_or_nil(XMLHelper.get_value(distribution, 'NumberofReturnRegisters'))
+        @number_of_return_registers_isdefaulted = get_software_defaulted(distribution, 'NumberofReturnRegisters') unless @number_of_return_registers.nil?
         @duct_leakage_to_outside_testing_exemption = to_boolean_or_nil(XMLHelper.get_value(distribution, 'extension/DuctLeakageToOutsideTestingExemption'))
         @duct_leakage_measurements.from_oga(distribution)
         @ducts.from_oga(distribution)
@@ -3240,8 +3320,8 @@ class HPXML < Object
       ducts_el = XMLHelper.add_element(air_distribution, 'Ducts')
       XMLHelper.add_element(ducts_el, 'DuctType', @duct_type) unless @duct_type.nil?
       XMLHelper.add_element(ducts_el, 'DuctInsulationRValue', to_float(@duct_insulation_r_value)) unless @duct_insulation_r_value.nil?
-      XMLHelper.add_element(ducts_el, 'DuctLocation', @duct_location) unless @duct_location.nil?
-      XMLHelper.add_element(ducts_el, 'DuctSurfaceArea', to_float(@duct_surface_area)) unless @duct_surface_area.nil?
+      XMLHelper.add_element(ducts_el, 'DuctLocation', @duct_location, @duct_location_isdefaulted) unless @duct_location.nil?
+      XMLHelper.add_element(ducts_el, 'DuctSurfaceArea', to_float(@duct_surface_area), @duct_surface_area_isdefaulted) unless @duct_surface_area.nil?
     end
 
     def from_oga(duct)
@@ -3251,8 +3331,10 @@ class HPXML < Object
       @duct_insulation_r_value = to_float_or_nil(XMLHelper.get_value(duct, 'DuctInsulationRValue'))
       @duct_insulation_material = XMLHelper.get_child_name(duct, 'DuctInsulationMaterial')
       @duct_location = XMLHelper.get_value(duct, 'DuctLocation')
+      @duct_location_isdefaulted = get_software_defaulted(duct, 'DuctLocation') unless @duct_location.nil?
       @duct_fraction_area = to_float_or_nil(XMLHelper.get_value(duct, 'FractionDuctArea'))
       @duct_surface_area = to_float_or_nil(XMLHelper.get_value(duct, 'DuctSurfaceArea'))
+      @duct_surface_area_isdefaulted = get_software_defaulted(duct, 'DuctSurfaceArea') unless @duct_surface_area.nil?
     end
   end
 
@@ -3417,16 +3499,16 @@ class HPXML < Object
       ventilation_fan = XMLHelper.add_element(ventilation_fans, 'VentilationFan')
       sys_id = XMLHelper.add_element(ventilation_fan, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(ventilation_fan, 'Quantity', to_integer(@quantity)) unless @quantity.nil?
+      XMLHelper.add_element(ventilation_fan, 'Quantity', to_integer(@quantity), @quantity_isdefaulted) unless @quantity.nil?
       XMLHelper.add_element(ventilation_fan, 'FanType', @fan_type) unless @fan_type.nil?
-      XMLHelper.add_element(ventilation_fan, 'RatedFlowRate', to_float(@rated_flow_rate)) unless @rated_flow_rate.nil?
+      XMLHelper.add_element(ventilation_fan, 'RatedFlowRate', to_float(@rated_flow_rate), @rated_flow_rate_isdefaulted) unless @rated_flow_rate.nil?
       XMLHelper.add_element(ventilation_fan, 'TestedFlowRate', to_float(@tested_flow_rate)) unless @tested_flow_rate.nil?
-      XMLHelper.add_element(ventilation_fan, 'HoursInOperation', to_float(@hours_in_operation)) unless @hours_in_operation.nil?
+      XMLHelper.add_element(ventilation_fan, 'HoursInOperation', to_float(@hours_in_operation), @hours_in_operation_isdefaulted) unless @hours_in_operation.nil?
       XMLHelper.add_element(ventilation_fan, 'FanLocation', @fan_location) unless @fan_location.nil?
       XMLHelper.add_element(ventilation_fan, 'UsedForLocalVentilation', to_boolean(@used_for_local_ventilation)) unless @used_for_local_ventilation.nil?
       XMLHelper.add_element(ventilation_fan, 'UsedForWholeBuildingVentilation', to_boolean(@used_for_whole_building_ventilation)) unless @used_for_whole_building_ventilation.nil?
       XMLHelper.add_element(ventilation_fan, 'UsedForSeasonalCoolingLoadReduction', to_boolean(@used_for_seasonal_cooling_load_reduction)) unless @used_for_seasonal_cooling_load_reduction.nil?
-      XMLHelper.add_element(ventilation_fan, 'IsSharedSystem', to_boolean(@is_shared_system)) unless @is_shared_system.nil?
+      XMLHelper.add_element(ventilation_fan, 'IsSharedSystem', to_boolean(@is_shared_system), @is_shared_system_isdefaulted) unless @is_shared_system.nil?
       if @is_shared_system
         XMLHelper.add_element(ventilation_fan, 'FractionRecirculation', to_float(@fraction_recirculation)) unless @fraction_recirculation.nil?
       end
@@ -3434,12 +3516,12 @@ class HPXML < Object
       XMLHelper.add_element(ventilation_fan, 'SensibleRecoveryEfficiency', to_float(@sensible_recovery_efficiency)) unless @sensible_recovery_efficiency.nil?
       XMLHelper.add_element(ventilation_fan, 'AdjustedTotalRecoveryEfficiency', to_float(@total_recovery_efficiency_adjusted)) unless @total_recovery_efficiency_adjusted.nil?
       XMLHelper.add_element(ventilation_fan, 'AdjustedSensibleRecoveryEfficiency', to_float(@sensible_recovery_efficiency_adjusted)) unless @sensible_recovery_efficiency_adjusted.nil?
-      XMLHelper.add_element(ventilation_fan, 'FanPower', to_float(@fan_power)) unless @fan_power.nil?
+      XMLHelper.add_element(ventilation_fan, 'FanPower', to_float(@fan_power), @fan_power_isdefaulted) unless @fan_power.nil?
       if not @distribution_system_idref.nil?
         attached_to_hvac_distribution_system = XMLHelper.add_element(ventilation_fan, 'AttachedToHVACDistributionSystem')
         XMLHelper.add_attribute(attached_to_hvac_distribution_system, 'idref', @distribution_system_idref)
       end
-      XMLHelper.add_extension(ventilation_fan, 'StartHour', to_integer(@start_hour)) unless @start_hour.nil?
+      XMLHelper.add_extension(ventilation_fan, 'StartHour', to_integer(@start_hour), @start_hour_isdefaulted) unless @start_hour.nil?
       if @is_shared_system
         XMLHelper.add_extension(ventilation_fan, 'InUnitFlowRate', to_float(@in_unit_flow_rate)) unless @in_unit_flow_rate.nil?
         if (not @preheating_fuel.nil?) && (not @preheating_efficiency_cop.nil?)
@@ -3468,12 +3550,16 @@ class HPXML < Object
 
       @id = HPXML::get_id(ventilation_fan)
       @quantity = to_integer_or_nil(XMLHelper.get_value(ventilation_fan, 'Quantity'))
+      @quantity_isdefaulted = get_software_defaulted(ventilation_fan, 'Quantity') unless @quantity.nil?
       @fan_type = XMLHelper.get_value(ventilation_fan, 'FanType')
       @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'IsSharedSystem'))
+      @is_shared_system_isdefaulted = get_software_defaulted(ventilation_fan, 'IsSharedSystem') unless @is_shared_system.nil?
       @rated_flow_rate = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'RatedFlowRate'))
+      @rated_flow_rate_isdefaulted = get_software_defaulted(ventilation_fan, 'RatedFlowRate') unless @rated_flow_rate.nil?
       @tested_flow_rate = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'TestedFlowRate'))
       @flow_rate_not_tested = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/FlowRateNotTested'))
       @fan_power = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'FanPower'))
+      @fan_power_isdefaulted = get_software_defaulted(ventilation_fan, 'FanPower') unless @fan_power.nil?
       @fan_power_defaulted = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/FanPowerDefaulted'))
       if @is_shared_system
         @fraction_recirculation = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'FractionRecirculation'))
@@ -3486,6 +3572,7 @@ class HPXML < Object
         @precooling_fraction_load_served = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/PreCooling/FractionVentilationCoolLoadServed'))
       end
       @hours_in_operation = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'HoursInOperation'))
+      @hours_in_operation_isdefaulted = get_software_defaulted(ventilation_fan, 'HoursInOperation') unless @hours_in_operation.nil?
       @fan_location = XMLHelper.get_value(ventilation_fan, 'FanLocation')
       @used_for_local_ventilation = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'UsedForLocalVentilation'))
       @used_for_whole_building_ventilation = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'UsedForWholeBuildingVentilation'))
@@ -3496,6 +3583,7 @@ class HPXML < Object
       @sensible_recovery_efficiency_adjusted = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'AdjustedSensibleRecoveryEfficiency'))
       @distribution_system_idref = HPXML::get_idref(XMLHelper.get_element(ventilation_fan, 'AttachedToHVACDistributionSystem'))
       @start_hour = to_integer_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/StartHour'))
+      @start_hour_isdefaulted = get_software_defaulted(ventilation_fan, 'extension/StartHour') unless @start_hour.nil?
     end
   end
 
@@ -3556,24 +3644,24 @@ class HPXML < Object
       XMLHelper.add_attribute(sys_id, 'id', @id)
       XMLHelper.add_element(water_heating_system, 'FuelType', @fuel_type) unless @fuel_type.nil?
       XMLHelper.add_element(water_heating_system, 'WaterHeaterType', @water_heater_type) unless @water_heater_type.nil?
-      XMLHelper.add_element(water_heating_system, 'Location', @location) unless @location.nil?
-      XMLHelper.add_element(water_heating_system, 'IsSharedSystem', to_boolean(@is_shared_system)) unless @is_shared_system.nil?
+      XMLHelper.add_element(water_heating_system, 'Location', @location, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(water_heating_system, 'IsSharedSystem', to_boolean(@is_shared_system), @is_shared_system_isdefaulted) unless @is_shared_system.nil?
       XMLHelper.add_element(water_heating_system, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
-      XMLHelper.add_element(water_heating_system, 'PerformanceAdjustment', to_float(@performance_adjustment)) unless @performance_adjustment.nil?
-      XMLHelper.add_element(water_heating_system, 'TankVolume', to_float(@tank_volume)) unless @tank_volume.nil?
+      XMLHelper.add_element(water_heating_system, 'PerformanceAdjustment', to_float(@performance_adjustment), @performance_adjustment_isdefaulted) unless @performance_adjustment.nil?
+      XMLHelper.add_element(water_heating_system, 'TankVolume', to_float(@tank_volume), @tank_volume_isdefaulted) unless @tank_volume.nil?
       XMLHelper.add_element(water_heating_system, 'FractionDHWLoadServed', to_float(@fraction_dhw_load_served)) unless @fraction_dhw_load_served.nil?
-      XMLHelper.add_element(water_heating_system, 'HeatingCapacity', to_float(@heating_capacity)) unless @heating_capacity.nil?
+      XMLHelper.add_element(water_heating_system, 'HeatingCapacity', to_float(@heating_capacity), @heating_capacity_isdefaulted) unless @heating_capacity.nil?
       XMLHelper.add_element(water_heating_system, 'EnergyFactor', to_float(@energy_factor)) unless @energy_factor.nil?
       XMLHelper.add_element(water_heating_system, 'UniformEnergyFactor', to_float(@uniform_energy_factor)) unless @uniform_energy_factor.nil?
       XMLHelper.add_element(water_heating_system, 'FirstHourRating', to_float(@first_hour_rating)) unless @first_hour_rating.nil?
-      XMLHelper.add_element(water_heating_system, 'RecoveryEfficiency', to_float(@recovery_efficiency)) unless @recovery_efficiency.nil?
+      XMLHelper.add_element(water_heating_system, 'RecoveryEfficiency', to_float(@recovery_efficiency), @recovery_efficiency_isdefaulted) unless @recovery_efficiency.nil?
       if not @jacket_r_value.nil?
         water_heater_insulation = XMLHelper.add_element(water_heating_system, 'WaterHeaterInsulation')
         jacket = XMLHelper.add_element(water_heater_insulation, 'Jacket')
         XMLHelper.add_element(jacket, 'JacketRValue', @jacket_r_value)
       end
-      XMLHelper.add_element(water_heating_system, 'StandbyLoss', to_float(@standby_loss)) unless @standby_loss.nil?
-      XMLHelper.add_element(water_heating_system, 'HotWaterTemperature', to_float(@temperature)) unless @temperature.nil?
+      XMLHelper.add_element(water_heating_system, 'StandbyLoss', to_float(@standby_loss), @standby_loss_isdefaulted) unless @standby_loss.nil?
+      XMLHelper.add_element(water_heating_system, 'HotWaterTemperature', to_float(@temperature), @temperature_isdefaulted) unless @temperature.nil?
       XMLHelper.add_element(water_heating_system, 'UsesDesuperheater', to_boolean(@uses_desuperheater)) unless @uses_desuperheater.nil?
       if not @related_hvac_idref.nil?
         related_hvac_idref_el = XMLHelper.add_element(water_heating_system, 'RelatedHVACSystem')
@@ -3589,22 +3677,30 @@ class HPXML < Object
       @fuel_type = XMLHelper.get_value(water_heating_system, 'FuelType')
       @water_heater_type = XMLHelper.get_value(water_heating_system, 'WaterHeaterType')
       @location = XMLHelper.get_value(water_heating_system, 'Location')
+      @location_isdefaulted = get_software_defaulted(water_heating_system, 'Location') unless @location.nil?
       @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(water_heating_system, 'IsSharedSystem'))
+      @is_shared_system_isdefaulted = get_software_defaulted(water_heating_system, 'IsSharedSystem') unless @is_shared_system.nil?
       @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(water_heating_system, 'NumberofUnitsServed'))
       @performance_adjustment = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'PerformanceAdjustment'))
+      @performance_adjustment_isdefaulted = get_software_defaulted(water_heating_system, 'PerformanceAdjustment') unless @performance_adjustment.nil?
       @tank_volume = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'TankVolume'))
+      @tank_volume_isdefaulted = get_software_defaulted(water_heating_system, 'TankVolume') unless @tank_volume.nil?
       @fraction_dhw_load_served = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'FractionDHWLoadServed'))
       @heating_capacity = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'HeatingCapacity'))
+      @heating_capacity_isdefaulted = get_software_defaulted(water_heating_system, 'HeatingCapacity') unless @heating_capacity.nil?
       @energy_factor = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'EnergyFactor'))
       @uniform_energy_factor = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'UniformEnergyFactor'))
       @first_hour_rating = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'FirstHourRating'))
       @recovery_efficiency = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'RecoveryEfficiency'))
+      @recovery_efficiency_isdefaulted = get_software_defaulted(water_heating_system, 'RecoveryEfficiency') unless @recovery_efficiency.nil?
       @uses_desuperheater = to_boolean_or_nil(XMLHelper.get_value(water_heating_system, 'UsesDesuperheater'))
       @jacket_r_value = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'WaterHeaterInsulation/Jacket/JacketRValue'))
       @related_hvac_idref = HPXML::get_idref(XMLHelper.get_element(water_heating_system, 'RelatedHVACSystem'))
       @energy_star = XMLHelper.get_values(water_heating_system, 'ThirdPartyCertification').include?('Energy Star')
       @standby_loss = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'StandbyLoss'))
+      @standby_loss_isdefaulted = get_software_defaulted(water_heating_system, 'StandbyLoss') unless @standby_loss.nil?
       @temperature = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'HotWaterTemperature'))
+      @temperature_isdefaulted = get_software_defaulted(water_heating_system, 'HotWaterTemperature') unless @temperature.nil?
     end
   end
 
@@ -3650,13 +3746,13 @@ class HPXML < Object
         system_type_e = XMLHelper.add_element(hot_water_distribution, 'SystemType')
         if @system_type == DHWDistTypeStandard
           standard = XMLHelper.add_element(system_type_e, @system_type)
-          XMLHelper.add_element(standard, 'PipingLength', to_float(@standard_piping_length)) unless @standard_piping_length.nil?
+          XMLHelper.add_element(standard, 'PipingLength', to_float(@standard_piping_length), @standard_piping_length_isdefaulted) unless @standard_piping_length.nil?
         elsif system_type == DHWDistTypeRecirc
           recirculation = XMLHelper.add_element(system_type_e, @system_type)
           XMLHelper.add_element(recirculation, 'ControlType', @recirculation_control_type) unless @recirculation_control_type.nil?
-          XMLHelper.add_element(recirculation, 'RecirculationPipingLoopLength', to_float(@recirculation_piping_length)) unless @recirculation_piping_length.nil?
-          XMLHelper.add_element(recirculation, 'BranchPipingLoopLength', to_float(@recirculation_branch_piping_length)) unless @recirculation_branch_piping_length.nil?
-          XMLHelper.add_element(recirculation, 'PumpPower', to_float(@recirculation_pump_power)) unless @recirculation_pump_power.nil?
+          XMLHelper.add_element(recirculation, 'RecirculationPipingLoopLength', to_float(@recirculation_piping_length), @recirculation_piping_length_isdefaulted) unless @recirculation_piping_length.nil?
+          XMLHelper.add_element(recirculation, 'BranchPipingLoopLength', to_float(@recirculation_branch_piping_length), @recirculation_branch_piping_length_isdefaulted) unless @recirculation_branch_piping_length.nil?
+          XMLHelper.add_element(recirculation, 'PumpPower', to_float(@recirculation_pump_power), @recirculation_pump_power_isdefaulted) unless @recirculation_pump_power.nil?
         else
           fail "Unhandled hot water distribution type '#{@system_type}'."
         end
@@ -3675,7 +3771,7 @@ class HPXML < Object
         extension = XMLHelper.create_elements_as_needed(hot_water_distribution, ['extension'])
         shared_recirculation = XMLHelper.add_element(extension, 'SharedRecirculation')
         XMLHelper.add_element(shared_recirculation, 'NumberofUnitsServed', to_integer(@shared_recirculation_number_of_units_served)) unless @shared_recirculation_number_of_units_served.nil?
-        XMLHelper.add_element(shared_recirculation, 'PumpPower', to_float(@shared_recirculation_pump_power)) unless @shared_recirculation_pump_power.nil?
+        XMLHelper.add_element(shared_recirculation, 'PumpPower', to_float(@shared_recirculation_pump_power), @shared_recirculation_pump_power_isdefaulted) unless @shared_recirculation_pump_power.nil?
         XMLHelper.add_element(shared_recirculation, 'ControlType', @shared_recirculation_control_type) unless @shared_recirculation_control_type.nil?
       end
     end
@@ -3688,11 +3784,15 @@ class HPXML < Object
       @pipe_r_value = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'PipeInsulation/PipeRValue'))
       if @system_type == 'Standard'
         @standard_piping_length = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'SystemType/Standard/PipingLength'))
+        @standard_piping_length_isdefaulted = get_software_defaulted(hot_water_distribution, 'SystemType/Standard/PipingLength') unless @standard_piping_length.nil?
       elsif @system_type == 'Recirculation'
         @recirculation_control_type = XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/ControlType')
         @recirculation_piping_length = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/RecirculationPipingLoopLength'))
+        @recirculation_piping_length_isdefaulted = get_software_defaulted(hot_water_distribution, 'SystemType/Recirculation/RecirculationPipingLoopLength') unless @recirculation_piping_length.nil?
         @recirculation_branch_piping_length = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/BranchPipingLoopLength'))
+        @recirculation_branch_piping_length_isdefaulted = get_software_defaulted(hot_water_distribution, 'SystemType/Recirculation/BranchPipingLoopLength') unless @recirculation_branch_piping_length.nil?
         @recirculation_pump_power = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/PumpPower'))
+        @recirculation_pump_power_isdefaulted = get_software_defaulted(hot_water_distribution, 'SystemType/Recirculation/PumpPower') unless @recirculation_pump_power.nil?
       end
       @dwhr_facilities_connected = XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/FacilitiesConnected')
       @dwhr_equal_flow = to_boolean_or_nil(XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/EqualFlow'))
@@ -3701,6 +3801,7 @@ class HPXML < Object
       if @has_shared_recirculation
         @shared_recirculation_number_of_units_served = to_integer_or_nil(XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/NumberofUnitsServed'))
         @shared_recirculation_pump_power = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/PumpPower'))
+        @shared_recirculation_pump_power_isdefaulted = get_software_defaulted(hot_water_distribution, 'extension/SharedRecirculation/PumpPower') unless @shared_recirculation_pump_power.nil?
         @shared_recirculation_control_type = XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/ControlType')
       end
     end
@@ -3766,7 +3867,7 @@ class HPXML < Object
       return if nil?
 
       water_heating = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Systems', 'WaterHeating'])
-      XMLHelper.add_extension(water_heating, 'WaterFixturesUsageMultiplier', to_float(@water_fixtures_usage_multiplier)) unless @water_fixtures_usage_multiplier.nil?
+      XMLHelper.add_extension(water_heating, 'WaterFixturesUsageMultiplier', to_float(@water_fixtures_usage_multiplier), @water_fixtures_usage_multiplier_isdefaulted) unless @water_fixtures_usage_multiplier.nil?
     end
 
     def from_oga(hpxml)
@@ -3776,6 +3877,7 @@ class HPXML < Object
       return if water_heating.nil?
 
       @water_fixtures_usage_multiplier = to_float_or_nil(XMLHelper.get_value(water_heating, 'extension/WaterFixturesUsageMultiplier'))
+      @water_fixtures_usage_multiplier_isdefaulted = get_software_defaulted(water_heating, 'extension/WaterFixturesUsageMultiplier') unless @water_fixtures_usage_multiplier.nil?
     end
   end
 
@@ -3835,7 +3937,7 @@ class HPXML < Object
       XMLHelper.add_element(solar_thermal_system, 'CollectorTilt', to_float(@collector_tilt)) unless @collector_tilt.nil?
       XMLHelper.add_element(solar_thermal_system, 'CollectorRatedOpticalEfficiency', to_float(@collector_frta)) unless @collector_frta.nil?
       XMLHelper.add_element(solar_thermal_system, 'CollectorRatedThermalLosses', to_float(@collector_frul)) unless @collector_frul.nil?
-      XMLHelper.add_element(solar_thermal_system, 'StorageVolume', to_float(@storage_volume)) unless @storage_volume.nil?
+      XMLHelper.add_element(solar_thermal_system, 'StorageVolume', to_float(@storage_volume), @storage_volume_isdefaulted) unless @storage_volume.nil?
       if not @water_heating_system_idref.nil?
         connected_to = XMLHelper.add_element(solar_thermal_system, 'ConnectedTo')
         XMLHelper.add_attribute(connected_to, 'idref', @water_heating_system_idref)
@@ -3856,6 +3958,7 @@ class HPXML < Object
       @collector_frta = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'CollectorRatedOpticalEfficiency'))
       @collector_frul = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'CollectorRatedThermalLosses'))
       @storage_volume = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'StorageVolume'))
+      @storage_volume_isdefaulted = get_software_defaulted(solar_thermal_system, 'StorageVolume') unless @storage_volume.nil?
       @water_heating_system_idref = HPXML::get_idref(XMLHelper.get_element(solar_thermal_system, 'ConnectedTo'))
       @solar_fraction = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'SolarFraction'))
     end
@@ -3897,15 +4000,15 @@ class HPXML < Object
       pv_system = XMLHelper.add_element(photovoltaics, 'PVSystem')
       sys_id = XMLHelper.add_element(pv_system, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(pv_system, 'IsSharedSystem', to_boolean(@is_shared_system)) unless @is_shared_system.nil?
-      XMLHelper.add_element(pv_system, 'Location', @location) unless @location.nil?
-      XMLHelper.add_element(pv_system, 'ModuleType', @module_type) unless @module_type.nil?
-      XMLHelper.add_element(pv_system, 'Tracking', @tracking) unless @tracking.nil?
+      XMLHelper.add_element(pv_system, 'IsSharedSystem', to_boolean(@is_shared_system), @is_shared_system_isdefaulted) unless @is_shared_system.nil?
+      XMLHelper.add_element(pv_system, 'Location', @location, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(pv_system, 'ModuleType', @module_type, @module_type_isdefaulted) unless @module_type.nil?
+      XMLHelper.add_element(pv_system, 'Tracking', @tracking, @tracking_isdefaulted) unless @tracking.nil?
       XMLHelper.add_element(pv_system, 'ArrayAzimuth', to_integer(@array_azimuth)) unless @array_azimuth.nil?
       XMLHelper.add_element(pv_system, 'ArrayTilt', to_float(@array_tilt)) unless @array_tilt.nil?
       XMLHelper.add_element(pv_system, 'MaxPowerOutput', to_float(@max_power_output)) unless @max_power_output.nil?
-      XMLHelper.add_element(pv_system, 'InverterEfficiency', to_float(@inverter_efficiency)) unless @inverter_efficiency.nil?
-      XMLHelper.add_element(pv_system, 'SystemLossesFraction', to_float(@system_losses_fraction)) unless @system_losses_fraction.nil?
+      XMLHelper.add_element(pv_system, 'InverterEfficiency', to_float(@inverter_efficiency), @inverter_efficiency_isdefaulted) unless @inverter_efficiency.nil?
+      XMLHelper.add_element(pv_system, 'SystemLossesFraction', to_float(@system_losses_fraction), @system_losses_fraction_isdefaulted) unless @system_losses_fraction.nil?
       XMLHelper.add_element(pv_system, 'YearModulesManufactured', to_integer(@year_modules_manufactured)) unless @year_modules_manufactured.nil?
       XMLHelper.add_extension(pv_system, 'NumberofBedroomsServed', to_integer(@number_of_bedrooms_served)) unless @number_of_bedrooms_served.nil?
     end
@@ -3915,15 +4018,21 @@ class HPXML < Object
 
       @id = HPXML::get_id(pv_system)
       @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(pv_system, 'IsSharedSystem'))
+      @is_shared_system_isdefaulted = get_software_defaulted(pv_system, 'IsSharedSystem') unless @is_shared_system.nil?
       @location = XMLHelper.get_value(pv_system, 'Location')
+      @location_isdefaulted = get_software_defaulted(pv_system, 'Location') unless @location.nil?
       @module_type = XMLHelper.get_value(pv_system, 'ModuleType')
+      @module_type_isdefaulted = get_software_defaulted(pv_system, 'ModuleType') unless @module_type.nil?
       @tracking = XMLHelper.get_value(pv_system, 'Tracking')
+      @tracking_isdefaulted = get_software_defaulted(pv_system, 'Tracking') unless @tracking.nil?
       @array_orientation = XMLHelper.get_value(pv_system, 'ArrayOrientation')
       @array_azimuth = to_integer_or_nil(XMLHelper.get_value(pv_system, 'ArrayAzimuth'))
       @array_tilt = to_float_or_nil(XMLHelper.get_value(pv_system, 'ArrayTilt'))
       @max_power_output = to_float_or_nil(XMLHelper.get_value(pv_system, 'MaxPowerOutput'))
       @inverter_efficiency = to_float_or_nil(XMLHelper.get_value(pv_system, 'InverterEfficiency'))
+      @inverter_efficiency_isdefaulted = get_software_defaulted(pv_system, 'InverterEfficiency') unless @inverter_efficiency.nil?
       @system_losses_fraction = to_float_or_nil(XMLHelper.get_value(pv_system, 'SystemLossesFraction'))
+      @system_losses_fraction_isdefaulted = get_software_defaulted(pv_system, 'SystemLossesFraction') unless @system_losses_fraction.nil?
       @number_of_panels = to_integer_or_nil(XMLHelper.get_value(pv_system, 'NumberOfPanels'))
       @year_modules_manufactured = to_integer_or_nil(XMLHelper.get_value(pv_system, 'YearModulesManufactured'))
       @number_of_bedrooms_served = to_integer_or_nil(XMLHelper.get_value(pv_system, 'extension/NumberofBedroomsServed'))
@@ -3980,22 +4089,22 @@ class HPXML < Object
       sys_id = XMLHelper.add_element(clothes_washer, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
       XMLHelper.add_element(clothes_washer, 'NumberofUnits', to_integer(@number_of_units)) unless @number_of_units.nil?
-      XMLHelper.add_element(clothes_washer, 'IsSharedAppliance', to_boolean(@is_shared_appliance)) unless @is_shared_appliance.nil?
+      XMLHelper.add_element(clothes_washer, 'IsSharedAppliance', to_boolean(@is_shared_appliance), @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
       XMLHelper.add_element(clothes_washer, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
       if not @water_heating_system_idref.nil?
         attached_water_heater = XMLHelper.add_element(clothes_washer, 'AttachedToWaterHeatingSystem')
         XMLHelper.add_attribute(attached_water_heater, 'idref', @water_heating_system_idref)
       end
-      XMLHelper.add_element(clothes_washer, 'Location', @location) unless @location.nil?
+      XMLHelper.add_element(clothes_washer, 'Location', @location, @location_isdefaulted) unless @location.nil?
       XMLHelper.add_element(clothes_washer, 'ModifiedEnergyFactor', to_float(@modified_energy_factor)) unless @modified_energy_factor.nil?
-      XMLHelper.add_element(clothes_washer, 'IntegratedModifiedEnergyFactor', to_float(@integrated_modified_energy_factor)) unless @integrated_modified_energy_factor.nil?
-      XMLHelper.add_element(clothes_washer, 'RatedAnnualkWh', to_float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
-      XMLHelper.add_element(clothes_washer, 'LabelElectricRate', to_float(@label_electric_rate)) unless @label_electric_rate.nil?
-      XMLHelper.add_element(clothes_washer, 'LabelGasRate', to_float(@label_gas_rate)) unless @label_gas_rate.nil?
-      XMLHelper.add_element(clothes_washer, 'LabelAnnualGasCost', to_float(@label_annual_gas_cost)) unless @label_annual_gas_cost.nil?
-      XMLHelper.add_element(clothes_washer, 'LabelUsage', to_float(@label_usage)) unless @label_usage.nil?
-      XMLHelper.add_element(clothes_washer, 'Capacity', to_float(@capacity)) unless @capacity.nil?
-      XMLHelper.add_extension(clothes_washer, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
+      XMLHelper.add_element(clothes_washer, 'IntegratedModifiedEnergyFactor', to_float(@integrated_modified_energy_factor), @integrated_modified_energy_factor_isdefaulted) unless @integrated_modified_energy_factor.nil?
+      XMLHelper.add_element(clothes_washer, 'RatedAnnualkWh', to_float(@rated_annual_kwh), @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(clothes_washer, 'LabelElectricRate', to_float(@label_electric_rate), @label_electric_rate_isdefaulted) unless @label_electric_rate.nil?
+      XMLHelper.add_element(clothes_washer, 'LabelGasRate', to_float(@label_gas_rate), @label_gas_rate_isdefaulted) unless @label_gas_rate.nil?
+      XMLHelper.add_element(clothes_washer, 'LabelAnnualGasCost', to_float(@label_annual_gas_cost), @label_annual_gas_cost_isdefaulted) unless @label_annual_gas_cost.nil?
+      XMLHelper.add_element(clothes_washer, 'LabelUsage', to_float(@label_usage), @label_usage_isdefaulted) unless @label_usage.nil?
+      XMLHelper.add_element(clothes_washer, 'Capacity', to_float(@capacity), @capacity_isdefaulted) unless @capacity.nil?
+      XMLHelper.add_extension(clothes_washer, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
     end
 
     def from_oga(clothes_washer)
@@ -4004,17 +4113,27 @@ class HPXML < Object
       @id = HPXML::get_id(clothes_washer)
       @number_of_units = to_integer_or_nil(XMLHelper.get_value(clothes_washer, 'NumberofUnits'))
       @is_shared_appliance = to_boolean_or_nil(XMLHelper.get_value(clothes_washer, 'IsSharedAppliance'))
+      @is_shared_appliance_isdefaulted = get_software_defaulted(clothes_washer, 'IsSharedAppliance') unless @is_shared_appliance.nil?
       @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(clothes_washer, 'NumberofUnitsServed'))
       @location = XMLHelper.get_value(clothes_washer, 'Location')
+      @location_isdefaulted = get_software_defaulted(clothes_washer, 'Location') unless @location.nil?
       @modified_energy_factor = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'ModifiedEnergyFactor'))
       @integrated_modified_energy_factor = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'IntegratedModifiedEnergyFactor'))
+      @integrated_modified_energy_factor_isdefaulted = get_software_defaulted(clothes_washer, 'IntegratedModifiedEnergyFactor') unless @integrated_modified_energy_factor.nil?
       @rated_annual_kwh = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'RatedAnnualkWh'))
+      @rated_annual_kwh_isdefaulted = get_software_defaulted(clothes_washer, 'RatedAnnualkWh') unless @rated_annual_kwh.nil?
       @label_electric_rate = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelElectricRate'))
+      @label_electric_rate_isdefaulted = get_software_defaulted(clothes_washer, 'LabelElectricRate') unless @label_electric_rate.nil?
       @label_gas_rate = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelGasRate'))
+      @label_gas_rate_isdefaulted = get_software_defaulted(clothes_washer, 'LabelGasRate') unless @label_gas_rate.nil?
       @label_annual_gas_cost = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelAnnualGasCost'))
+      @label_annual_gas_cost_isdefaulted = get_software_defaulted(clothes_washer, 'LabelAnnualGasCost') unless @label_annual_gas_cost.nil?
       @label_usage = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelUsage'))
+      @label_usage_isdefaulted = get_software_defaulted(clothes_washer, 'LabelUsage') unless @label_usage.nil?
       @capacity = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'Capacity'))
+      @capacity_isdefaulted = get_software_defaulted(clothes_washer, 'Capacity') unless @capacity.nil?
       @usage_multiplier = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'extension/UsageMultiplier'))
+      @usage_multiplier_isdefaulted = get_software_defaulted(clothes_washer, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
       @water_heating_system_idref = HPXML::get_idref(XMLHelper.get_element(clothes_washer, 'AttachedToWaterHeatingSystem'))
     end
   end
@@ -4056,16 +4175,16 @@ class HPXML < Object
       sys_id = XMLHelper.add_element(clothes_dryer, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
       XMLHelper.add_element(clothes_dryer, 'NumberofUnits', to_integer(@number_of_units)) unless @number_of_units.nil?
-      XMLHelper.add_element(clothes_dryer, 'IsSharedAppliance', to_boolean(@is_shared_appliance)) unless @is_shared_appliance.nil?
+      XMLHelper.add_element(clothes_dryer, 'IsSharedAppliance', to_boolean(@is_shared_appliance), @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
       XMLHelper.add_element(clothes_dryer, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
-      XMLHelper.add_element(clothes_dryer, 'Location', @location) unless @location.nil?
+      XMLHelper.add_element(clothes_dryer, 'Location', @location, @location_isdefaulted) unless @location.nil?
       XMLHelper.add_element(clothes_dryer, 'FuelType', @fuel_type) unless @fuel_type.nil?
       XMLHelper.add_element(clothes_dryer, 'EnergyFactor', to_float(@energy_factor)) unless @energy_factor.nil?
-      XMLHelper.add_element(clothes_dryer, 'CombinedEnergyFactor', to_float(@combined_energy_factor)) unless @combined_energy_factor.nil?
-      XMLHelper.add_element(clothes_dryer, 'ControlType', @control_type) unless @control_type.nil?
-      XMLHelper.add_extension(clothes_dryer, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(clothes_dryer, 'IsVented', to_boolean(@is_vented)) unless @is_vented.nil?
-      XMLHelper.add_extension(clothes_dryer, 'VentedFlowRate', to_float(@vented_flow_rate)) unless @vented_flow_rate.nil?
+      XMLHelper.add_element(clothes_dryer, 'CombinedEnergyFactor', to_float(@combined_energy_factor), @combined_energy_factor_isdefaulted) unless @combined_energy_factor.nil?
+      XMLHelper.add_element(clothes_dryer, 'ControlType', @control_type, @control_type_isdefaulted) unless @control_type.nil?
+      XMLHelper.add_extension(clothes_dryer, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(clothes_dryer, 'IsVented', to_boolean(@is_vented), @is_vented_isdefaulted) unless @is_vented.nil?
+      XMLHelper.add_extension(clothes_dryer, 'VentedFlowRate', to_float(@vented_flow_rate), @vented_flow_rate_isdefaulted) unless @vented_flow_rate.nil?
     end
 
     def from_oga(clothes_dryer)
@@ -4074,15 +4193,22 @@ class HPXML < Object
       @id = HPXML::get_id(clothes_dryer)
       @number_of_units = to_integer_or_nil(XMLHelper.get_value(clothes_dryer, 'NumberofUnits'))
       @is_shared_appliance = to_boolean_or_nil(XMLHelper.get_value(clothes_dryer, 'IsSharedAppliance'))
+      @is_shared_appliance_isdefaulted = get_software_defaulted(clothes_dryer, 'IsSharedAppliance') unless @is_shared_appliance.nil?
       @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(clothes_dryer, 'NumberofUnitsServed'))
       @location = XMLHelper.get_value(clothes_dryer, 'Location')
+      @location_isdefaulted = get_software_defaulted(clothes_dryer, 'Location') unless @location.nil?
       @fuel_type = XMLHelper.get_value(clothes_dryer, 'FuelType')
       @energy_factor = to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'EnergyFactor'))
       @combined_energy_factor = to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'CombinedEnergyFactor'))
+      @combined_energy_factor_isdefaulted = get_software_defaulted(clothes_dryer, 'CombinedEnergyFactor') unless @combined_energy_factor.nil?
       @control_type = XMLHelper.get_value(clothes_dryer, 'ControlType')
+      @control_type_isdefaulted = get_software_defaulted(clothes_dryer, 'ControlType') unless @control_type.nil?
       @usage_multiplier = to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'extension/UsageMultiplier'))
+      @usage_multiplier_isdefaulted = get_software_defaulted(clothes_dryer, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
       @is_vented = to_boolean_or_nil(XMLHelper.get_value(clothes_dryer, 'extension/IsVented'))
+      @is_vented_isdefaulted = get_software_defaulted(clothes_dryer, 'extension/IsVented') unless @is_vented.nil?
       @vented_flow_rate = to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'extension/VentedFlowRate'))
+      @vented_flow_rate_isdefaulted = get_software_defaulted(clothes_dryer, 'extension/VentedFlowRate') unless @vented_flow_rate.nil?
     end
   end
 
@@ -4134,20 +4260,20 @@ class HPXML < Object
       dishwasher = XMLHelper.add_element(appliances, 'Dishwasher')
       sys_id = XMLHelper.add_element(dishwasher, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(dishwasher, 'IsSharedAppliance', to_boolean(@is_shared_appliance)) unless @is_shared_appliance.nil?
+      XMLHelper.add_element(dishwasher, 'IsSharedAppliance', to_boolean(@is_shared_appliance), @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
       if not @water_heating_system_idref.nil?
         attached_water_heater = XMLHelper.add_element(dishwasher, 'AttachedToWaterHeatingSystem')
         XMLHelper.add_attribute(attached_water_heater, 'idref', @water_heating_system_idref)
       end
-      XMLHelper.add_element(dishwasher, 'Location', @location) unless @location.nil?
-      XMLHelper.add_element(dishwasher, 'RatedAnnualkWh', to_float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(dishwasher, 'Location', @location, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(dishwasher, 'RatedAnnualkWh', to_float(@rated_annual_kwh), @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
       XMLHelper.add_element(dishwasher, 'EnergyFactor', to_float(@energy_factor)) unless @energy_factor.nil?
-      XMLHelper.add_element(dishwasher, 'PlaceSettingCapacity', to_integer(@place_setting_capacity)) unless @place_setting_capacity.nil?
-      XMLHelper.add_element(dishwasher, 'LabelElectricRate', to_float(@label_electric_rate)) unless @label_electric_rate.nil?
-      XMLHelper.add_element(dishwasher, 'LabelGasRate', to_float(@label_gas_rate)) unless @label_gas_rate.nil?
-      XMLHelper.add_element(dishwasher, 'LabelAnnualGasCost', to_float(@label_annual_gas_cost)) unless @label_annual_gas_cost.nil?
-      XMLHelper.add_element(dishwasher, 'LabelUsage', to_float(@label_usage)) unless @label_usage.nil?
-      XMLHelper.add_extension(dishwasher, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
+      XMLHelper.add_element(dishwasher, 'PlaceSettingCapacity', to_integer(@place_setting_capacity), @place_setting_capacity_isdefaulted) unless @place_setting_capacity.nil?
+      XMLHelper.add_element(dishwasher, 'LabelElectricRate', to_float(@label_electric_rate), @label_electric_rate_isdefaulted) unless @label_electric_rate.nil?
+      XMLHelper.add_element(dishwasher, 'LabelGasRate', to_float(@label_gas_rate), @label_gas_rate_isdefaulted) unless @label_gas_rate.nil?
+      XMLHelper.add_element(dishwasher, 'LabelAnnualGasCost', to_float(@label_annual_gas_cost), @label_annual_gas_cost_isdefaulted) unless @label_annual_gas_cost.nil?
+      XMLHelper.add_element(dishwasher, 'LabelUsage', to_float(@label_usage), @label_usage_isdefaulted) unless @label_usage.nil?
+      XMLHelper.add_extension(dishwasher, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
     end
 
     def from_oga(dishwasher)
@@ -4155,15 +4281,24 @@ class HPXML < Object
 
       @id = HPXML::get_id(dishwasher)
       @is_shared_appliance = to_boolean_or_nil(XMLHelper.get_value(dishwasher, 'IsSharedAppliance'))
+      @is_shared_appliance_isdefaulted = get_software_defaulted(dishwasher, 'IsSharedAppliance') unless @is_shared_appliance.nil?
       @location = XMLHelper.get_value(dishwasher, 'Location')
+      @location_isdefaulted = get_software_defaulted(dishwasher, 'Location') unless @location.nil?
       @rated_annual_kwh = to_float_or_nil(XMLHelper.get_value(dishwasher, 'RatedAnnualkWh'))
+      @rated_annual_kwh_isdefaulted = get_software_defaulted(dishwasher, 'RatedAnnualkWh') unless @rated_annual_kwh.nil?
       @energy_factor = to_float_or_nil(XMLHelper.get_value(dishwasher, 'EnergyFactor'))
       @place_setting_capacity = to_integer_or_nil(XMLHelper.get_value(dishwasher, 'PlaceSettingCapacity'))
+      @place_setting_capacity_isdefaulted = get_software_defaulted(dishwasher, 'PlaceSettingCapacity') unless @place_setting_capacity.nil?
       @label_electric_rate = to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelElectricRate'))
+      @label_electric_rate_isdefaulted = get_software_defaulted(dishwasher, 'LabelElectricRate') unless @label_electric_rate.nil?
       @label_gas_rate = to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelGasRate'))
+      @label_gas_rate_isdefaulted = get_software_defaulted(dishwasher, 'LabelGasRate') unless @label_gas_rate.nil?
       @label_annual_gas_cost = to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelAnnualGasCost'))
+      @label_annual_gas_cost_isdefaulted = get_software_defaulted(dishwasher, 'LabelAnnualGasCost') unless @label_annual_gas_cost.nil?
       @label_usage = to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelUsage'))
+      @label_usage_isdefaulted = get_software_defaulted(dishwasher, 'LabelUsage') unless @label_usage.nil?
       @usage_multiplier = to_float_or_nil(XMLHelper.get_value(dishwasher, 'extension/UsageMultiplier'))
+      @usage_multiplier_isdefaulted = get_software_defaulted(dishwasher, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
       @water_heating_system_idref = HPXML::get_idref(XMLHelper.get_element(dishwasher, 'AttachedToWaterHeatingSystem'))
     end
   end
@@ -4215,14 +4350,14 @@ class HPXML < Object
       refrigerator = XMLHelper.add_element(appliances, 'Refrigerator')
       sys_id = XMLHelper.add_element(refrigerator, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(refrigerator, 'Location', @location) unless @location.nil?
-      XMLHelper.add_element(refrigerator, 'RatedAnnualkWh', to_float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
-      XMLHelper.add_element(refrigerator, 'PrimaryIndicator', to_boolean(@primary_indicator)) unless @primary_indicator.nil?
+      XMLHelper.add_element(refrigerator, 'Location', @location, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(refrigerator, 'RatedAnnualkWh', to_float(@rated_annual_kwh), @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(refrigerator, 'PrimaryIndicator', to_boolean(@primary_indicator), @primary_indicator_isdefaulted) unless @primary_indicator.nil?
       XMLHelper.add_extension(refrigerator, 'AdjustedAnnualkWh', to_float(@adjusted_annual_kwh)) unless @adjusted_annual_kwh.nil?
-      XMLHelper.add_extension(refrigerator, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(refrigerator, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(refrigerator, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(refrigerator, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
+      XMLHelper.add_extension(refrigerator, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(refrigerator, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(refrigerator, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(refrigerator, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(refrigerator)
@@ -4230,13 +4365,20 @@ class HPXML < Object
 
       @id = HPXML::get_id(refrigerator)
       @location = XMLHelper.get_value(refrigerator, 'Location')
+      @location_isdefaulted = get_software_defaulted(refrigerator, 'Location') unless @location.nil?
       @rated_annual_kwh = to_float_or_nil(XMLHelper.get_value(refrigerator, 'RatedAnnualkWh'))
+      @rated_annual_kwh_isdefaulted = get_software_defaulted(refrigerator, 'RatedAnnualkWh') unless @rated_annual_kwh.nil?
       @primary_indicator = to_boolean_or_nil(XMLHelper.get_value(refrigerator, 'PrimaryIndicator'))
+      @primary_indicator_isdefaulted = get_software_defaulted(refrigerator, 'PrimaryIndicator') unless @primary_indicator.nil?
       @adjusted_annual_kwh = to_float_or_nil(XMLHelper.get_value(refrigerator, 'extension/AdjustedAnnualkWh'))
       @usage_multiplier = to_float_or_nil(XMLHelper.get_value(refrigerator, 'extension/UsageMultiplier'))
+      @usage_multiplier_isdefaulted = get_software_defaulted(refrigerator, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
       @weekday_fractions = XMLHelper.get_value(refrigerator, 'extension/WeekdayScheduleFractions')
+      @weekday_fractions_isdefaulted = get_software_defaulted(refrigerator, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
       @weekend_fractions = XMLHelper.get_value(refrigerator, 'extension/WeekendScheduleFractions')
+      @weekend_fractions_isdefaulted = get_software_defaulted(refrigerator, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
       @monthly_multipliers = XMLHelper.get_value(refrigerator, 'extension/MonthlyScheduleMultipliers')
+      @monthly_multipliers_isdefaulted = get_software_defaulted(refrigerator, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
     end
   end
 
@@ -4275,13 +4417,13 @@ class HPXML < Object
       freezer = XMLHelper.add_element(appliances, 'Freezer')
       sys_id = XMLHelper.add_element(freezer, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(freezer, 'Location', @location) unless @location.nil?
-      XMLHelper.add_element(freezer, 'RatedAnnualkWh', to_float(@rated_annual_kwh)) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(freezer, 'Location', @location, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(freezer, 'RatedAnnualkWh', to_float(@rated_annual_kwh), @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
       XMLHelper.add_extension(freezer, 'AdjustedAnnualkWh', to_float(@adjusted_annual_kwh)) unless @adjusted_annual_kwh.nil?
-      XMLHelper.add_extension(freezer, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(freezer, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(freezer, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(freezer, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
+      XMLHelper.add_extension(freezer, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(freezer, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(freezer, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(freezer, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(freezer)
@@ -4289,12 +4431,18 @@ class HPXML < Object
 
       @id = HPXML::get_id(freezer)
       @location = XMLHelper.get_value(freezer, 'Location')
+      @location_isdefaulted = get_software_defaulted(freezer, 'Location') unless @location.nil?
       @rated_annual_kwh = to_float_or_nil(XMLHelper.get_value(freezer, 'RatedAnnualkWh'))
+      @rated_annual_kwh_isdefaulted = get_software_defaulted(freezer, 'RatedAnnualkWh') unless @rated_annual_kwh.nil?
       @adjusted_annual_kwh = to_float_or_nil(XMLHelper.get_value(freezer, 'extension/AdjustedAnnualkWh'))
       @usage_multiplier = to_float_or_nil(XMLHelper.get_value(freezer, 'extension/UsageMultiplier'))
+      @usage_multiplier_isdefaulted = get_software_defaulted(freezer, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
       @weekday_fractions = XMLHelper.get_value(freezer, 'extension/WeekdayScheduleFractions')
+      @weekday_fractions_isdefaulted = get_software_defaulted(freezer, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
       @weekend_fractions = XMLHelper.get_value(freezer, 'extension/WeekendScheduleFractions')
+      @weekend_fractions_isdefaulted = get_software_defaulted(freezer, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
       @monthly_multipliers = XMLHelper.get_value(freezer, 'extension/MonthlyScheduleMultipliers')
+      @monthly_multipliers_isdefaulted = get_software_defaulted(freezer, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
     end
   end
 
@@ -4386,13 +4534,13 @@ class HPXML < Object
       cooking_range = XMLHelper.add_element(appliances, 'CookingRange')
       sys_id = XMLHelper.add_element(cooking_range, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(cooking_range, 'Location', @location) unless @location.nil?
+      XMLHelper.add_element(cooking_range, 'Location', @location, @location_isdefaulted) unless @location.nil?
       XMLHelper.add_element(cooking_range, 'FuelType', @fuel_type) unless @fuel_type.nil?
-      XMLHelper.add_element(cooking_range, 'IsInduction', to_boolean(@is_induction)) unless @is_induction.nil?
-      XMLHelper.add_extension(cooking_range, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(cooking_range, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(cooking_range, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(cooking_range, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
+      XMLHelper.add_element(cooking_range, 'IsInduction', to_boolean(@is_induction), @is_induction_isdefaulted) unless @is_induction.nil?
+      XMLHelper.add_extension(cooking_range, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(cooking_range, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(cooking_range, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(cooking_range, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(cooking_range)
@@ -4400,12 +4548,18 @@ class HPXML < Object
 
       @id = HPXML::get_id(cooking_range)
       @location = XMLHelper.get_value(cooking_range, 'Location')
+      @location_isdefaulted = get_software_defaulted(cooking_range, 'Location') unless @location.nil?
       @fuel_type = XMLHelper.get_value(cooking_range, 'FuelType')
       @is_induction = to_boolean_or_nil(XMLHelper.get_value(cooking_range, 'IsInduction'))
+      @is_induction_isdefaulted = get_software_defaulted(cooking_range, 'IsInduction') unless @is_induction.nil?
       @usage_multiplier = to_float_or_nil(XMLHelper.get_value(cooking_range, 'extension/UsageMultiplier'))
+      @usage_multiplier_isdefaulted = get_software_defaulted(cooking_range, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
       @weekday_fractions = XMLHelper.get_value(cooking_range, 'extension/WeekdayScheduleFractions')
+      @weekday_fractions_isdefaulted = get_software_defaulted(cooking_range, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
       @weekend_fractions = XMLHelper.get_value(cooking_range, 'extension/WeekendScheduleFractions')
+      @weekend_fractions_isdefaulted = get_software_defaulted(cooking_range, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
       @monthly_multipliers = XMLHelper.get_value(cooking_range, 'extension/MonthlyScheduleMultipliers')
+      @monthly_multipliers_isdefaulted = get_software_defaulted(cooking_range, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
     end
   end
 
@@ -4443,7 +4597,7 @@ class HPXML < Object
       oven = XMLHelper.add_element(appliances, 'Oven')
       sys_id = XMLHelper.add_element(oven, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(oven, 'IsConvection', to_boolean(@is_convection)) unless @is_convection.nil?
+      XMLHelper.add_element(oven, 'IsConvection', to_boolean(@is_convection), @is_convection_isdefaulted) unless @is_convection.nil?
     end
 
     def from_oga(oven)
@@ -4451,6 +4605,7 @@ class HPXML < Object
 
       @id = HPXML::get_id(oven)
       @is_convection = to_boolean_or_nil(XMLHelper.get_value(oven, 'IsConvection'))
+      @is_convection_isdefaulted = get_software_defaulted(oven, 'IsConvection') unless @is_convection.nil?
     end
   end
 
@@ -4524,31 +4679,31 @@ class HPXML < Object
       return if nil?
 
       lighting = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Lighting'])
-      XMLHelper.add_extension(lighting, 'InteriorUsageMultiplier', to_float(@interior_usage_multiplier)) unless @interior_usage_multiplier.nil?
-      XMLHelper.add_extension(lighting, 'GarageUsageMultiplier', to_float(@garage_usage_multiplier)) unless @garage_usage_multiplier.nil?
-      XMLHelper.add_extension(lighting, 'ExteriorUsageMultiplier', to_float(@exterior_usage_multiplier)) unless @exterior_usage_multiplier.nil?
-      XMLHelper.add_extension(lighting, 'InteriorWeekdayScheduleFractions', @interior_weekday_fractions) unless @interior_weekday_fractions.nil?
-      XMLHelper.add_extension(lighting, 'InteriorWeekendScheduleFractions', @interior_weekend_fractions) unless @interior_weekend_fractions.nil?
-      XMLHelper.add_extension(lighting, 'InteriorMonthlyScheduleMultipliers', @interior_monthly_multipliers) unless @interior_monthly_multipliers.nil?
-      XMLHelper.add_extension(lighting, 'GarageWeekdayScheduleFractions', @garage_weekday_fractions) unless @garage_weekday_fractions.nil?
-      XMLHelper.add_extension(lighting, 'GarageWeekendScheduleFractions', @garage_weekend_fractions) unless @garage_weekend_fractions.nil?
-      XMLHelper.add_extension(lighting, 'GarageMonthlyScheduleMultipliers', @garage_monthly_multipliers) unless @garage_monthly_multipliers.nil?
-      XMLHelper.add_extension(lighting, 'ExteriorWeekdayScheduleFractions', @exterior_weekday_fractions) unless @exterior_weekday_fractions.nil?
-      XMLHelper.add_extension(lighting, 'ExteriorWeekendScheduleFractions', @exterior_weekend_fractions) unless @exterior_weekend_fractions.nil?
-      XMLHelper.add_extension(lighting, 'ExteriorMonthlyScheduleMultipliers', @exterior_monthly_multipliers) unless @exterior_monthly_multipliers.nil?
+      XMLHelper.add_extension(lighting, 'InteriorUsageMultiplier', to_float(@interior_usage_multiplier), @interior_usage_multiplier_isdefaulted) unless @interior_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'GarageUsageMultiplier', to_float(@garage_usage_multiplier), @garage_usage_multiplier_isdefaulted) unless @garage_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorUsageMultiplier', to_float(@exterior_usage_multiplier), @exterior_usage_multiplier_isdefaulted) unless @exterior_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'InteriorWeekdayScheduleFractions', @interior_weekday_fractions, @interior_weekday_fractions_isdefaulted) unless @interior_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'InteriorWeekendScheduleFractions', @interior_weekend_fractions, @interior_weekend_fractions_isdefaulted) unless @interior_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'InteriorMonthlyScheduleMultipliers', @interior_monthly_multipliers, @interior_monthly_multipliers_isdefaulted) unless @interior_monthly_multipliers.nil?
+      XMLHelper.add_extension(lighting, 'GarageWeekdayScheduleFractions', @garage_weekday_fractions, @garage_weekday_fractions_isdefaulted) unless @garage_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'GarageWeekendScheduleFractions', @garage_weekend_fractions, @garage_weekend_fractions_isdefaulted) unless @garage_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'GarageMonthlyScheduleMultipliers', @garage_monthly_multipliers, @garage_monthly_multipliers_isdefaulted) unless @garage_monthly_multipliers.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorWeekdayScheduleFractions', @exterior_weekday_fractions, @exterior_weekday_fractions_isdefaulted) unless @exterior_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorWeekendScheduleFractions', @exterior_weekend_fractions, @exterior_weekend_fractions_isdefaulted) unless @exterior_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorMonthlyScheduleMultipliers', @exterior_monthly_multipliers, @exterior_monthly_multipliers_isdefaulted) unless @exterior_monthly_multipliers.nil?
       if @holiday_exists
         exterior_holiday_lighting = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Lighting', 'extension', 'ExteriorHolidayLighting'])
         if not @holiday_kwh_per_day.nil?
           holiday_lighting_load = XMLHelper.add_element(exterior_holiday_lighting, 'Load')
           XMLHelper.add_element(holiday_lighting_load, 'Units', 'kWh/day')
-          XMLHelper.add_element(holiday_lighting_load, 'Value', to_float(@holiday_kwh_per_day))
+          XMLHelper.add_element(holiday_lighting_load, 'Value', to_float(@holiday_kwh_per_day), @holiday_kwh_per_day_isdefaulted)
         end
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginMonth', to_integer(@holiday_period_begin_month)) unless @holiday_period_begin_month.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginDayOfMonth', to_integer(@holiday_period_begin_day_of_month)) unless @holiday_period_begin_day_of_month.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndMonth', to_integer(@holiday_period_end_month)) unless @holiday_period_end_month.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndDayOfMonth', to_integer(@holiday_period_end_day_of_month)) unless @holiday_period_end_day_of_month.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'WeekdayScheduleFractions', @holiday_weekday_fractions) unless @holiday_weekday_fractions.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'WeekendScheduleFractions', @holiday_weekend_fractions) unless @holiday_weekend_fractions.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginMonth', to_integer(@holiday_period_begin_month), @holiday_period_begin_month_isdefaulted) unless @holiday_period_begin_month.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginDayOfMonth', to_integer(@holiday_period_begin_day_of_month), @holiday_period_begin_day_of_month_isdefaulted) unless @holiday_period_begin_day_of_month.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndMonth', to_integer(@holiday_period_end_month), @holiday_period_end_month_isdefaulted) unless @holiday_period_end_month.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndDayOfMonth', to_integer(@holiday_period_end_day_of_month), @holiday_period_end_day_of_month_isdefaulted) unless @holiday_period_end_day_of_month.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'WeekdayScheduleFractions', @holiday_weekday_fractions, @holiday_weekday_fractions_isdefaulted) unless @holiday_weekday_fractions.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'WeekendScheduleFractions', @holiday_weekend_fractions, @holiday_weekend_fractions_isdefaulted) unless @holiday_weekend_fractions.nil?
       end
     end
 
@@ -4559,26 +4714,45 @@ class HPXML < Object
       return if lighting.nil?
 
       @interior_usage_multiplier = to_float_or_nil(XMLHelper.get_value(lighting, 'extension/InteriorUsageMultiplier'))
+      @interior_usage_multiplier_isdefaulted = get_software_defaulted(lighting, 'extension/InteriorUsageMultiplier') unless @interior_usage_multiplier.nil?
       @garage_usage_multiplier = to_float_or_nil(XMLHelper.get_value(lighting, 'extension/GarageUsageMultiplier'))
+      @garage_usage_multiplier_isdefaulted = get_software_defaulted(lighting, 'extension/GarageUsageMultiplier') unless @garage_usage_multiplier.nil?
       @exterior_usage_multiplier = to_float_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorUsageMultiplier'))
+      @exterior_usage_multiplier_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorUsageMultiplier') unless @exterior_usage_multiplier.nil?
       @interior_weekday_fractions = XMLHelper.get_value(lighting, 'extension/InteriorWeekdayScheduleFractions')
+      @interior_weekday_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/InteriorWeekdayScheduleFractions') unless @interior_weekday_fractions.nil?
       @interior_weekend_fractions = XMLHelper.get_value(lighting, 'extension/InteriorWeekendScheduleFractions')
+      @interior_weekend_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/InteriorWeekendScheduleFractions') unless @interior_weekend_fractions.nil?
       @interior_monthly_multipliers = XMLHelper.get_value(lighting, 'extension/InteriorMonthlyScheduleMultipliers')
+      @interior_monthly_multipliers_isdefaulted = get_software_defaulted(lighting, 'extension/InteriorMonthlyScheduleMultipliers') unless @interior_monthly_multipliers.nil?
       @garage_weekday_fractions = XMLHelper.get_value(lighting, 'extension/GarageWeekdayScheduleFractions')
+      @garage_weekday_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/GarageWeekdayScheduleFractions') unless @garage_weekday_fractions.nil?
       @garage_weekend_fractions = XMLHelper.get_value(lighting, 'extension/GarageWeekendScheduleFractions')
+      @garage_weekend_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/GarageWeekendScheduleFractions') unless @garage_weekend_fractions.nil?
       @garage_monthly_multipliers = XMLHelper.get_value(lighting, 'extension/GarageMonthlyScheduleMultipliers')
+      @garage_monthly_multipliers_isdefaulted = get_software_defaulted(lighting, 'extension/GarageMonthlyScheduleMultipliers') unless @garage_monthly_multipliers.nil?
       @exterior_weekday_fractions = XMLHelper.get_value(lighting, 'extension/ExteriorWeekdayScheduleFractions')
+      @exterior_weekday_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorWeekdayScheduleFractions') unless @exterior_weekday_fractions.nil?
       @exterior_weekend_fractions = XMLHelper.get_value(lighting, 'extension/ExteriorWeekendScheduleFractions')
+      @exterior_weekend_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorWeekendScheduleFractions') unless @exterior_weekend_fractions.nil?
       @exterior_monthly_multipliers = XMLHelper.get_value(lighting, 'extension/ExteriorMonthlyScheduleMultipliers')
+      @exterior_monthly_multipliers_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorMonthlyScheduleMultipliers') unless @exterior_monthly_multipliers.nil?
       if not XMLHelper.get_element(hpxml, 'Building/BuildingDetails/Lighting/extension/ExteriorHolidayLighting').nil?
         @holiday_exists = true
         @holiday_kwh_per_day = to_float_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/Load[Units="kWh/day"]/Value'))
+        @holiday_kwh_per_day_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/Load[Units="kWh/day"]/Value') unless @holiday_kwh_per_day.nil?
         @holiday_period_begin_month = to_integer_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginMonth'))
+        @holiday_period_begin_month_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginMonth') unless @holiday_period_begin_month.nil?
         @holiday_period_begin_day_of_month = to_integer_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginDayOfMonth'))
+        @holiday_period_begin_day_of_month_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginDayOfMonth') unless @holiday_period_begin_day_of_month.nil?
         @holiday_period_end_month = to_integer_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/PeriodEndMonth'))
+        @holiday_period_end_month_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodEndMonth') unless @holiday_period_end_month.nil?
         @holiday_period_end_day_of_month = to_integer_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/PeriodEndDayOfMonth'))
+        @holiday_period_end_day_of_month_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodEndDayOfMonth') unless @holiday_period_end_day_of_month.nil?
         @holiday_weekday_fractions = XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/WeekdayScheduleFractions')
+        @holiday_weekday_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekdayScheduleFractions') unless @holiday_weekday_fractions.nil?
         @holiday_weekend_fractions = XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/WeekendScheduleFractions')
+        @holiday_weekend_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekendScheduleFractions') unless @holiday_weekend_fractions.nil?
       else
         @holiday_exists = false
       end
@@ -4622,15 +4796,17 @@ class HPXML < Object
       if not @efficiency.nil?
         airflow = XMLHelper.add_element(ceiling_fan, 'Airflow')
         XMLHelper.add_element(airflow, 'FanSpeed', 'medium')
-        XMLHelper.add_element(airflow, 'Efficiency', to_float(@efficiency))
+        XMLHelper.add_element(airflow, 'Efficiency', to_float(@efficiency), @efficiency_isdefaulted)
       end
-      XMLHelper.add_element(ceiling_fan, 'Quantity', to_integer(@quantity)) unless @quantity.nil?
+      XMLHelper.add_element(ceiling_fan, 'Quantity', to_integer(@quantity), @quantity_isdefaulted) unless @quantity.nil?
     end
 
     def from_oga(ceiling_fan)
       @id = HPXML::get_id(ceiling_fan)
       @efficiency = to_float_or_nil(XMLHelper.get_value(ceiling_fan, "Airflow[FanSpeed='medium']/Efficiency"))
+      @efficiency_isdefaulted = get_software_defaulted(ceiling_fan, "Airflow[FanSpeed='medium']/Efficiency") unless @efficiency.nil?
       @quantity = to_integer_or_nil(XMLHelper.get_value(ceiling_fan, 'Quantity'))
+      @quantity_isdefaulted = get_software_defaulted(ceiling_fan, 'Quantity') unless @quantity.nil?
     end
   end
 
@@ -4682,11 +4858,11 @@ class HPXML < Object
       if not @pump_kwh_per_year.nil?
         load = XMLHelper.add_element(pool_pump, 'Load')
         XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
-        XMLHelper.add_element(load, 'Value', to_float(@pump_kwh_per_year))
-        XMLHelper.add_extension(pool_pump, 'UsageMultiplier', to_float(@pump_usage_multiplier)) unless @pump_usage_multiplier.nil?
-        XMLHelper.add_extension(pool_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions) unless @pump_weekday_fractions.nil?
-        XMLHelper.add_extension(pool_pump, 'WeekendScheduleFractions', @pump_weekend_fractions) unless @pump_weekend_fractions.nil?
-        XMLHelper.add_extension(pool_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers) unless @pump_monthly_multipliers.nil?
+        XMLHelper.add_element(load, 'Value', to_float(@pump_kwh_per_year), @pump_kwh_per_year_isdefaulted)
+        XMLHelper.add_extension(pool_pump, 'UsageMultiplier', to_float(@pump_usage_multiplier), @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
+        XMLHelper.add_extension(pool_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
+        XMLHelper.add_extension(pool_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
+        XMLHelper.add_extension(pool_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
       end
       if not @heater_type.nil?
         heater = XMLHelper.add_element(pool, 'Heater')
@@ -4700,12 +4876,12 @@ class HPXML < Object
         if (not @heater_load_units.nil?) && (not @heater_load_value.nil?)
           load = XMLHelper.add_element(heater, 'Load')
           XMLHelper.add_element(load, 'Units', @heater_load_units)
-          XMLHelper.add_element(load, 'Value', to_float(@heater_load_value))
+          XMLHelper.add_element(load, 'Value', to_float(@heater_load_value), @heater_load_value_isdefaulted)
         end
-        XMLHelper.add_extension(heater, 'UsageMultiplier', to_float(@heater_usage_multiplier)) unless @heater_usage_multiplier.nil?
-        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions) unless @heater_weekday_fractions.nil?
-        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions) unless @heater_weekend_fractions.nil?
-        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers) unless @heater_monthly_multipliers.nil?
+        XMLHelper.add_extension(heater, 'UsageMultiplier', to_float(@heater_usage_multiplier), @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
+        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
+        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
+        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
       end
     end
 
@@ -4714,20 +4890,30 @@ class HPXML < Object
       pool_pump = XMLHelper.get_element(pool, 'PoolPumps/PoolPump')
       @pump_id = HPXML::get_id(pool_pump)
       @pump_kwh_per_year = to_float_or_nil(XMLHelper.get_value(pool_pump, "Load[Units='#{UnitsKwhPerYear}']/Value"))
+      @pump_kwh_per_year_isdefaulted = get_software_defaulted(pool_pump, "Load[Units='#{UnitsKwhPerYear}']/Value") unless @pump_kwh_per_year.nil?
       @pump_usage_multiplier = to_float_or_nil(XMLHelper.get_value(pool_pump, 'extension/UsageMultiplier'))
+      @pump_usage_multiplier_isdefaulted = get_software_defaulted(pool_pump, 'extension/UsageMultiplier') unless @pump_usage_multiplier.nil?
       @pump_weekday_fractions = XMLHelper.get_value(pool_pump, 'extension/WeekdayScheduleFractions')
+      @pump_weekday_fractions_isdefaulted = get_software_defaulted(pool_pump, 'extension/WeekdayScheduleFractions') unless @pump_weekday_fractions.nil?
       @pump_weekend_fractions = XMLHelper.get_value(pool_pump, 'extension/WeekendScheduleFractions')
+      @pump_weekend_fractions_isdefaulted = get_software_defaulted(pool_pump, 'extension/WeekendScheduleFractions') unless @pump_weekend_fractions.nil?
       @pump_monthly_multipliers = XMLHelper.get_value(pool_pump, 'extension/MonthlyScheduleMultipliers')
+      @pump_monthly_multipliers_isdefaulted = get_software_defaulted(pool_pump, 'extension/MonthlyScheduleMultipliers') unless @pump_monthly_multipliers.nil?
       heater = XMLHelper.get_element(pool, 'Heater')
       if not heater.nil?
         @heater_id = HPXML::get_id(heater)
         @heater_type = XMLHelper.get_value(heater, 'Type')
         @heater_load_units = XMLHelper.get_value(heater, 'Load/Units')
         @heater_load_value = to_float_or_nil(XMLHelper.get_value(heater, 'Load/Value'))
+        @heater_load_value_isdefaulted = get_software_defaulted(heater, 'Load/Value') unless @heater_load_value.nil?
         @heater_usage_multiplier = to_float_or_nil(XMLHelper.get_value(heater, 'extension/UsageMultiplier'))
+        @heater_usage_multiplier_isdefaulted = get_software_defaulted(heater, 'extension/UsageMultiplier') unless @heater_usage_multiplier.nil?
         @heater_weekday_fractions = XMLHelper.get_value(heater, 'extension/WeekdayScheduleFractions')
+        @heater_weekday_fractions_isdefaulted = get_software_defaulted(heater, 'extension/WeekdayScheduleFractions') unless @heater_weekday_fractions.nil?
         @heater_weekend_fractions = XMLHelper.get_value(heater, 'extension/WeekendScheduleFractions')
+        @heater_weekend_fractions_isdefaulted = get_software_defaulted(heater, 'extension/WeekendScheduleFractions') unless @heater_weekend_fractions.nil?
         @heater_monthly_multipliers = XMLHelper.get_value(heater, 'extension/MonthlyScheduleMultipliers')
+        @heater_monthly_multipliers_isdefaulted = get_software_defaulted(heater, 'extension/MonthlyScheduleMultipliers') unless @heater_monthly_multipliers.nil?
       end
     end
   end
@@ -4780,11 +4966,11 @@ class HPXML < Object
       if not @pump_kwh_per_year.nil?
         load = XMLHelper.add_element(hot_tub_pump, 'Load')
         XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
-        XMLHelper.add_element(load, 'Value', to_float(@pump_kwh_per_year))
-        XMLHelper.add_extension(hot_tub_pump, 'UsageMultiplier', to_float(@pump_usage_multiplier)) unless @pump_usage_multiplier.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions) unless @pump_weekday_fractions.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'WeekendScheduleFractions', @pump_weekend_fractions) unless @pump_weekend_fractions.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers) unless @pump_monthly_multipliers.nil?
+        XMLHelper.add_element(load, 'Value', to_float(@pump_kwh_per_year), @pump_kwh_per_year_isdefaulted)
+        XMLHelper.add_extension(hot_tub_pump, 'UsageMultiplier', to_float(@pump_usage_multiplier), @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
       end
       if not @heater_type.nil?
         heater = XMLHelper.add_element(hot_tub, 'Heater')
@@ -4798,12 +4984,12 @@ class HPXML < Object
         if (not @heater_load_units.nil?) && (not @heater_load_value.nil?)
           load = XMLHelper.add_element(heater, 'Load')
           XMLHelper.add_element(load, 'Units', @heater_load_units)
-          XMLHelper.add_element(load, 'Value', to_float(@heater_load_value))
+          XMLHelper.add_element(load, 'Value', to_float(@heater_load_value), @heater_load_value_isdefaulted)
         end
-        XMLHelper.add_extension(heater, 'UsageMultiplier', to_float(@heater_usage_multiplier)) unless @heater_usage_multiplier.nil?
-        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions) unless @heater_weekday_fractions.nil?
-        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions) unless @heater_weekend_fractions.nil?
-        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers) unless @heater_monthly_multipliers.nil?
+        XMLHelper.add_extension(heater, 'UsageMultiplier', to_float(@heater_usage_multiplier), @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
+        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
+        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
+        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
       end
     end
 
@@ -4812,20 +4998,30 @@ class HPXML < Object
       hot_tub_pump = XMLHelper.get_element(hot_tub, 'HotTubPumps/HotTubPump')
       @pump_id = HPXML::get_id(hot_tub_pump)
       @pump_kwh_per_year = to_float_or_nil(XMLHelper.get_value(hot_tub_pump, "Load[Units='#{UnitsKwhPerYear}']/Value"))
+      @pump_kwh_per_year_isdefaulted = get_software_defaulted(hot_tub_pump, "Load[Units='#{UnitsKwhPerYear}']/Value") unless @pump_kwh_per_year.nil?
       @pump_usage_multiplier = to_float_or_nil(XMLHelper.get_value(hot_tub_pump, 'extension/UsageMultiplier'))
+      @pump_usage_multiplier_isdefaulted = get_software_defaulted(hot_tub_pump, 'extension/UsageMultiplier') unless @pump_usage_multiplier.nil?
       @pump_weekday_fractions = XMLHelper.get_value(hot_tub_pump, 'extension/WeekdayScheduleFractions')
+      @pump_weekday_fractions_isdefaulted = get_software_defaulted(hot_tub_pump, 'extension/WeekdayScheduleFractions') unless @pump_weekday_fractions.nil?
       @pump_weekend_fractions = XMLHelper.get_value(hot_tub_pump, 'extension/WeekendScheduleFractions')
+      @pump_weekend_fractions_isdefaulted = get_software_defaulted(hot_tub_pump, 'extension/WeekendScheduleFractions') unless @pump_weekend_fractions.nil?
       @pump_monthly_multipliers = XMLHelper.get_value(hot_tub_pump, 'extension/MonthlyScheduleMultipliers')
+      @pump_monthly_multipliers_isdefaulted = get_software_defaulted(hot_tub_pump, 'extension/MonthlyScheduleMultipliers') unless @pump_monthly_multipliers.nil?
       heater = XMLHelper.get_element(hot_tub, 'Heater')
       if not heater.nil?
         @heater_id = HPXML::get_id(heater)
         @heater_type = XMLHelper.get_value(heater, 'Type')
         @heater_load_units = XMLHelper.get_value(heater, 'Load/Units')
         @heater_load_value = to_float_or_nil(XMLHelper.get_value(heater, 'Load/Value'))
+        @heater_load_value_isdefaulted = get_software_defaulted(heater, 'Load/Value') unless @heater_load_value.nil?
         @heater_usage_multiplier = to_float_or_nil(XMLHelper.get_value(heater, 'extension/UsageMultiplier'))
+        @heater_usage_multiplier_isdefaulted = get_software_defaulted(heater, 'extension/UsageMultiplier') unless @heater_usage_multiplier.nil?
         @heater_weekday_fractions = XMLHelper.get_value(heater, 'extension/WeekdayScheduleFractions')
+        @heater_weekday_fractions_isdefaulted = get_software_defaulted(heater, 'extension/WeekdayScheduleFractions') unless @heater_weekday_fractions.nil?
         @heater_weekend_fractions = XMLHelper.get_value(heater, 'extension/WeekendScheduleFractions')
+        @heater_weekend_fractions_isdefaulted = get_software_defaulted(heater, 'extension/WeekendScheduleFractions') unless @heater_weekend_fractions.nil?
         @heater_monthly_multipliers = XMLHelper.get_value(heater, 'extension/MonthlyScheduleMultipliers')
+        @heater_monthly_multipliers_isdefaulted = get_software_defaulted(heater, 'extension/MonthlyScheduleMultipliers') unless @heater_monthly_multipliers.nil?
       end
     end
   end
@@ -4866,31 +5062,39 @@ class HPXML < Object
       sys_id = XMLHelper.add_element(plug_load, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
       XMLHelper.add_element(plug_load, 'PlugLoadType', @plug_load_type) unless @plug_load_type.nil?
-      XMLHelper.add_element(plug_load, 'Location', @location) unless @location.nil?
+      XMLHelper.add_element(plug_load, 'Location', @location, @location_isdefaulted) unless @location.nil?
       if not @kWh_per_year.nil?
         load = XMLHelper.add_element(plug_load, 'Load')
         XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
-        XMLHelper.add_element(load, 'Value', to_float(@kWh_per_year))
+        XMLHelper.add_element(load, 'Value', to_float(@kWh_per_year), @kWh_per_year_isdefaulted)
       end
-      XMLHelper.add_extension(plug_load, 'FracSensible', to_float(@frac_sensible)) unless @frac_sensible.nil?
-      XMLHelper.add_extension(plug_load, 'FracLatent', to_float(@frac_latent)) unless @frac_latent.nil?
-      XMLHelper.add_extension(plug_load, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(plug_load, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(plug_load, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(plug_load, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
+      XMLHelper.add_extension(plug_load, 'FracSensible', to_float(@frac_sensible), @frac_sensible_isdefaulted) unless @frac_sensible.nil?
+      XMLHelper.add_extension(plug_load, 'FracLatent', to_float(@frac_latent), @frac_latent_isdefaulted) unless @frac_latent.nil?
+      XMLHelper.add_extension(plug_load, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(plug_load, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(plug_load, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(plug_load, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(plug_load)
       @id = HPXML::get_id(plug_load)
       @plug_load_type = XMLHelper.get_value(plug_load, 'PlugLoadType')
       @location = XMLHelper.get_value(plug_load, 'Location')
+      @location_isdefaulted = get_software_defaulted(plug_load, 'Location') unless @location.nil?
       @kWh_per_year = to_float_or_nil(XMLHelper.get_value(plug_load, "Load[Units='#{UnitsKwhPerYear}']/Value"))
+      @kWh_per_year_isdefaulted = get_software_defaulted(plug_load, "Load[Units='#{UnitsKwhPerYear}']/Value") unless @kWh_per_year.nil?
       @frac_sensible = to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/FracSensible'))
+      @frac_sensible_isdefaulted = get_software_defaulted(plug_load, 'extension/FracSensible') unless @frac_sensible.nil?
       @frac_latent = to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/FracLatent'))
+      @frac_latent_isdefaulted = get_software_defaulted(plug_load, 'extension/FracLatent') unless @frac_latent.nil?
       @usage_multiplier = to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/UsageMultiplier'))
+      @usage_multiplier_isdefaulted = get_software_defaulted(plug_load, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
       @weekday_fractions = XMLHelper.get_value(plug_load, 'extension/WeekdayScheduleFractions')
+      @weekday_fractions_isdefaulted = get_software_defaulted(plug_load, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
       @weekend_fractions = XMLHelper.get_value(plug_load, 'extension/WeekendScheduleFractions')
+      @weekend_fractions_isdefaulted = get_software_defaulted(plug_load, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
       @monthly_multipliers = XMLHelper.get_value(plug_load, 'extension/MonthlyScheduleMultipliers')
+      @monthly_multipliers_isdefaulted = get_software_defaulted(plug_load, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
     end
   end
 
@@ -4930,33 +5134,41 @@ class HPXML < Object
       sys_id = XMLHelper.add_element(fuel_load, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
       XMLHelper.add_element(fuel_load, 'FuelLoadType', @fuel_load_type) unless @fuel_load_type.nil?
-      XMLHelper.add_element(fuel_load, 'Location', @location) unless @location.nil?
+      XMLHelper.add_element(fuel_load, 'Location', @location, @location_isdefaulted) unless @location.nil?
       if not @therm_per_year.nil?
         load = XMLHelper.add_element(fuel_load, 'Load')
         XMLHelper.add_element(load, 'Units', UnitsThermPerYear)
-        XMLHelper.add_element(load, 'Value', to_float(@therm_per_year))
+        XMLHelper.add_element(load, 'Value', to_float(@therm_per_year), @therm_per_year_isdefaulted)
       end
       XMLHelper.add_element(fuel_load, 'FuelType', @fuel_type) unless @fuel_type.nil?
-      XMLHelper.add_extension(fuel_load, 'FracSensible', to_float(@frac_sensible)) unless @frac_sensible.nil?
-      XMLHelper.add_extension(fuel_load, 'FracLatent', to_float(@frac_latent)) unless @frac_latent.nil?
-      XMLHelper.add_extension(fuel_load, 'UsageMultiplier', to_float(@usage_multiplier)) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(fuel_load, 'WeekdayScheduleFractions', @weekday_fractions) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(fuel_load, 'WeekendScheduleFractions', @weekend_fractions) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(fuel_load, 'MonthlyScheduleMultipliers', @monthly_multipliers) unless @monthly_multipliers.nil?
+      XMLHelper.add_extension(fuel_load, 'FracSensible', to_float(@frac_sensible), @frac_sensible_isdefaulted) unless @frac_sensible.nil?
+      XMLHelper.add_extension(fuel_load, 'FracLatent', to_float(@frac_latent), @frac_latent_isdefaulted) unless @frac_latent.nil?
+      XMLHelper.add_extension(fuel_load, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(fuel_load, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(fuel_load, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(fuel_load, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(fuel_load)
       @id = HPXML::get_id(fuel_load)
       @fuel_load_type = XMLHelper.get_value(fuel_load, 'FuelLoadType')
       @location = XMLHelper.get_value(fuel_load, 'Location')
+      @location_isdefaulted = get_software_defaulted(fuel_load, 'Location') unless @location.nil?
       @therm_per_year = to_float_or_nil(XMLHelper.get_value(fuel_load, "Load[Units='#{UnitsThermPerYear}']/Value"))
+      @therm_per_year_isdefaulted = get_software_defaulted(fuel_load, "Load[Units='#{UnitsThermPerYear}']/Value") unless @therm_per_year.nil?
       @fuel_type = XMLHelper.get_value(fuel_load, 'FuelType')
       @frac_sensible = to_float_or_nil(XMLHelper.get_value(fuel_load, 'extension/FracSensible'))
+      @frac_sensible_isdefaulted = get_software_defaulted(fuel_load, 'extension/FracSensible') unless @frac_sensible.nil?
       @frac_latent = to_float_or_nil(XMLHelper.get_value(fuel_load, 'extension/FracLatent'))
+      @frac_latent_isdefaulted = get_software_defaulted(fuel_load, 'extension/FracLatent') unless @frac_latent.nil?
       @usage_multiplier = to_float_or_nil(XMLHelper.get_value(fuel_load, 'extension/UsageMultiplier'))
+      @usage_multiplier_isdefaulted = get_software_defaulted(fuel_load, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
       @weekday_fractions = XMLHelper.get_value(fuel_load, 'extension/WeekdayScheduleFractions')
+      @weekday_fractions_isdefaulted = get_software_defaulted(fuel_load, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
       @weekend_fractions = XMLHelper.get_value(fuel_load, 'extension/WeekendScheduleFractions')
+      @weekend_fractions_isdefaulted = get_software_defaulted(fuel_load, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
       @monthly_multipliers = XMLHelper.get_value(fuel_load, 'extension/MonthlyScheduleMultipliers')
+      @monthly_multipliers_isdefaulted = get_software_defaulted(fuel_load, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
     end
   end
 
@@ -5286,4 +5498,10 @@ def to_boolean_or_nil(value)
   return if value.nil?
 
   return to_boolean(value)
+end
+
+def get_software_defaulted(parent, element_name)
+  el = XMLHelper.get_element(parent, element_name)
+  is_defaulted = XMLHelper.get_attribute_value(el, 'dataSource') == 'software'
+  return is_defaulted
 end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -988,7 +988,7 @@ class HPXML < Object
       XMLHelper.add_element(building_construction, 'ResidentialFacilityType', @residential_facility_type, :string) unless @residential_facility_type.nil?
       XMLHelper.add_element(building_construction, 'NumberofConditionedFloors', @number_of_conditioned_floors, :integer) unless @number_of_conditioned_floors.nil?
       XMLHelper.add_element(building_construction, 'NumberofConditionedFloorsAboveGrade', @number_of_conditioned_floors_above_grade, :integer) unless @number_of_conditioned_floors_above_grade.nil?
-      XMLHelper.add_element(building_construction, 'AverageCeilingHeight', @average_ceiling_height, :float) unless @average_ceiling_height.nil?
+      XMLHelper.add_element(building_construction, 'AverageCeilingHeight', @average_ceiling_height, :float, @average_ceiling_height_isdefaulted) unless @average_ceiling_height.nil?
       XMLHelper.add_element(building_construction, 'NumberofBedrooms', @number_of_bedrooms, :integer) unless @number_of_bedrooms.nil?
       XMLHelper.add_element(building_construction, 'NumberofBathrooms', @number_of_bathrooms, :integer, @number_of_bathrooms_isdefaulted) unless @number_of_bathrooms.nil?
       XMLHelper.add_element(building_construction, 'ConditionedFloorArea', @conditioned_floor_area, :float) unless @conditioned_floor_area.nil?
@@ -1006,7 +1006,7 @@ class HPXML < Object
       @year_built = XMLHelper.get_value(building_construction, 'YearBuilt', :integer)
       @number_of_conditioned_floors = XMLHelper.get_value(building_construction, 'NumberofConditionedFloors', :integer)
       @number_of_conditioned_floors_above_grade = XMLHelper.get_value(building_construction, 'NumberofConditionedFloorsAboveGrade', :integer)
-      @average_ceiling_height = XMLHelper.get_value(building_construction, 'AverageCeilingHeight', :float)
+      @average_ceiling_height, @average_ceiling_height_isdefaulted = XMLHelper.get_value_and_defaulted(building_construction, 'AverageCeilingHeight', :float)
       @number_of_bedrooms = XMLHelper.get_value(building_construction, 'NumberofBedrooms', :integer)
       @number_of_bathrooms, @number_of_bathrooms_isdefaulted = XMLHelper.get_value_and_defaulted(building_construction, 'NumberofBathrooms', :integer)
       @conditioned_floor_area = XMLHelper.get_value(building_construction, 'ConditionedFloorArea', :float)
@@ -3686,7 +3686,7 @@ class HPXML < Object
       end
       if not @pipe_r_value.nil?
         pipe_insulation = XMLHelper.add_element(hot_water_distribution, 'PipeInsulation')
-        XMLHelper.add_element(pipe_insulation, 'PipeRValue', @pipe_r_value, :float)
+        XMLHelper.add_element(pipe_insulation, 'PipeRValue', @pipe_r_value, :float, @pipe_r_value_isdefaulted)
       end
       if (not @dwhr_facilities_connected.nil?) || (not @dwhr_equal_flow.nil?) || (not @dwhr_efficiency.nil?)
         drain_water_heat_recovery = XMLHelper.add_element(hot_water_distribution, 'DrainWaterHeatRecovery')
@@ -3708,7 +3708,7 @@ class HPXML < Object
 
       @id = HPXML::get_id(hot_water_distribution)
       @system_type = XMLHelper.get_child_name(hot_water_distribution, 'SystemType')
-      @pipe_r_value = XMLHelper.get_value(hot_water_distribution, 'PipeInsulation/PipeRValue', :float)
+      @pipe_r_value, @pipe_r_value_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'PipeInsulation/PipeRValue', :float)
       if @system_type == 'Standard'
         @standard_piping_length, @standard_piping_length_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Standard/PipingLength', :float)
       elsif @system_type == 'Recirculation'

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -770,51 +770,51 @@ class HPXML < Object
 
       hpxml = XMLHelper.get_element(doc, '/HPXML')
       header = XMLHelper.add_element(hpxml, 'XMLTransactionHeaderInformation')
-      XMLHelper.add_element(header, 'XMLType', @xml_type)
-      XMLHelper.add_element(header, 'XMLGeneratedBy', @xml_generated_by)
+      XMLHelper.add_element(header, 'XMLType', @xml_type, :string)
+      XMLHelper.add_element(header, 'XMLGeneratedBy', @xml_generated_by, :string)
       if not @created_date_and_time.nil?
-        XMLHelper.add_element(header, 'CreatedDateAndTime', @created_date_and_time)
+        XMLHelper.add_element(header, 'CreatedDateAndTime', @created_date_and_time, :string)
       else
-        XMLHelper.add_element(header, 'CreatedDateAndTime', Time.now.strftime('%Y-%m-%dT%H:%M:%S%:z'))
+        XMLHelper.add_element(header, 'CreatedDateAndTime', Time.now.strftime('%Y-%m-%dT%H:%M:%S%:z'), :string)
       end
-      XMLHelper.add_element(header, 'Transaction', @transaction)
+      XMLHelper.add_element(header, 'Transaction', @transaction, :string)
 
       software_info = XMLHelper.add_element(hpxml, 'SoftwareInfo')
-      XMLHelper.add_element(software_info, 'SoftwareProgramUsed', @software_program_used) unless @software_program_used.nil?
-      XMLHelper.add_element(software_info, 'SoftwareProgramVersion', software_program_version) unless software_program_version.nil?
+      XMLHelper.add_element(software_info, 'SoftwareProgramUsed', @software_program_used, :string) unless @software_program_used.nil?
+      XMLHelper.add_element(software_info, 'SoftwareProgramVersion', @software_program_version, :string) unless @software_program_version.nil?
       if not @apply_ashrae140_assumptions.nil?
         extension = XMLHelper.create_elements_as_needed(software_info, ['extension'])
-        XMLHelper.add_element(extension, 'ApplyASHRAE140Assumptions', to_boolean(@apply_ashrae140_assumptions)) unless @apply_ashrae140_assumptions.nil?
+        XMLHelper.add_element(extension, 'ApplyASHRAE140Assumptions', @apply_ashrae140_assumptions, :boolean) unless @apply_ashrae140_assumptions.nil?
       end
       if (not @eri_calculation_version.nil?) || (not @eri_design.nil?)
         extension = XMLHelper.create_elements_as_needed(software_info, ['extension'])
         eri_calculation = XMLHelper.add_element(extension, 'ERICalculation')
-        XMLHelper.add_element(eri_calculation, 'Version', @eri_calculation_version) unless @eri_calculation_version.nil?
-        XMLHelper.add_element(eri_calculation, 'Design', @eri_design) unless @eri_design.nil?
+        XMLHelper.add_element(eri_calculation, 'Version', @eri_calculation_version, :string) unless @eri_calculation_version.nil?
+        XMLHelper.add_element(eri_calculation, 'Design', @eri_design, :string) unless @eri_design.nil?
       end
       if (not @timestep.nil?) || (not @sim_begin_month.nil?) || (not @sim_begin_day.nil?) || (not @sim_end_month.nil?) || (not @sim_end_day.nil?) || (not @dst_enabled.nil?) || (not @dst_begin_month.nil?) || (not @dst_begin_day.nil?) || (not @dst_end_month.nil?) || (not @dst_end_day.nil?)
         extension = XMLHelper.create_elements_as_needed(software_info, ['extension'])
         simulation_control = XMLHelper.add_element(extension, 'SimulationControl')
-        XMLHelper.add_element(simulation_control, 'Timestep', to_integer(@timestep), @timestep_isdefaulted) unless @timestep.nil?
-        XMLHelper.add_element(simulation_control, 'BeginMonth', to_integer(@sim_begin_month), @sim_begin_month_isdefaulted) unless @sim_begin_month.nil?
-        XMLHelper.add_element(simulation_control, 'BeginDayOfMonth', to_integer(@sim_begin_day), @sim_begin_day_isdefaulted) unless @sim_begin_day.nil?
-        XMLHelper.add_element(simulation_control, 'EndMonth', to_integer(@sim_end_month), @sim_end_month_isdefaulted) unless @sim_end_month.nil?
-        XMLHelper.add_element(simulation_control, 'EndDayOfMonth', to_integer(@sim_end_day), @sim_end_day_isdefaulted) unless @sim_end_day.nil?
-        XMLHelper.add_element(simulation_control, 'CalendarYear', to_integer(@sim_calendar_year), @sim_calendar_year_isdefaulted) unless @sim_calendar_year.nil?
+        XMLHelper.add_element(simulation_control, 'Timestep', @timestep, :integer, @timestep_isdefaulted) unless @timestep.nil?
+        XMLHelper.add_element(simulation_control, 'BeginMonth', @sim_begin_month, :integer, @sim_begin_month_isdefaulted) unless @sim_begin_month.nil?
+        XMLHelper.add_element(simulation_control, 'BeginDayOfMonth', @sim_begin_day, :integer, @sim_begin_day_isdefaulted) unless @sim_begin_day.nil?
+        XMLHelper.add_element(simulation_control, 'EndMonth', @sim_end_month, :integer, @sim_end_month_isdefaulted) unless @sim_end_month.nil?
+        XMLHelper.add_element(simulation_control, 'EndDayOfMonth', @sim_end_day, :integer, @sim_end_day_isdefaulted) unless @sim_end_day.nil?
+        XMLHelper.add_element(simulation_control, 'CalendarYear', @sim_calendar_year, :integer, @sim_calendar_year_isdefaulted) unless @sim_calendar_year.nil?
         if (not @dst_enabled.nil?) || (not @dst_begin_month.nil?) || (not @dst_begin_day.nil?) || (not @dst_end_month.nil?) || (not @dst_end_day.nil?)
           daylight_saving = XMLHelper.add_element(simulation_control, 'DaylightSaving')
-          XMLHelper.add_element(daylight_saving, 'Enabled', to_boolean(@dst_enabled), @dst_enabled_isdefaulted) unless @dst_enabled.nil?
-          XMLHelper.add_element(daylight_saving, 'BeginMonth', to_integer(@dst_begin_month), @dst_begin_month_isdefaulted) unless @dst_begin_month.nil?
-          XMLHelper.add_element(daylight_saving, 'BeginDayOfMonth', to_integer(@dst_begin_day), @dst_begin_day_isdefaulted) unless @dst_begin_day.nil?
-          XMLHelper.add_element(daylight_saving, 'EndMonth', to_integer(@dst_end_month), @dst_end_month_isdefaulted) unless @dst_end_month.nil?
-          XMLHelper.add_element(daylight_saving, 'EndDayOfMonth', to_integer(@dst_end_day), @dst_end_day_isdefaulted) unless @dst_end_day.nil?
+          XMLHelper.add_element(daylight_saving, 'Enabled', @dst_enabled, :boolean, @dst_enabled_isdefaulted) unless @dst_enabled.nil?
+          XMLHelper.add_element(daylight_saving, 'BeginMonth', @dst_begin_month, :integer, @dst_begin_month_isdefaulted) unless @dst_begin_month.nil?
+          XMLHelper.add_element(daylight_saving, 'BeginDayOfMonth', @dst_begin_day, :integer, @dst_begin_day_isdefaulted) unless @dst_begin_day.nil?
+          XMLHelper.add_element(daylight_saving, 'EndMonth', @dst_end_month, :integer, @dst_end_month_isdefaulted) unless @dst_end_month.nil?
+          XMLHelper.add_element(daylight_saving, 'EndDayOfMonth', @dst_end_day, :integer, @dst_end_day_isdefaulted) unless @dst_end_day.nil?
         end
       end
       if (not @use_max_load_for_heat_pumps.nil?) || (not @allow_increased_fixed_capacities.nil?)
         extension = XMLHelper.create_elements_as_needed(software_info, ['extension'])
         hvac_sizing_control = XMLHelper.add_element(extension, 'HVACSizingControl')
-        XMLHelper.add_element(hvac_sizing_control, 'UseMaxLoadForHeatPumps', to_boolean(@use_max_load_for_heat_pumps), @use_max_load_for_heat_pumps_isdefaulted) unless @use_max_load_for_heat_pumps.nil?
-        XMLHelper.add_element(hvac_sizing_control, 'AllowIncreasedFixedCapacities', to_boolean(@allow_increased_fixed_capacities), @allow_increased_fixed_capacities_isdefaulted) unless @allow_increased_fixed_capacities.nil?
+        XMLHelper.add_element(hvac_sizing_control, 'UseMaxLoadForHeatPumps', @use_max_load_for_heat_pumps, :boolean, @use_max_load_for_heat_pumps_isdefaulted) unless @use_max_load_for_heat_pumps.nil?
+        XMLHelper.add_element(hvac_sizing_control, 'AllowIncreasedFixedCapacities', @allow_increased_fixed_capacities, :boolean, @allow_increased_fixed_capacities_isdefaulted) unless @allow_increased_fixed_capacities.nil?
       end
 
       building = XMLHelper.add_element(hpxml, 'Building')
@@ -825,23 +825,23 @@ class HPXML < Object
         site_id = XMLHelper.add_element(site, 'SiteID')
         XMLHelper.add_attribute(site_id, 'id', 'SiteID')
         address = XMLHelper.add_element(site, 'Address')
-        XMLHelper.add_element(address, 'StateCode', @state_code)
+        XMLHelper.add_element(address, 'StateCode', @state_code, :string)
       end
       project_status = XMLHelper.add_element(building, 'ProjectStatus')
-      XMLHelper.add_element(project_status, 'EventType', @event_type)
+      XMLHelper.add_element(project_status, 'EventType', @event_type, :string)
     end
 
     def from_oga(hpxml)
       return if hpxml.nil?
 
-      @xml_type = XMLHelper.get_value(hpxml, 'XMLTransactionHeaderInformation/XMLType')
-      @xml_generated_by = XMLHelper.get_value(hpxml, 'XMLTransactionHeaderInformation/XMLGeneratedBy')
-      @created_date_and_time = XMLHelper.get_value(hpxml, 'XMLTransactionHeaderInformation/CreatedDateAndTime')
-      @transaction = XMLHelper.get_value(hpxml, 'XMLTransactionHeaderInformation/Transaction')
-      @software_program_used = XMLHelper.get_value(hpxml, 'SoftwareInfo/SoftwareProgramUsed')
-      @software_program_version = XMLHelper.get_value(hpxml, 'SoftwareInfo/SoftwareProgramVersion')
-      @eri_calculation_version = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ERICalculation/Version')
-      @eri_design = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ERICalculation/Design')
+      @xml_type = XMLHelper.get_value(hpxml, 'XMLTransactionHeaderInformation/XMLType', :string)
+      @xml_generated_by = XMLHelper.get_value(hpxml, 'XMLTransactionHeaderInformation/XMLGeneratedBy', :string)
+      @created_date_and_time = XMLHelper.get_value(hpxml, 'XMLTransactionHeaderInformation/CreatedDateAndTime', :string)
+      @transaction = XMLHelper.get_value(hpxml, 'XMLTransactionHeaderInformation/Transaction', :string)
+      @software_program_used = XMLHelper.get_value(hpxml, 'SoftwareInfo/SoftwareProgramUsed', :string)
+      @software_program_version = XMLHelper.get_value(hpxml, 'SoftwareInfo/SoftwareProgramVersion', :string)
+      @eri_calculation_version = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ERICalculation/Version', :string)
+      @eri_design = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ERICalculation/Design', :string)
       @timestep, @timestep_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/Timestep', :integer)
       @sim_begin_month, @sim_begin_month_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginMonth', :integer)
       @sim_begin_day, @sim_begin_day_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginDayOfMonth', :integer)
@@ -857,8 +857,8 @@ class HPXML < Object
       @use_max_load_for_heat_pumps, @use_max_load_for_heat_pumps_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/HVACSizingControl/UseMaxLoadForHeatPumps', :boolean)
       @allow_increased_fixed_capacities, @allow_increased_fixed_capacities_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/HVACSizingControl/AllowIncreasedFixedCapacities', :boolean)
       @building_id = HPXML::get_id(hpxml, 'Building/BuildingID')
-      @event_type = XMLHelper.get_value(hpxml, 'Building/ProjectStatus/EventType')
-      @state_code = XMLHelper.get_value(hpxml, 'Building/Site/Address/StateCode')
+      @event_type = XMLHelper.get_value(hpxml, 'Building/ProjectStatus/EventType', :string)
+      @state_code = XMLHelper.get_value(hpxml, 'Building/Site/Address/StateCode', :string)
     end
   end
 
@@ -875,16 +875,16 @@ class HPXML < Object
       return if nil?
 
       site = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'BuildingSummary', 'Site'])
-      XMLHelper.add_element(site, 'SiteType', @site_type, @site_type_isdefaulted) unless @site_type.nil?
-      XMLHelper.add_element(site, 'Surroundings', @surroundings) unless @surroundings.nil?
-      XMLHelper.add_element(site, 'OrientationOfFrontOfHome', @orientation_of_front_of_home) unless @orientation_of_front_of_home.nil?
+      XMLHelper.add_element(site, 'SiteType', @site_type, :string, @site_type_isdefaulted) unless @site_type.nil?
+      XMLHelper.add_element(site, 'Surroundings', @surroundings, :string) unless @surroundings.nil?
+      XMLHelper.add_element(site, 'OrientationOfFrontOfHome', @orientation_of_front_of_home, :string) unless @orientation_of_front_of_home.nil?
       if (not @fuels.nil?) && (not @fuels.empty?)
         fuel_types_available = XMLHelper.add_element(site, 'FuelTypesAvailable')
         @fuels.each do |fuel|
-          XMLHelper.add_element(fuel_types_available, 'Fuel', fuel)
+          XMLHelper.add_element(fuel_types_available, 'Fuel', fuel, :string)
         end
       end
-      XMLHelper.add_extension(site, 'ShelterCoefficient', to_float(@shelter_coefficient), shelter_coefficient_isdefaulted) unless @shelter_coefficient.nil?
+      XMLHelper.add_extension(site, 'ShelterCoefficient', @shelter_coefficient, :float, shelter_coefficient_isdefaulted) unless @shelter_coefficient.nil?
     end
 
     def from_oga(hpxml)
@@ -893,10 +893,10 @@ class HPXML < Object
       site = XMLHelper.get_element(hpxml, 'Building/BuildingDetails/BuildingSummary/Site')
       return if site.nil?
 
-      @site_type, @site_type_isdefaulted = XMLHelper.get_value_and_defaulted(site, 'SiteType')
-      @surroundings = XMLHelper.get_value(site, 'Surroundings')
-      @orientation_of_front_of_home = XMLHelper.get_value(site, 'OrientationOfFrontOfHome')
-      @fuels = XMLHelper.get_values(site, 'FuelTypesAvailable/Fuel')
+      @site_type, @site_type_isdefaulted = XMLHelper.get_value_and_defaulted(site, 'SiteType', :string)
+      @surroundings = XMLHelper.get_value(site, 'Surroundings', :string)
+      @orientation_of_front_of_home = XMLHelper.get_value(site, 'OrientationOfFrontOfHome', :string)
+      @fuels = XMLHelper.get_values(site, 'FuelTypesAvailable/Fuel', :string)
       @shelter_coefficient, @shelter_coefficient_isdefaulted = XMLHelper.get_value_and_defaulted(site, 'extension/ShelterCoefficient', :float)
     end
   end
@@ -929,9 +929,9 @@ class HPXML < Object
 
       neighbors = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'BuildingSummary', 'Site', 'extension', 'Neighbors'])
       neighbor_building = XMLHelper.add_element(neighbors, 'NeighborBuilding')
-      XMLHelper.add_element(neighbor_building, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(neighbor_building, 'Distance', to_float(@distance)) unless @distance.nil?
-      XMLHelper.add_element(neighbor_building, 'Height', to_float(@height)) unless @height.nil?
+      XMLHelper.add_element(neighbor_building, 'Azimuth', @azimuth, :integer) unless @azimuth.nil?
+      XMLHelper.add_element(neighbor_building, 'Distance', @distance, :float) unless @distance.nil?
+      XMLHelper.add_element(neighbor_building, 'Height', @height, :float) unless @height.nil?
     end
 
     def from_oga(neighbor_building)
@@ -956,7 +956,7 @@ class HPXML < Object
       return if nil?
 
       building_occupancy = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'BuildingSummary', 'BuildingOccupancy'])
-      XMLHelper.add_element(building_occupancy, 'NumberofResidents', to_float(@number_of_residents), @number_of_residents_isdefaulted) unless @number_of_residents.nil?
+      XMLHelper.add_element(building_occupancy, 'NumberofResidents', @number_of_residents, :float, @number_of_residents_isdefaulted) unless @number_of_residents.nil?
     end
 
     def from_oga(hpxml)
@@ -985,16 +985,16 @@ class HPXML < Object
       return if nil?
 
       building_construction = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'BuildingSummary', 'BuildingConstruction'])
-      XMLHelper.add_element(building_construction, 'ResidentialFacilityType', @residential_facility_type) unless @residential_facility_type.nil?
-      XMLHelper.add_element(building_construction, 'NumberofConditionedFloors', to_integer(@number_of_conditioned_floors)) unless @number_of_conditioned_floors.nil?
-      XMLHelper.add_element(building_construction, 'NumberofConditionedFloorsAboveGrade', to_integer(@number_of_conditioned_floors_above_grade)) unless @number_of_conditioned_floors_above_grade.nil?
-      XMLHelper.add_element(building_construction, 'AverageCeilingHeight', to_float(@average_ceiling_height)) unless @average_ceiling_height.nil?
-      XMLHelper.add_element(building_construction, 'NumberofBedrooms', to_integer(@number_of_bedrooms)) unless @number_of_bedrooms.nil?
-      XMLHelper.add_element(building_construction, 'NumberofBathrooms', to_integer(@number_of_bathrooms), @number_of_bathrooms_isdefaulted) unless @number_of_bathrooms.nil?
-      XMLHelper.add_element(building_construction, 'ConditionedFloorArea', to_float(@conditioned_floor_area)) unless @conditioned_floor_area.nil?
-      XMLHelper.add_element(building_construction, 'ConditionedBuildingVolume', to_float(@conditioned_building_volume), @conditioned_building_volume_isdefaulted) unless @conditioned_building_volume.nil?
-      XMLHelper.add_extension(building_construction, 'UseOnlyIdealAirSystem', to_boolean(@use_only_ideal_air_system)) unless @use_only_ideal_air_system.nil?
-      XMLHelper.add_extension(building_construction, 'HasFlueOrChimney', to_boolean(@has_flue_or_chimney), @has_flue_or_chimney_isdefaulted) unless @has_flue_or_chimney.nil?
+      XMLHelper.add_element(building_construction, 'ResidentialFacilityType', @residential_facility_type, :string) unless @residential_facility_type.nil?
+      XMLHelper.add_element(building_construction, 'NumberofConditionedFloors', @number_of_conditioned_floors, :integer) unless @number_of_conditioned_floors.nil?
+      XMLHelper.add_element(building_construction, 'NumberofConditionedFloorsAboveGrade', @number_of_conditioned_floors_above_grade, :integer) unless @number_of_conditioned_floors_above_grade.nil?
+      XMLHelper.add_element(building_construction, 'AverageCeilingHeight', @average_ceiling_height, :float) unless @average_ceiling_height.nil?
+      XMLHelper.add_element(building_construction, 'NumberofBedrooms', @number_of_bedrooms, :integer) unless @number_of_bedrooms.nil?
+      XMLHelper.add_element(building_construction, 'NumberofBathrooms', @number_of_bathrooms, :integer, @number_of_bathrooms_isdefaulted) unless @number_of_bathrooms.nil?
+      XMLHelper.add_element(building_construction, 'ConditionedFloorArea', @conditioned_floor_area, :float) unless @conditioned_floor_area.nil?
+      XMLHelper.add_element(building_construction, 'ConditionedBuildingVolume', @conditioned_building_volume, :float, @conditioned_building_volume_isdefaulted) unless @conditioned_building_volume.nil?
+      XMLHelper.add_extension(building_construction, 'UseOnlyIdealAirSystem', @use_only_ideal_air_system, :boolean) unless @use_only_ideal_air_system.nil?
+      XMLHelper.add_extension(building_construction, 'HasFlueOrChimney', @has_flue_or_chimney, :boolean, @has_flue_or_chimney_isdefaulted) unless @has_flue_or_chimney.nil?
     end
 
     def from_oga(hpxml)
@@ -1012,7 +1012,7 @@ class HPXML < Object
       @conditioned_floor_area = XMLHelper.get_value(building_construction, 'ConditionedFloorArea', :float)
       @conditioned_building_volume, @conditioned_building_volume_isdefaulted = XMLHelper.get_value_and_defaulted(building_construction, 'ConditionedBuildingVolume', :float)
       @use_only_ideal_air_system = XMLHelper.get_value(building_construction, 'extension/UseOnlyIdealAirSystem', :boolean)
-      @residential_facility_type = XMLHelper.get_value(building_construction, 'ResidentialFacilityType')
+      @residential_facility_type = XMLHelper.get_value(building_construction, 'ResidentialFacilityType', :string)
       @has_flue_or_chimney, @has_flue_or_chimney_isdefaulted = XMLHelper.get_value_and_defaulted(building_construction, 'extension/HasFlueOrChimney', :boolean)
     end
   end
@@ -1034,17 +1034,17 @@ class HPXML < Object
 
       if (not @iecc_year.nil?) && (not @iecc_zone.nil?)
         climate_zone_iecc = XMLHelper.add_element(climate_and_risk_zones, 'ClimateZoneIECC')
-        XMLHelper.add_element(climate_zone_iecc, 'Year', to_integer(@iecc_year)) unless @iecc_year.nil?
-        XMLHelper.add_element(climate_zone_iecc, 'ClimateZone', @iecc_zone) unless @iecc_zone.nil?
+        XMLHelper.add_element(climate_zone_iecc, 'Year', @iecc_year, :integer) unless @iecc_year.nil?
+        XMLHelper.add_element(climate_zone_iecc, 'ClimateZone', @iecc_zone, :string) unless @iecc_zone.nil?
       end
 
       if not @weather_station_id.nil?
         weather_station = XMLHelper.add_element(climate_and_risk_zones, 'WeatherStation')
         sys_id = XMLHelper.add_element(weather_station, 'SystemIdentifier')
         XMLHelper.add_attribute(sys_id, 'id', @weather_station_id)
-        XMLHelper.add_element(weather_station, 'Name', @weather_station_name) unless @weather_station_name.nil?
-        XMLHelper.add_element(weather_station, 'WMO', @weather_station_wmo) unless @weather_station_wmo.nil?
-        XMLHelper.add_extension(weather_station, 'EPWFilePath', @weather_station_epw_filepath) unless @weather_station_epw_filepath.nil?
+        XMLHelper.add_element(weather_station, 'Name', @weather_station_name, :string) unless @weather_station_name.nil?
+        XMLHelper.add_element(weather_station, 'WMO', @weather_station_wmo, :string) unless @weather_station_wmo.nil?
+        XMLHelper.add_extension(weather_station, 'EPWFilePath', @weather_station_epw_filepath, :string) unless @weather_station_epw_filepath.nil?
       end
     end
 
@@ -1054,14 +1054,14 @@ class HPXML < Object
       climate_and_risk_zones = XMLHelper.get_element(hpxml, 'Building/BuildingDetails/ClimateandRiskZones')
       return if climate_and_risk_zones.nil?
 
-      @iecc_year = XMLHelper.get_value(climate_and_risk_zones, 'ClimateZoneIECC/Year')
-      @iecc_zone = XMLHelper.get_value(climate_and_risk_zones, 'ClimateZoneIECC/ClimateZone')
+      @iecc_year = XMLHelper.get_value(climate_and_risk_zones, 'ClimateZoneIECC/Year', :integer)
+      @iecc_zone = XMLHelper.get_value(climate_and_risk_zones, 'ClimateZoneIECC/ClimateZone', :string)
       weather_station = XMLHelper.get_element(climate_and_risk_zones, 'WeatherStation')
       if not weather_station.nil?
         @weather_station_id = HPXML::get_id(weather_station)
-        @weather_station_name = XMLHelper.get_value(weather_station, 'Name')
-        @weather_station_wmo = XMLHelper.get_value(weather_station, 'WMO')
-        @weather_station_epw_filepath = XMLHelper.get_value(weather_station, 'extension/EPWFilePath')
+        @weather_station_name = XMLHelper.get_value(weather_station, 'Name', :string)
+        @weather_station_wmo = XMLHelper.get_value(weather_station, 'WMO', :string)
+        @weather_station_epw_filepath = XMLHelper.get_value(weather_station, 'extension/EPWFilePath', :string)
       end
     end
   end
@@ -1097,16 +1097,16 @@ class HPXML < Object
       air_infiltration_measurement = XMLHelper.add_element(air_infiltration, 'AirInfiltrationMeasurement')
       sys_id = XMLHelper.add_element(air_infiltration_measurement, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(air_infiltration_measurement, 'HousePressure', to_float(@house_pressure)) unless @house_pressure.nil?
+      XMLHelper.add_element(air_infiltration_measurement, 'HousePressure', @house_pressure, :float) unless @house_pressure.nil?
       if (not @unit_of_measure.nil?) && (not @air_leakage.nil?)
         building_air_leakage = XMLHelper.add_element(air_infiltration_measurement, 'BuildingAirLeakage')
-        XMLHelper.add_element(building_air_leakage, 'UnitofMeasure', @unit_of_measure)
-        XMLHelper.add_element(building_air_leakage, 'AirLeakage', to_float(@air_leakage))
+        XMLHelper.add_element(building_air_leakage, 'UnitofMeasure', @unit_of_measure, :string)
+        XMLHelper.add_element(building_air_leakage, 'AirLeakage', @air_leakage, :float)
       end
-      XMLHelper.add_element(air_infiltration_measurement, 'EffectiveLeakageArea', to_float(@effective_leakage_area)) unless @effective_leakage_area.nil?
-      XMLHelper.add_element(air_infiltration_measurement, 'InfiltrationVolume', to_float(@infiltration_volume), @infiltration_volume_isdefaulted) unless @infiltration_volume.nil?
-      XMLHelper.add_extension(air_infiltration_measurement, 'InfiltrationHeight', to_float(@infiltration_height)) unless @infiltration_height.nil?
-      XMLHelper.add_extension(air_infiltration_measurement, 'Aext', to_float(@a_ext)) unless @a_ext.nil?
+      XMLHelper.add_element(air_infiltration_measurement, 'EffectiveLeakageArea', @effective_leakage_area, :float) unless @effective_leakage_area.nil?
+      XMLHelper.add_element(air_infiltration_measurement, 'InfiltrationVolume', @infiltration_volume, :float, @infiltration_volume_isdefaulted) unless @infiltration_volume.nil?
+      XMLHelper.add_extension(air_infiltration_measurement, 'InfiltrationHeight', @infiltration_height, :float) unless @infiltration_height.nil?
+      XMLHelper.add_extension(air_infiltration_measurement, 'Aext', @a_ext, :float) unless @a_ext.nil?
     end
 
     def from_oga(air_infiltration_measurement)
@@ -1114,11 +1114,11 @@ class HPXML < Object
 
       @id = HPXML::get_id(air_infiltration_measurement)
       @house_pressure = XMLHelper.get_value(air_infiltration_measurement, 'HousePressure', :float)
-      @unit_of_measure = XMLHelper.get_value(air_infiltration_measurement, 'BuildingAirLeakage/UnitofMeasure')
+      @unit_of_measure = XMLHelper.get_value(air_infiltration_measurement, 'BuildingAirLeakage/UnitofMeasure', :string)
       @air_leakage = XMLHelper.get_value(air_infiltration_measurement, 'BuildingAirLeakage/AirLeakage', :float)
       @effective_leakage_area = XMLHelper.get_value(air_infiltration_measurement, 'EffectiveLeakageArea', :float)
       @infiltration_volume, @infiltration_volume_isdefaulted = XMLHelper.get_value_and_defaulted(air_infiltration_measurement, 'InfiltrationVolume', :float)
-      @leakiness_description = XMLHelper.get_value(air_infiltration_measurement, 'LeakinessDescription')
+      @leakiness_description = XMLHelper.get_value(air_infiltration_measurement, 'LeakinessDescription', :string)
       @infiltration_height = XMLHelper.get_value(air_infiltration_measurement, 'extension/InfiltrationHeight', :float)
       @a_ext = XMLHelper.get_value(air_infiltration_measurement, 'extension/Aext', :float)
     end
@@ -1202,29 +1202,29 @@ class HPXML < Object
         attic_type_e = XMLHelper.add_element(attic, 'AtticType')
         if @attic_type == AtticTypeUnvented
           attic_type_attic = XMLHelper.add_element(attic_type_e, 'Attic')
-          XMLHelper.add_element(attic_type_attic, 'Vented', false)
+          XMLHelper.add_element(attic_type_attic, 'Vented', false, :boolean)
         elsif @attic_type == AtticTypeVented
           attic_type_attic = XMLHelper.add_element(attic_type_e, 'Attic')
-          XMLHelper.add_element(attic_type_attic, 'Vented', true)
+          XMLHelper.add_element(attic_type_attic, 'Vented', true, :boolean)
           if not @vented_attic_sla.nil?
             ventilation_rate = XMLHelper.add_element(attic, 'VentilationRate')
-            XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsSLA)
-            XMLHelper.add_element(ventilation_rate, 'Value', to_float(@vented_attic_sla), @vented_attic_sla_isdefaulted)
+            XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsSLA, :string)
+            XMLHelper.add_element(ventilation_rate, 'Value', @vented_attic_sla, :float, @vented_attic_sla_isdefaulted)
           elsif not @vented_attic_ach.nil?
             ventilation_rate = XMLHelper.add_element(attic, 'VentilationRate')
-            XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsACHNatural)
-            XMLHelper.add_element(ventilation_rate, 'Value', to_float(@vented_attic_ach))
+            XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsACHNatural, :string)
+            XMLHelper.add_element(ventilation_rate, 'Value', @vented_attic_ach, :float)
           end
         elsif @attic_type == AtticTypeConditioned
           attic_type_attic = XMLHelper.add_element(attic_type_e, 'Attic')
-          XMLHelper.add_element(attic_type_attic, 'Conditioned', true)
+          XMLHelper.add_element(attic_type_attic, 'Conditioned', true, :boolean)
         elsif (@attic_type == AtticTypeFlatRoof) || (@attic_type == AtticTypeCathedral)
           XMLHelper.add_element(attic_type_e, @attic_type)
         else
           fail "Unhandled attic type '#{@attic_type}'."
         end
       end
-      XMLHelper.add_element(attic, 'WithinInfiltrationVolume', to_boolean(@within_infiltration_volume)) unless @within_infiltration_volume.nil?
+      XMLHelper.add_element(attic, 'WithinInfiltrationVolume', within_infiltration_volume, :boolean) unless @within_infiltration_volume.nil?
     end
 
     def from_oga(attic)
@@ -1367,26 +1367,26 @@ class HPXML < Object
           XMLHelper.add_element(foundation_type_e, @foundation_type)
         elsif @foundation_type == FoundationTypeBasementConditioned
           basement = XMLHelper.add_element(foundation_type_e, 'Basement')
-          XMLHelper.add_element(basement, 'Conditioned', true)
+          XMLHelper.add_element(basement, 'Conditioned', true, :boolean)
         elsif @foundation_type == FoundationTypeBasementUnconditioned
           basement = XMLHelper.add_element(foundation_type_e, 'Basement')
-          XMLHelper.add_element(basement, 'Conditioned', false)
+          XMLHelper.add_element(basement, 'Conditioned', false, :boolean)
         elsif @foundation_type == FoundationTypeCrawlspaceVented
           crawlspace = XMLHelper.add_element(foundation_type_e, 'Crawlspace')
-          XMLHelper.add_element(crawlspace, 'Vented', true)
+          XMLHelper.add_element(crawlspace, 'Vented', true, :boolean)
           if not @vented_crawlspace_sla.nil?
             ventilation_rate = XMLHelper.add_element(foundation, 'VentilationRate')
-            XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsSLA)
-            XMLHelper.add_element(ventilation_rate, 'Value', to_float(@vented_crawlspace_sla), @vented_crawlspace_sla_isdefaulted)
+            XMLHelper.add_element(ventilation_rate, 'UnitofMeasure', UnitsSLA, :string)
+            XMLHelper.add_element(ventilation_rate, 'Value', @vented_crawlspace_sla, :float, @vented_crawlspace_sla_isdefaulted)
           end
         elsif @foundation_type == FoundationTypeCrawlspaceUnvented
           crawlspace = XMLHelper.add_element(foundation_type_e, 'Crawlspace')
-          XMLHelper.add_element(crawlspace, 'Vented', false)
+          XMLHelper.add_element(crawlspace, 'Vented', false, :boolean)
         else
           fail "Unhandled foundation type '#{@foundation_type}'."
         end
       end
-      XMLHelper.add_element(foundation, 'WithinInfiltrationVolume', to_boolean(@within_infiltration_volume)) unless @within_infiltration_volume.nil?
+      XMLHelper.add_element(foundation, 'WithinInfiltrationVolume', @within_infiltration_volume, :boolean) unless @within_infiltration_volume.nil?
     end
 
     def from_oga(foundation)
@@ -1506,16 +1506,16 @@ class HPXML < Object
       roof = XMLHelper.add_element(roofs, 'Roof')
       sys_id = XMLHelper.add_element(roof, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(roof, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
-      XMLHelper.add_element(roof, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(roof, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(roof, 'RoofType', @roof_type, @roof_type_isdefaulted) unless @roof_type.nil?
-      XMLHelper.add_element(roof, 'RoofColor', @roof_color, @roof_color_isdefaulted) unless @roof_color.nil?
-      XMLHelper.add_element(roof, 'SolarAbsorptance', to_float(@solar_absorptance), @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
-      XMLHelper.add_element(roof, 'Emittance', to_float(@emittance), @emittance_isdefaulted) unless @emittance.nil?
-      XMLHelper.add_element(roof, 'Pitch', to_float(@pitch)) unless @pitch.nil?
-      XMLHelper.add_element(roof, 'RadiantBarrier', to_boolean(@radiant_barrier), @radiant_barrier_isdefaulted) unless @radiant_barrier.nil?
-      XMLHelper.add_element(roof, 'RadiantBarrierGrade', to_integer(@radiant_barrier_grade)) unless @radiant_barrier_grade.nil?
+      XMLHelper.add_element(roof, 'InteriorAdjacentTo', @interior_adjacent_to, :string) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(roof, 'Area', @area, :float) unless @area.nil?
+      XMLHelper.add_element(roof, 'Azimuth', @azimuth, :integer) unless @azimuth.nil?
+      XMLHelper.add_element(roof, 'RoofType', @roof_type, :string, @roof_type_isdefaulted) unless @roof_type.nil?
+      XMLHelper.add_element(roof, 'RoofColor', @roof_color, :string, @roof_color_isdefaulted) unless @roof_color.nil?
+      XMLHelper.add_element(roof, 'SolarAbsorptance', @solar_absorptance, :float, @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
+      XMLHelper.add_element(roof, 'Emittance', @emittance, :float, @emittance_isdefaulted) unless @emittance.nil?
+      XMLHelper.add_element(roof, 'Pitch', @pitch, :float) unless @pitch.nil?
+      XMLHelper.add_element(roof, 'RadiantBarrier', @radiant_barrier, :boolean, @radiant_barrier_isdefaulted) unless @radiant_barrier.nil?
+      XMLHelper.add_element(roof, 'RadiantBarrierGrade', @radiant_barrier_grade, :integer) unless @radiant_barrier_grade.nil?
       insulation = XMLHelper.add_element(roof, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @insulation_id.nil?
@@ -1523,18 +1523,18 @@ class HPXML < Object
       else
         XMLHelper.add_attribute(sys_id, 'id', @id + 'Insulation')
       end
-      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', to_float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', @insulation_assembly_r_value, :float) unless @insulation_assembly_r_value.nil?
     end
 
     def from_oga(roof)
       return if roof.nil?
 
       @id = HPXML::get_id(roof)
-      @interior_adjacent_to = XMLHelper.get_value(roof, 'InteriorAdjacentTo')
+      @interior_adjacent_to = XMLHelper.get_value(roof, 'InteriorAdjacentTo', :string)
       @area = XMLHelper.get_value(roof, 'Area', :float)
       @azimuth = XMLHelper.get_value(roof, 'Azimuth', :integer)
-      @roof_type, @roof_type_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'RoofType')
-      @roof_color, @roof_color_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'RoofColor')
+      @roof_type, @roof_type_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'RoofType', :string)
+      @roof_color, @roof_color_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'RoofColor', :string)
       @solar_absorptance, @solar_absorptance_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'SolarAbsorptance', :float)
       @emittance, @emittance_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'Emittance', :float)
       @pitch = XMLHelper.get_value(roof, 'Pitch', :float)
@@ -1610,14 +1610,14 @@ class HPXML < Object
       rim_joist = XMLHelper.add_element(rim_joists, 'RimJoist')
       sys_id = XMLHelper.add_element(rim_joist, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(rim_joist, 'ExteriorAdjacentTo', @exterior_adjacent_to) unless @exterior_adjacent_to.nil?
-      XMLHelper.add_element(rim_joist, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
-      XMLHelper.add_element(rim_joist, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(rim_joist, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(rim_joist, 'Siding', @siding, @siding_isdefaulted) unless @siding.nil?
-      XMLHelper.add_element(rim_joist, 'Color', @color, @color_isdefaulted) unless @color.nil?
-      XMLHelper.add_element(rim_joist, 'SolarAbsorptance', to_float(@solar_absorptance), @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
-      XMLHelper.add_element(rim_joist, 'Emittance', to_float(@emittance), @emittance_isdefaulted) unless @emittance.nil?
+      XMLHelper.add_element(rim_joist, 'ExteriorAdjacentTo', @exterior_adjacent_to, :string) unless @exterior_adjacent_to.nil?
+      XMLHelper.add_element(rim_joist, 'InteriorAdjacentTo', @interior_adjacent_to, :string) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(rim_joist, 'Area', @area, :float) unless @area.nil?
+      XMLHelper.add_element(rim_joist, 'Azimuth', @azimuth, :integer) unless @azimuth.nil?
+      XMLHelper.add_element(rim_joist, 'Siding', @siding, :string, @siding_isdefaulted) unless @siding.nil?
+      XMLHelper.add_element(rim_joist, 'Color', @color, :string, @color_isdefaulted) unless @color.nil?
+      XMLHelper.add_element(rim_joist, 'SolarAbsorptance', @solar_absorptance, :float, @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
+      XMLHelper.add_element(rim_joist, 'Emittance', @emittance, :float, @emittance_isdefaulted) unless @emittance.nil?
       insulation = XMLHelper.add_element(rim_joist, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @insulation_id.nil?
@@ -1625,19 +1625,19 @@ class HPXML < Object
       else
         XMLHelper.add_attribute(sys_id, 'id', @id + 'Insulation')
       end
-      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', to_float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', @insulation_assembly_r_value, :float) unless @insulation_assembly_r_value.nil?
     end
 
     def from_oga(rim_joist)
       return if rim_joist.nil?
 
       @id = HPXML::get_id(rim_joist)
-      @exterior_adjacent_to = XMLHelper.get_value(rim_joist, 'ExteriorAdjacentTo')
-      @interior_adjacent_to = XMLHelper.get_value(rim_joist, 'InteriorAdjacentTo')
+      @exterior_adjacent_to = XMLHelper.get_value(rim_joist, 'ExteriorAdjacentTo', :string)
+      @interior_adjacent_to = XMLHelper.get_value(rim_joist, 'InteriorAdjacentTo', :string)
       @area = XMLHelper.get_value(rim_joist, 'Area', :float)
       @azimuth = XMLHelper.get_value(rim_joist, 'Azimuth', :integer)
-      @siding, @siding_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'Siding')
-      @color, @color_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'Color')
+      @siding, @siding_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'Siding', :string)
+      @color, @color_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'Color', :string)
       @solar_absorptance, @solar_absorptance_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'SolarAbsorptance', :float)
       @emittance, @emittance_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'Emittance', :float)
       insulation = XMLHelper.get_element(rim_joist, 'Insulation')
@@ -1738,18 +1738,18 @@ class HPXML < Object
       wall = XMLHelper.add_element(walls, 'Wall')
       sys_id = XMLHelper.add_element(wall, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(wall, 'ExteriorAdjacentTo', @exterior_adjacent_to) unless @exterior_adjacent_to.nil?
-      XMLHelper.add_element(wall, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(wall, 'ExteriorAdjacentTo', @exterior_adjacent_to, :string) unless @exterior_adjacent_to.nil?
+      XMLHelper.add_element(wall, 'InteriorAdjacentTo', @interior_adjacent_to, :string) unless @interior_adjacent_to.nil?
       if not @wall_type.nil?
         wall_type_e = XMLHelper.add_element(wall, 'WallType')
         XMLHelper.add_element(wall_type_e, @wall_type)
       end
-      XMLHelper.add_element(wall, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(wall, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(wall, 'Siding', @siding, @siding_isdefaulted) unless @siding.nil?
-      XMLHelper.add_element(wall, 'Color', @color, @color_isdefaulted) unless @color.nil?
-      XMLHelper.add_element(wall, 'SolarAbsorptance', to_float(@solar_absorptance), @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
-      XMLHelper.add_element(wall, 'Emittance', to_float(@emittance), @emittance_isdefaulted) unless @emittance.nil?
+      XMLHelper.add_element(wall, 'Area', @area, :float) unless @area.nil?
+      XMLHelper.add_element(wall, 'Azimuth', @azimuth, :integer) unless @azimuth.nil?
+      XMLHelper.add_element(wall, 'Siding', @siding, :string, @siding_isdefaulted) unless @siding.nil?
+      XMLHelper.add_element(wall, 'Color', @color, :string, @color_isdefaulted) unless @color.nil?
+      XMLHelper.add_element(wall, 'SolarAbsorptance', @solar_absorptance, :float, @solar_absorptance_isdefaulted) unless @solar_absorptance.nil?
+      XMLHelper.add_element(wall, 'Emittance', @emittance, :float, @emittance_isdefaulted) unless @emittance.nil?
       insulation = XMLHelper.add_element(wall, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @insulation_id.nil?
@@ -1757,22 +1757,22 @@ class HPXML < Object
       else
         XMLHelper.add_attribute(sys_id, 'id', @id + 'Insulation')
       end
-      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', to_float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', @insulation_assembly_r_value, :float) unless @insulation_assembly_r_value.nil?
     end
 
     def from_oga(wall)
       return if wall.nil?
 
       @id = HPXML::get_id(wall)
-      @exterior_adjacent_to = XMLHelper.get_value(wall, 'ExteriorAdjacentTo')
-      @interior_adjacent_to = XMLHelper.get_value(wall, 'InteriorAdjacentTo')
+      @exterior_adjacent_to = XMLHelper.get_value(wall, 'ExteriorAdjacentTo', :string)
+      @interior_adjacent_to = XMLHelper.get_value(wall, 'InteriorAdjacentTo', :string)
       @wall_type = XMLHelper.get_child_name(wall, 'WallType')
       @optimum_value_engineering = XMLHelper.get_value(wall, 'WallType/WoodStud/OptimumValueEngineering', :boolean)
       @area = XMLHelper.get_value(wall, 'Area', :float)
-      @orientation = XMLHelper.get_value(wall, 'Orientation')
+      @orientation = XMLHelper.get_value(wall, 'Orientation', :string)
       @azimuth = XMLHelper.get_value(wall, 'Azimuth', :integer)
-      @siding, @siding_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'Siding')
-      @color, @color_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'Color')
+      @siding, @siding_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'Siding', :string)
+      @color, @color_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'Color', :string)
       @solar_absorptance, @solar_absorptance_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'SolarAbsorptance', :float)
       @emittance, @emittance_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'Emittance', :float)
       insulation = XMLHelper.get_element(wall, 'Insulation')
@@ -1881,13 +1881,13 @@ class HPXML < Object
       foundation_wall = XMLHelper.add_element(foundation_walls, 'FoundationWall')
       sys_id = XMLHelper.add_element(foundation_wall, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(foundation_wall, 'ExteriorAdjacentTo', @exterior_adjacent_to) unless @exterior_adjacent_to.nil?
-      XMLHelper.add_element(foundation_wall, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
-      XMLHelper.add_element(foundation_wall, 'Height', to_float(@height)) unless @height.nil?
-      XMLHelper.add_element(foundation_wall, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(foundation_wall, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(foundation_wall, 'Thickness', to_float(@thickness), @thickness_isdefaulted) unless @thickness.nil?
-      XMLHelper.add_element(foundation_wall, 'DepthBelowGrade', to_float(@depth_below_grade)) unless @depth_below_grade.nil?
+      XMLHelper.add_element(foundation_wall, 'ExteriorAdjacentTo', @exterior_adjacent_to, :string) unless @exterior_adjacent_to.nil?
+      XMLHelper.add_element(foundation_wall, 'InteriorAdjacentTo', @interior_adjacent_to, :string) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(foundation_wall, 'Height', @height, :float) unless @height.nil?
+      XMLHelper.add_element(foundation_wall, 'Area', @area, :float) unless @area.nil?
+      XMLHelper.add_element(foundation_wall, 'Azimuth', @azimuth, :integer) unless @azimuth.nil?
+      XMLHelper.add_element(foundation_wall, 'Thickness', @thickness, :float, @thickness_isdefaulted) unless @thickness.nil?
+      XMLHelper.add_element(foundation_wall, 'DepthBelowGrade', @depth_below_grade, :float) unless @depth_below_grade.nil?
       insulation = XMLHelper.add_element(foundation_wall, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @insulation_id.nil?
@@ -1895,20 +1895,20 @@ class HPXML < Object
       else
         XMLHelper.add_attribute(sys_id, 'id', @id + 'Insulation')
       end
-      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', to_float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', @insulation_assembly_r_value, :float) unless @insulation_assembly_r_value.nil?
       if not @insulation_exterior_r_value.nil?
         layer = XMLHelper.add_element(insulation, 'Layer')
-        XMLHelper.add_element(layer, 'InstallationType', 'continuous - exterior')
-        XMLHelper.add_element(layer, 'NominalRValue', to_float(@insulation_exterior_r_value))
-        XMLHelper.add_extension(layer, 'DistanceToTopOfInsulation', to_float(@insulation_exterior_distance_to_top)) unless @insulation_exterior_distance_to_top.nil?
-        XMLHelper.add_extension(layer, 'DistanceToBottomOfInsulation', to_float(@insulation_exterior_distance_to_bottom)) unless @insulation_exterior_distance_to_bottom.nil?
+        XMLHelper.add_element(layer, 'InstallationType', 'continuous - exterior', :string)
+        XMLHelper.add_element(layer, 'NominalRValue', @insulation_exterior_r_value, :float)
+        XMLHelper.add_extension(layer, 'DistanceToTopOfInsulation', @insulation_exterior_distance_to_top, :float) unless @insulation_exterior_distance_to_top.nil?
+        XMLHelper.add_extension(layer, 'DistanceToBottomOfInsulation', @insulation_exterior_distance_to_bottom, :float) unless @insulation_exterior_distance_to_bottom.nil?
       end
       if not @insulation_interior_r_value.nil?
         layer = XMLHelper.add_element(insulation, 'Layer')
-        XMLHelper.add_element(layer, 'InstallationType', 'continuous - interior')
-        XMLHelper.add_element(layer, 'NominalRValue', to_float(@insulation_interior_r_value))
-        XMLHelper.add_extension(layer, 'DistanceToTopOfInsulation', to_float(@insulation_interior_distance_to_top)) unless @insulation_interior_distance_to_top.nil?
-        XMLHelper.add_extension(layer, 'DistanceToBottomOfInsulation', to_float(@insulation_interior_distance_to_bottom)) unless @insulation_interior_distance_to_bottom.nil?
+        XMLHelper.add_element(layer, 'InstallationType', 'continuous - interior', :string)
+        XMLHelper.add_element(layer, 'NominalRValue', @insulation_interior_r_value, :float)
+        XMLHelper.add_extension(layer, 'DistanceToTopOfInsulation', @insulation_interior_distance_to_top, :float) unless @insulation_interior_distance_to_top.nil?
+        XMLHelper.add_extension(layer, 'DistanceToBottomOfInsulation', @insulation_interior_distance_to_bottom, :float) unless @insulation_interior_distance_to_bottom.nil?
       end
     end
 
@@ -1916,8 +1916,8 @@ class HPXML < Object
       return if foundation_wall.nil?
 
       @id = HPXML::get_id(foundation_wall)
-      @exterior_adjacent_to = XMLHelper.get_value(foundation_wall, 'ExteriorAdjacentTo')
-      @interior_adjacent_to = XMLHelper.get_value(foundation_wall, 'InteriorAdjacentTo')
+      @exterior_adjacent_to = XMLHelper.get_value(foundation_wall, 'ExteriorAdjacentTo', :string)
+      @interior_adjacent_to = XMLHelper.get_value(foundation_wall, 'InteriorAdjacentTo', :string)
       @height = XMLHelper.get_value(foundation_wall, 'Height', :float)
       @area = XMLHelper.get_value(foundation_wall, 'Area', :float)
       @azimuth = XMLHelper.get_value(foundation_wall, 'Azimuth', :integer)
@@ -2021,9 +2021,9 @@ class HPXML < Object
       frame_floor = XMLHelper.add_element(frame_floors, 'FrameFloor')
       sys_id = XMLHelper.add_element(frame_floor, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(frame_floor, 'ExteriorAdjacentTo', @exterior_adjacent_to) unless @exterior_adjacent_to.nil?
-      XMLHelper.add_element(frame_floor, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
-      XMLHelper.add_element(frame_floor, 'Area', to_float(@area)) unless @area.nil?
+      XMLHelper.add_element(frame_floor, 'ExteriorAdjacentTo', @exterior_adjacent_to, :string) unless @exterior_adjacent_to.nil?
+      XMLHelper.add_element(frame_floor, 'InteriorAdjacentTo', @interior_adjacent_to, :string) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(frame_floor, 'Area', @area, :float) unless @area.nil?
       insulation = XMLHelper.add_element(frame_floor, 'Insulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @insulation_id.nil?
@@ -2031,16 +2031,16 @@ class HPXML < Object
       else
         XMLHelper.add_attribute(sys_id, 'id', @id + 'Insulation')
       end
-      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', to_float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
-      XMLHelper.add_extension(frame_floor, 'OtherSpaceAboveOrBelow', @other_space_above_or_below) unless @other_space_above_or_below.nil?
+      XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', @insulation_assembly_r_value, :float) unless @insulation_assembly_r_value.nil?
+      XMLHelper.add_extension(frame_floor, 'OtherSpaceAboveOrBelow', @other_space_above_or_below, :string) unless @other_space_above_or_below.nil?
     end
 
     def from_oga(frame_floor)
       return if frame_floor.nil?
 
       @id = HPXML::get_id(frame_floor)
-      @exterior_adjacent_to = XMLHelper.get_value(frame_floor, 'ExteriorAdjacentTo')
-      @interior_adjacent_to = XMLHelper.get_value(frame_floor, 'InteriorAdjacentTo')
+      @exterior_adjacent_to = XMLHelper.get_value(frame_floor, 'ExteriorAdjacentTo', :string)
+      @interior_adjacent_to = XMLHelper.get_value(frame_floor, 'InteriorAdjacentTo', :string)
       @area = XMLHelper.get_value(frame_floor, 'Area', :float)
       insulation = XMLHelper.get_element(frame_floor, 'Insulation')
       if not insulation.nil?
@@ -2049,7 +2049,7 @@ class HPXML < Object
         @insulation_cavity_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue", :float)
         @insulation_continuous_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
       end
-      @other_space_above_or_below = XMLHelper.get_value(frame_floor, 'extension/OtherSpaceAboveOrBelow')
+      @other_space_above_or_below = XMLHelper.get_value(frame_floor, 'extension/OtherSpaceAboveOrBelow', :string)
     end
   end
 
@@ -2121,14 +2121,14 @@ class HPXML < Object
       slab = XMLHelper.add_element(slabs, 'Slab')
       sys_id = XMLHelper.add_element(slab, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(slab, 'InteriorAdjacentTo', @interior_adjacent_to) unless @interior_adjacent_to.nil?
-      XMLHelper.add_element(slab, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(slab, 'Thickness', to_float(@thickness), @thickness_isdefaulted) unless @thickness.nil?
-      XMLHelper.add_element(slab, 'ExposedPerimeter', to_float(@exposed_perimeter)) unless @exposed_perimeter.nil?
-      XMLHelper.add_element(slab, 'PerimeterInsulationDepth', to_float(@perimeter_insulation_depth)) unless @perimeter_insulation_depth.nil?
-      XMLHelper.add_element(slab, 'UnderSlabInsulationWidth', to_float(@under_slab_insulation_width)) unless @under_slab_insulation_width.nil?
-      XMLHelper.add_element(slab, 'UnderSlabInsulationSpansEntireSlab', to_boolean(@under_slab_insulation_spans_entire_slab)) unless @under_slab_insulation_spans_entire_slab.nil?
-      XMLHelper.add_element(slab, 'DepthBelowGrade', to_float(@depth_below_grade)) unless @depth_below_grade.nil?
+      XMLHelper.add_element(slab, 'InteriorAdjacentTo', @interior_adjacent_to, :string) unless @interior_adjacent_to.nil?
+      XMLHelper.add_element(slab, 'Area', @area, :float) unless @area.nil?
+      XMLHelper.add_element(slab, 'Thickness', @thickness, :float, @thickness_isdefaulted) unless @thickness.nil?
+      XMLHelper.add_element(slab, 'ExposedPerimeter', @exposed_perimeter, :float) unless @exposed_perimeter.nil?
+      XMLHelper.add_element(slab, 'PerimeterInsulationDepth', @perimeter_insulation_depth, :float) unless @perimeter_insulation_depth.nil?
+      XMLHelper.add_element(slab, 'UnderSlabInsulationWidth', @under_slab_insulation_width, :float) unless @under_slab_insulation_width.nil?
+      XMLHelper.add_element(slab, 'UnderSlabInsulationSpansEntireSlab', @under_slab_insulation_spans_entire_slab, :boolean) unless @under_slab_insulation_spans_entire_slab.nil?
+      XMLHelper.add_element(slab, 'DepthBelowGrade', @depth_below_grade, :float) unless @depth_below_grade.nil?
       insulation = XMLHelper.add_element(slab, 'PerimeterInsulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @perimeter_insulation_id.nil?
@@ -2137,8 +2137,8 @@ class HPXML < Object
         XMLHelper.add_attribute(sys_id, 'id', @id + 'PerimeterInsulation')
       end
       layer = XMLHelper.add_element(insulation, 'Layer')
-      XMLHelper.add_element(layer, 'InstallationType', 'continuous')
-      XMLHelper.add_element(layer, 'NominalRValue', to_float(@perimeter_insulation_r_value)) unless @perimeter_insulation_r_value.nil?
+      XMLHelper.add_element(layer, 'InstallationType', 'continuous', :string)
+      XMLHelper.add_element(layer, 'NominalRValue', @perimeter_insulation_r_value, :float) unless @perimeter_insulation_r_value.nil?
       insulation = XMLHelper.add_element(slab, 'UnderSlabInsulation')
       sys_id = XMLHelper.add_element(insulation, 'SystemIdentifier')
       if not @under_slab_insulation_id.nil?
@@ -2147,17 +2147,17 @@ class HPXML < Object
         XMLHelper.add_attribute(sys_id, 'id', @id + 'UnderSlabInsulation')
       end
       layer = XMLHelper.add_element(insulation, 'Layer')
-      XMLHelper.add_element(layer, 'InstallationType', 'continuous')
-      XMLHelper.add_element(layer, 'NominalRValue', to_float(@under_slab_insulation_r_value)) unless @under_slab_insulation_r_value.nil?
-      XMLHelper.add_extension(slab, 'CarpetFraction', to_float(@carpet_fraction), @carpet_fraction_isdefaulted) unless @carpet_fraction.nil?
-      XMLHelper.add_extension(slab, 'CarpetRValue', to_float(@carpet_r_value), @carpet_r_value_isdefaulted) unless @carpet_r_value.nil?
+      XMLHelper.add_element(layer, 'InstallationType', 'continuous', :string)
+      XMLHelper.add_element(layer, 'NominalRValue', @under_slab_insulation_r_value, :float) unless @under_slab_insulation_r_value.nil?
+      XMLHelper.add_extension(slab, 'CarpetFraction', @carpet_fraction, :float, @carpet_fraction_isdefaulted) unless @carpet_fraction.nil?
+      XMLHelper.add_extension(slab, 'CarpetRValue', @carpet_r_value, :float, @carpet_r_value_isdefaulted) unless @carpet_r_value.nil?
     end
 
     def from_oga(slab)
       return if slab.nil?
 
       @id = HPXML::get_id(slab)
-      @interior_adjacent_to = XMLHelper.get_value(slab, 'InteriorAdjacentTo')
+      @interior_adjacent_to = XMLHelper.get_value(slab, 'InteriorAdjacentTo', :string)
       @area = XMLHelper.get_value(slab, 'Area', :float)
       @thickness, @thickness_isdefaulted = XMLHelper.get_value_and_defaulted(slab, 'Thickness', :float)
       @exposed_perimeter = XMLHelper.get_value(slab, 'ExposedPerimeter', :float)
@@ -2252,24 +2252,24 @@ class HPXML < Object
       window = XMLHelper.add_element(windows, 'Window')
       sys_id = XMLHelper.add_element(window, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(window, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(window, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(window, 'UFactor', to_float(@ufactor)) unless @ufactor.nil?
-      XMLHelper.add_element(window, 'SHGC', to_float(@shgc)) unless @shgc.nil?
+      XMLHelper.add_element(window, 'Area', @area, :float) unless @area.nil?
+      XMLHelper.add_element(window, 'Azimuth', @azimuth, :integer) unless @azimuth.nil?
+      XMLHelper.add_element(window, 'UFactor', @ufactor, :float) unless @ufactor.nil?
+      XMLHelper.add_element(window, 'SHGC', @shgc, :float) unless @shgc.nil?
       if (not @interior_shading_factor_summer.nil?) || (not @interior_shading_factor_winter.nil?)
         interior_shading = XMLHelper.add_element(window, 'InteriorShading')
         sys_id = XMLHelper.add_element(interior_shading, 'SystemIdentifier')
         XMLHelper.add_attribute(sys_id, 'id', "#{id}InteriorShading")
-        XMLHelper.add_element(interior_shading, 'SummerShadingCoefficient', to_float(@interior_shading_factor_summer), @interior_shading_factor_summer_isdefaulted) unless @interior_shading_factor_summer.nil?
-        XMLHelper.add_element(interior_shading, 'WinterShadingCoefficient', to_float(@interior_shading_factor_winter), @interior_shading_factor_winter_isdefaulted) unless @interior_shading_factor_winter.nil?
+        XMLHelper.add_element(interior_shading, 'SummerShadingCoefficient', @interior_shading_factor_summer, :float, @interior_shading_factor_summer_isdefaulted) unless @interior_shading_factor_summer.nil?
+        XMLHelper.add_element(interior_shading, 'WinterShadingCoefficient', @interior_shading_factor_winter, :float, @interior_shading_factor_winter_isdefaulted) unless @interior_shading_factor_winter.nil?
       end
       if (not @overhangs_depth.nil?) || (not @overhangs_distance_to_top_of_window.nil?) || (not @overhangs_distance_to_bottom_of_window.nil?)
         overhangs = XMLHelper.add_element(window, 'Overhangs')
-        XMLHelper.add_element(overhangs, 'Depth', to_float(@overhangs_depth)) unless @overhangs_depth.nil?
-        XMLHelper.add_element(overhangs, 'DistanceToTopOfWindow', to_float(@overhangs_distance_to_top_of_window)) unless @overhangs_distance_to_top_of_window.nil?
-        XMLHelper.add_element(overhangs, 'DistanceToBottomOfWindow', to_float(@overhangs_distance_to_bottom_of_window)) unless @overhangs_distance_to_bottom_of_window.nil?
+        XMLHelper.add_element(overhangs, 'Depth', @overhangs_depth, :float) unless @overhangs_depth.nil?
+        XMLHelper.add_element(overhangs, 'DistanceToTopOfWindow', @overhangs_distance_to_top_of_window, :float) unless @overhangs_distance_to_top_of_window.nil?
+        XMLHelper.add_element(overhangs, 'DistanceToBottomOfWindow', @overhangs_distance_to_bottom_of_window, :float) unless @overhangs_distance_to_bottom_of_window.nil?
       end
-      XMLHelper.add_element(window, 'FractionOperable', to_float(@fraction_operable), @fraction_operable_isdefaulted) unless @fraction_operable.nil?
+      XMLHelper.add_element(window, 'FractionOperable', @fraction_operable, :float, @fraction_operable_isdefaulted) unless @fraction_operable.nil?
       if not @wall_idref.nil?
         attached_to_wall = XMLHelper.add_element(window, 'AttachedToWall')
         XMLHelper.add_attribute(attached_to_wall, 'idref', @wall_idref)
@@ -2282,17 +2282,17 @@ class HPXML < Object
       @id = HPXML::get_id(window)
       @area = XMLHelper.get_value(window, 'Area', :float)
       @azimuth = XMLHelper.get_value(window, 'Azimuth', :integer)
-      @orientation = XMLHelper.get_value(window, 'Orientation')
+      @orientation = XMLHelper.get_value(window, 'Orientation', :string)
       @frame_type = XMLHelper.get_child_name(window, 'FrameType')
       @aluminum_thermal_break = XMLHelper.get_value(window, 'FrameType/Aluminum/ThermalBreak', :boolean)
-      @glass_layers = XMLHelper.get_value(window, 'GlassLayers')
-      @glass_type = XMLHelper.get_value(window, 'GlassType')
-      @gas_fill = XMLHelper.get_value(window, 'GasFill')
+      @glass_layers = XMLHelper.get_value(window, 'GlassLayers', :string)
+      @glass_type = XMLHelper.get_value(window, 'GlassType', :string)
+      @gas_fill = XMLHelper.get_value(window, 'GasFill', :string)
       @ufactor = XMLHelper.get_value(window, 'UFactor', :float)
       @shgc = XMLHelper.get_value(window, 'SHGC', :float)
       @interior_shading_factor_summer, @interior_shading_factor_summer_isdefaulted = XMLHelper.get_value_and_defaulted(window, 'InteriorShading/SummerShadingCoefficient', :float)
       @interior_shading_factor_winter, @interior_shading_factor_winter_isdefaulted = XMLHelper.get_value_and_defaulted(window, 'InteriorShading/WinterShadingCoefficient', :float)
-      @exterior_shading = XMLHelper.get_value(window, 'ExteriorShading/Type')
+      @exterior_shading = XMLHelper.get_value(window, 'ExteriorShading/Type', :string)
       @overhangs_depth = XMLHelper.get_value(window, 'Overhangs/Depth', :float)
       @overhangs_distance_to_top_of_window = XMLHelper.get_value(window, 'Overhangs/DistanceToTopOfWindow', :float)
       @overhangs_distance_to_bottom_of_window = XMLHelper.get_value(window, 'Overhangs/DistanceToBottomOfWindow', :float)
@@ -2365,16 +2365,16 @@ class HPXML < Object
       skylight = XMLHelper.add_element(skylights, 'Skylight')
       sys_id = XMLHelper.add_element(skylight, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(skylight, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(skylight, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(skylight, 'UFactor', to_float(@ufactor)) unless @ufactor.nil?
-      XMLHelper.add_element(skylight, 'SHGC', to_float(@shgc)) unless @shgc.nil?
+      XMLHelper.add_element(skylight, 'Area', @area, :float) unless @area.nil?
+      XMLHelper.add_element(skylight, 'Azimuth', @azimuth, :integer) unless @azimuth.nil?
+      XMLHelper.add_element(skylight, 'UFactor', @ufactor, :float) unless @ufactor.nil?
+      XMLHelper.add_element(skylight, 'SHGC', @shgc, :float) unless @shgc.nil?
       if (not @interior_shading_factor_summer.nil?) || (not @interior_shading_factor_winter.nil?)
         interior_shading = XMLHelper.add_element(skylight, 'InteriorShading')
         sys_id = XMLHelper.add_element(interior_shading, 'SystemIdentifier')
         XMLHelper.add_attribute(sys_id, 'id', "#{id}InteriorShading")
-        XMLHelper.add_element(interior_shading, 'SummerShadingCoefficient', to_float(@interior_shading_factor_summer), @interior_shading_factor_summer_isdefaulted) unless @interior_shading_factor_summer.nil?
-        XMLHelper.add_element(interior_shading, 'WinterShadingCoefficient', to_float(@interior_shading_factor_winter), @interior_shading_factor_winter_isdefaulted) unless @interior_shading_factor_winter.nil?
+        XMLHelper.add_element(interior_shading, 'SummerShadingCoefficient', @interior_shading_factor_summer, :float, @interior_shading_factor_summer_isdefaulted) unless @interior_shading_factor_summer.nil?
+        XMLHelper.add_element(interior_shading, 'WinterShadingCoefficient', @interior_shading_factor_winter, :float, @interior_shading_factor_winter_isdefaulted) unless @interior_shading_factor_winter.nil?
       end
       if not @roof_idref.nil?
         attached_to_roof = XMLHelper.add_element(skylight, 'AttachedToRoof')
@@ -2388,17 +2388,17 @@ class HPXML < Object
       @id = HPXML::get_id(skylight)
       @area = XMLHelper.get_value(skylight, 'Area', :float)
       @azimuth = XMLHelper.get_value(skylight, 'Azimuth', :integer)
-      @orientation = XMLHelper.get_value(skylight, 'Orientation')
+      @orientation = XMLHelper.get_value(skylight, 'Orientation', :string)
       @frame_type = XMLHelper.get_child_name(skylight, 'FrameType')
       @aluminum_thermal_break = XMLHelper.get_value(skylight, 'FrameType/Aluminum/ThermalBreak', :boolean)
-      @glass_layers = XMLHelper.get_value(skylight, 'GlassLayers')
-      @glass_type = XMLHelper.get_value(skylight, 'GlassType')
-      @gas_fill = XMLHelper.get_value(skylight, 'GasFill')
+      @glass_layers = XMLHelper.get_value(skylight, 'GlassLayers', :string)
+      @glass_type = XMLHelper.get_value(skylight, 'GlassType', :string)
+      @gas_fill = XMLHelper.get_value(skylight, 'GasFill', :string)
       @ufactor = XMLHelper.get_value(skylight, 'UFactor', :float)
       @shgc = XMLHelper.get_value(skylight, 'SHGC', :float)
       @interior_shading_factor_summer, @interior_shading_factor_summer_isdefaulted = XMLHelper.get_value_and_defaulted(skylight, 'InteriorShading/SummerShadingCoefficient', :float)
       @interior_shading_factor_winter, @interior_shading_factor_winter_isdefaulted = XMLHelper.get_value_and_defaulted(skylight, 'InteriorShading/WinterShadingCoefficient', :float)
-      @exterior_shading = XMLHelper.get_value(skylight, 'ExteriorShading/Type')
+      @exterior_shading = XMLHelper.get_value(skylight, 'ExteriorShading/Type', :string)
       @roof_idref = HPXML::get_idref(XMLHelper.get_element(skylight, 'AttachedToRoof'))
     end
   end
@@ -2469,9 +2469,9 @@ class HPXML < Object
         attached_to_wall = XMLHelper.add_element(door, 'AttachedToWall')
         XMLHelper.add_attribute(attached_to_wall, 'idref', @wall_idref)
       end
-      XMLHelper.add_element(door, 'Area', to_float(@area)) unless @area.nil?
-      XMLHelper.add_element(door, 'Azimuth', to_integer(@azimuth)) unless @azimuth.nil?
-      XMLHelper.add_element(door, 'RValue', to_float(@r_value)) unless @r_value.nil?
+      XMLHelper.add_element(door, 'Area', @area, :float) unless @area.nil?
+      XMLHelper.add_element(door, 'Azimuth', @azimuth, :integer) unless @azimuth.nil?
+      XMLHelper.add_element(door, 'RValue', @r_value, :float) unless @r_value.nil?
     end
 
     def from_oga(door)
@@ -2560,14 +2560,14 @@ class HPXML < Object
         distribution_system = XMLHelper.add_element(heating_system, 'DistributionSystem')
         XMLHelper.add_attribute(distribution_system, 'idref', @distribution_system_idref)
       end
-      XMLHelper.add_element(heating_system, 'IsSharedSystem', to_boolean(@is_shared_system)) unless @is_shared_system.nil?
-      XMLHelper.add_element(heating_system, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
+      XMLHelper.add_element(heating_system, 'IsSharedSystem', @is_shared_system, :boolean) unless @is_shared_system.nil?
+      XMLHelper.add_element(heating_system, 'NumberofUnitsServed', @number_of_units_served, :integer) unless @number_of_units_served.nil?
       if not @heating_system_type.nil?
         heating_system_type_e = XMLHelper.add_element(heating_system, 'HeatingSystemType')
         XMLHelper.add_element(heating_system_type_e, @heating_system_type)
       end
-      XMLHelper.add_element(heating_system, 'HeatingSystemFuel', @heating_system_fuel) unless @heating_system_fuel.nil?
-      XMLHelper.add_element(heating_system, 'HeatingCapacity', to_float(@heating_capacity)) unless @heating_capacity.nil?
+      XMLHelper.add_element(heating_system, 'HeatingSystemFuel', @heating_system_fuel, :string) unless @heating_system_fuel.nil?
+      XMLHelper.add_element(heating_system, 'HeatingCapacity', @heating_capacity, :float) unless @heating_capacity.nil?
 
       efficiency_units = nil
       efficiency_value = nil
@@ -2580,21 +2580,21 @@ class HPXML < Object
       end
       if not efficiency_value.nil?
         annual_efficiency = XMLHelper.add_element(heating_system, 'AnnualHeatingEfficiency')
-        XMLHelper.add_element(annual_efficiency, 'Units', efficiency_units)
-        XMLHelper.add_element(annual_efficiency, 'Value', to_float(efficiency_value))
+        XMLHelper.add_element(annual_efficiency, 'Units', efficiency_units, :string)
+        XMLHelper.add_element(annual_efficiency, 'Value', efficiency_value, :float)
       end
-      XMLHelper.add_element(heating_system, 'FractionHeatLoadServed', to_float(@fraction_heat_load_served)) unless @fraction_heat_load_served.nil?
-      XMLHelper.add_element(heating_system, 'ElectricAuxiliaryEnergy', to_float(@electric_auxiliary_energy), @electric_auxiliary_energy_isdefaulted) unless @electric_auxiliary_energy.nil?
-      XMLHelper.add_extension(heating_system, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
-      XMLHelper.add_extension(heating_system, 'FanCoilWatts', to_float(@fan_coil_watts)) unless @fan_coil_watts.nil?
-      XMLHelper.add_extension(heating_system, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm), @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
-      XMLHelper.add_extension(heating_system, 'FanPowerWatts', to_float(@fan_watts), @fan_watts_isdefaulted) unless @fan_watts.nil?
-      XMLHelper.add_extension(heating_system, 'SeedId', @seed_id) unless @seed_id.nil?
+      XMLHelper.add_element(heating_system, 'FractionHeatLoadServed', @fraction_heat_load_served, :float) unless @fraction_heat_load_served.nil?
+      XMLHelper.add_element(heating_system, 'ElectricAuxiliaryEnergy', @electric_auxiliary_energy, :float, @electric_auxiliary_energy_isdefaulted) unless @electric_auxiliary_energy.nil?
+      XMLHelper.add_extension(heating_system, 'SharedLoopWatts', @shared_loop_watts, :float) unless @shared_loop_watts.nil?
+      XMLHelper.add_extension(heating_system, 'FanCoilWatts', @fan_coil_watts, :float) unless @fan_coil_watts.nil?
+      XMLHelper.add_extension(heating_system, 'FanPowerWattsPerCFM', @fan_watts_per_cfm, :float, @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
+      XMLHelper.add_extension(heating_system, 'FanPowerWatts', @fan_watts, :float, @fan_watts_isdefaulted) unless @fan_watts.nil?
+      XMLHelper.add_extension(heating_system, 'SeedId', @seed_id, :string) unless @seed_id.nil?
       if not @wlhp_heating_efficiency_cop.nil?
         wlhp = XMLHelper.create_elements_as_needed(heating_system, ['extension', 'WaterLoopHeatPump'])
         annual_efficiency = XMLHelper.add_element(wlhp, 'AnnualHeatingEfficiency')
-        XMLHelper.add_element(annual_efficiency, 'Units', UnitsCOP)
-        XMLHelper.add_element(annual_efficiency, 'Value', to_float(@wlhp_heating_efficiency_cop))
+        XMLHelper.add_element(annual_efficiency, 'Units', UnitsCOP, :string)
+        XMLHelper.add_element(annual_efficiency, 'Value', @wlhp_heating_efficiency_cop, :float)
       end
     end
 
@@ -2607,7 +2607,7 @@ class HPXML < Object
       @is_shared_system = XMLHelper.get_value(heating_system, 'IsSharedSystem', :boolean)
       @number_of_units_served = XMLHelper.get_value(heating_system, 'NumberofUnitsServed', :integer)
       @heating_system_type = XMLHelper.get_child_name(heating_system, 'HeatingSystemType')
-      @heating_system_fuel = XMLHelper.get_value(heating_system, 'HeatingSystemFuel')
+      @heating_system_fuel = XMLHelper.get_value(heating_system, 'HeatingSystemFuel', :string)
       @heating_capacity = XMLHelper.get_value(heating_system, 'HeatingCapacity', :float)
       if [HVACTypeFurnace, HVACTypeWallFurnace, HVACTypeFloorFurnace, HVACTypeBoiler].include? @heating_system_type
         @heating_efficiency_afue = XMLHelper.get_value(heating_system, "AnnualHeatingEfficiency[Units='#{UnitsAFUE}']/Value", :float)
@@ -2616,8 +2616,8 @@ class HPXML < Object
       end
       @fraction_heat_load_served = XMLHelper.get_value(heating_system, 'FractionHeatLoadServed', :float)
       @electric_auxiliary_energy, @electric_auxiliary_energy_isdefaulted = XMLHelper.get_value_and_defaulted(heating_system, 'ElectricAuxiliaryEnergy', :float)
-      @energy_star = XMLHelper.get_values(heating_system, 'ThirdPartyCertification').include?('Energy Star')
-      @seed_id = XMLHelper.get_value(heating_system, 'extension/SeedId')
+      @energy_star = XMLHelper.get_values(heating_system, 'ThirdPartyCertification', :string).include?('Energy Star')
+      @seed_id = XMLHelper.get_value(heating_system, 'extension/SeedId', :string)
       @fan_watts_per_cfm, @fan_watts_per_cfm_isdefaulted = XMLHelper.get_value_and_defaulted(heating_system, 'extension/FanPowerWattsPerCFM', :float)
       @fan_watts, @fan_watts_isdefaulted = XMLHelper.get_value_and_defaulted(heating_system, 'extension/FanPowerWatts', :float)
       @shared_loop_watts = XMLHelper.get_value(heating_system, 'extension/SharedLoopWatts', :float)
@@ -2701,13 +2701,13 @@ class HPXML < Object
         distribution_system = XMLHelper.add_element(cooling_system, 'DistributionSystem')
         XMLHelper.add_attribute(distribution_system, 'idref', @distribution_system_idref)
       end
-      XMLHelper.add_element(cooling_system, 'IsSharedSystem', to_boolean(@is_shared_system)) unless @is_shared_system.nil?
-      XMLHelper.add_element(cooling_system, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
-      XMLHelper.add_element(cooling_system, 'CoolingSystemType', @cooling_system_type) unless @cooling_system_type.nil?
-      XMLHelper.add_element(cooling_system, 'CoolingSystemFuel', @cooling_system_fuel) unless @cooling_system_fuel.nil?
-      XMLHelper.add_element(cooling_system, 'CoolingCapacity', to_float(@cooling_capacity)) unless @cooling_capacity.nil?
-      XMLHelper.add_element(cooling_system, 'CompressorType', @compressor_type, @compressor_type_isdefaulted) unless @compressor_type.nil?
-      XMLHelper.add_element(cooling_system, 'FractionCoolLoadServed', to_float(@fraction_cool_load_served)) unless @fraction_cool_load_served.nil?
+      XMLHelper.add_element(cooling_system, 'IsSharedSystem', @is_shared_system, :boolean) unless @is_shared_system.nil?
+      XMLHelper.add_element(cooling_system, 'NumberofUnitsServed', @number_of_units_served, :integer) unless @number_of_units_served.nil?
+      XMLHelper.add_element(cooling_system, 'CoolingSystemType', @cooling_system_type, :string) unless @cooling_system_type.nil?
+      XMLHelper.add_element(cooling_system, 'CoolingSystemFuel', @cooling_system_fuel, :string) unless @cooling_system_fuel.nil?
+      XMLHelper.add_element(cooling_system, 'CoolingCapacity', @cooling_capacity, :float) unless @cooling_capacity.nil?
+      XMLHelper.add_element(cooling_system, 'CompressorType', @compressor_type, :string, @compressor_type_isdefaulted) unless @compressor_type.nil?
+      XMLHelper.add_element(cooling_system, 'FractionCoolLoadServed', @fraction_cool_load_served, :float) unless @fraction_cool_load_served.nil?
 
       efficiency_units = nil
       efficiency_value = nil
@@ -2723,21 +2723,21 @@ class HPXML < Object
       end
       if not efficiency_value.nil?
         annual_efficiency = XMLHelper.add_element(cooling_system, 'AnnualCoolingEfficiency')
-        XMLHelper.add_element(annual_efficiency, 'Units', efficiency_units)
-        XMLHelper.add_element(annual_efficiency, 'Value', to_float(efficiency_value))
+        XMLHelper.add_element(annual_efficiency, 'Units', efficiency_units, :string)
+        XMLHelper.add_element(annual_efficiency, 'Value', efficiency_value, :float)
       end
-      XMLHelper.add_element(cooling_system, 'SensibleHeatFraction', to_float(@cooling_shr), @cooling_shr_isdefaulted) unless @cooling_shr.nil?
-      XMLHelper.add_extension(cooling_system, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm), @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
-      XMLHelper.add_extension(cooling_system, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
-      XMLHelper.add_extension(cooling_system, 'FanCoilWatts', to_float(@fan_coil_watts)) unless @fan_coil_watts.nil?
-      XMLHelper.add_extension(cooling_system, 'SeedId', @seed_id) unless @seed_id.nil?
+      XMLHelper.add_element(cooling_system, 'SensibleHeatFraction', @cooling_shr, :float, @cooling_shr_isdefaulted) unless @cooling_shr.nil?
+      XMLHelper.add_extension(cooling_system, 'FanPowerWattsPerCFM', @fan_watts_per_cfm, :float, @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
+      XMLHelper.add_extension(cooling_system, 'SharedLoopWatts', @shared_loop_watts, :float) unless @shared_loop_watts.nil?
+      XMLHelper.add_extension(cooling_system, 'FanCoilWatts', @fan_coil_watts, :float) unless @fan_coil_watts.nil?
+      XMLHelper.add_extension(cooling_system, 'SeedId', @seed_id, :string) unless @seed_id.nil?
       if (not @wlhp_cooling_capacity.nil?) || (not @wlhp_cooling_efficiency_eer.nil?)
         wlhp = XMLHelper.create_elements_as_needed(cooling_system, ['extension', 'WaterLoopHeatPump'])
-        XMLHelper.add_element(wlhp, 'CoolingCapacity', to_float(@wlhp_cooling_capacity)) unless @wlhp_cooling_capacity.nil?
+        XMLHelper.add_element(wlhp, 'CoolingCapacity', @wlhp_cooling_capacity, :float) unless @wlhp_cooling_capacity.nil?
         if not @wlhp_cooling_efficiency_eer.nil?
           annual_efficiency = XMLHelper.add_element(wlhp, 'AnnualCoolingEfficiency')
-          XMLHelper.add_element(annual_efficiency, 'Units', UnitsEER)
-          XMLHelper.add_element(annual_efficiency, 'Value', to_float(@wlhp_cooling_efficiency_eer))
+          XMLHelper.add_element(annual_efficiency, 'Units', UnitsEER, :string)
+          XMLHelper.add_element(annual_efficiency, 'Value', @wlhp_cooling_efficiency_eer, :float)
         end
       end
     end
@@ -2750,10 +2750,10 @@ class HPXML < Object
       @year_installed = XMLHelper.get_value(cooling_system, 'YearInstalled', :integer)
       @is_shared_system = XMLHelper.get_value(cooling_system, 'IsSharedSystem', :boolean)
       @number_of_units_served = XMLHelper.get_value(cooling_system, 'NumberofUnitsServed', :integer)
-      @cooling_system_type = XMLHelper.get_value(cooling_system, 'CoolingSystemType')
-      @cooling_system_fuel = XMLHelper.get_value(cooling_system, 'CoolingSystemFuel')
+      @cooling_system_type = XMLHelper.get_value(cooling_system, 'CoolingSystemType', :string)
+      @cooling_system_fuel = XMLHelper.get_value(cooling_system, 'CoolingSystemFuel', :string)
       @cooling_capacity = XMLHelper.get_value(cooling_system, 'CoolingCapacity', :float)
-      @compressor_type, @compressor_type_isdefaulted = XMLHelper.get_value_and_defaulted(cooling_system, 'CompressorType')
+      @compressor_type, @compressor_type_isdefaulted = XMLHelper.get_value_and_defaulted(cooling_system, 'CompressorType', :string)
       @fraction_cool_load_served = XMLHelper.get_value(cooling_system, 'FractionCoolLoadServed', :float)
       if [HVACTypeCentralAirConditioner, HVACTypeMiniSplitAirConditioner].include? @cooling_system_type
         @cooling_efficiency_seer = XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsSEER}']/Value", :float)
@@ -2763,8 +2763,8 @@ class HPXML < Object
         @cooling_efficiency_kw_per_ton = XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsKwPerTon}']/Value", :float)
       end
       @cooling_shr, @cooling_shr_isdefaulted = XMLHelper.get_value_and_defaulted(cooling_system, 'SensibleHeatFraction', :float)
-      @energy_star = XMLHelper.get_values(cooling_system, 'ThirdPartyCertification').include?('Energy Star')
-      @seed_id = XMLHelper.get_value(cooling_system, 'extension/SeedId')
+      @energy_star = XMLHelper.get_values(cooling_system, 'ThirdPartyCertification', :string).include?('Energy Star')
+      @seed_id = XMLHelper.get_value(cooling_system, 'extension/SeedId', :string)
       @fan_watts_per_cfm, @fan_watts_per_cfm_isdefaulted = XMLHelper.get_value_and_defaulted(cooling_system, 'extension/FanPowerWattsPerCFM', :float)
       @shared_loop_watts = XMLHelper.get_value(cooling_system, 'extension/SharedLoopWatts', :float)
       @fan_coil_watts = XMLHelper.get_value(cooling_system, 'extension/FanCoilWatts', :float)
@@ -2843,31 +2843,31 @@ class HPXML < Object
         distribution_system = XMLHelper.add_element(heat_pump, 'DistributionSystem')
         XMLHelper.add_attribute(distribution_system, 'idref', @distribution_system_idref)
       end
-      XMLHelper.add_element(heat_pump, 'IsSharedSystem', to_boolean(@is_shared_system)) unless @is_shared_system.nil?
-      XMLHelper.add_element(heat_pump, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
-      XMLHelper.add_element(heat_pump, 'HeatPumpType', @heat_pump_type) unless @heat_pump_type.nil?
-      XMLHelper.add_element(heat_pump, 'HeatPumpFuel', @heat_pump_fuel) unless @heat_pump_fuel.nil?
-      XMLHelper.add_element(heat_pump, 'HeatingCapacity', to_float(@heating_capacity)) unless @heating_capacity.nil?
-      XMLHelper.add_element(heat_pump, 'HeatingCapacity17F', to_float(@heating_capacity_17F)) unless @heating_capacity_17F.nil?
-      XMLHelper.add_element(heat_pump, 'CoolingCapacity', to_float(@cooling_capacity)) unless @cooling_capacity.nil?
-      XMLHelper.add_element(heat_pump, 'CompressorType', @compressor_type, @compressor_type_isdefaulted) unless @compressor_type.nil?
-      XMLHelper.add_element(heat_pump, 'CoolingSensibleHeatFraction', to_float(@cooling_shr), @cooling_shr_isdefaulted) unless @cooling_shr.nil?
+      XMLHelper.add_element(heat_pump, 'IsSharedSystem', @is_shared_system, :boolean) unless @is_shared_system.nil?
+      XMLHelper.add_element(heat_pump, 'NumberofUnitsServed', @number_of_units_served, :integer) unless @number_of_units_served.nil?
+      XMLHelper.add_element(heat_pump, 'HeatPumpType', @heat_pump_type, :string) unless @heat_pump_type.nil?
+      XMLHelper.add_element(heat_pump, 'HeatPumpFuel', @heat_pump_fuel, :string) unless @heat_pump_fuel.nil?
+      XMLHelper.add_element(heat_pump, 'HeatingCapacity', @heating_capacity, :float) unless @heating_capacity.nil?
+      XMLHelper.add_element(heat_pump, 'HeatingCapacity17F', @heating_capacity_17F, :float) unless @heating_capacity_17F.nil?
+      XMLHelper.add_element(heat_pump, 'CoolingCapacity', @cooling_capacity, :float) unless @cooling_capacity.nil?
+      XMLHelper.add_element(heat_pump, 'CompressorType', @compressor_type, :string, @compressor_type_isdefaulted) unless @compressor_type.nil?
+      XMLHelper.add_element(heat_pump, 'CoolingSensibleHeatFraction', @cooling_shr, :float, @cooling_shr_isdefaulted) unless @cooling_shr.nil?
       if not @backup_heating_fuel.nil?
-        XMLHelper.add_element(heat_pump, 'BackupSystemFuel', @backup_heating_fuel)
+        XMLHelper.add_element(heat_pump, 'BackupSystemFuel', @backup_heating_fuel, :string)
         efficiencies = { 'Percent' => @backup_heating_efficiency_percent,
                          UnitsAFUE => @backup_heating_efficiency_afue }
         efficiencies.each do |units, value|
           next if value.nil?
 
           backup_eff = XMLHelper.add_element(heat_pump, 'BackupAnnualHeatingEfficiency')
-          XMLHelper.add_element(backup_eff, 'Units', units)
-          XMLHelper.add_element(backup_eff, 'Value', to_float(value))
+          XMLHelper.add_element(backup_eff, 'Units', units, :string)
+          XMLHelper.add_element(backup_eff, 'Value', value, :float)
         end
-        XMLHelper.add_element(heat_pump, 'BackupHeatingCapacity', to_float(@backup_heating_capacity)) unless @backup_heating_capacity.nil?
-        XMLHelper.add_element(heat_pump, 'BackupHeatingSwitchoverTemperature', to_float(@backup_heating_switchover_temp)) unless @backup_heating_switchover_temp.nil?
+        XMLHelper.add_element(heat_pump, 'BackupHeatingCapacity', @backup_heating_capacity, :float) unless @backup_heating_capacity.nil?
+        XMLHelper.add_element(heat_pump, 'BackupHeatingSwitchoverTemperature', @backup_heating_switchover_temp, :float) unless @backup_heating_switchover_temp.nil?
       end
-      XMLHelper.add_element(heat_pump, 'FractionHeatLoadServed', to_float(@fraction_heat_load_served)) unless @fraction_heat_load_served.nil?
-      XMLHelper.add_element(heat_pump, 'FractionCoolLoadServed', to_float(@fraction_cool_load_served)) unless @fraction_cool_load_served.nil?
+      XMLHelper.add_element(heat_pump, 'FractionHeatLoadServed', @fraction_heat_load_served, :float) unless @fraction_heat_load_served.nil?
+      XMLHelper.add_element(heat_pump, 'FractionCoolLoadServed', @fraction_cool_load_served, :float) unless @fraction_cool_load_served.nil?
 
       clg_efficiency_units = nil
       clg_efficiency_value = nil
@@ -2886,18 +2886,18 @@ class HPXML < Object
       end
       if not clg_efficiency_value.nil?
         annual_efficiency = XMLHelper.add_element(heat_pump, 'AnnualCoolingEfficiency')
-        XMLHelper.add_element(annual_efficiency, 'Units', clg_efficiency_units)
-        XMLHelper.add_element(annual_efficiency, 'Value', to_float(clg_efficiency_value))
+        XMLHelper.add_element(annual_efficiency, 'Units', clg_efficiency_units, :string)
+        XMLHelper.add_element(annual_efficiency, 'Value', clg_efficiency_value, :float)
       end
       if not htg_efficiency_value.nil?
         annual_efficiency = XMLHelper.add_element(heat_pump, 'AnnualHeatingEfficiency')
-        XMLHelper.add_element(annual_efficiency, 'Units', htg_efficiency_units)
-        XMLHelper.add_element(annual_efficiency, 'Value', to_float(htg_efficiency_value))
+        XMLHelper.add_element(annual_efficiency, 'Units', htg_efficiency_units, :string)
+        XMLHelper.add_element(annual_efficiency, 'Value', htg_efficiency_value, :float)
       end
-      XMLHelper.add_extension(heat_pump, 'FanPowerWattsPerCFM', to_float(@fan_watts_per_cfm), @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
-      XMLHelper.add_extension(heat_pump, 'PumpPowerWattsPerTon', to_float(@pump_watts_per_ton), @pump_watts_per_ton_isdefaulted) unless @pump_watts_per_ton.nil?
-      XMLHelper.add_extension(heat_pump, 'SharedLoopWatts', to_float(@shared_loop_watts)) unless @shared_loop_watts.nil?
-      XMLHelper.add_extension(heat_pump, 'SeedId', @seed_id) unless @seed_id.nil?
+      XMLHelper.add_extension(heat_pump, 'FanPowerWattsPerCFM', @fan_watts_per_cfm, :float, @fan_watts_per_cfm_isdefaulted) unless @fan_watts_per_cfm.nil?
+      XMLHelper.add_extension(heat_pump, 'PumpPowerWattsPerTon', @pump_watts_per_ton, :float, @pump_watts_per_ton_isdefaulted) unless @pump_watts_per_ton.nil?
+      XMLHelper.add_extension(heat_pump, 'SharedLoopWatts', @shared_loop_watts, :float) unless @shared_loop_watts.nil?
+      XMLHelper.add_extension(heat_pump, 'SeedId', @seed_id, :string) unless @seed_id.nil?
     end
 
     def from_oga(heat_pump)
@@ -2908,14 +2908,14 @@ class HPXML < Object
       @year_installed = XMLHelper.get_value(heat_pump, 'YearInstalled', :integer)
       @is_shared_system = XMLHelper.get_value(heat_pump, 'IsSharedSystem', :boolean)
       @number_of_units_served = XMLHelper.get_value(heat_pump, 'NumberofUnitsServed', :integer)
-      @heat_pump_type = XMLHelper.get_value(heat_pump, 'HeatPumpType')
-      @heat_pump_fuel = XMLHelper.get_value(heat_pump, 'HeatPumpFuel')
+      @heat_pump_type = XMLHelper.get_value(heat_pump, 'HeatPumpType', :string)
+      @heat_pump_fuel = XMLHelper.get_value(heat_pump, 'HeatPumpFuel', :string)
       @heating_capacity = XMLHelper.get_value(heat_pump, 'HeatingCapacity', :float)
       @heating_capacity_17F = XMLHelper.get_value(heat_pump, 'HeatingCapacity17F', :float)
       @cooling_capacity = XMLHelper.get_value(heat_pump, 'CoolingCapacity', :float)
-      @compressor_type, @compressor_type_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'CompressorType')
+      @compressor_type, @compressor_type_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'CompressorType', :string)
       @cooling_shr, @cooling_shr_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'CoolingSensibleHeatFraction', :float)
-      @backup_heating_fuel = XMLHelper.get_value(heat_pump, 'BackupSystemFuel')
+      @backup_heating_fuel = XMLHelper.get_value(heat_pump, 'BackupSystemFuel', :string)
       @backup_heating_capacity = XMLHelper.get_value(heat_pump, 'BackupHeatingCapacity', :float)
       @backup_heating_efficiency_percent = XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='Percent']/Value", :float)
       @backup_heating_efficiency_afue = XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='#{UnitsAFUE}']/Value", :float)
@@ -2932,10 +2932,10 @@ class HPXML < Object
       elsif [HVACTypeHeatPumpGroundToAir].include? @heat_pump_type
         @heating_efficiency_cop = XMLHelper.get_value(heat_pump, "AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value", :float)
       end
-      @energy_star = XMLHelper.get_values(heat_pump, 'ThirdPartyCertification').include?('Energy Star')
+      @energy_star = XMLHelper.get_values(heat_pump, 'ThirdPartyCertification', :string).include?('Energy Star')
       @pump_watts_per_ton, @pump_watts_per_ton_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'extension/PumpPowerWattsPerTon', :float)
       @fan_watts_per_cfm, @fan_watts_per_cfm_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'extension/FanPowerWattsPerCFM', :float)
-      @seed_id = XMLHelper.get_value(heat_pump, 'extension/SeedId')
+      @seed_id = XMLHelper.get_value(heat_pump, 'extension/SeedId', :string)
       @shared_loop_watts = XMLHelper.get_value(heat_pump, 'extension/SharedLoopWatts', :float)
     end
   end
@@ -2979,27 +2979,27 @@ class HPXML < Object
       hvac_control = XMLHelper.add_element(hvac, 'HVACControl')
       sys_id = XMLHelper.add_element(hvac_control, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(hvac_control, 'ControlType', @control_type) unless @control_type.nil?
-      XMLHelper.add_element(hvac_control, 'SetpointTempHeatingSeason', to_float(@heating_setpoint_temp)) unless @heating_setpoint_temp.nil?
-      XMLHelper.add_element(hvac_control, 'SetbackTempHeatingSeason', to_float(@heating_setback_temp)) unless @heating_setback_temp.nil?
-      XMLHelper.add_element(hvac_control, 'TotalSetbackHoursperWeekHeating', to_integer(@heating_setback_hours_per_week)) unless @heating_setback_hours_per_week.nil?
-      XMLHelper.add_element(hvac_control, 'SetupTempCoolingSeason', to_float(@cooling_setup_temp)) unless @cooling_setup_temp.nil?
-      XMLHelper.add_element(hvac_control, 'SetpointTempCoolingSeason', to_float(@cooling_setpoint_temp)) unless @cooling_setpoint_temp.nil?
-      XMLHelper.add_element(hvac_control, 'TotalSetupHoursperWeekCooling', to_integer(@cooling_setup_hours_per_week)) unless @cooling_setup_hours_per_week.nil?
-      XMLHelper.add_extension(hvac_control, 'SetbackStartHourHeating', to_integer(@heating_setback_start_hour), @heating_setback_start_hour_isdefaulted) unless @heating_setback_start_hour.nil?
-      XMLHelper.add_extension(hvac_control, 'SetupStartHourCooling', to_integer(@cooling_setup_start_hour), @cooling_setup_start_hour_isdefaulted) unless @cooling_setup_start_hour.nil?
-      XMLHelper.add_extension(hvac_control, 'CeilingFanSetpointTempCoolingSeasonOffset', to_float(@ceiling_fan_cooling_setpoint_temp_offset)) unless @ceiling_fan_cooling_setpoint_temp_offset.nil?
-      XMLHelper.add_extension(hvac_control, 'WeekdaySetpointTempsHeatingSeason', @weekday_heating_setpoints) unless @weekday_heating_setpoints.nil?
-      XMLHelper.add_extension(hvac_control, 'WeekendSetpointTempsHeatingSeason', @weekend_heating_setpoints) unless @weekend_heating_setpoints.nil?
-      XMLHelper.add_extension(hvac_control, 'WeekdaySetpointTempsCoolingSeason', @weekday_cooling_setpoints) unless @weekday_cooling_setpoints.nil?
-      XMLHelper.add_extension(hvac_control, 'WeekendSetpointTempsCoolingSeason', @weekend_cooling_setpoints) unless @weekend_cooling_setpoints.nil?
+      XMLHelper.add_element(hvac_control, 'ControlType', @control_type, :string) unless @control_type.nil?
+      XMLHelper.add_element(hvac_control, 'SetpointTempHeatingSeason', @heating_setpoint_temp, :float) unless @heating_setpoint_temp.nil?
+      XMLHelper.add_element(hvac_control, 'SetbackTempHeatingSeason', @heating_setback_temp, :float) unless @heating_setback_temp.nil?
+      XMLHelper.add_element(hvac_control, 'TotalSetbackHoursperWeekHeating', @heating_setback_hours_per_week, :integer) unless @heating_setback_hours_per_week.nil?
+      XMLHelper.add_element(hvac_control, 'SetupTempCoolingSeason', @cooling_setup_temp, :float) unless @cooling_setup_temp.nil?
+      XMLHelper.add_element(hvac_control, 'SetpointTempCoolingSeason', @cooling_setpoint_temp, :float) unless @cooling_setpoint_temp.nil?
+      XMLHelper.add_element(hvac_control, 'TotalSetupHoursperWeekCooling', @cooling_setup_hours_per_week, :integer) unless @cooling_setup_hours_per_week.nil?
+      XMLHelper.add_extension(hvac_control, 'SetbackStartHourHeating', @heating_setback_start_hour, :integer, @heating_setback_start_hour_isdefaulted) unless @heating_setback_start_hour.nil?
+      XMLHelper.add_extension(hvac_control, 'SetupStartHourCooling', @cooling_setup_start_hour, :integer, @cooling_setup_start_hour_isdefaulted) unless @cooling_setup_start_hour.nil?
+      XMLHelper.add_extension(hvac_control, 'CeilingFanSetpointTempCoolingSeasonOffset', @ceiling_fan_cooling_setpoint_temp_offset, :float) unless @ceiling_fan_cooling_setpoint_temp_offset.nil?
+      XMLHelper.add_extension(hvac_control, 'WeekdaySetpointTempsHeatingSeason', @weekday_heating_setpoints, :string) unless @weekday_heating_setpoints.nil?
+      XMLHelper.add_extension(hvac_control, 'WeekendSetpointTempsHeatingSeason', @weekend_heating_setpoints, :string) unless @weekend_heating_setpoints.nil?
+      XMLHelper.add_extension(hvac_control, 'WeekdaySetpointTempsCoolingSeason', @weekday_cooling_setpoints, :string) unless @weekday_cooling_setpoints.nil?
+      XMLHelper.add_extension(hvac_control, 'WeekendSetpointTempsCoolingSeason', @weekend_cooling_setpoints, :string) unless @weekend_cooling_setpoints.nil?
     end
 
     def from_oga(hvac_control)
       return if hvac_control.nil?
 
       @id = HPXML::get_id(hvac_control)
-      @control_type = XMLHelper.get_value(hvac_control, 'ControlType')
+      @control_type = XMLHelper.get_value(hvac_control, 'ControlType', :string)
       @heating_setpoint_temp = XMLHelper.get_value(hvac_control, 'SetpointTempHeatingSeason', :float)
       @heating_setback_temp = XMLHelper.get_value(hvac_control, 'SetbackTempHeatingSeason', :float)
       @heating_setback_hours_per_week = XMLHelper.get_value(hvac_control, 'TotalSetbackHoursperWeekHeating', :integer)
@@ -3009,10 +3009,10 @@ class HPXML < Object
       @cooling_setup_hours_per_week = XMLHelper.get_value(hvac_control, 'TotalSetupHoursperWeekCooling', :integer)
       @cooling_setup_start_hour, @cooling_setup_start_hour_isdefaulted = XMLHelper.get_value_and_defaulted(hvac_control, 'extension/SetupStartHourCooling', :integer)
       @ceiling_fan_cooling_setpoint_temp_offset = XMLHelper.get_value(hvac_control, 'extension/CeilingFanSetpointTempCoolingSeasonOffset', :float)
-      @weekday_heating_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekdaySetpointTempsHeatingSeason')
-      @weekend_heating_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekendSetpointTempsHeatingSeason')
-      @weekday_cooling_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekdaySetpointTempsCoolingSeason')
-      @weekend_cooling_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekendSetpointTempsCoolingSeason')
+      @weekday_heating_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekdaySetpointTempsHeatingSeason', :string)
+      @weekend_heating_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekendSetpointTempsHeatingSeason', :string)
+      @weekday_cooling_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekdaySetpointTempsCoolingSeason', :string)
+      @weekend_cooling_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekendSetpointTempsCoolingSeason', :string)
     end
   end
 
@@ -3109,22 +3109,22 @@ class HPXML < Object
       distribution_system_type_e = XMLHelper.add_element(hvac_distribution, 'DistributionSystemType')
       if [HVACDistributionTypeAir, HVACDistributionTypeHydronic, HVACDistributionTypeHydronicAndAir].include? @distribution_system_type
         XMLHelper.add_element(distribution_system_type_e, @distribution_system_type)
-        XMLHelper.add_element(hvac_distribution, 'ConditionedFloorAreaServed', Float(@conditioned_floor_area_served)) unless @conditioned_floor_area_served.nil?
+        XMLHelper.add_element(hvac_distribution, 'ConditionedFloorAreaServed', @conditioned_floor_area_served, :float) unless @conditioned_floor_area_served.nil?
       elsif [HVACDistributionTypeDSE].include? @distribution_system_type
-        XMLHelper.add_element(distribution_system_type_e, 'Other', @distribution_system_type)
-        XMLHelper.add_element(hvac_distribution, 'AnnualHeatingDistributionSystemEfficiency', to_float(@annual_heating_dse)) unless @annual_heating_dse.nil?
-        XMLHelper.add_element(hvac_distribution, 'AnnualCoolingDistributionSystemEfficiency', to_float(@annual_cooling_dse)) unless @annual_cooling_dse.nil?
+        XMLHelper.add_element(distribution_system_type_e, 'Other', @distribution_system_type, :string)
+        XMLHelper.add_element(hvac_distribution, 'AnnualHeatingDistributionSystemEfficiency', @annual_heating_dse, :float) unless @annual_heating_dse.nil?
+        XMLHelper.add_element(hvac_distribution, 'AnnualCoolingDistributionSystemEfficiency', @annual_cooling_dse, :float) unless @annual_cooling_dse.nil?
       else
         fail "Unexpected distribution_system_type '#{@distribution_system_type}'."
       end
 
       if [HPXML::HVACDistributionTypeHydronic].include? @distribution_system_type
         distribution = XMLHelper.get_element(hvac_distribution, 'DistributionSystemType/HydronicDistribution')
-        XMLHelper.add_element(distribution, 'HydronicDistributionType', @hydronic_type) unless @hydronic_type.nil?
+        XMLHelper.add_element(distribution, 'HydronicDistributionType', @hydronic_type, :string) unless @hydronic_type.nil?
       end
       if [HPXML::HVACDistributionTypeHydronicAndAir].include? @distribution_system_type
         distribution = XMLHelper.get_element(hvac_distribution, 'DistributionSystemType/HydronicAndAirDistribution')
-        XMLHelper.add_element(distribution, 'HydronicAndAirDistributionType', @hydronic_and_air_type) unless @hydronic_and_air_type.nil?
+        XMLHelper.add_element(distribution, 'HydronicAndAirDistributionType', @hydronic_and_air_type, :string) unless @hydronic_and_air_type.nil?
       end
       if [HPXML::HVACDistributionTypeAir, HPXML::HVACDistributionTypeHydronicAndAir].include? @distribution_system_type
         if @distribution_system_type == HPXML::HVACDistributionTypeAir
@@ -3134,8 +3134,8 @@ class HPXML < Object
         end
         @duct_leakage_measurements.to_oga(distribution)
         @ducts.to_oga(distribution)
-        XMLHelper.add_element(distribution, 'NumberofReturnRegisters', Integer(@number_of_return_registers), @number_of_return_registers_isdefaulted) unless @number_of_return_registers.nil?
-        XMLHelper.add_extension(distribution, 'DuctLeakageToOutsideTestingExemption', to_boolean(@duct_leakage_to_outside_testing_exemption)) unless @duct_leakage_to_outside_testing_exemption.nil?
+        XMLHelper.add_element(distribution, 'NumberofReturnRegisters', @number_of_return_registers, :integer, @number_of_return_registers_isdefaulted) unless @number_of_return_registers.nil?
+        XMLHelper.add_extension(distribution, 'DuctLeakageToOutsideTestingExemption', @duct_leakage_to_outside_testing_exemption, :boolean) unless @duct_leakage_to_outside_testing_exemption.nil?
       end
     end
 
@@ -3145,7 +3145,7 @@ class HPXML < Object
       @id = HPXML::get_id(hvac_distribution)
       @distribution_system_type = XMLHelper.get_child_name(hvac_distribution, 'DistributionSystemType')
       if @distribution_system_type == 'Other'
-        @distribution_system_type = XMLHelper.get_value(XMLHelper.get_element(hvac_distribution, 'DistributionSystemType'), 'Other')
+        @distribution_system_type = XMLHelper.get_value(XMLHelper.get_element(hvac_distribution, 'DistributionSystemType'), 'Other', :string)
       end
       @annual_heating_dse = XMLHelper.get_value(hvac_distribution, 'AnnualHeatingDistributionSystemEfficiency', :float)
       @annual_cooling_dse = XMLHelper.get_value(hvac_distribution, 'AnnualCoolingDistributionSystemEfficiency', :float)
@@ -3157,10 +3157,10 @@ class HPXML < Object
       hydronic_and_air_distribution = XMLHelper.get_element(hvac_distribution, 'DistributionSystemType/HydronicAndAirDistribution')
 
       if not hydronic_distribution.nil?
-        @hydronic_type = XMLHelper.get_value(hydronic_distribution, 'HydronicDistributionType')
+        @hydronic_type = XMLHelper.get_value(hydronic_distribution, 'HydronicDistributionType', :string)
       end
       if not hydronic_and_air_distribution.nil?
-        @hydronic_and_air_type = XMLHelper.get_value(hydronic_and_air_distribution, 'HydronicAndAirDistributionType')
+        @hydronic_and_air_type = XMLHelper.get_value(hydronic_and_air_distribution, 'HydronicAndAirDistributionType', :string)
       end
       if (not air_distribution.nil?) || (not hydronic_and_air_distribution.nil?)
         distribution = air_distribution
@@ -3207,23 +3207,23 @@ class HPXML < Object
 
     def to_oga(air_distribution)
       duct_leakage_measurement_el = XMLHelper.add_element(air_distribution, 'DuctLeakageMeasurement')
-      XMLHelper.add_element(duct_leakage_measurement_el, 'DuctType', @duct_type) unless @duct_type.nil?
+      XMLHelper.add_element(duct_leakage_measurement_el, 'DuctType', @duct_type, :string) unless @duct_type.nil?
       if not @duct_leakage_value.nil?
         duct_leakage_el = XMLHelper.add_element(duct_leakage_measurement_el, 'DuctLeakage')
-        XMLHelper.add_element(duct_leakage_el, 'Units', @duct_leakage_units) unless @duct_leakage_units.nil?
-        XMLHelper.add_element(duct_leakage_el, 'Value', to_float(@duct_leakage_value))
-        XMLHelper.add_element(duct_leakage_el, 'TotalOrToOutside', @duct_leakage_total_or_to_outside) unless @duct_leakage_total_or_to_outside.nil?
+        XMLHelper.add_element(duct_leakage_el, 'Units', @duct_leakage_units, :string) unless @duct_leakage_units.nil?
+        XMLHelper.add_element(duct_leakage_el, 'Value', @duct_leakage_value, :float)
+        XMLHelper.add_element(duct_leakage_el, 'TotalOrToOutside', @duct_leakage_total_or_to_outside, :string) unless @duct_leakage_total_or_to_outside.nil?
       end
     end
 
     def from_oga(duct_leakage_measurement)
       return if duct_leakage_measurement.nil?
 
-      @duct_type = XMLHelper.get_value(duct_leakage_measurement, 'DuctType')
-      @duct_leakage_test_method = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakageTestMethod')
-      @duct_leakage_units = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/Units')
+      @duct_type = XMLHelper.get_value(duct_leakage_measurement, 'DuctType', :string)
+      @duct_leakage_test_method = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakageTestMethod', :string)
+      @duct_leakage_units = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/Units', :string)
       @duct_leakage_value = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/Value', :float)
-      @duct_leakage_total_or_to_outside = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/TotalOrToOutside')
+      @duct_leakage_total_or_to_outside = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/TotalOrToOutside', :string)
     end
   end
 
@@ -3261,19 +3261,19 @@ class HPXML < Object
 
     def to_oga(air_distribution)
       ducts_el = XMLHelper.add_element(air_distribution, 'Ducts')
-      XMLHelper.add_element(ducts_el, 'DuctType', @duct_type) unless @duct_type.nil?
-      XMLHelper.add_element(ducts_el, 'DuctInsulationRValue', to_float(@duct_insulation_r_value)) unless @duct_insulation_r_value.nil?
-      XMLHelper.add_element(ducts_el, 'DuctLocation', @duct_location, @duct_location_isdefaulted) unless @duct_location.nil?
-      XMLHelper.add_element(ducts_el, 'DuctSurfaceArea', to_float(@duct_surface_area), @duct_surface_area_isdefaulted) unless @duct_surface_area.nil?
+      XMLHelper.add_element(ducts_el, 'DuctType', @duct_type, :string) unless @duct_type.nil?
+      XMLHelper.add_element(ducts_el, 'DuctInsulationRValue', @duct_insulation_r_value, :float) unless @duct_insulation_r_value.nil?
+      XMLHelper.add_element(ducts_el, 'DuctLocation', @duct_location, :string, @duct_location_isdefaulted) unless @duct_location.nil?
+      XMLHelper.add_element(ducts_el, 'DuctSurfaceArea', @duct_surface_area, :float, @duct_surface_area_isdefaulted) unless @duct_surface_area.nil?
     end
 
     def from_oga(duct)
       return if duct.nil?
 
-      @duct_type = XMLHelper.get_value(duct, 'DuctType')
+      @duct_type = XMLHelper.get_value(duct, 'DuctType', :string)
       @duct_insulation_r_value = XMLHelper.get_value(duct, 'DuctInsulationRValue', :float)
       @duct_insulation_material = XMLHelper.get_child_name(duct, 'DuctInsulationMaterial')
-      @duct_location, @duct_location_isdefaulted = XMLHelper.get_value_and_defaulted(duct, 'DuctLocation')
+      @duct_location, @duct_location_isdefaulted = XMLHelper.get_value_and_defaulted(duct, 'DuctLocation', :string)
       @duct_fraction_area = XMLHelper.get_value(duct, 'FractionDuctArea', :float)
       @duct_surface_area, @duct_surface_area_isdefaulted = XMLHelper.get_value_and_defaulted(duct, 'DuctSurfaceArea', :float)
     end
@@ -3440,50 +3440,50 @@ class HPXML < Object
       ventilation_fan = XMLHelper.add_element(ventilation_fans, 'VentilationFan')
       sys_id = XMLHelper.add_element(ventilation_fan, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(ventilation_fan, 'Quantity', to_integer(@quantity), @quantity_isdefaulted) unless @quantity.nil?
-      XMLHelper.add_element(ventilation_fan, 'FanType', @fan_type) unless @fan_type.nil?
-      XMLHelper.add_element(ventilation_fan, 'RatedFlowRate', to_float(@rated_flow_rate), @rated_flow_rate_isdefaulted) unless @rated_flow_rate.nil?
-      XMLHelper.add_element(ventilation_fan, 'TestedFlowRate', to_float(@tested_flow_rate)) unless @tested_flow_rate.nil?
-      XMLHelper.add_element(ventilation_fan, 'HoursInOperation', to_float(@hours_in_operation), @hours_in_operation_isdefaulted) unless @hours_in_operation.nil?
-      XMLHelper.add_element(ventilation_fan, 'FanLocation', @fan_location) unless @fan_location.nil?
-      XMLHelper.add_element(ventilation_fan, 'UsedForLocalVentilation', to_boolean(@used_for_local_ventilation)) unless @used_for_local_ventilation.nil?
-      XMLHelper.add_element(ventilation_fan, 'UsedForWholeBuildingVentilation', to_boolean(@used_for_whole_building_ventilation)) unless @used_for_whole_building_ventilation.nil?
-      XMLHelper.add_element(ventilation_fan, 'UsedForSeasonalCoolingLoadReduction', to_boolean(@used_for_seasonal_cooling_load_reduction)) unless @used_for_seasonal_cooling_load_reduction.nil?
-      XMLHelper.add_element(ventilation_fan, 'IsSharedSystem', to_boolean(@is_shared_system), @is_shared_system_isdefaulted) unless @is_shared_system.nil?
+      XMLHelper.add_element(ventilation_fan, 'Quantity', @quantity, :integer, @quantity_isdefaulted) unless @quantity.nil?
+      XMLHelper.add_element(ventilation_fan, 'FanType', @fan_type, :string) unless @fan_type.nil?
+      XMLHelper.add_element(ventilation_fan, 'RatedFlowRate', @rated_flow_rate, :float, @rated_flow_rate_isdefaulted) unless @rated_flow_rate.nil?
+      XMLHelper.add_element(ventilation_fan, 'TestedFlowRate', @tested_flow_rate, :float) unless @tested_flow_rate.nil?
+      XMLHelper.add_element(ventilation_fan, 'HoursInOperation', @hours_in_operation, :float, @hours_in_operation_isdefaulted) unless @hours_in_operation.nil?
+      XMLHelper.add_element(ventilation_fan, 'FanLocation', @fan_location, :string) unless @fan_location.nil?
+      XMLHelper.add_element(ventilation_fan, 'UsedForLocalVentilation', @used_for_local_ventilation, :boolean) unless @used_for_local_ventilation.nil?
+      XMLHelper.add_element(ventilation_fan, 'UsedForWholeBuildingVentilation', @used_for_whole_building_ventilation, :boolean) unless @used_for_whole_building_ventilation.nil?
+      XMLHelper.add_element(ventilation_fan, 'UsedForSeasonalCoolingLoadReduction', @used_for_seasonal_cooling_load_reduction, :boolean) unless @used_for_seasonal_cooling_load_reduction.nil?
+      XMLHelper.add_element(ventilation_fan, 'IsSharedSystem', @is_shared_system, :boolean, @is_shared_system_isdefaulted) unless @is_shared_system.nil?
       if @is_shared_system
-        XMLHelper.add_element(ventilation_fan, 'FractionRecirculation', to_float(@fraction_recirculation)) unless @fraction_recirculation.nil?
+        XMLHelper.add_element(ventilation_fan, 'FractionRecirculation', @fraction_recirculation, :float) unless @fraction_recirculation.nil?
       end
-      XMLHelper.add_element(ventilation_fan, 'TotalRecoveryEfficiency', to_float(@total_recovery_efficiency)) unless @total_recovery_efficiency.nil?
-      XMLHelper.add_element(ventilation_fan, 'SensibleRecoveryEfficiency', to_float(@sensible_recovery_efficiency)) unless @sensible_recovery_efficiency.nil?
-      XMLHelper.add_element(ventilation_fan, 'AdjustedTotalRecoveryEfficiency', to_float(@total_recovery_efficiency_adjusted)) unless @total_recovery_efficiency_adjusted.nil?
-      XMLHelper.add_element(ventilation_fan, 'AdjustedSensibleRecoveryEfficiency', to_float(@sensible_recovery_efficiency_adjusted)) unless @sensible_recovery_efficiency_adjusted.nil?
-      XMLHelper.add_element(ventilation_fan, 'FanPower', to_float(@fan_power), @fan_power_isdefaulted) unless @fan_power.nil?
+      XMLHelper.add_element(ventilation_fan, 'TotalRecoveryEfficiency', @total_recovery_efficiency, :float) unless @total_recovery_efficiency.nil?
+      XMLHelper.add_element(ventilation_fan, 'SensibleRecoveryEfficiency', @sensible_recovery_efficiency, :float) unless @sensible_recovery_efficiency.nil?
+      XMLHelper.add_element(ventilation_fan, 'AdjustedTotalRecoveryEfficiency', @total_recovery_efficiency_adjusted, :float) unless @total_recovery_efficiency_adjusted.nil?
+      XMLHelper.add_element(ventilation_fan, 'AdjustedSensibleRecoveryEfficiency', @sensible_recovery_efficiency_adjusted, :float) unless @sensible_recovery_efficiency_adjusted.nil?
+      XMLHelper.add_element(ventilation_fan, 'FanPower', @fan_power, :float, @fan_power_isdefaulted) unless @fan_power.nil?
       if not @distribution_system_idref.nil?
         attached_to_hvac_distribution_system = XMLHelper.add_element(ventilation_fan, 'AttachedToHVACDistributionSystem')
         XMLHelper.add_attribute(attached_to_hvac_distribution_system, 'idref', @distribution_system_idref)
       end
-      XMLHelper.add_extension(ventilation_fan, 'StartHour', to_integer(@start_hour), @start_hour_isdefaulted) unless @start_hour.nil?
+      XMLHelper.add_extension(ventilation_fan, 'StartHour', @start_hour, :integer, @start_hour_isdefaulted) unless @start_hour.nil?
       if @is_shared_system
-        XMLHelper.add_extension(ventilation_fan, 'InUnitFlowRate', to_float(@in_unit_flow_rate)) unless @in_unit_flow_rate.nil?
+        XMLHelper.add_extension(ventilation_fan, 'InUnitFlowRate', @in_unit_flow_rate, :float) unless @in_unit_flow_rate.nil?
         if (not @preheating_fuel.nil?) && (not @preheating_efficiency_cop.nil?)
           precond_htg = XMLHelper.create_elements_as_needed(ventilation_fan, ['extension', 'PreHeating'])
-          XMLHelper.add_element(precond_htg, 'Fuel', @preheating_fuel) unless @preheating_fuel.nil?
+          XMLHelper.add_element(precond_htg, 'Fuel', @preheating_fuel, :string) unless @preheating_fuel.nil?
           eff = XMLHelper.add_element(precond_htg, 'AnnualHeatingEfficiency') unless @preheating_efficiency_cop.nil?
-          XMLHelper.add_element(eff, 'Value', to_float(@preheating_efficiency_cop)) unless eff.nil?
-          XMLHelper.add_element(eff, 'Units', UnitsCOP) unless eff.nil?
-          XMLHelper.add_element(precond_htg, 'FractionVentilationHeatLoadServed', to_float(@preheating_fraction_load_served)) unless @preheating_fraction_load_served.nil?
+          XMLHelper.add_element(eff, 'Value', @preheating_efficiency_cop, :float) unless eff.nil?
+          XMLHelper.add_element(eff, 'Units', UnitsCOP, :string) unless eff.nil?
+          XMLHelper.add_element(precond_htg, 'FractionVentilationHeatLoadServed', @preheating_fraction_load_served, :float) unless @preheating_fraction_load_served.nil?
         end
         if (not @precooling_fuel.nil?) && (not @precooling_efficiency_cop.nil?)
           precond_clg = XMLHelper.create_elements_as_needed(ventilation_fan, ['extension', 'PreCooling'])
-          XMLHelper.add_element(precond_clg, 'Fuel', @precooling_fuel) unless @precooling_fuel.nil?
+          XMLHelper.add_element(precond_clg, 'Fuel', @precooling_fuel, :string) unless @precooling_fuel.nil?
           eff = XMLHelper.add_element(precond_clg, 'AnnualCoolingEfficiency') unless @precooling_efficiency_cop.nil?
-          XMLHelper.add_element(eff, 'Value', to_float(@precooling_efficiency_cop)) unless eff.nil?
-          XMLHelper.add_element(eff, 'Units', UnitsCOP) unless eff.nil?
-          XMLHelper.add_element(precond_clg, 'FractionVentilationCoolLoadServed', to_float(@precooling_fraction_load_served)) unless @precooling_fraction_load_served.nil?
+          XMLHelper.add_element(eff, 'Value', @precooling_efficiency_cop, :float) unless eff.nil?
+          XMLHelper.add_element(eff, 'Units', UnitsCOP, :string) unless eff.nil?
+          XMLHelper.add_element(precond_clg, 'FractionVentilationCoolLoadServed', @precooling_fraction_load_served, :float) unless @precooling_fraction_load_served.nil?
         end
       end
-      XMLHelper.add_extension(ventilation_fan, 'FlowRateNotTested', @flow_rate_not_tested) unless @flow_rate_not_tested.nil?
-      XMLHelper.add_extension(ventilation_fan, 'FanPowerDefaulted', @fan_power_defaulted) unless @fan_power_defaulted.nil?
+      XMLHelper.add_extension(ventilation_fan, 'FlowRateNotTested', @flow_rate_not_tested, :boolean) unless @flow_rate_not_tested.nil?
+      XMLHelper.add_extension(ventilation_fan, 'FanPowerDefaulted', @fan_power_defaulted, :boolean) unless @fan_power_defaulted.nil?
     end
 
     def from_oga(ventilation_fan)
@@ -3491,7 +3491,7 @@ class HPXML < Object
 
       @id = HPXML::get_id(ventilation_fan)
       @quantity, @quantity_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'Quantity', :integer)
-      @fan_type = XMLHelper.get_value(ventilation_fan, 'FanType')
+      @fan_type = XMLHelper.get_value(ventilation_fan, 'FanType', :string)
       @is_shared_system, @is_shared_system_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'IsSharedSystem', :boolean)
       @rated_flow_rate, @rated_flow_rate_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'RatedFlowRate', :float)
       @tested_flow_rate = XMLHelper.get_value(ventilation_fan, 'TestedFlowRate', :float)
@@ -3501,15 +3501,15 @@ class HPXML < Object
       if @is_shared_system
         @fraction_recirculation = XMLHelper.get_value(ventilation_fan, 'FractionRecirculation', :float)
         @in_unit_flow_rate = XMLHelper.get_value(ventilation_fan, 'extension/InUnitFlowRate', :float)
-        @preheating_fuel = XMLHelper.get_value(ventilation_fan, 'extension/PreHeating/Fuel')
+        @preheating_fuel = XMLHelper.get_value(ventilation_fan, 'extension/PreHeating/Fuel', :string)
         @preheating_efficiency_cop = XMLHelper.get_value(ventilation_fan, "extension/PreHeating/AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value", :float)
         @preheating_fraction_load_served = XMLHelper.get_value(ventilation_fan, 'extension/PreHeating/FractionVentilationHeatLoadServed', :float)
-        @precooling_fuel = XMLHelper.get_value(ventilation_fan, 'extension/PreCooling/Fuel')
+        @precooling_fuel = XMLHelper.get_value(ventilation_fan, 'extension/PreCooling/Fuel', :string)
         @precooling_efficiency_cop = XMLHelper.get_value(ventilation_fan, "extension/PreCooling/AnnualCoolingEfficiency[Units='#{UnitsCOP}']/Value", :float)
         @precooling_fraction_load_served = XMLHelper.get_value(ventilation_fan, 'extension/PreCooling/FractionVentilationCoolLoadServed', :float)
       end
       @hours_in_operation, @hours_in_operation_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'HoursInOperation', :float)
-      @fan_location = XMLHelper.get_value(ventilation_fan, 'FanLocation')
+      @fan_location = XMLHelper.get_value(ventilation_fan, 'FanLocation', :string)
       @used_for_local_ventilation = XMLHelper.get_value(ventilation_fan, 'UsedForLocalVentilation', :boolean)
       @used_for_whole_building_ventilation = XMLHelper.get_value(ventilation_fan, 'UsedForWholeBuildingVentilation', :boolean)
       @used_for_seasonal_cooling_load_reduction = XMLHelper.get_value(ventilation_fan, 'UsedForSeasonalCoolingLoadReduction', :boolean)
@@ -3577,27 +3577,27 @@ class HPXML < Object
       water_heating_system = XMLHelper.add_element(water_heating, 'WaterHeatingSystem')
       sys_id = XMLHelper.add_element(water_heating_system, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(water_heating_system, 'FuelType', @fuel_type) unless @fuel_type.nil?
-      XMLHelper.add_element(water_heating_system, 'WaterHeaterType', @water_heater_type) unless @water_heater_type.nil?
-      XMLHelper.add_element(water_heating_system, 'Location', @location, @location_isdefaulted) unless @location.nil?
-      XMLHelper.add_element(water_heating_system, 'IsSharedSystem', to_boolean(@is_shared_system), @is_shared_system_isdefaulted) unless @is_shared_system.nil?
-      XMLHelper.add_element(water_heating_system, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
-      XMLHelper.add_element(water_heating_system, 'PerformanceAdjustment', to_float(@performance_adjustment), @performance_adjustment_isdefaulted) unless @performance_adjustment.nil?
-      XMLHelper.add_element(water_heating_system, 'TankVolume', to_float(@tank_volume), @tank_volume_isdefaulted) unless @tank_volume.nil?
-      XMLHelper.add_element(water_heating_system, 'FractionDHWLoadServed', to_float(@fraction_dhw_load_served)) unless @fraction_dhw_load_served.nil?
-      XMLHelper.add_element(water_heating_system, 'HeatingCapacity', to_float(@heating_capacity), @heating_capacity_isdefaulted) unless @heating_capacity.nil?
-      XMLHelper.add_element(water_heating_system, 'EnergyFactor', to_float(@energy_factor)) unless @energy_factor.nil?
-      XMLHelper.add_element(water_heating_system, 'UniformEnergyFactor', to_float(@uniform_energy_factor)) unless @uniform_energy_factor.nil?
-      XMLHelper.add_element(water_heating_system, 'FirstHourRating', to_float(@first_hour_rating)) unless @first_hour_rating.nil?
-      XMLHelper.add_element(water_heating_system, 'RecoveryEfficiency', to_float(@recovery_efficiency), @recovery_efficiency_isdefaulted) unless @recovery_efficiency.nil?
+      XMLHelper.add_element(water_heating_system, 'FuelType', @fuel_type, :string) unless @fuel_type.nil?
+      XMLHelper.add_element(water_heating_system, 'WaterHeaterType', @water_heater_type, :string) unless @water_heater_type.nil?
+      XMLHelper.add_element(water_heating_system, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(water_heating_system, 'IsSharedSystem', @is_shared_system, :boolean, @is_shared_system_isdefaulted) unless @is_shared_system.nil?
+      XMLHelper.add_element(water_heating_system, 'NumberofUnitsServed', @number_of_units_served, :integer) unless @number_of_units_served.nil?
+      XMLHelper.add_element(water_heating_system, 'PerformanceAdjustment', @performance_adjustment, :float, @performance_adjustment_isdefaulted) unless @performance_adjustment.nil?
+      XMLHelper.add_element(water_heating_system, 'TankVolume', @tank_volume, :float, @tank_volume_isdefaulted) unless @tank_volume.nil?
+      XMLHelper.add_element(water_heating_system, 'FractionDHWLoadServed', @fraction_dhw_load_served, :float) unless @fraction_dhw_load_served.nil?
+      XMLHelper.add_element(water_heating_system, 'HeatingCapacity', @heating_capacity, :float, @heating_capacity_isdefaulted) unless @heating_capacity.nil?
+      XMLHelper.add_element(water_heating_system, 'EnergyFactor', @energy_factor, :float) unless @energy_factor.nil?
+      XMLHelper.add_element(water_heating_system, 'UniformEnergyFactor', @uniform_energy_factor, :float) unless @uniform_energy_factor.nil?
+      XMLHelper.add_element(water_heating_system, 'FirstHourRating', @first_hour_rating, :float) unless @first_hour_rating.nil?
+      XMLHelper.add_element(water_heating_system, 'RecoveryEfficiency', @recovery_efficiency, :float, @recovery_efficiency_isdefaulted) unless @recovery_efficiency.nil?
       if not @jacket_r_value.nil?
         water_heater_insulation = XMLHelper.add_element(water_heating_system, 'WaterHeaterInsulation')
         jacket = XMLHelper.add_element(water_heater_insulation, 'Jacket')
-        XMLHelper.add_element(jacket, 'JacketRValue', @jacket_r_value)
+        XMLHelper.add_element(jacket, 'JacketRValue', @jacket_r_value, :float)
       end
-      XMLHelper.add_element(water_heating_system, 'StandbyLoss', to_float(@standby_loss), @standby_loss_isdefaulted) unless @standby_loss.nil?
-      XMLHelper.add_element(water_heating_system, 'HotWaterTemperature', to_float(@temperature), @temperature_isdefaulted) unless @temperature.nil?
-      XMLHelper.add_element(water_heating_system, 'UsesDesuperheater', to_boolean(@uses_desuperheater)) unless @uses_desuperheater.nil?
+      XMLHelper.add_element(water_heating_system, 'StandbyLoss', @standby_loss, :float, @standby_loss_isdefaulted) unless @standby_loss.nil?
+      XMLHelper.add_element(water_heating_system, 'HotWaterTemperature', @temperature, :float, @temperature_isdefaulted) unless @temperature.nil?
+      XMLHelper.add_element(water_heating_system, 'UsesDesuperheater', @uses_desuperheater, :boolean) unless @uses_desuperheater.nil?
       if not @related_hvac_idref.nil?
         related_hvac_idref_el = XMLHelper.add_element(water_heating_system, 'RelatedHVACSystem')
         XMLHelper.add_attribute(related_hvac_idref_el, 'idref', @related_hvac_idref)
@@ -3609,9 +3609,9 @@ class HPXML < Object
 
       @id = HPXML::get_id(water_heating_system)
       @year_installed = XMLHelper.get_value(water_heating_system, 'YearInstalled', :integer)
-      @fuel_type = XMLHelper.get_value(water_heating_system, 'FuelType')
-      @water_heater_type = XMLHelper.get_value(water_heating_system, 'WaterHeaterType')
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'Location')
+      @fuel_type = XMLHelper.get_value(water_heating_system, 'FuelType', :string)
+      @water_heater_type = XMLHelper.get_value(water_heating_system, 'WaterHeaterType', :string)
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'Location', :string)
       @is_shared_system, @is_shared_system_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'IsSharedSystem', :boolean)
       @number_of_units_served = XMLHelper.get_value(water_heating_system, 'NumberofUnitsServed', :integer)
       @performance_adjustment, @performance_adjustment_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'PerformanceAdjustment', :float)
@@ -3625,7 +3625,7 @@ class HPXML < Object
       @uses_desuperheater = XMLHelper.get_value(water_heating_system, 'UsesDesuperheater', :boolean)
       @jacket_r_value = XMLHelper.get_value(water_heating_system, 'WaterHeaterInsulation/Jacket/JacketRValue', :float)
       @related_hvac_idref = HPXML::get_idref(XMLHelper.get_element(water_heating_system, 'RelatedHVACSystem'))
-      @energy_star = XMLHelper.get_values(water_heating_system, 'ThirdPartyCertification').include?('Energy Star')
+      @energy_star = XMLHelper.get_values(water_heating_system, 'ThirdPartyCertification', :string).include?('Energy Star')
       @standby_loss, @standby_loss_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'StandbyLoss', :float)
       @temperature, @temperature_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'HotWaterTemperature', :float)
     end
@@ -3673,33 +3673,33 @@ class HPXML < Object
         system_type_e = XMLHelper.add_element(hot_water_distribution, 'SystemType')
         if @system_type == DHWDistTypeStandard
           standard = XMLHelper.add_element(system_type_e, @system_type)
-          XMLHelper.add_element(standard, 'PipingLength', to_float(@standard_piping_length), @standard_piping_length_isdefaulted) unless @standard_piping_length.nil?
+          XMLHelper.add_element(standard, 'PipingLength', @standard_piping_length, :float, @standard_piping_length_isdefaulted) unless @standard_piping_length.nil?
         elsif system_type == DHWDistTypeRecirc
           recirculation = XMLHelper.add_element(system_type_e, @system_type)
-          XMLHelper.add_element(recirculation, 'ControlType', @recirculation_control_type) unless @recirculation_control_type.nil?
-          XMLHelper.add_element(recirculation, 'RecirculationPipingLoopLength', to_float(@recirculation_piping_length), @recirculation_piping_length_isdefaulted) unless @recirculation_piping_length.nil?
-          XMLHelper.add_element(recirculation, 'BranchPipingLoopLength', to_float(@recirculation_branch_piping_length), @recirculation_branch_piping_length_isdefaulted) unless @recirculation_branch_piping_length.nil?
-          XMLHelper.add_element(recirculation, 'PumpPower', to_float(@recirculation_pump_power), @recirculation_pump_power_isdefaulted) unless @recirculation_pump_power.nil?
+          XMLHelper.add_element(recirculation, 'ControlType', @recirculation_control_type, :string) unless @recirculation_control_type.nil?
+          XMLHelper.add_element(recirculation, 'RecirculationPipingLoopLength', @recirculation_piping_length, :float, @recirculation_piping_length_isdefaulted) unless @recirculation_piping_length.nil?
+          XMLHelper.add_element(recirculation, 'BranchPipingLoopLength', @recirculation_branch_piping_length, :float, @recirculation_branch_piping_length_isdefaulted) unless @recirculation_branch_piping_length.nil?
+          XMLHelper.add_element(recirculation, 'PumpPower', @recirculation_pump_power, :float, @recirculation_pump_power_isdefaulted) unless @recirculation_pump_power.nil?
         else
           fail "Unhandled hot water distribution type '#{@system_type}'."
         end
       end
       if not @pipe_r_value.nil?
         pipe_insulation = XMLHelper.add_element(hot_water_distribution, 'PipeInsulation')
-        XMLHelper.add_element(pipe_insulation, 'PipeRValue', to_float(@pipe_r_value))
+        XMLHelper.add_element(pipe_insulation, 'PipeRValue', @pipe_r_value, :float)
       end
       if (not @dwhr_facilities_connected.nil?) || (not @dwhr_equal_flow.nil?) || (not @dwhr_efficiency.nil?)
         drain_water_heat_recovery = XMLHelper.add_element(hot_water_distribution, 'DrainWaterHeatRecovery')
-        XMLHelper.add_element(drain_water_heat_recovery, 'FacilitiesConnected', @dwhr_facilities_connected) unless @dwhr_facilities_connected.nil?
-        XMLHelper.add_element(drain_water_heat_recovery, 'EqualFlow', to_boolean(@dwhr_equal_flow)) unless @dwhr_equal_flow.nil?
-        XMLHelper.add_element(drain_water_heat_recovery, 'Efficiency', to_float(@dwhr_efficiency)) unless @dwhr_efficiency.nil?
+        XMLHelper.add_element(drain_water_heat_recovery, 'FacilitiesConnected', @dwhr_facilities_connected, :string) unless @dwhr_facilities_connected.nil?
+        XMLHelper.add_element(drain_water_heat_recovery, 'EqualFlow', @dwhr_equal_flow, :boolean) unless @dwhr_equal_flow.nil?
+        XMLHelper.add_element(drain_water_heat_recovery, 'Efficiency', @dwhr_efficiency, :float) unless @dwhr_efficiency.nil?
       end
       if @has_shared_recirculation
         extension = XMLHelper.create_elements_as_needed(hot_water_distribution, ['extension'])
         shared_recirculation = XMLHelper.add_element(extension, 'SharedRecirculation')
-        XMLHelper.add_element(shared_recirculation, 'NumberofUnitsServed', to_integer(@shared_recirculation_number_of_units_served)) unless @shared_recirculation_number_of_units_served.nil?
-        XMLHelper.add_element(shared_recirculation, 'PumpPower', to_float(@shared_recirculation_pump_power), @shared_recirculation_pump_power_isdefaulted) unless @shared_recirculation_pump_power.nil?
-        XMLHelper.add_element(shared_recirculation, 'ControlType', @shared_recirculation_control_type) unless @shared_recirculation_control_type.nil?
+        XMLHelper.add_element(shared_recirculation, 'NumberofUnitsServed', @shared_recirculation_number_of_units_served, :integer) unless @shared_recirculation_number_of_units_served.nil?
+        XMLHelper.add_element(shared_recirculation, 'PumpPower', @shared_recirculation_pump_power, :float, @shared_recirculation_pump_power_isdefaulted) unless @shared_recirculation_pump_power.nil?
+        XMLHelper.add_element(shared_recirculation, 'ControlType', @shared_recirculation_control_type, :string) unless @shared_recirculation_control_type.nil?
       end
     end
 
@@ -3712,19 +3712,19 @@ class HPXML < Object
       if @system_type == 'Standard'
         @standard_piping_length, @standard_piping_length_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Standard/PipingLength', :float)
       elsif @system_type == 'Recirculation'
-        @recirculation_control_type = XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/ControlType')
+        @recirculation_control_type = XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/ControlType', :string)
         @recirculation_piping_length, @recirculation_piping_length_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Recirculation/RecirculationPipingLoopLength', :float)
         @recirculation_branch_piping_length, @recirculation_branch_piping_length_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Recirculation/BranchPipingLoopLength', :float)
         @recirculation_pump_power, @recirculation_pump_power_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Recirculation/PumpPower', :float)
       end
-      @dwhr_facilities_connected = XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/FacilitiesConnected')
+      @dwhr_facilities_connected = XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/FacilitiesConnected', :string)
       @dwhr_equal_flow = XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/EqualFlow', :boolean)
       @dwhr_efficiency = XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/Efficiency', :float)
       @has_shared_recirculation = XMLHelper.has_element(hot_water_distribution, 'extension/SharedRecirculation')
       if @has_shared_recirculation
         @shared_recirculation_number_of_units_served = XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/NumberofUnitsServed', :integer)
         @shared_recirculation_pump_power, @shared_recirculation_pump_power_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'extension/SharedRecirculation/PumpPower', :float)
-        @shared_recirculation_control_type = XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/ControlType')
+        @shared_recirculation_control_type = XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/ControlType', :string)
       end
     end
   end
@@ -3763,15 +3763,15 @@ class HPXML < Object
       water_fixture = XMLHelper.add_element(water_heating, 'WaterFixture')
       sys_id = XMLHelper.add_element(water_fixture, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(water_fixture, 'WaterFixtureType', @water_fixture_type) unless @water_fixture_type.nil?
-      XMLHelper.add_element(water_fixture, 'LowFlow', to_boolean(@low_flow)) unless @low_flow.nil?
+      XMLHelper.add_element(water_fixture, 'WaterFixtureType', @water_fixture_type, :string) unless @water_fixture_type.nil?
+      XMLHelper.add_element(water_fixture, 'LowFlow', @low_flow, :boolean) unless @low_flow.nil?
     end
 
     def from_oga(water_fixture)
       return if water_fixture.nil?
 
       @id = HPXML::get_id(water_fixture)
-      @water_fixture_type = XMLHelper.get_value(water_fixture, 'WaterFixtureType')
+      @water_fixture_type = XMLHelper.get_value(water_fixture, 'WaterFixtureType', :string)
       @low_flow = XMLHelper.get_value(water_fixture, 'LowFlow', :boolean)
     end
   end
@@ -3789,7 +3789,7 @@ class HPXML < Object
       return if nil?
 
       water_heating = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Systems', 'WaterHeating'])
-      XMLHelper.add_extension(water_heating, 'WaterFixturesUsageMultiplier', to_float(@water_fixtures_usage_multiplier), @water_fixtures_usage_multiplier_isdefaulted) unless @water_fixtures_usage_multiplier.nil?
+      XMLHelper.add_extension(water_heating, 'WaterFixturesUsageMultiplier', @water_fixtures_usage_multiplier, :float, @water_fixtures_usage_multiplier_isdefaulted) unless @water_fixtures_usage_multiplier.nil?
     end
 
     def from_oga(hpxml)
@@ -3850,31 +3850,31 @@ class HPXML < Object
       solar_thermal_system = XMLHelper.add_element(solar_thermal, 'SolarThermalSystem')
       sys_id = XMLHelper.add_element(solar_thermal_system, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(solar_thermal_system, 'SystemType', @system_type) unless @system_type.nil?
-      XMLHelper.add_element(solar_thermal_system, 'CollectorArea', to_float(@collector_area)) unless @collector_area.nil?
-      XMLHelper.add_element(solar_thermal_system, 'CollectorLoopType', @collector_loop_type) unless @collector_loop_type.nil?
-      XMLHelper.add_element(solar_thermal_system, 'CollectorType', @collector_type) unless @collector_type.nil?
-      XMLHelper.add_element(solar_thermal_system, 'CollectorAzimuth', to_integer(@collector_azimuth)) unless @collector_azimuth.nil?
-      XMLHelper.add_element(solar_thermal_system, 'CollectorTilt', to_float(@collector_tilt)) unless @collector_tilt.nil?
-      XMLHelper.add_element(solar_thermal_system, 'CollectorRatedOpticalEfficiency', to_float(@collector_frta)) unless @collector_frta.nil?
-      XMLHelper.add_element(solar_thermal_system, 'CollectorRatedThermalLosses', to_float(@collector_frul)) unless @collector_frul.nil?
-      XMLHelper.add_element(solar_thermal_system, 'StorageVolume', to_float(@storage_volume), @storage_volume_isdefaulted) unless @storage_volume.nil?
+      XMLHelper.add_element(solar_thermal_system, 'SystemType', @system_type, :string) unless @system_type.nil?
+      XMLHelper.add_element(solar_thermal_system, 'CollectorArea', @collector_area, :float) unless @collector_area.nil?
+      XMLHelper.add_element(solar_thermal_system, 'CollectorLoopType', @collector_loop_type, :string) unless @collector_loop_type.nil?
+      XMLHelper.add_element(solar_thermal_system, 'CollectorType', @collector_type, :string) unless @collector_type.nil?
+      XMLHelper.add_element(solar_thermal_system, 'CollectorAzimuth', @collector_azimuth, :integer) unless @collector_azimuth.nil?
+      XMLHelper.add_element(solar_thermal_system, 'CollectorTilt', @collector_tilt, :float) unless @collector_tilt.nil?
+      XMLHelper.add_element(solar_thermal_system, 'CollectorRatedOpticalEfficiency', @collector_frta, :float) unless @collector_frta.nil?
+      XMLHelper.add_element(solar_thermal_system, 'CollectorRatedThermalLosses', @collector_frul, :float) unless @collector_frul.nil?
+      XMLHelper.add_element(solar_thermal_system, 'StorageVolume', @storage_volume, :float, @storage_volume_isdefaulted) unless @storage_volume.nil?
       if not @water_heating_system_idref.nil?
         connected_to = XMLHelper.add_element(solar_thermal_system, 'ConnectedTo')
         XMLHelper.add_attribute(connected_to, 'idref', @water_heating_system_idref)
       end
-      XMLHelper.add_element(solar_thermal_system, 'SolarFraction', to_float(@solar_fraction)) unless @solar_fraction.nil?
+      XMLHelper.add_element(solar_thermal_system, 'SolarFraction', @solar_fraction, :float) unless @solar_fraction.nil?
     end
 
     def from_oga(solar_thermal_system)
       return if solar_thermal_system.nil?
 
       @id = HPXML::get_id(solar_thermal_system)
-      @system_type = XMLHelper.get_value(solar_thermal_system, 'SystemType')
+      @system_type = XMLHelper.get_value(solar_thermal_system, 'SystemType', :string)
       @collector_area = XMLHelper.get_value(solar_thermal_system, 'CollectorArea', :float)
-      @collector_loop_type = XMLHelper.get_value(solar_thermal_system, 'CollectorLoopType')
+      @collector_loop_type = XMLHelper.get_value(solar_thermal_system, 'CollectorLoopType', :string)
       @collector_azimuth = XMLHelper.get_value(solar_thermal_system, 'CollectorAzimuth', :integer)
-      @collector_type = XMLHelper.get_value(solar_thermal_system, 'CollectorType')
+      @collector_type = XMLHelper.get_value(solar_thermal_system, 'CollectorType', :string)
       @collector_tilt = XMLHelper.get_value(solar_thermal_system, 'CollectorTilt', :float)
       @collector_frta = XMLHelper.get_value(solar_thermal_system, 'CollectorRatedOpticalEfficiency', :float)
       @collector_frul = XMLHelper.get_value(solar_thermal_system, 'CollectorRatedThermalLosses', :float)
@@ -3920,17 +3920,17 @@ class HPXML < Object
       pv_system = XMLHelper.add_element(photovoltaics, 'PVSystem')
       sys_id = XMLHelper.add_element(pv_system, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(pv_system, 'IsSharedSystem', to_boolean(@is_shared_system), @is_shared_system_isdefaulted) unless @is_shared_system.nil?
-      XMLHelper.add_element(pv_system, 'Location', @location, @location_isdefaulted) unless @location.nil?
-      XMLHelper.add_element(pv_system, 'ModuleType', @module_type, @module_type_isdefaulted) unless @module_type.nil?
-      XMLHelper.add_element(pv_system, 'Tracking', @tracking, @tracking_isdefaulted) unless @tracking.nil?
-      XMLHelper.add_element(pv_system, 'ArrayAzimuth', to_integer(@array_azimuth)) unless @array_azimuth.nil?
-      XMLHelper.add_element(pv_system, 'ArrayTilt', to_float(@array_tilt)) unless @array_tilt.nil?
-      XMLHelper.add_element(pv_system, 'MaxPowerOutput', to_float(@max_power_output)) unless @max_power_output.nil?
-      XMLHelper.add_element(pv_system, 'InverterEfficiency', to_float(@inverter_efficiency), @inverter_efficiency_isdefaulted) unless @inverter_efficiency.nil?
-      XMLHelper.add_element(pv_system, 'SystemLossesFraction', to_float(@system_losses_fraction), @system_losses_fraction_isdefaulted) unless @system_losses_fraction.nil?
-      XMLHelper.add_element(pv_system, 'YearModulesManufactured', to_integer(@year_modules_manufactured)) unless @year_modules_manufactured.nil?
-      XMLHelper.add_extension(pv_system, 'NumberofBedroomsServed', to_integer(@number_of_bedrooms_served)) unless @number_of_bedrooms_served.nil?
+      XMLHelper.add_element(pv_system, 'IsSharedSystem', @is_shared_system, :boolean, @is_shared_system_isdefaulted) unless @is_shared_system.nil?
+      XMLHelper.add_element(pv_system, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(pv_system, 'ModuleType', @module_type, :string, @module_type_isdefaulted) unless @module_type.nil?
+      XMLHelper.add_element(pv_system, 'Tracking', @tracking, :string, @tracking_isdefaulted) unless @tracking.nil?
+      XMLHelper.add_element(pv_system, 'ArrayAzimuth', @array_azimuth, :integer) unless @array_azimuth.nil?
+      XMLHelper.add_element(pv_system, 'ArrayTilt', @array_tilt, :float) unless @array_tilt.nil?
+      XMLHelper.add_element(pv_system, 'MaxPowerOutput', @max_power_output, :float) unless @max_power_output.nil?
+      XMLHelper.add_element(pv_system, 'InverterEfficiency', @inverter_efficiency, :float, @inverter_efficiency_isdefaulted) unless @inverter_efficiency.nil?
+      XMLHelper.add_element(pv_system, 'SystemLossesFraction', @system_losses_fraction, :float, @system_losses_fraction_isdefaulted) unless @system_losses_fraction.nil?
+      XMLHelper.add_element(pv_system, 'YearModulesManufactured', @year_modules_manufactured, :integer) unless @year_modules_manufactured.nil?
+      XMLHelper.add_extension(pv_system, 'NumberofBedroomsServed', @number_of_bedrooms_served, :integer) unless @number_of_bedrooms_served.nil?
     end
 
     def from_oga(pv_system)
@@ -3938,10 +3938,10 @@ class HPXML < Object
 
       @id = HPXML::get_id(pv_system)
       @is_shared_system, @is_shared_system_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'IsSharedSystem', :boolean)
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'Location')
-      @module_type, @module_type_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'ModuleType')
-      @tracking, @tracking_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'Tracking')
-      @array_orientation = XMLHelper.get_value(pv_system, 'ArrayOrientation')
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'Location', :string)
+      @module_type, @module_type_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'ModuleType', :string)
+      @tracking, @tracking_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'Tracking', :string)
+      @array_orientation = XMLHelper.get_value(pv_system, 'ArrayOrientation', :string)
       @array_azimuth = XMLHelper.get_value(pv_system, 'ArrayAzimuth', :integer)
       @array_tilt = XMLHelper.get_value(pv_system, 'ArrayTilt', :float)
       @max_power_output = XMLHelper.get_value(pv_system, 'MaxPowerOutput', :float)
@@ -4002,23 +4002,23 @@ class HPXML < Object
       clothes_washer = XMLHelper.add_element(appliances, 'ClothesWasher')
       sys_id = XMLHelper.add_element(clothes_washer, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(clothes_washer, 'NumberofUnits', to_integer(@number_of_units)) unless @number_of_units.nil?
-      XMLHelper.add_element(clothes_washer, 'IsSharedAppliance', to_boolean(@is_shared_appliance), @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
-      XMLHelper.add_element(clothes_washer, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
+      XMLHelper.add_element(clothes_washer, 'NumberofUnits', @number_of_units, :integer) unless @number_of_units.nil?
+      XMLHelper.add_element(clothes_washer, 'IsSharedAppliance', @is_shared_appliance, :boolean, @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
+      XMLHelper.add_element(clothes_washer, 'NumberofUnitsServed', @number_of_units_served, :integer) unless @number_of_units_served.nil?
       if not @water_heating_system_idref.nil?
         attached_water_heater = XMLHelper.add_element(clothes_washer, 'AttachedToWaterHeatingSystem')
         XMLHelper.add_attribute(attached_water_heater, 'idref', @water_heating_system_idref)
       end
-      XMLHelper.add_element(clothes_washer, 'Location', @location, @location_isdefaulted) unless @location.nil?
-      XMLHelper.add_element(clothes_washer, 'ModifiedEnergyFactor', to_float(@modified_energy_factor)) unless @modified_energy_factor.nil?
-      XMLHelper.add_element(clothes_washer, 'IntegratedModifiedEnergyFactor', to_float(@integrated_modified_energy_factor), @integrated_modified_energy_factor_isdefaulted) unless @integrated_modified_energy_factor.nil?
-      XMLHelper.add_element(clothes_washer, 'RatedAnnualkWh', to_float(@rated_annual_kwh), @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
-      XMLHelper.add_element(clothes_washer, 'LabelElectricRate', to_float(@label_electric_rate), @label_electric_rate_isdefaulted) unless @label_electric_rate.nil?
-      XMLHelper.add_element(clothes_washer, 'LabelGasRate', to_float(@label_gas_rate), @label_gas_rate_isdefaulted) unless @label_gas_rate.nil?
-      XMLHelper.add_element(clothes_washer, 'LabelAnnualGasCost', to_float(@label_annual_gas_cost), @label_annual_gas_cost_isdefaulted) unless @label_annual_gas_cost.nil?
-      XMLHelper.add_element(clothes_washer, 'LabelUsage', to_float(@label_usage), @label_usage_isdefaulted) unless @label_usage.nil?
-      XMLHelper.add_element(clothes_washer, 'Capacity', to_float(@capacity), @capacity_isdefaulted) unless @capacity.nil?
-      XMLHelper.add_extension(clothes_washer, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_element(clothes_washer, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(clothes_washer, 'ModifiedEnergyFactor', @modified_energy_factor, :float) unless @modified_energy_factor.nil?
+      XMLHelper.add_element(clothes_washer, 'IntegratedModifiedEnergyFactor', @integrated_modified_energy_factor, :float, @integrated_modified_energy_factor_isdefaulted) unless @integrated_modified_energy_factor.nil?
+      XMLHelper.add_element(clothes_washer, 'RatedAnnualkWh', @rated_annual_kwh, :float, @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(clothes_washer, 'LabelElectricRate', @label_electric_rate, :float, @label_electric_rate_isdefaulted) unless @label_electric_rate.nil?
+      XMLHelper.add_element(clothes_washer, 'LabelGasRate', @label_gas_rate, :float, @label_gas_rate_isdefaulted) unless @label_gas_rate.nil?
+      XMLHelper.add_element(clothes_washer, 'LabelAnnualGasCost', @label_annual_gas_cost, :float, @label_annual_gas_cost_isdefaulted) unless @label_annual_gas_cost.nil?
+      XMLHelper.add_element(clothes_washer, 'LabelUsage', @label_usage, :float, @label_usage_isdefaulted) unless @label_usage.nil?
+      XMLHelper.add_element(clothes_washer, 'Capacity', @capacity, :float, @capacity_isdefaulted) unless @capacity.nil?
+      XMLHelper.add_extension(clothes_washer, 'UsageMultiplier', @usage_multiplier, :float, @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
     end
 
     def from_oga(clothes_washer)
@@ -4028,7 +4028,7 @@ class HPXML < Object
       @number_of_units = XMLHelper.get_value(clothes_washer, 'NumberofUnits', :integer)
       @is_shared_appliance, @is_shared_appliance_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'IsSharedAppliance', :boolean)
       @number_of_units_served = XMLHelper.get_value(clothes_washer, 'NumberofUnitsServed', :integer)
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'Location')
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'Location', :string)
       @modified_energy_factor = XMLHelper.get_value(clothes_washer, 'ModifiedEnergyFactor', :float)
       @integrated_modified_energy_factor, @integrated_modified_energy_factor_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'IntegratedModifiedEnergyFactor', :float)
       @rated_annual_kwh, @rated_annual_kwh_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'RatedAnnualkWh', :float)
@@ -4078,17 +4078,17 @@ class HPXML < Object
       clothes_dryer = XMLHelper.add_element(appliances, 'ClothesDryer')
       sys_id = XMLHelper.add_element(clothes_dryer, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(clothes_dryer, 'NumberofUnits', to_integer(@number_of_units)) unless @number_of_units.nil?
-      XMLHelper.add_element(clothes_dryer, 'IsSharedAppliance', to_boolean(@is_shared_appliance), @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
-      XMLHelper.add_element(clothes_dryer, 'NumberofUnitsServed', to_integer(@number_of_units_served)) unless @number_of_units_served.nil?
-      XMLHelper.add_element(clothes_dryer, 'Location', @location, @location_isdefaulted) unless @location.nil?
-      XMLHelper.add_element(clothes_dryer, 'FuelType', @fuel_type) unless @fuel_type.nil?
-      XMLHelper.add_element(clothes_dryer, 'EnergyFactor', to_float(@energy_factor)) unless @energy_factor.nil?
-      XMLHelper.add_element(clothes_dryer, 'CombinedEnergyFactor', to_float(@combined_energy_factor), @combined_energy_factor_isdefaulted) unless @combined_energy_factor.nil?
-      XMLHelper.add_element(clothes_dryer, 'ControlType', @control_type, @control_type_isdefaulted) unless @control_type.nil?
-      XMLHelper.add_extension(clothes_dryer, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(clothes_dryer, 'IsVented', to_boolean(@is_vented), @is_vented_isdefaulted) unless @is_vented.nil?
-      XMLHelper.add_extension(clothes_dryer, 'VentedFlowRate', to_float(@vented_flow_rate), @vented_flow_rate_isdefaulted) unless @vented_flow_rate.nil?
+      XMLHelper.add_element(clothes_dryer, 'NumberofUnits', @number_of_units, :integer) unless @number_of_units.nil?
+      XMLHelper.add_element(clothes_dryer, 'IsSharedAppliance', @is_shared_appliance, :boolean, @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
+      XMLHelper.add_element(clothes_dryer, 'NumberofUnitsServed', @number_of_units_served, :integer) unless @number_of_units_served.nil?
+      XMLHelper.add_element(clothes_dryer, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(clothes_dryer, 'FuelType', @fuel_type, :string) unless @fuel_type.nil?
+      XMLHelper.add_element(clothes_dryer, 'EnergyFactor', @energy_factor, :float) unless @energy_factor.nil?
+      XMLHelper.add_element(clothes_dryer, 'CombinedEnergyFactor', @combined_energy_factor, :float, @combined_energy_factor_isdefaulted) unless @combined_energy_factor.nil?
+      XMLHelper.add_element(clothes_dryer, 'ControlType', @control_type, :string, @control_type_isdefaulted) unless @control_type.nil?
+      XMLHelper.add_extension(clothes_dryer, 'UsageMultiplier', @usage_multiplier, :float, @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(clothes_dryer, 'IsVented', @is_vented, :boolean, @is_vented_isdefaulted) unless @is_vented.nil?
+      XMLHelper.add_extension(clothes_dryer, 'VentedFlowRate', @vented_flow_rate, :float, @vented_flow_rate_isdefaulted) unless @vented_flow_rate.nil?
     end
 
     def from_oga(clothes_dryer)
@@ -4098,11 +4098,11 @@ class HPXML < Object
       @number_of_units = XMLHelper.get_value(clothes_dryer, 'NumberofUnits', :integer)
       @is_shared_appliance, @is_shared_appliance_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'IsSharedAppliance', :boolean)
       @number_of_units_served = XMLHelper.get_value(clothes_dryer, 'NumberofUnitsServed', :integer)
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'Location')
-      @fuel_type = XMLHelper.get_value(clothes_dryer, 'FuelType')
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'Location', :string)
+      @fuel_type = XMLHelper.get_value(clothes_dryer, 'FuelType', :string)
       @energy_factor = XMLHelper.get_value(clothes_dryer, 'EnergyFactor', :float)
       @combined_energy_factor, @combined_energy_factor_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'CombinedEnergyFactor', :float)
-      @control_type, @control_type_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'ControlType')
+      @control_type, @control_type_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'ControlType', :string)
       @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'extension/UsageMultiplier', :float)
       @is_vented, @is_vented_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'extension/IsVented', :boolean)
       @vented_flow_rate, @vented_flow_rate_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'extension/VentedFlowRate', :float)
@@ -4157,20 +4157,20 @@ class HPXML < Object
       dishwasher = XMLHelper.add_element(appliances, 'Dishwasher')
       sys_id = XMLHelper.add_element(dishwasher, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(dishwasher, 'IsSharedAppliance', to_boolean(@is_shared_appliance), @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
+      XMLHelper.add_element(dishwasher, 'IsSharedAppliance', @is_shared_appliance, :boolean, @is_shared_appliance_isdefaulted) unless @is_shared_appliance.nil?
       if not @water_heating_system_idref.nil?
         attached_water_heater = XMLHelper.add_element(dishwasher, 'AttachedToWaterHeatingSystem')
         XMLHelper.add_attribute(attached_water_heater, 'idref', @water_heating_system_idref)
       end
-      XMLHelper.add_element(dishwasher, 'Location', @location, @location_isdefaulted) unless @location.nil?
-      XMLHelper.add_element(dishwasher, 'RatedAnnualkWh', to_float(@rated_annual_kwh), @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
-      XMLHelper.add_element(dishwasher, 'EnergyFactor', to_float(@energy_factor)) unless @energy_factor.nil?
-      XMLHelper.add_element(dishwasher, 'PlaceSettingCapacity', to_integer(@place_setting_capacity), @place_setting_capacity_isdefaulted) unless @place_setting_capacity.nil?
-      XMLHelper.add_element(dishwasher, 'LabelElectricRate', to_float(@label_electric_rate), @label_electric_rate_isdefaulted) unless @label_electric_rate.nil?
-      XMLHelper.add_element(dishwasher, 'LabelGasRate', to_float(@label_gas_rate), @label_gas_rate_isdefaulted) unless @label_gas_rate.nil?
-      XMLHelper.add_element(dishwasher, 'LabelAnnualGasCost', to_float(@label_annual_gas_cost), @label_annual_gas_cost_isdefaulted) unless @label_annual_gas_cost.nil?
-      XMLHelper.add_element(dishwasher, 'LabelUsage', to_float(@label_usage), @label_usage_isdefaulted) unless @label_usage.nil?
-      XMLHelper.add_extension(dishwasher, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_element(dishwasher, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(dishwasher, 'RatedAnnualkWh', @rated_annual_kwh, :float, @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(dishwasher, 'EnergyFactor', @energy_factor, :float) unless @energy_factor.nil?
+      XMLHelper.add_element(dishwasher, 'PlaceSettingCapacity', @place_setting_capacity, :integer, @place_setting_capacity_isdefaulted) unless @place_setting_capacity.nil?
+      XMLHelper.add_element(dishwasher, 'LabelElectricRate', @label_electric_rate, :float, @label_electric_rate_isdefaulted) unless @label_electric_rate.nil?
+      XMLHelper.add_element(dishwasher, 'LabelGasRate', @label_gas_rate, :float, @label_gas_rate_isdefaulted) unless @label_gas_rate.nil?
+      XMLHelper.add_element(dishwasher, 'LabelAnnualGasCost', @label_annual_gas_cost, :float, @label_annual_gas_cost_isdefaulted) unless @label_annual_gas_cost.nil?
+      XMLHelper.add_element(dishwasher, 'LabelUsage', @label_usage, :float, @label_usage_isdefaulted) unless @label_usage.nil?
+      XMLHelper.add_extension(dishwasher, 'UsageMultiplier', @usage_multiplier, :float, @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
     end
 
     def from_oga(dishwasher)
@@ -4178,7 +4178,7 @@ class HPXML < Object
 
       @id = HPXML::get_id(dishwasher)
       @is_shared_appliance, @is_shared_appliance_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'IsSharedAppliance', :boolean)
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'Location')
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'Location', :string)
       @rated_annual_kwh, @rated_annual_kwh_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'RatedAnnualkWh', :float)
       @energy_factor = XMLHelper.get_value(dishwasher, 'EnergyFactor', :float)
       @place_setting_capacity, @place_setting_capacity_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'PlaceSettingCapacity', :integer)
@@ -4238,28 +4238,28 @@ class HPXML < Object
       refrigerator = XMLHelper.add_element(appliances, 'Refrigerator')
       sys_id = XMLHelper.add_element(refrigerator, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(refrigerator, 'Location', @location, @location_isdefaulted) unless @location.nil?
-      XMLHelper.add_element(refrigerator, 'RatedAnnualkWh', to_float(@rated_annual_kwh), @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
-      XMLHelper.add_element(refrigerator, 'PrimaryIndicator', to_boolean(@primary_indicator), @primary_indicator_isdefaulted) unless @primary_indicator.nil?
-      XMLHelper.add_extension(refrigerator, 'AdjustedAnnualkWh', to_float(@adjusted_annual_kwh)) unless @adjusted_annual_kwh.nil?
-      XMLHelper.add_extension(refrigerator, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(refrigerator, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(refrigerator, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(refrigerator, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
+      XMLHelper.add_element(refrigerator, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(refrigerator, 'RatedAnnualkWh', @rated_annual_kwh, :float, @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
+      XMLHelper.add_element(refrigerator, 'PrimaryIndicator', @primary_indicator, :boolean, @primary_indicator_isdefaulted) unless @primary_indicator.nil?
+      XMLHelper.add_extension(refrigerator, 'AdjustedAnnualkWh', @adjusted_annual_kwh, :float) unless @adjusted_annual_kwh.nil?
+      XMLHelper.add_extension(refrigerator, 'UsageMultiplier', @usage_multiplier, :float, @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(refrigerator, 'WeekdayScheduleFractions', @weekday_fractions, :string, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(refrigerator, 'WeekendScheduleFractions', @weekend_fractions, :string, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(refrigerator, 'MonthlyScheduleMultipliers', @monthly_multipliers, :string, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(refrigerator)
       return if refrigerator.nil?
 
       @id = HPXML::get_id(refrigerator)
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'Location')
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'Location', :string)
       @rated_annual_kwh, @rated_annual_kwh_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'RatedAnnualkWh', :float)
       @primary_indicator, @primary_indicator_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'PrimaryIndicator', :boolean)
       @adjusted_annual_kwh = XMLHelper.get_value(refrigerator, 'extension/AdjustedAnnualkWh', :float)
       @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/UsageMultiplier', :float)
-      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/WeekdayScheduleFractions')
-      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/WeekendScheduleFractions')
-      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/MonthlyScheduleMultipliers')
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/WeekdayScheduleFractions', :string)
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/WeekendScheduleFractions', :string)
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/MonthlyScheduleMultipliers', :string)
     end
   end
 
@@ -4298,26 +4298,26 @@ class HPXML < Object
       freezer = XMLHelper.add_element(appliances, 'Freezer')
       sys_id = XMLHelper.add_element(freezer, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(freezer, 'Location', @location, @location_isdefaulted) unless @location.nil?
-      XMLHelper.add_element(freezer, 'RatedAnnualkWh', to_float(@rated_annual_kwh), @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
-      XMLHelper.add_extension(freezer, 'AdjustedAnnualkWh', to_float(@adjusted_annual_kwh)) unless @adjusted_annual_kwh.nil?
-      XMLHelper.add_extension(freezer, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(freezer, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(freezer, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(freezer, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
+      XMLHelper.add_element(freezer, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(freezer, 'RatedAnnualkWh', @rated_annual_kwh, :float, @rated_annual_kwh_isdefaulted) unless @rated_annual_kwh.nil?
+      XMLHelper.add_extension(freezer, 'AdjustedAnnualkWh', @adjusted_annual_kwh, :float) unless @adjusted_annual_kwh.nil?
+      XMLHelper.add_extension(freezer, 'UsageMultiplier', @usage_multiplier, :float, @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(freezer, 'WeekdayScheduleFractions', @weekday_fractions, :string, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(freezer, 'WeekendScheduleFractions', @weekend_fractions, :string, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(freezer, 'MonthlyScheduleMultipliers', @monthly_multipliers, :string, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(freezer)
       return if freezer.nil?
 
       @id = HPXML::get_id(freezer)
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'Location')
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'Location', :string)
       @rated_annual_kwh, @rated_annual_kwh_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'RatedAnnualkWh', :float)
       @adjusted_annual_kwh = XMLHelper.get_value(freezer, 'extension/AdjustedAnnualkWh', :float)
       @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/UsageMultiplier', :float)
-      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/WeekdayScheduleFractions')
-      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/WeekendScheduleFractions')
-      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/MonthlyScheduleMultipliers')
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/WeekdayScheduleFractions', :string)
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/WeekendScheduleFractions', :string)
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/MonthlyScheduleMultipliers', :string)
     end
   end
 
@@ -4355,11 +4355,11 @@ class HPXML < Object
       dehumidifier = XMLHelper.add_element(appliances, 'Dehumidifier')
       sys_id = XMLHelper.add_element(dehumidifier, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(dehumidifier, 'Capacity', to_float(@capacity)) unless @capacity.nil?
-      XMLHelper.add_element(dehumidifier, 'EnergyFactor', to_float(@energy_factor)) unless @energy_factor.nil?
-      XMLHelper.add_element(dehumidifier, 'IntegratedEnergyFactor', to_float(@integrated_energy_factor)) unless @integrated_energy_factor.nil?
-      XMLHelper.add_element(dehumidifier, 'DehumidistatSetpoint', to_float(@rh_setpoint)) unless @rh_setpoint.nil?
-      XMLHelper.add_element(dehumidifier, 'FractionDehumidificationLoadServed', to_float(@fraction_served)) unless @fraction_served.nil?
+      XMLHelper.add_element(dehumidifier, 'Capacity', @capacity, :float) unless @capacity.nil?
+      XMLHelper.add_element(dehumidifier, 'EnergyFactor', @energy_factor, :float) unless @energy_factor.nil?
+      XMLHelper.add_element(dehumidifier, 'IntegratedEnergyFactor', @integrated_energy_factor, :float) unless @integrated_energy_factor.nil?
+      XMLHelper.add_element(dehumidifier, 'DehumidistatSetpoint', @rh_setpoint, :float) unless @rh_setpoint.nil?
+      XMLHelper.add_element(dehumidifier, 'FractionDehumidificationLoadServed', @fraction_served, :float) unless @fraction_served.nil?
     end
 
     def from_oga(dehumidifier)
@@ -4409,26 +4409,26 @@ class HPXML < Object
       cooking_range = XMLHelper.add_element(appliances, 'CookingRange')
       sys_id = XMLHelper.add_element(cooking_range, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(cooking_range, 'Location', @location, @location_isdefaulted) unless @location.nil?
-      XMLHelper.add_element(cooking_range, 'FuelType', @fuel_type) unless @fuel_type.nil?
-      XMLHelper.add_element(cooking_range, 'IsInduction', to_boolean(@is_induction), @is_induction_isdefaulted) unless @is_induction.nil?
-      XMLHelper.add_extension(cooking_range, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(cooking_range, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(cooking_range, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(cooking_range, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
+      XMLHelper.add_element(cooking_range, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(cooking_range, 'FuelType', @fuel_type, :string) unless @fuel_type.nil?
+      XMLHelper.add_element(cooking_range, 'IsInduction', @is_induction, :boolean, @is_induction_isdefaulted) unless @is_induction.nil?
+      XMLHelper.add_extension(cooking_range, 'UsageMultiplier', @usage_multiplier, :float, @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(cooking_range, 'WeekdayScheduleFractions', @weekday_fractions, :string, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(cooking_range, 'WeekendScheduleFractions', @weekend_fractions, :string, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(cooking_range, 'MonthlyScheduleMultipliers', @monthly_multipliers, :string, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(cooking_range)
       return if cooking_range.nil?
 
       @id = HPXML::get_id(cooking_range)
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'Location')
-      @fuel_type = XMLHelper.get_value(cooking_range, 'FuelType')
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'Location', :string)
+      @fuel_type = XMLHelper.get_value(cooking_range, 'FuelType', :string)
       @is_induction, @is_induction_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'IsInduction', :boolean)
       @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/UsageMultiplier', :float)
-      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/WeekdayScheduleFractions')
-      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/WeekendScheduleFractions')
-      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/MonthlyScheduleMultipliers')
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/WeekdayScheduleFractions', :string)
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/WeekendScheduleFractions', :string)
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/MonthlyScheduleMultipliers', :string)
     end
   end
 
@@ -4466,7 +4466,7 @@ class HPXML < Object
       oven = XMLHelper.add_element(appliances, 'Oven')
       sys_id = XMLHelper.add_element(oven, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(oven, 'IsConvection', to_boolean(@is_convection), @is_convection_isdefaulted) unless @is_convection.nil?
+      XMLHelper.add_element(oven, 'IsConvection', @is_convection, :boolean, @is_convection_isdefaulted) unless @is_convection.nil?
     end
 
     def from_oga(oven)
@@ -4511,8 +4511,8 @@ class HPXML < Object
       lighting_group = XMLHelper.add_element(lighting, 'LightingGroup')
       sys_id = XMLHelper.add_element(lighting_group, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(lighting_group, 'Location', @location) unless @location.nil?
-      XMLHelper.add_element(lighting_group, 'FractionofUnitsInLocation', to_float(@fraction_of_units_in_location)) unless @fraction_of_units_in_location.nil?
+      XMLHelper.add_element(lighting_group, 'Location', @location, :string) unless @location.nil?
+      XMLHelper.add_element(lighting_group, 'FractionofUnitsInLocation', @fraction_of_units_in_location, :float) unless @fraction_of_units_in_location.nil?
       if not @lighting_type.nil?
         lighting_type = XMLHelper.add_element(lighting_group, 'LightingType')
         XMLHelper.add_element(lighting_type, @lighting_type)
@@ -4523,7 +4523,7 @@ class HPXML < Object
       return if lighting_group.nil?
 
       @id = HPXML::get_id(lighting_group)
-      @location = XMLHelper.get_value(lighting_group, 'Location')
+      @location = XMLHelper.get_value(lighting_group, 'Location', :string)
       @fraction_of_units_in_location = XMLHelper.get_value(lighting_group, 'FractionofUnitsInLocation', :float)
       @lighting_type = XMLHelper.get_child_name(lighting_group, 'LightingType')
     end
@@ -4547,31 +4547,31 @@ class HPXML < Object
       return if nil?
 
       lighting = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Lighting'])
-      XMLHelper.add_extension(lighting, 'InteriorUsageMultiplier', to_float(@interior_usage_multiplier), @interior_usage_multiplier_isdefaulted) unless @interior_usage_multiplier.nil?
-      XMLHelper.add_extension(lighting, 'GarageUsageMultiplier', to_float(@garage_usage_multiplier), @garage_usage_multiplier_isdefaulted) unless @garage_usage_multiplier.nil?
-      XMLHelper.add_extension(lighting, 'ExteriorUsageMultiplier', to_float(@exterior_usage_multiplier), @exterior_usage_multiplier_isdefaulted) unless @exterior_usage_multiplier.nil?
-      XMLHelper.add_extension(lighting, 'InteriorWeekdayScheduleFractions', @interior_weekday_fractions, @interior_weekday_fractions_isdefaulted) unless @interior_weekday_fractions.nil?
-      XMLHelper.add_extension(lighting, 'InteriorWeekendScheduleFractions', @interior_weekend_fractions, @interior_weekend_fractions_isdefaulted) unless @interior_weekend_fractions.nil?
-      XMLHelper.add_extension(lighting, 'InteriorMonthlyScheduleMultipliers', @interior_monthly_multipliers, @interior_monthly_multipliers_isdefaulted) unless @interior_monthly_multipliers.nil?
-      XMLHelper.add_extension(lighting, 'GarageWeekdayScheduleFractions', @garage_weekday_fractions, @garage_weekday_fractions_isdefaulted) unless @garage_weekday_fractions.nil?
-      XMLHelper.add_extension(lighting, 'GarageWeekendScheduleFractions', @garage_weekend_fractions, @garage_weekend_fractions_isdefaulted) unless @garage_weekend_fractions.nil?
-      XMLHelper.add_extension(lighting, 'GarageMonthlyScheduleMultipliers', @garage_monthly_multipliers, @garage_monthly_multipliers_isdefaulted) unless @garage_monthly_multipliers.nil?
-      XMLHelper.add_extension(lighting, 'ExteriorWeekdayScheduleFractions', @exterior_weekday_fractions, @exterior_weekday_fractions_isdefaulted) unless @exterior_weekday_fractions.nil?
-      XMLHelper.add_extension(lighting, 'ExteriorWeekendScheduleFractions', @exterior_weekend_fractions, @exterior_weekend_fractions_isdefaulted) unless @exterior_weekend_fractions.nil?
-      XMLHelper.add_extension(lighting, 'ExteriorMonthlyScheduleMultipliers', @exterior_monthly_multipliers, @exterior_monthly_multipliers_isdefaulted) unless @exterior_monthly_multipliers.nil?
+      XMLHelper.add_extension(lighting, 'InteriorUsageMultiplier', @interior_usage_multiplier, :float, @interior_usage_multiplier_isdefaulted) unless @interior_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'GarageUsageMultiplier', @garage_usage_multiplier, :float, @garage_usage_multiplier_isdefaulted) unless @garage_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorUsageMultiplier', @exterior_usage_multiplier, :float, @exterior_usage_multiplier_isdefaulted) unless @exterior_usage_multiplier.nil?
+      XMLHelper.add_extension(lighting, 'InteriorWeekdayScheduleFractions', @interior_weekday_fractions, :string, @interior_weekday_fractions_isdefaulted) unless @interior_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'InteriorWeekendScheduleFractions', @interior_weekend_fractions, :string, @interior_weekend_fractions_isdefaulted) unless @interior_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'InteriorMonthlyScheduleMultipliers', @interior_monthly_multipliers, :string, @interior_monthly_multipliers_isdefaulted) unless @interior_monthly_multipliers.nil?
+      XMLHelper.add_extension(lighting, 'GarageWeekdayScheduleFractions', @garage_weekday_fractions, :string, @garage_weekday_fractions_isdefaulted) unless @garage_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'GarageWeekendScheduleFractions', @garage_weekend_fractions, :string, @garage_weekend_fractions_isdefaulted) unless @garage_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'GarageMonthlyScheduleMultipliers', @garage_monthly_multipliers, :string, @garage_monthly_multipliers_isdefaulted) unless @garage_monthly_multipliers.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorWeekdayScheduleFractions', @exterior_weekday_fractions, :string, @exterior_weekday_fractions_isdefaulted) unless @exterior_weekday_fractions.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorWeekendScheduleFractions', @exterior_weekend_fractions, :string, @exterior_weekend_fractions_isdefaulted) unless @exterior_weekend_fractions.nil?
+      XMLHelper.add_extension(lighting, 'ExteriorMonthlyScheduleMultipliers', @exterior_monthly_multipliers, :string, @exterior_monthly_multipliers_isdefaulted) unless @exterior_monthly_multipliers.nil?
       if @holiday_exists
         exterior_holiday_lighting = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'Lighting', 'extension', 'ExteriorHolidayLighting'])
         if not @holiday_kwh_per_day.nil?
           holiday_lighting_load = XMLHelper.add_element(exterior_holiday_lighting, 'Load')
-          XMLHelper.add_element(holiday_lighting_load, 'Units', 'kWh/day')
-          XMLHelper.add_element(holiday_lighting_load, 'Value', to_float(@holiday_kwh_per_day), @holiday_kwh_per_day_isdefaulted)
+          XMLHelper.add_element(holiday_lighting_load, 'Units', 'kWh/day', :string)
+          XMLHelper.add_element(holiday_lighting_load, 'Value', @holiday_kwh_per_day, :float, @holiday_kwh_per_day_isdefaulted)
         end
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginMonth', to_integer(@holiday_period_begin_month), @holiday_period_begin_month_isdefaulted) unless @holiday_period_begin_month.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginDayOfMonth', to_integer(@holiday_period_begin_day), @holiday_period_begin_day_isdefaulted) unless @holiday_period_begin_day.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndMonth', to_integer(@holiday_period_end_month), @holiday_period_end_month_isdefaulted) unless @holiday_period_end_month.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndDayOfMonth', to_integer(@holiday_period_end_day), @holiday_period_end_day_isdefaulted) unless @holiday_period_end_day.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'WeekdayScheduleFractions', @holiday_weekday_fractions, @holiday_weekday_fractions_isdefaulted) unless @holiday_weekday_fractions.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'WeekendScheduleFractions', @holiday_weekend_fractions, @holiday_weekend_fractions_isdefaulted) unless @holiday_weekend_fractions.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginMonth', @holiday_period_begin_month, :integer, @holiday_period_begin_month_isdefaulted) unless @holiday_period_begin_month.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginDayOfMonth', @holiday_period_begin_day, :integer, @holiday_period_begin_day_isdefaulted) unless @holiday_period_begin_day.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndMonth', @holiday_period_end_month, :integer, @holiday_period_end_month_isdefaulted) unless @holiday_period_end_month.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndDayOfMonth', @holiday_period_end_day, :integer, @holiday_period_end_day_isdefaulted) unless @holiday_period_end_day.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'WeekdayScheduleFractions', @holiday_weekday_fractions, :string, @holiday_weekday_fractions_isdefaulted) unless @holiday_weekday_fractions.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'WeekendScheduleFractions', @holiday_weekend_fractions, :string, @holiday_weekend_fractions_isdefaulted) unless @holiday_weekend_fractions.nil?
       end
     end
 
@@ -4584,15 +4584,15 @@ class HPXML < Object
       @interior_usage_multiplier, @interior_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorUsageMultiplier', :float)
       @garage_usage_multiplier, @garage_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageUsageMultiplier', :float)
       @exterior_usage_multiplier, @exterior_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorUsageMultiplier', :float)
-      @interior_weekday_fractions, @interior_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorWeekdayScheduleFractions')
-      @interior_weekend_fractions, @interior_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorWeekendScheduleFractions')
-      @interior_monthly_multipliers, @interior_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorMonthlyScheduleMultipliers')
-      @garage_weekday_fractions, @garage_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageWeekdayScheduleFractions')
-      @garage_weekend_fractions, @garage_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageWeekendScheduleFractions')
-      @garage_monthly_multipliers, @garage_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageMonthlyScheduleMultipliers')
-      @exterior_weekday_fractions, @exterior_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorWeekdayScheduleFractions')
-      @exterior_weekend_fractions, @exterior_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorWeekendScheduleFractions')
-      @exterior_monthly_multipliers, @exterior_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorMonthlyScheduleMultipliers')
+      @interior_weekday_fractions, @interior_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorWeekdayScheduleFractions', :string)
+      @interior_weekend_fractions, @interior_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorWeekendScheduleFractions', :string)
+      @interior_monthly_multipliers, @interior_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorMonthlyScheduleMultipliers', :string)
+      @garage_weekday_fractions, @garage_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageWeekdayScheduleFractions', :string)
+      @garage_weekend_fractions, @garage_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageWeekendScheduleFractions', :string)
+      @garage_monthly_multipliers, @garage_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageMonthlyScheduleMultipliers', :string)
+      @exterior_weekday_fractions, @exterior_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorWeekdayScheduleFractions', :string)
+      @exterior_weekend_fractions, @exterior_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorWeekendScheduleFractions', :string)
+      @exterior_monthly_multipliers, @exterior_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorMonthlyScheduleMultipliers', :string)
       if not XMLHelper.get_element(hpxml, 'Building/BuildingDetails/Lighting/extension/ExteriorHolidayLighting').nil?
         @holiday_exists = true
         @holiday_kwh_per_day, @holiday_kwh_per_day_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/Load[Units="kWh/day"]/Value', :float)
@@ -4600,8 +4600,8 @@ class HPXML < Object
         @holiday_period_begin_day, @holiday_period_begin_day_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginDayOfMonth', :integer)
         @holiday_period_end_month, @holiday_period_end_month_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodEndMonth', :integer)
         @holiday_period_end_day, @holiday_period_end_day_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodEndDayOfMonth', :integer)
-        @holiday_weekday_fractions, @holiday_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekdayScheduleFractions')
-        @holiday_weekend_fractions, @holiday_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekendScheduleFractions')
+        @holiday_weekday_fractions, @holiday_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekdayScheduleFractions', :string)
+        @holiday_weekend_fractions, @holiday_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekendScheduleFractions', :string)
       else
         @holiday_exists = false
       end
@@ -4644,10 +4644,10 @@ class HPXML < Object
       XMLHelper.add_attribute(sys_id, 'id', @id)
       if not @efficiency.nil?
         airflow = XMLHelper.add_element(ceiling_fan, 'Airflow')
-        XMLHelper.add_element(airflow, 'FanSpeed', 'medium')
-        XMLHelper.add_element(airflow, 'Efficiency', to_float(@efficiency), @efficiency_isdefaulted)
+        XMLHelper.add_element(airflow, 'FanSpeed', 'medium', :string)
+        XMLHelper.add_element(airflow, 'Efficiency', @efficiency, :float, @efficiency_isdefaulted)
       end
-      XMLHelper.add_element(ceiling_fan, 'Quantity', to_integer(@quantity), @quantity_isdefaulted) unless @quantity.nil?
+      XMLHelper.add_element(ceiling_fan, 'Quantity', @quantity, :integer, @quantity_isdefaulted) unless @quantity.nil?
     end
 
     def from_oga(ceiling_fan)
@@ -4704,12 +4704,12 @@ class HPXML < Object
       end
       if not @pump_kwh_per_year.nil?
         load = XMLHelper.add_element(pool_pump, 'Load')
-        XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
-        XMLHelper.add_element(load, 'Value', to_float(@pump_kwh_per_year), @pump_kwh_per_year_isdefaulted)
-        XMLHelper.add_extension(pool_pump, 'UsageMultiplier', to_float(@pump_usage_multiplier), @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
-        XMLHelper.add_extension(pool_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
-        XMLHelper.add_extension(pool_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
-        XMLHelper.add_extension(pool_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
+        XMLHelper.add_element(load, 'Units', UnitsKwhPerYear, :string)
+        XMLHelper.add_element(load, 'Value', @pump_kwh_per_year, :float, @pump_kwh_per_year_isdefaulted)
+        XMLHelper.add_extension(pool_pump, 'UsageMultiplier', @pump_usage_multiplier, :float, @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
+        XMLHelper.add_extension(pool_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, :string, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
+        XMLHelper.add_extension(pool_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, :string, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
+        XMLHelper.add_extension(pool_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, :string, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
       end
       if not @heater_type.nil?
         heater = XMLHelper.add_element(pool, 'Heater')
@@ -4719,16 +4719,16 @@ class HPXML < Object
         else
           XMLHelper.add_attribute(sys_id, 'id', @id + 'Heater')
         end
-        XMLHelper.add_element(heater, 'Type', @heater_type)
+        XMLHelper.add_element(heater, 'Type', @heater_type, :string)
         if (not @heater_load_units.nil?) && (not @heater_load_value.nil?)
           load = XMLHelper.add_element(heater, 'Load')
-          XMLHelper.add_element(load, 'Units', @heater_load_units)
-          XMLHelper.add_element(load, 'Value', to_float(@heater_load_value), @heater_load_value_isdefaulted)
+          XMLHelper.add_element(load, 'Units', @heater_load_units, :string)
+          XMLHelper.add_element(load, 'Value', @heater_load_value, :float, @heater_load_value_isdefaulted)
         end
-        XMLHelper.add_extension(heater, 'UsageMultiplier', to_float(@heater_usage_multiplier), @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
-        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
-        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
-        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
+        XMLHelper.add_extension(heater, 'UsageMultiplier', @heater_usage_multiplier, :float, @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
+        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, :string, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
+        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, :string, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
+        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, :string, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
       end
     end
 
@@ -4738,19 +4738,19 @@ class HPXML < Object
       @pump_id = HPXML::get_id(pool_pump)
       @pump_kwh_per_year, @pump_kwh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
       @pump_usage_multiplier, @pump_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/UsageMultiplier', :float)
-      @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekdayScheduleFractions')
-      @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekendScheduleFractions')
-      @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/MonthlyScheduleMultipliers')
+      @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekdayScheduleFractions', :string)
+      @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekendScheduleFractions', :string)
+      @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/MonthlyScheduleMultipliers', :string)
       heater = XMLHelper.get_element(pool, 'Heater')
       if not heater.nil?
         @heater_id = HPXML::get_id(heater)
-        @heater_type = XMLHelper.get_value(heater, 'Type')
-        @heater_load_units = XMLHelper.get_value(heater, 'Load/Units')
+        @heater_type = XMLHelper.get_value(heater, 'Type', :string)
+        @heater_load_units = XMLHelper.get_value(heater, 'Load/Units', :string)
         @heater_load_value, @heater_load_value_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'Load/Value', :float)
         @heater_usage_multiplier, @heater_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/UsageMultiplier', :float)
-        @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekdayScheduleFractions')
-        @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekendScheduleFractions')
-        @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/MonthlyScheduleMultipliers')
+        @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekdayScheduleFractions', :string)
+        @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekendScheduleFractions', :string)
+        @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/MonthlyScheduleMultipliers', :string)
       end
     end
   end
@@ -4802,12 +4802,12 @@ class HPXML < Object
       end
       if not @pump_kwh_per_year.nil?
         load = XMLHelper.add_element(hot_tub_pump, 'Load')
-        XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
-        XMLHelper.add_element(load, 'Value', to_float(@pump_kwh_per_year), @pump_kwh_per_year_isdefaulted)
-        XMLHelper.add_extension(hot_tub_pump, 'UsageMultiplier', to_float(@pump_usage_multiplier), @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
+        XMLHelper.add_element(load, 'Units', UnitsKwhPerYear, :string)
+        XMLHelper.add_element(load, 'Value', @pump_kwh_per_year, :float, @pump_kwh_per_year_isdefaulted)
+        XMLHelper.add_extension(hot_tub_pump, 'UsageMultiplier', @pump_usage_multiplier, :float, @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, :string, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, :string, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
+        XMLHelper.add_extension(hot_tub_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, :string, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
       end
       if not @heater_type.nil?
         heater = XMLHelper.add_element(hot_tub, 'Heater')
@@ -4817,16 +4817,16 @@ class HPXML < Object
         else
           XMLHelper.add_attribute(sys_id, 'id', @id + 'Heater')
         end
-        XMLHelper.add_element(heater, 'Type', @heater_type)
+        XMLHelper.add_element(heater, 'Type', @heater_type, :string)
         if (not @heater_load_units.nil?) && (not @heater_load_value.nil?)
           load = XMLHelper.add_element(heater, 'Load')
-          XMLHelper.add_element(load, 'Units', @heater_load_units)
-          XMLHelper.add_element(load, 'Value', to_float(@heater_load_value), @heater_load_value_isdefaulted)
+          XMLHelper.add_element(load, 'Units', @heater_load_units, :string)
+          XMLHelper.add_element(load, 'Value', @heater_load_value, :float, @heater_load_value_isdefaulted)
         end
-        XMLHelper.add_extension(heater, 'UsageMultiplier', to_float(@heater_usage_multiplier), @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
-        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
-        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
-        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
+        XMLHelper.add_extension(heater, 'UsageMultiplier', @heater_usage_multiplier, :float, @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
+        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, :string, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
+        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, :string, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
+        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, :string, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
       end
     end
 
@@ -4836,19 +4836,19 @@ class HPXML < Object
       @pump_id = HPXML::get_id(hot_tub_pump)
       @pump_kwh_per_year, @pump_kwh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
       @pump_usage_multiplier, @pump_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/UsageMultiplier', :float)
-      @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekdayScheduleFractions')
-      @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekendScheduleFractions')
-      @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/MonthlyScheduleMultipliers')
+      @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekdayScheduleFractions', :string)
+      @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekendScheduleFractions', :string)
+      @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/MonthlyScheduleMultipliers', :string)
       heater = XMLHelper.get_element(hot_tub, 'Heater')
       if not heater.nil?
         @heater_id = HPXML::get_id(heater)
-        @heater_type = XMLHelper.get_value(heater, 'Type')
-        @heater_load_units = XMLHelper.get_value(heater, 'Load/Units')
+        @heater_type = XMLHelper.get_value(heater, 'Type', :string)
+        @heater_load_units = XMLHelper.get_value(heater, 'Load/Units', :string)
         @heater_load_value, @heater_load_value_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'Load/Value', :float)
         @heater_usage_multiplier, @heater_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/UsageMultiplier', :float)
-        @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekdayScheduleFractions')
-        @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekendScheduleFractions')
-        @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/MonthlyScheduleMultipliers')
+        @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekdayScheduleFractions', :string)
+        @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekendScheduleFractions', :string)
+        @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/MonthlyScheduleMultipliers', :string)
       end
     end
   end
@@ -4888,32 +4888,32 @@ class HPXML < Object
       plug_load = XMLHelper.add_element(misc_loads, 'PlugLoad')
       sys_id = XMLHelper.add_element(plug_load, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(plug_load, 'PlugLoadType', @plug_load_type) unless @plug_load_type.nil?
-      XMLHelper.add_element(plug_load, 'Location', @location, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(plug_load, 'PlugLoadType', @plug_load_type, :string) unless @plug_load_type.nil?
+      XMLHelper.add_element(plug_load, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
       if not @kWh_per_year.nil?
         load = XMLHelper.add_element(plug_load, 'Load')
-        XMLHelper.add_element(load, 'Units', UnitsKwhPerYear)
-        XMLHelper.add_element(load, 'Value', to_float(@kWh_per_year), @kWh_per_year_isdefaulted)
+        XMLHelper.add_element(load, 'Units', UnitsKwhPerYear, :string)
+        XMLHelper.add_element(load, 'Value', @kWh_per_year, :float, @kWh_per_year_isdefaulted)
       end
-      XMLHelper.add_extension(plug_load, 'FracSensible', to_float(@frac_sensible), @frac_sensible_isdefaulted) unless @frac_sensible.nil?
-      XMLHelper.add_extension(plug_load, 'FracLatent', to_float(@frac_latent), @frac_latent_isdefaulted) unless @frac_latent.nil?
-      XMLHelper.add_extension(plug_load, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(plug_load, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(plug_load, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(plug_load, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
+      XMLHelper.add_extension(plug_load, 'FracSensible', @frac_sensible, :float, @frac_sensible_isdefaulted) unless @frac_sensible.nil?
+      XMLHelper.add_extension(plug_load, 'FracLatent', @frac_latent, :float, @frac_latent_isdefaulted) unless @frac_latent.nil?
+      XMLHelper.add_extension(plug_load, 'UsageMultiplier', @usage_multiplier, :float, @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(plug_load, 'WeekdayScheduleFractions', @weekday_fractions, :string, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(plug_load, 'WeekendScheduleFractions', @weekend_fractions, :string, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(plug_load, 'MonthlyScheduleMultipliers', @monthly_multipliers, :string, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(plug_load)
       @id = HPXML::get_id(plug_load)
-      @plug_load_type = XMLHelper.get_value(plug_load, 'PlugLoadType')
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'Location')
+      @plug_load_type = XMLHelper.get_value(plug_load, 'PlugLoadType', :string)
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'Location', :string)
       @kWh_per_year, @kWh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
       @frac_sensible, @frac_sensible_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/FracSensible', :float)
       @frac_latent, @frac_latent_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/FracLatent', :float)
       @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/UsageMultiplier', :float)
-      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/WeekdayScheduleFractions')
-      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/WeekendScheduleFractions')
-      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/MonthlyScheduleMultipliers')
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/WeekdayScheduleFractions', :string)
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/WeekendScheduleFractions', :string)
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/MonthlyScheduleMultipliers', :string)
     end
   end
 
@@ -4952,34 +4952,34 @@ class HPXML < Object
       fuel_load = XMLHelper.add_element(misc_loads, 'FuelLoad')
       sys_id = XMLHelper.add_element(fuel_load, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      XMLHelper.add_element(fuel_load, 'FuelLoadType', @fuel_load_type) unless @fuel_load_type.nil?
-      XMLHelper.add_element(fuel_load, 'Location', @location, @location_isdefaulted) unless @location.nil?
+      XMLHelper.add_element(fuel_load, 'FuelLoadType', @fuel_load_type, :string) unless @fuel_load_type.nil?
+      XMLHelper.add_element(fuel_load, 'Location', @location, :string, @location_isdefaulted) unless @location.nil?
       if not @therm_per_year.nil?
         load = XMLHelper.add_element(fuel_load, 'Load')
-        XMLHelper.add_element(load, 'Units', UnitsThermPerYear)
-        XMLHelper.add_element(load, 'Value', to_float(@therm_per_year), @therm_per_year_isdefaulted)
+        XMLHelper.add_element(load, 'Units', UnitsThermPerYear, :string)
+        XMLHelper.add_element(load, 'Value', @therm_per_year, :float, @therm_per_year_isdefaulted)
       end
-      XMLHelper.add_element(fuel_load, 'FuelType', @fuel_type) unless @fuel_type.nil?
-      XMLHelper.add_extension(fuel_load, 'FracSensible', to_float(@frac_sensible), @frac_sensible_isdefaulted) unless @frac_sensible.nil?
-      XMLHelper.add_extension(fuel_load, 'FracLatent', to_float(@frac_latent), @frac_latent_isdefaulted) unless @frac_latent.nil?
-      XMLHelper.add_extension(fuel_load, 'UsageMultiplier', to_float(@usage_multiplier), @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
-      XMLHelper.add_extension(fuel_load, 'WeekdayScheduleFractions', @weekday_fractions, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
-      XMLHelper.add_extension(fuel_load, 'WeekendScheduleFractions', @weekend_fractions, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
-      XMLHelper.add_extension(fuel_load, 'MonthlyScheduleMultipliers', @monthly_multipliers, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
+      XMLHelper.add_element(fuel_load, 'FuelType', @fuel_type, :string) unless @fuel_type.nil?
+      XMLHelper.add_extension(fuel_load, 'FracSensible', @frac_sensible, :float, @frac_sensible_isdefaulted) unless @frac_sensible.nil?
+      XMLHelper.add_extension(fuel_load, 'FracLatent', @frac_latent, :float, @frac_latent_isdefaulted) unless @frac_latent.nil?
+      XMLHelper.add_extension(fuel_load, 'UsageMultiplier', @usage_multiplier, :float, @usage_multiplier_isdefaulted) unless @usage_multiplier.nil?
+      XMLHelper.add_extension(fuel_load, 'WeekdayScheduleFractions', @weekday_fractions, :string, @weekday_fractions_isdefaulted) unless @weekday_fractions.nil?
+      XMLHelper.add_extension(fuel_load, 'WeekendScheduleFractions', @weekend_fractions, :string, @weekend_fractions_isdefaulted) unless @weekend_fractions.nil?
+      XMLHelper.add_extension(fuel_load, 'MonthlyScheduleMultipliers', @monthly_multipliers, :string, @monthly_multipliers_isdefaulted) unless @monthly_multipliers.nil?
     end
 
     def from_oga(fuel_load)
       @id = HPXML::get_id(fuel_load)
-      @fuel_load_type = XMLHelper.get_value(fuel_load, 'FuelLoadType')
-      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'Location')
+      @fuel_load_type = XMLHelper.get_value(fuel_load, 'FuelLoadType', :string)
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'Location', :string)
       @therm_per_year, @therm_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, "Load[Units='#{UnitsThermPerYear}']/Value", :float)
-      @fuel_type = XMLHelper.get_value(fuel_load, 'FuelType')
+      @fuel_type = XMLHelper.get_value(fuel_load, 'FuelType', :string)
       @frac_sensible, @frac_sensible_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/FracSensible', :float)
       @frac_latent, @frac_latent_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/FracLatent', :float)
       @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/UsageMultiplier', :float)
-      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/WeekdayScheduleFractions')
-      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/WeekendScheduleFractions')
-      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/MonthlyScheduleMultipliers')
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/WeekdayScheduleFractions', :string)
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/WeekendScheduleFractions', :string)
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/MonthlyScheduleMultipliers', :string)
     end
   end
 

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -692,8 +692,8 @@ class HPXML < Object
     ATTRS = [:xml_type, :xml_generated_by, :created_date_and_time, :transaction,
              :software_program_used, :software_program_version, :eri_calculation_version,
              :eri_design, :timestep, :building_id, :event_type, :state_code,
-             :sim_begin_month, :sim_begin_day_of_month, :sim_end_month, :sim_end_day_of_month, :sim_calendar_year,
-             :dst_enabled, :dst_begin_month, :dst_begin_day_of_month, :dst_end_month, :dst_end_day_of_month,
+             :sim_begin_month, :sim_begin_day, :sim_end_month, :sim_end_day, :sim_calendar_year,
+             :dst_enabled, :dst_begin_month, :dst_begin_day, :dst_end_month, :dst_end_day,
              :use_max_load_for_heat_pumps, :allow_increased_fixed_capacities,
              :apply_ashrae140_assumptions]
     attr_accessor(*ATTRS)
@@ -728,31 +728,31 @@ class HPXML < Object
 
       months_days = { [1, 3, 5, 7, 8, 10, 12] => (1..31).to_a, [4, 6, 9, 11] => (1..30).to_a, [2] => (1..28).to_a }
       months_days.each do |months, valid_days|
-        { 'Run Period' => [@sim_begin_month, @sim_begin_day_of_month, @sim_end_month, @sim_end_day_of_month], 'Daylight Saving' => [@dst_begin_month, @dst_begin_day_of_month, @dst_end_month, @dst_end_day_of_month] }.each do |sim_ctl, months_and_days|
-          begin_month, begin_day_of_month, end_month, end_day_of_month = months_and_days
-          if (not begin_day_of_month.nil?) && (months.include? begin_month)
-            if not valid_days.include? begin_day_of_month
-              fail "#{sim_ctl} Begin Day of Month (#{begin_day_of_month}) must be one of: #{valid_days.join(', ')}."
+        { 'Run Period' => [@sim_begin_month, @sim_begin_day, @sim_end_month, @sim_end_day], 'Daylight Saving' => [@dst_begin_month, @dst_begin_day, @dst_end_month, @dst_end_day] }.each do |sim_ctl, months_and_days|
+          begin_month, begin_day, end_month, end_day = months_and_days
+          if (not begin_day.nil?) && (months.include? begin_month)
+            if not valid_days.include? begin_day
+              fail "#{sim_ctl} Begin Day of Month (#{begin_day}) must be one of: #{valid_days.join(', ')}."
             end
           end
-          next unless (not end_day_of_month.nil?) && (months.include? end_month)
-          if not valid_days.include? end_day_of_month
-            fail "#{sim_ctl} End Day of Month (#{end_day_of_month}) must be one of: #{valid_days.join(', ')}."
+          next unless (not end_day.nil?) && (months.include? end_month)
+          if not valid_days.include? end_day
+            fail "#{sim_ctl} End Day of Month (#{end_day}) must be one of: #{valid_days.join(', ')}."
           end
         end
       end
 
-      { 'Run Period' => [@sim_begin_month, @sim_begin_day_of_month, @sim_end_month, @sim_end_day_of_month] }.each do |sim_ctl, months_and_days|
-        begin_month, begin_day_of_month, end_month, end_day_of_month = months_and_days
+      { 'Run Period' => [@sim_begin_month, @sim_begin_day, @sim_end_month, @sim_end_day] }.each do |sim_ctl, months_and_days|
+        begin_month, begin_day, end_month, end_day = months_and_days
         next unless (not begin_month.nil?) && (not end_month.nil?)
         if begin_month > end_month
           fail "#{sim_ctl} Begin Month (#{begin_month}) cannot come after #{sim_ctl} End Month (#{end_month})."
         end
 
-        next unless (not begin_day_of_month.nil?) && (not end_day_of_month.nil?)
+        next unless (not begin_day.nil?) && (not end_day.nil?)
         next unless begin_month == end_month
-        if begin_day_of_month > end_day_of_month
-          fail "#{sim_ctl} Begin Day of Month (#{begin_day_of_month}) cannot come after #{sim_ctl} End Day of Month (#{end_day_of_month}) for the same month (#{begin_month})."
+        if begin_day > end_day
+          fail "#{sim_ctl} Begin Day of Month (#{begin_day}) cannot come after #{sim_ctl} End Day of Month (#{end_day}) for the same month (#{begin_month})."
         end
       end
 
@@ -792,22 +792,22 @@ class HPXML < Object
         XMLHelper.add_element(eri_calculation, 'Version', @eri_calculation_version) unless @eri_calculation_version.nil?
         XMLHelper.add_element(eri_calculation, 'Design', @eri_design) unless @eri_design.nil?
       end
-      if (not @timestep.nil?) || (not @sim_begin_month.nil?) || (not @sim_begin_day_of_month.nil?) || (not @sim_end_month.nil?) || (not @sim_end_day_of_month.nil?) || (not @dst_enabled.nil?) || (not @dst_begin_month.nil?) || (not @dst_begin_day_of_month.nil?) || (not @dst_end_month.nil?) || (not @dst_end_day_of_month.nil?)
+      if (not @timestep.nil?) || (not @sim_begin_month.nil?) || (not @sim_begin_day.nil?) || (not @sim_end_month.nil?) || (not @sim_end_day.nil?) || (not @dst_enabled.nil?) || (not @dst_begin_month.nil?) || (not @dst_begin_day.nil?) || (not @dst_end_month.nil?) || (not @dst_end_day.nil?)
         extension = XMLHelper.create_elements_as_needed(software_info, ['extension'])
         simulation_control = XMLHelper.add_element(extension, 'SimulationControl')
         XMLHelper.add_element(simulation_control, 'Timestep', to_integer(@timestep), @timestep_isdefaulted) unless @timestep.nil?
         XMLHelper.add_element(simulation_control, 'BeginMonth', to_integer(@sim_begin_month), @sim_begin_month_isdefaulted) unless @sim_begin_month.nil?
-        XMLHelper.add_element(simulation_control, 'BeginDayOfMonth', to_integer(@sim_begin_day_of_month), @sim_begin_day_of_month_isdefaulted) unless @sim_begin_day_of_month.nil?
+        XMLHelper.add_element(simulation_control, 'BeginDayOfMonth', to_integer(@sim_begin_day), @sim_begin_day_isdefaulted) unless @sim_begin_day.nil?
         XMLHelper.add_element(simulation_control, 'EndMonth', to_integer(@sim_end_month), @sim_end_month_isdefaulted) unless @sim_end_month.nil?
-        XMLHelper.add_element(simulation_control, 'EndDayOfMonth', to_integer(@sim_end_day_of_month), @sim_end_day_of_month_isdefaulted) unless @sim_end_day_of_month.nil?
+        XMLHelper.add_element(simulation_control, 'EndDayOfMonth', to_integer(@sim_end_day), @sim_end_day_isdefaulted) unless @sim_end_day.nil?
         XMLHelper.add_element(simulation_control, 'CalendarYear', to_integer(@sim_calendar_year), @sim_calendar_year_isdefaulted) unless @sim_calendar_year.nil?
-        if (not @dst_enabled.nil?) || (not @dst_begin_month.nil?) || (not @dst_begin_day_of_month.nil?) || (not @dst_end_month.nil?) || (not @dst_end_day_of_month.nil?)
+        if (not @dst_enabled.nil?) || (not @dst_begin_month.nil?) || (not @dst_begin_day.nil?) || (not @dst_end_month.nil?) || (not @dst_end_day.nil?)
           daylight_saving = XMLHelper.add_element(simulation_control, 'DaylightSaving')
           XMLHelper.add_element(daylight_saving, 'Enabled', to_boolean(@dst_enabled), @dst_enabled_isdefaulted) unless @dst_enabled.nil?
           XMLHelper.add_element(daylight_saving, 'BeginMonth', to_integer(@dst_begin_month), @dst_begin_month_isdefaulted) unless @dst_begin_month.nil?
-          XMLHelper.add_element(daylight_saving, 'BeginDayOfMonth', to_integer(@dst_begin_day_of_month), @dst_begin_day_of_month_isdefaulted) unless @dst_begin_day_of_month.nil?
+          XMLHelper.add_element(daylight_saving, 'BeginDayOfMonth', to_integer(@dst_begin_day), @dst_begin_day_isdefaulted) unless @dst_begin_day.nil?
           XMLHelper.add_element(daylight_saving, 'EndMonth', to_integer(@dst_end_month), @dst_end_month_isdefaulted) unless @dst_end_month.nil?
-          XMLHelper.add_element(daylight_saving, 'EndDayOfMonth', to_integer(@dst_end_day_of_month), @dst_end_day_of_month_isdefaulted) unless @dst_end_day_of_month.nil?
+          XMLHelper.add_element(daylight_saving, 'EndDayOfMonth', to_integer(@dst_end_day), @dst_end_day_isdefaulted) unless @dst_end_day.nil?
         end
       end
       if (not @use_max_load_for_heat_pumps.nil?) || (not @allow_increased_fixed_capacities.nil?)
@@ -842,33 +842,20 @@ class HPXML < Object
       @software_program_version = XMLHelper.get_value(hpxml, 'SoftwareInfo/SoftwareProgramVersion')
       @eri_calculation_version = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ERICalculation/Version')
       @eri_design = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ERICalculation/Design')
-      @timestep = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/Timestep'))
-      @timestep_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/Timestep') unless @timestep.nil?
-      @sim_begin_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginMonth'))
-      @sim_begin_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginMonth') unless @sim_begin_month.nil?
-      @sim_begin_day_of_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginDayOfMonth'))
-      @sim_begin_day_of_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginDayOfMonth') unless @sim_begin_day_of_month.nil?
-      @sim_end_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/EndMonth'))
-      @sim_end_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/EndMonth') unless @sim_end_month.nil?
-      @sim_end_day_of_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/EndDayOfMonth'))
-      @sim_end_day_of_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/EndDayOfMonth') unless @sim_end_day_of_month.nil?
-      @sim_calendar_year = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/CalendarYear'))
-      @sim_calendar_year_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/CalendarYear') unless @sim_calendar_year.nil?
-      @dst_enabled = to_boolean_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/Enabled'))
-      @dst_enabled_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/Enabled') unless @dst_enabled.nil?
-      @dst_begin_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginMonth'))
-      @dst_begin_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginMonth') unless @dst_begin_month.nil?
-      @dst_begin_day_of_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginDayOfMonth'))
-      @dst_begin_day_of_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginDayOfMonth') unless @dst_begin_day_of_month.nil?
-      @dst_end_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndMonth'))
-      @dst_end_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndMonth') unless @dst_end_month.nil?
-      @dst_end_day_of_month = to_integer_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndDayOfMonth'))
-      @dst_end_day_of_month_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndDayOfMonth') unless @dst_end_day_of_month.nil?
-      @apply_ashrae140_assumptions = to_boolean_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ApplyASHRAE140Assumptions'))
-      @use_max_load_for_heat_pumps = to_boolean_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/HVACSizingControl/UseMaxLoadForHeatPumps'))
-      @use_max_load_for_heat_pumps_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/HVACSizingControl/UseMaxLoadForHeatPumps') unless @use_max_load_for_heat_pumps.nil?
-      @allow_increased_fixed_capacities = to_boolean_or_nil(XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/HVACSizingControl/AllowIncreasedFixedCapacities'))
-      @allow_increased_fixed_capacities_isdefaulted = get_software_defaulted(hpxml, 'SoftwareInfo/extension/HVACSizingControl/AllowIncreasedFixedCapacities') unless @allow_increased_fixed_capacities.nil?
+      @timestep, @timestep_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/Timestep', :integer)
+      @sim_begin_month, @sim_begin_month_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginMonth', :integer)
+      @sim_begin_day, @sim_begin_day_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/BeginDayOfMonth', :integer)
+      @sim_end_month, @sim_end_month_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/EndMonth', :integer)
+      @sim_end_day, @sim_end_day_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/EndDayOfMonth', :integer)
+      @sim_calendar_year, @sim_calendar_year_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/CalendarYear', :integer)
+      @dst_enabled, @dst_enabled_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/Enabled', :boolean)
+      @dst_begin_month, @dst_begin_month_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginMonth', :integer)
+      @dst_begin_day, @dst_begin_day_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/BeginDayOfMonth', :integer)
+      @dst_end_month, @dst_end_month_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndMonth', :integer)
+      @dst_end_day, @dst_end_day_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/SimulationControl/DaylightSaving/EndDayOfMonth', :integer)
+      @apply_ashrae140_assumptions = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ApplyASHRAE140Assumptions', :boolean)
+      @use_max_load_for_heat_pumps, @use_max_load_for_heat_pumps_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/HVACSizingControl/UseMaxLoadForHeatPumps', :boolean)
+      @allow_increased_fixed_capacities, @allow_increased_fixed_capacities_isdefaulted = XMLHelper.get_value_and_defaulted(hpxml, 'SoftwareInfo/extension/HVACSizingControl/AllowIncreasedFixedCapacities', :boolean)
       @building_id = HPXML::get_id(hpxml, 'Building/BuildingID')
       @event_type = XMLHelper.get_value(hpxml, 'Building/ProjectStatus/EventType')
       @state_code = XMLHelper.get_value(hpxml, 'Building/Site/Address/StateCode')
@@ -906,13 +893,11 @@ class HPXML < Object
       site = XMLHelper.get_element(hpxml, 'Building/BuildingDetails/BuildingSummary/Site')
       return if site.nil?
 
-      @site_type = XMLHelper.get_value(site, 'SiteType')
-      @site_type_isdefaulted = get_software_defaulted(site, 'SiteType') unless @site_type.nil?
+      @site_type, @site_type_isdefaulted = XMLHelper.get_value_and_defaulted(site, 'SiteType')
       @surroundings = XMLHelper.get_value(site, 'Surroundings')
       @orientation_of_front_of_home = XMLHelper.get_value(site, 'OrientationOfFrontOfHome')
       @fuels = XMLHelper.get_values(site, 'FuelTypesAvailable/Fuel')
-      @shelter_coefficient = to_float_or_nil(XMLHelper.get_value(site, 'extension/ShelterCoefficient'))
-      @shelter_coefficient_isdefaulted = get_software_defaulted(site, 'extension/ShelterCoefficient') unless @shelter_coefficient.nil?
+      @shelter_coefficient, @shelter_coefficient_isdefaulted = XMLHelper.get_value_and_defaulted(site, 'extension/ShelterCoefficient', :float)
     end
   end
 
@@ -952,9 +937,9 @@ class HPXML < Object
     def from_oga(neighbor_building)
       return if neighbor_building.nil?
 
-      @azimuth = to_integer_or_nil(XMLHelper.get_value(neighbor_building, 'Azimuth'))
-      @distance = to_float_or_nil(XMLHelper.get_value(neighbor_building, 'Distance'))
-      @height = to_float_or_nil(XMLHelper.get_value(neighbor_building, 'Height'))
+      @azimuth = XMLHelper.get_value(neighbor_building, 'Azimuth', :integer)
+      @distance = XMLHelper.get_value(neighbor_building, 'Distance', :float)
+      @height = XMLHelper.get_value(neighbor_building, 'Height', :float)
     end
   end
 
@@ -980,8 +965,7 @@ class HPXML < Object
       building_occupancy = XMLHelper.get_element(hpxml, 'Building/BuildingDetails/BuildingSummary/BuildingOccupancy')
       return if building_occupancy.nil?
 
-      @number_of_residents = to_float_or_nil(XMLHelper.get_value(building_occupancy, 'NumberofResidents'))
-      @number_of_residents_isdefaulted = get_software_defaulted(building_occupancy, 'NumberofResidents') unless @number_of_residents.nil?
+      @number_of_residents, @number_of_residents_isdefaulted = XMLHelper.get_value_and_defaulted(building_occupancy, 'NumberofResidents', :float)
     end
   end
 
@@ -1019,20 +1003,17 @@ class HPXML < Object
       building_construction = XMLHelper.get_element(hpxml, 'Building/BuildingDetails/BuildingSummary/BuildingConstruction')
       return if building_construction.nil?
 
-      @year_built = to_integer_or_nil(XMLHelper.get_value(building_construction, 'YearBuilt'))
-      @number_of_conditioned_floors = to_integer_or_nil(XMLHelper.get_value(building_construction, 'NumberofConditionedFloors'))
-      @number_of_conditioned_floors_above_grade = to_integer_or_nil(XMLHelper.get_value(building_construction, 'NumberofConditionedFloorsAboveGrade'))
-      @average_ceiling_height = to_float_or_nil(XMLHelper.get_value(building_construction, 'AverageCeilingHeight'))
-      @number_of_bedrooms = to_integer_or_nil(XMLHelper.get_value(building_construction, 'NumberofBedrooms'))
-      @number_of_bathrooms = to_integer_or_nil(XMLHelper.get_value(building_construction, 'NumberofBathrooms'))
-      @number_of_bathrooms_isdefaulted = get_software_defaulted(building_construction, 'NumberofBathrooms') unless @number_of_bathrooms.nil?
-      @conditioned_floor_area = to_float_or_nil(XMLHelper.get_value(building_construction, 'ConditionedFloorArea'))
-      @conditioned_building_volume = to_float_or_nil(XMLHelper.get_value(building_construction, 'ConditionedBuildingVolume'))
-      @conditioned_building_volume_isdefaulted = get_software_defaulted(building_construction, 'ConditionedBuildingVolume') unless @conditioned_building_volume.nil?
-      @use_only_ideal_air_system = to_boolean_or_nil(XMLHelper.get_value(building_construction, 'extension/UseOnlyIdealAirSystem'))
+      @year_built = XMLHelper.get_value(building_construction, 'YearBuilt', :integer)
+      @number_of_conditioned_floors = XMLHelper.get_value(building_construction, 'NumberofConditionedFloors', :integer)
+      @number_of_conditioned_floors_above_grade = XMLHelper.get_value(building_construction, 'NumberofConditionedFloorsAboveGrade', :integer)
+      @average_ceiling_height = XMLHelper.get_value(building_construction, 'AverageCeilingHeight', :float)
+      @number_of_bedrooms = XMLHelper.get_value(building_construction, 'NumberofBedrooms', :integer)
+      @number_of_bathrooms, @number_of_bathrooms_isdefaulted = XMLHelper.get_value_and_defaulted(building_construction, 'NumberofBathrooms', :integer)
+      @conditioned_floor_area = XMLHelper.get_value(building_construction, 'ConditionedFloorArea', :float)
+      @conditioned_building_volume, @conditioned_building_volume_isdefaulted = XMLHelper.get_value_and_defaulted(building_construction, 'ConditionedBuildingVolume', :float)
+      @use_only_ideal_air_system = XMLHelper.get_value(building_construction, 'extension/UseOnlyIdealAirSystem', :boolean)
       @residential_facility_type = XMLHelper.get_value(building_construction, 'ResidentialFacilityType')
-      @has_flue_or_chimney = to_boolean_or_nil(XMLHelper.get_value(building_construction, 'extension/HasFlueOrChimney'))
-      @has_flue_or_chimney_isdefaulted = get_software_defaulted(building_construction, 'extension/HasFlueOrChimney') unless @has_flue_or_chimney.nil?
+      @has_flue_or_chimney, @has_flue_or_chimney_isdefaulted = XMLHelper.get_value_and_defaulted(building_construction, 'extension/HasFlueOrChimney', :boolean)
     end
   end
 
@@ -1132,15 +1113,14 @@ class HPXML < Object
       return if air_infiltration_measurement.nil?
 
       @id = HPXML::get_id(air_infiltration_measurement)
-      @house_pressure = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'HousePressure'))
+      @house_pressure = XMLHelper.get_value(air_infiltration_measurement, 'HousePressure', :float)
       @unit_of_measure = XMLHelper.get_value(air_infiltration_measurement, 'BuildingAirLeakage/UnitofMeasure')
-      @air_leakage = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'BuildingAirLeakage/AirLeakage'))
-      @effective_leakage_area = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'EffectiveLeakageArea'))
-      @infiltration_volume = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'InfiltrationVolume'))
-      @infiltration_volume_isdefaulted = get_software_defaulted(air_infiltration_measurement, 'InfiltrationVolume') unless @infiltration_volume.nil?
+      @air_leakage = XMLHelper.get_value(air_infiltration_measurement, 'BuildingAirLeakage/AirLeakage', :float)
+      @effective_leakage_area = XMLHelper.get_value(air_infiltration_measurement, 'EffectiveLeakageArea', :float)
+      @infiltration_volume, @infiltration_volume_isdefaulted = XMLHelper.get_value_and_defaulted(air_infiltration_measurement, 'InfiltrationVolume', :float)
       @leakiness_description = XMLHelper.get_value(air_infiltration_measurement, 'LeakinessDescription')
-      @infiltration_height = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'extension/InfiltrationHeight'))
-      @a_ext = to_float_or_nil(XMLHelper.get_value(air_infiltration_measurement, 'extension/Aext'))
+      @infiltration_height = XMLHelper.get_value(air_infiltration_measurement, 'extension/InfiltrationHeight', :float)
+      @a_ext = XMLHelper.get_value(air_infiltration_measurement, 'extension/Aext', :float)
     end
   end
 
@@ -1263,11 +1243,10 @@ class HPXML < Object
         @attic_type = AtticTypeCathedral
       end
       if @attic_type == AtticTypeVented
-        @vented_attic_sla = to_float_or_nil(XMLHelper.get_value(attic, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value"))
-        @vented_attic_sla_isdefaulted = get_software_defaulted(attic, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value") unless @vented_attic_sla.nil?
-        @vented_attic_ach = to_float_or_nil(XMLHelper.get_value(attic, "VentilationRate[UnitofMeasure='#{UnitsACHNatural}']/Value"))
+        @vented_attic_sla, @vented_attic_sla_isdefaulted = XMLHelper.get_value_and_defaulted(attic, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value", :float)
+        @vented_attic_ach = XMLHelper.get_value(attic, "VentilationRate[UnitofMeasure='#{UnitsACHNatural}']/Value", :float)
       end
-      @within_infiltration_volume = to_boolean_or_nil(XMLHelper.get_value(attic, 'WithinInfiltrationVolume'))
+      @within_infiltration_volume = XMLHelper.get_value(attic, 'WithinInfiltrationVolume', :boolean)
       @attached_to_roof_idrefs = []
       XMLHelper.get_elements(attic, 'AttachedToRoof').each do |roof|
         @attached_to_roof_idrefs << HPXML::get_idref(roof)
@@ -1428,10 +1407,9 @@ class HPXML < Object
         @foundation_type = FoundationTypeAmbient
       end
       if @foundation_type == FoundationTypeCrawlspaceVented
-        @vented_crawlspace_sla = to_float_or_nil(XMLHelper.get_value(foundation, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value"))
-        @vented_crawlspace_sla_isdefaulted = get_software_defaulted(foundation, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value") unless @vented_crawlspace_sla.nil?
+        @vented_crawlspace_sla, @vented_crawlspace_sla_isdefaulted = XMLHelper.get_value_and_defaulted(foundation, "VentilationRate[UnitofMeasure='#{UnitsSLA}']/Value", :float)
       end
-      @within_infiltration_volume = to_boolean_or_nil(XMLHelper.get_value(foundation, 'WithinInfiltrationVolume'))
+      @within_infiltration_volume = XMLHelper.get_value(foundation, 'WithinInfiltrationVolume', :boolean)
       @attached_to_slab_idrefs = []
       XMLHelper.get_elements(foundation, 'AttachedToSlab').each do |slab|
         @attached_to_slab_idrefs << HPXML::get_idref(slab)
@@ -1553,26 +1531,21 @@ class HPXML < Object
 
       @id = HPXML::get_id(roof)
       @interior_adjacent_to = XMLHelper.get_value(roof, 'InteriorAdjacentTo')
-      @area = to_float_or_nil(XMLHelper.get_value(roof, 'Area'))
-      @azimuth = to_integer_or_nil(XMLHelper.get_value(roof, 'Azimuth'))
-      @roof_type = XMLHelper.get_value(roof, 'RoofType')
-      @roof_type_isdefaulted = get_software_defaulted(roof, 'RoofType') unless @roof_type.nil?
-      @roof_color = XMLHelper.get_value(roof, 'RoofColor')
-      @roof_color_isdefaulted = get_software_defaulted(roof, 'RoofColor') unless @roof_color.nil?
-      @solar_absorptance = to_float_or_nil(XMLHelper.get_value(roof, 'SolarAbsorptance'))
-      @solar_absorptance_isdefaulted = get_software_defaulted(roof, 'SolarAbsorptance') unless @solar_absorptance.nil?
-      @emittance = to_float_or_nil(XMLHelper.get_value(roof, 'Emittance'))
-      @emittance_isdefaulted = get_software_defaulted(roof, 'Emittance') unless @emittance.nil?
-      @pitch = to_float_or_nil(XMLHelper.get_value(roof, 'Pitch'))
-      @radiant_barrier = to_boolean_or_nil(XMLHelper.get_value(roof, 'RadiantBarrier'))
-      @radiant_barrier_isdefaulted = get_software_defaulted(roof, 'RadiantBarrier') unless @radiant_barrier.nil?
-      @radiant_barrier_grade = to_integer_or_nil(XMLHelper.get_value(roof, 'RadiantBarrierGrade'))
+      @area = XMLHelper.get_value(roof, 'Area', :float)
+      @azimuth = XMLHelper.get_value(roof, 'Azimuth', :integer)
+      @roof_type, @roof_type_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'RoofType')
+      @roof_color, @roof_color_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'RoofColor')
+      @solar_absorptance, @solar_absorptance_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'SolarAbsorptance', :float)
+      @emittance, @emittance_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'Emittance', :float)
+      @pitch = XMLHelper.get_value(roof, 'Pitch', :float)
+      @radiant_barrier, @radiant_barrier_isdefaulted = XMLHelper.get_value_and_defaulted(roof, 'RadiantBarrier', :boolean)
+      @radiant_barrier_grade = XMLHelper.get_value(roof, 'RadiantBarrierGrade', :integer)
       insulation = XMLHelper.get_element(roof, 'Insulation')
       if not insulation.nil?
         @insulation_id = HPXML::get_id(insulation)
-        @insulation_assembly_r_value = to_float_or_nil(XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue'))
-        @insulation_cavity_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
-        @insulation_continuous_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+        @insulation_assembly_r_value = XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue', :float)
+        @insulation_cavity_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue", :float)
+        @insulation_continuous_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
       end
     end
   end
@@ -1661,22 +1634,18 @@ class HPXML < Object
       @id = HPXML::get_id(rim_joist)
       @exterior_adjacent_to = XMLHelper.get_value(rim_joist, 'ExteriorAdjacentTo')
       @interior_adjacent_to = XMLHelper.get_value(rim_joist, 'InteriorAdjacentTo')
-      @area = to_float_or_nil(XMLHelper.get_value(rim_joist, 'Area'))
-      @azimuth = to_integer_or_nil(XMLHelper.get_value(rim_joist, 'Azimuth'))
-      @siding = XMLHelper.get_value(rim_joist, 'Siding')
-      @siding_isdefaulted = get_software_defaulted(rim_joist, 'Siding') unless @siding.nil?
-      @color = XMLHelper.get_value(rim_joist, 'Color')
-      @color_isdefaulted = get_software_defaulted(rim_joist, 'Color') unless @color.nil?
-      @solar_absorptance = to_float_or_nil(XMLHelper.get_value(rim_joist, 'SolarAbsorptance'))
-      @solar_absorptance_isdefaulted = get_software_defaulted(rim_joist, 'SolarAbsorptance') unless @solar_absorptance.nil?
-      @emittance = to_float_or_nil(XMLHelper.get_value(rim_joist, 'Emittance'))
-      @emittance_isdefaulted = get_software_defaulted(rim_joist, 'Emittance') unless @emittance.nil?
+      @area = XMLHelper.get_value(rim_joist, 'Area', :float)
+      @azimuth = XMLHelper.get_value(rim_joist, 'Azimuth', :integer)
+      @siding, @siding_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'Siding')
+      @color, @color_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'Color')
+      @solar_absorptance, @solar_absorptance_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'SolarAbsorptance', :float)
+      @emittance, @emittance_isdefaulted = XMLHelper.get_value_and_defaulted(rim_joist, 'Emittance', :float)
       insulation = XMLHelper.get_element(rim_joist, 'Insulation')
       if not insulation.nil?
         @insulation_id = HPXML::get_id(insulation)
-        @insulation_assembly_r_value = to_float_or_nil(XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue'))
-        @insulation_cavity_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
-        @insulation_continuous_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+        @insulation_assembly_r_value = XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue', :float)
+        @insulation_cavity_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue", :float)
+        @insulation_continuous_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
       end
     end
   end
@@ -1798,24 +1767,20 @@ class HPXML < Object
       @exterior_adjacent_to = XMLHelper.get_value(wall, 'ExteriorAdjacentTo')
       @interior_adjacent_to = XMLHelper.get_value(wall, 'InteriorAdjacentTo')
       @wall_type = XMLHelper.get_child_name(wall, 'WallType')
-      @optimum_value_engineering = to_boolean_or_nil(XMLHelper.get_value(wall, 'WallType/WoodStud/OptimumValueEngineering'))
-      @area = to_float_or_nil(XMLHelper.get_value(wall, 'Area'))
+      @optimum_value_engineering = XMLHelper.get_value(wall, 'WallType/WoodStud/OptimumValueEngineering', :boolean)
+      @area = XMLHelper.get_value(wall, 'Area', :float)
       @orientation = XMLHelper.get_value(wall, 'Orientation')
-      @azimuth = to_integer_or_nil(XMLHelper.get_value(wall, 'Azimuth'))
-      @siding = XMLHelper.get_value(wall, 'Siding')
-      @siding_isdefaulted = get_software_defaulted(wall, 'Siding') unless @siding.nil?
-      @color = XMLHelper.get_value(wall, 'Color')
-      @color_isdefaulted = get_software_defaulted(wall, 'Color') unless @color.nil?
-      @solar_absorptance = to_float_or_nil(XMLHelper.get_value(wall, 'SolarAbsorptance'))
-      @solar_absorptance_isdefaulted = get_software_defaulted(wall, 'SolarAbsorptance') unless @solar_absorptance.nil?
-      @emittance = to_float_or_nil(XMLHelper.get_value(wall, 'Emittance'))
-      @emittance_isdefaulted = get_software_defaulted(wall, 'Emittance') unless @emittance.nil?
+      @azimuth = XMLHelper.get_value(wall, 'Azimuth', :integer)
+      @siding, @siding_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'Siding')
+      @color, @color_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'Color')
+      @solar_absorptance, @solar_absorptance_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'SolarAbsorptance', :float)
+      @emittance, @emittance_isdefaulted = XMLHelper.get_value_and_defaulted(wall, 'Emittance', :float)
       insulation = XMLHelper.get_element(wall, 'Insulation')
       if not insulation.nil?
         @insulation_id = HPXML::get_id(insulation)
-        @insulation_assembly_r_value = to_float_or_nil(XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue'))
-        @insulation_cavity_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
-        @insulation_continuous_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+        @insulation_assembly_r_value = XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue', :float)
+        @insulation_cavity_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue", :float)
+        @insulation_continuous_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
       end
     end
   end
@@ -1953,24 +1918,23 @@ class HPXML < Object
       @id = HPXML::get_id(foundation_wall)
       @exterior_adjacent_to = XMLHelper.get_value(foundation_wall, 'ExteriorAdjacentTo')
       @interior_adjacent_to = XMLHelper.get_value(foundation_wall, 'InteriorAdjacentTo')
-      @height = to_float_or_nil(XMLHelper.get_value(foundation_wall, 'Height'))
-      @area = to_float_or_nil(XMLHelper.get_value(foundation_wall, 'Area'))
-      @azimuth = to_integer_or_nil(XMLHelper.get_value(foundation_wall, 'Azimuth'))
-      @thickness = to_float_or_nil(XMLHelper.get_value(foundation_wall, 'Thickness'))
-      @thickness_isdefaulted = get_software_defaulted(foundation_wall, 'Thickness') unless @thickness.nil?
-      @depth_below_grade = to_float_or_nil(XMLHelper.get_value(foundation_wall, 'DepthBelowGrade'))
+      @height = XMLHelper.get_value(foundation_wall, 'Height', :float)
+      @area = XMLHelper.get_value(foundation_wall, 'Area', :float)
+      @azimuth = XMLHelper.get_value(foundation_wall, 'Azimuth', :integer)
+      @thickness, @thickness_isdefaulted = XMLHelper.get_value_and_defaulted(foundation_wall, 'Thickness', :float)
+      @depth_below_grade = XMLHelper.get_value(foundation_wall, 'DepthBelowGrade', :float)
       insulation = XMLHelper.get_element(foundation_wall, 'Insulation')
       if not insulation.nil?
         @insulation_id = HPXML::get_id(insulation)
-        @insulation_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
-        @insulation_interior_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/NominalRValue"))
-        @insulation_interior_distance_to_top = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/extension/DistanceToTopOfInsulation"))
-        @insulation_interior_distance_to_bottom = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/extension/DistanceToBottomOfInsulation"))
-        @insulation_exterior_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/NominalRValue"))
-        @insulation_exterior_distance_to_top = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/extension/DistanceToTopOfInsulation"))
-        @insulation_exterior_distance_to_bottom = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/extension/DistanceToBottomOfInsulation"))
-        @insulation_continuous_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
-        @insulation_assembly_r_value = to_float_or_nil(XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue'))
+        @insulation_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
+        @insulation_interior_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/NominalRValue", :float)
+        @insulation_interior_distance_to_top = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/extension/DistanceToTopOfInsulation", :float)
+        @insulation_interior_distance_to_bottom = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - interior']/extension/DistanceToBottomOfInsulation", :float)
+        @insulation_exterior_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/NominalRValue", :float)
+        @insulation_exterior_distance_to_top = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/extension/DistanceToTopOfInsulation", :float)
+        @insulation_exterior_distance_to_bottom = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous - exterior']/extension/DistanceToBottomOfInsulation", :float)
+        @insulation_continuous_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
+        @insulation_assembly_r_value = XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue', :float)
       end
     end
   end
@@ -2077,13 +2041,13 @@ class HPXML < Object
       @id = HPXML::get_id(frame_floor)
       @exterior_adjacent_to = XMLHelper.get_value(frame_floor, 'ExteriorAdjacentTo')
       @interior_adjacent_to = XMLHelper.get_value(frame_floor, 'InteriorAdjacentTo')
-      @area = to_float_or_nil(XMLHelper.get_value(frame_floor, 'Area'))
+      @area = XMLHelper.get_value(frame_floor, 'Area', :float)
       insulation = XMLHelper.get_element(frame_floor, 'Insulation')
       if not insulation.nil?
         @insulation_id = HPXML::get_id(insulation)
-        @insulation_assembly_r_value = to_float_or_nil(XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue'))
-        @insulation_cavity_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
-        @insulation_continuous_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+        @insulation_assembly_r_value = XMLHelper.get_value(insulation, 'AssemblyEffectiveRValue', :float)
+        @insulation_cavity_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue", :float)
+        @insulation_continuous_r_value = XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
       end
       @other_space_above_or_below = XMLHelper.get_value(frame_floor, 'extension/OtherSpaceAboveOrBelow')
     end
@@ -2194,27 +2158,24 @@ class HPXML < Object
 
       @id = HPXML::get_id(slab)
       @interior_adjacent_to = XMLHelper.get_value(slab, 'InteriorAdjacentTo')
-      @area = to_float_or_nil(XMLHelper.get_value(slab, 'Area'))
-      @thickness = to_float_or_nil(XMLHelper.get_value(slab, 'Thickness'))
-      @thickness_isdefaulted = get_software_defaulted(slab, 'Thickness') unless @thickness.nil?
-      @exposed_perimeter = to_float_or_nil(XMLHelper.get_value(slab, 'ExposedPerimeter'))
-      @perimeter_insulation_depth = to_float_or_nil(XMLHelper.get_value(slab, 'PerimeterInsulationDepth'))
-      @under_slab_insulation_width = to_float_or_nil(XMLHelper.get_value(slab, 'UnderSlabInsulationWidth'))
-      @under_slab_insulation_spans_entire_slab = to_boolean_or_nil(XMLHelper.get_value(slab, 'UnderSlabInsulationSpansEntireSlab'))
-      @depth_below_grade = to_float_or_nil(XMLHelper.get_value(slab, 'DepthBelowGrade'))
-      @carpet_fraction = to_float_or_nil(XMLHelper.get_value(slab, 'extension/CarpetFraction'))
-      @carpet_fraction_isdefaulted = get_software_defaulted(slab, 'extension/CarpetFraction') unless @carpet_fraction.nil?
-      @carpet_r_value = to_float_or_nil(XMLHelper.get_value(slab, 'extension/CarpetRValue'))
-      @carpet_r_value_isdefaulted = get_software_defaulted(slab, 'extension/CarpetRValue') unless @carpet_r_value.nil?
+      @area = XMLHelper.get_value(slab, 'Area', :float)
+      @thickness, @thickness_isdefaulted = XMLHelper.get_value_and_defaulted(slab, 'Thickness', :float)
+      @exposed_perimeter = XMLHelper.get_value(slab, 'ExposedPerimeter', :float)
+      @perimeter_insulation_depth = XMLHelper.get_value(slab, 'PerimeterInsulationDepth', :float)
+      @under_slab_insulation_width = XMLHelper.get_value(slab, 'UnderSlabInsulationWidth', :float)
+      @under_slab_insulation_spans_entire_slab = XMLHelper.get_value(slab, 'UnderSlabInsulationSpansEntireSlab', :boolean)
+      @depth_below_grade = XMLHelper.get_value(slab, 'DepthBelowGrade', :float)
+      @carpet_fraction, @carpet_fraction_isdefaulted = XMLHelper.get_value_and_defaulted(slab, 'extension/CarpetFraction', :float)
+      @carpet_r_value, @carpet_r_value_isdefaulted = XMLHelper.get_value_and_defaulted(slab, 'extension/CarpetRValue', :float)
       perimeter_insulation = XMLHelper.get_element(slab, 'PerimeterInsulation')
       if not perimeter_insulation.nil?
         @perimeter_insulation_id = HPXML::get_id(perimeter_insulation)
-        @perimeter_insulation_r_value = to_float_or_nil(XMLHelper.get_value(perimeter_insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+        @perimeter_insulation_r_value = XMLHelper.get_value(perimeter_insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
       end
       under_slab_insulation = XMLHelper.get_element(slab, 'UnderSlabInsulation')
       if not under_slab_insulation.nil?
         @under_slab_insulation_id = HPXML::get_id(under_slab_insulation)
-        @under_slab_insulation_r_value = to_float_or_nil(XMLHelper.get_value(under_slab_insulation, "Layer[InstallationType='continuous']/NominalRValue"))
+        @under_slab_insulation_r_value = XMLHelper.get_value(under_slab_insulation, "Layer[InstallationType='continuous']/NominalRValue", :float)
       end
     end
   end
@@ -2319,26 +2280,23 @@ class HPXML < Object
       return if window.nil?
 
       @id = HPXML::get_id(window)
-      @area = to_float_or_nil(XMLHelper.get_value(window, 'Area'))
-      @azimuth = to_integer_or_nil(XMLHelper.get_value(window, 'Azimuth'))
+      @area = XMLHelper.get_value(window, 'Area', :float)
+      @azimuth = XMLHelper.get_value(window, 'Azimuth', :integer)
       @orientation = XMLHelper.get_value(window, 'Orientation')
       @frame_type = XMLHelper.get_child_name(window, 'FrameType')
-      @aluminum_thermal_break = to_boolean_or_nil(XMLHelper.get_value(window, 'FrameType/Aluminum/ThermalBreak'))
+      @aluminum_thermal_break = XMLHelper.get_value(window, 'FrameType/Aluminum/ThermalBreak', :boolean)
       @glass_layers = XMLHelper.get_value(window, 'GlassLayers')
       @glass_type = XMLHelper.get_value(window, 'GlassType')
       @gas_fill = XMLHelper.get_value(window, 'GasFill')
-      @ufactor = to_float_or_nil(XMLHelper.get_value(window, 'UFactor'))
-      @shgc = to_float_or_nil(XMLHelper.get_value(window, 'SHGC'))
-      @interior_shading_factor_summer = to_float_or_nil(XMLHelper.get_value(window, 'InteriorShading/SummerShadingCoefficient'))
-      @interior_shading_factor_summer_isdefaulted = get_software_defaulted(window, 'InteriorShading/SummerShadingCoefficient') unless @interior_shading_factor_summer.nil?
-      @interior_shading_factor_winter = to_float_or_nil(XMLHelper.get_value(window, 'InteriorShading/WinterShadingCoefficient'))
-      @interior_shading_factor_winter_isdefaulted = get_software_defaulted(window, 'InteriorShading/WinterShadingCoefficient') unless @interior_shading_factor_winter.nil?
+      @ufactor = XMLHelper.get_value(window, 'UFactor', :float)
+      @shgc = XMLHelper.get_value(window, 'SHGC', :float)
+      @interior_shading_factor_summer, @interior_shading_factor_summer_isdefaulted = XMLHelper.get_value_and_defaulted(window, 'InteriorShading/SummerShadingCoefficient', :float)
+      @interior_shading_factor_winter, @interior_shading_factor_winter_isdefaulted = XMLHelper.get_value_and_defaulted(window, 'InteriorShading/WinterShadingCoefficient', :float)
       @exterior_shading = XMLHelper.get_value(window, 'ExteriorShading/Type')
-      @overhangs_depth = to_float_or_nil(XMLHelper.get_value(window, 'Overhangs/Depth'))
-      @overhangs_distance_to_top_of_window = to_float_or_nil(XMLHelper.get_value(window, 'Overhangs/DistanceToTopOfWindow'))
-      @overhangs_distance_to_bottom_of_window = to_float_or_nil(XMLHelper.get_value(window, 'Overhangs/DistanceToBottomOfWindow'))
-      @fraction_operable = to_float_or_nil(XMLHelper.get_value(window, 'FractionOperable'))
-      @fraction_operable_isdefaulted = get_software_defaulted(window, 'FractionOperable') unless @fraction_operable.nil?
+      @overhangs_depth = XMLHelper.get_value(window, 'Overhangs/Depth', :float)
+      @overhangs_distance_to_top_of_window = XMLHelper.get_value(window, 'Overhangs/DistanceToTopOfWindow', :float)
+      @overhangs_distance_to_bottom_of_window = XMLHelper.get_value(window, 'Overhangs/DistanceToBottomOfWindow', :float)
+      @fraction_operable, @fraction_operable_isdefaulted = XMLHelper.get_value_and_defaulted(window, 'FractionOperable', :float)
       @wall_idref = HPXML::get_idref(XMLHelper.get_element(window, 'AttachedToWall'))
     end
   end
@@ -2428,20 +2386,18 @@ class HPXML < Object
       return if skylight.nil?
 
       @id = HPXML::get_id(skylight)
-      @area = to_float_or_nil(XMLHelper.get_value(skylight, 'Area'))
-      @azimuth = to_integer_or_nil(XMLHelper.get_value(skylight, 'Azimuth'))
+      @area = XMLHelper.get_value(skylight, 'Area', :float)
+      @azimuth = XMLHelper.get_value(skylight, 'Azimuth', :integer)
       @orientation = XMLHelper.get_value(skylight, 'Orientation')
       @frame_type = XMLHelper.get_child_name(skylight, 'FrameType')
-      @aluminum_thermal_break = to_boolean_or_nil(XMLHelper.get_value(skylight, 'FrameType/Aluminum/ThermalBreak'))
+      @aluminum_thermal_break = XMLHelper.get_value(skylight, 'FrameType/Aluminum/ThermalBreak', :boolean)
       @glass_layers = XMLHelper.get_value(skylight, 'GlassLayers')
       @glass_type = XMLHelper.get_value(skylight, 'GlassType')
       @gas_fill = XMLHelper.get_value(skylight, 'GasFill')
-      @ufactor = to_float_or_nil(XMLHelper.get_value(skylight, 'UFactor'))
-      @shgc = to_float_or_nil(XMLHelper.get_value(skylight, 'SHGC'))
-      @interior_shading_factor_summer = to_float_or_nil(XMLHelper.get_value(skylight, 'InteriorShading/SummerShadingCoefficient'))
-      @interior_shading_factor_summer_isdefaulted = get_software_defaulted(skylight, 'InteriorShading/SummerShadingCoefficient') unless @interior_shading_factor_summer.nil?
-      @interior_shading_factor_winter = to_float_or_nil(XMLHelper.get_value(skylight, 'InteriorShading/WinterShadingCoefficient'))
-      @interior_shading_factor_winter_isdefaulted = get_software_defaulted(skylight, 'InteriorShading/WinterShadingCoefficient') unless @interior_shading_factor_winter.nil?
+      @ufactor = XMLHelper.get_value(skylight, 'UFactor', :float)
+      @shgc = XMLHelper.get_value(skylight, 'SHGC', :float)
+      @interior_shading_factor_summer, @interior_shading_factor_summer_isdefaulted = XMLHelper.get_value_and_defaulted(skylight, 'InteriorShading/SummerShadingCoefficient', :float)
+      @interior_shading_factor_winter, @interior_shading_factor_winter_isdefaulted = XMLHelper.get_value_and_defaulted(skylight, 'InteriorShading/WinterShadingCoefficient', :float)
       @exterior_shading = XMLHelper.get_value(skylight, 'ExteriorShading/Type')
       @roof_idref = HPXML::get_idref(XMLHelper.get_element(skylight, 'AttachedToRoof'))
     end
@@ -2523,9 +2479,9 @@ class HPXML < Object
 
       @id = HPXML::get_id(door)
       @wall_idref = HPXML::get_idref(XMLHelper.get_element(door, 'AttachedToWall'))
-      @area = to_float_or_nil(XMLHelper.get_value(door, 'Area'))
-      @azimuth = to_integer_or_nil(XMLHelper.get_value(door, 'Azimuth'))
-      @r_value = to_float_or_nil(XMLHelper.get_value(door, 'RValue'))
+      @area = XMLHelper.get_value(door, 'Area', :float)
+      @azimuth = XMLHelper.get_value(door, 'Azimuth', :integer)
+      @r_value = XMLHelper.get_value(door, 'RValue', :float)
     end
   end
 
@@ -2647,29 +2603,26 @@ class HPXML < Object
 
       @id = HPXML::get_id(heating_system)
       @distribution_system_idref = HPXML::get_idref(XMLHelper.get_element(heating_system, 'DistributionSystem'))
-      @year_installed = to_integer_or_nil(XMLHelper.get_value(heating_system, 'YearInstalled'))
-      @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(heating_system, 'IsSharedSystem'))
-      @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(heating_system, 'NumberofUnitsServed'))
+      @year_installed = XMLHelper.get_value(heating_system, 'YearInstalled', :integer)
+      @is_shared_system = XMLHelper.get_value(heating_system, 'IsSharedSystem', :boolean)
+      @number_of_units_served = XMLHelper.get_value(heating_system, 'NumberofUnitsServed', :integer)
       @heating_system_type = XMLHelper.get_child_name(heating_system, 'HeatingSystemType')
       @heating_system_fuel = XMLHelper.get_value(heating_system, 'HeatingSystemFuel')
-      @heating_capacity = to_float_or_nil(XMLHelper.get_value(heating_system, 'HeatingCapacity'))
+      @heating_capacity = XMLHelper.get_value(heating_system, 'HeatingCapacity', :float)
       if [HVACTypeFurnace, HVACTypeWallFurnace, HVACTypeFloorFurnace, HVACTypeBoiler].include? @heating_system_type
-        @heating_efficiency_afue = to_float_or_nil(XMLHelper.get_value(heating_system, "AnnualHeatingEfficiency[Units='#{UnitsAFUE}']/Value"))
+        @heating_efficiency_afue = XMLHelper.get_value(heating_system, "AnnualHeatingEfficiency[Units='#{UnitsAFUE}']/Value", :float)
       elsif [HVACTypeElectricResistance, HVACTypeStove, HVACTypePortableHeater, HVACTypeFixedHeater, HVACTypeFireplace].include? @heating_system_type
-        @heating_efficiency_percent = to_float_or_nil(XMLHelper.get_value(heating_system, "AnnualHeatingEfficiency[Units='Percent']/Value"))
+        @heating_efficiency_percent = XMLHelper.get_value(heating_system, "AnnualHeatingEfficiency[Units='Percent']/Value", :float)
       end
-      @fraction_heat_load_served = to_float_or_nil(XMLHelper.get_value(heating_system, 'FractionHeatLoadServed'))
-      @electric_auxiliary_energy = to_float_or_nil(XMLHelper.get_value(heating_system, 'ElectricAuxiliaryEnergy'))
-      @electric_auxiliary_energy_isdefaulted = get_software_defaulted(heating_system, 'ElectricAuxiliaryEnergy') unless @electric_auxiliary_energy.nil?
+      @fraction_heat_load_served = XMLHelper.get_value(heating_system, 'FractionHeatLoadServed', :float)
+      @electric_auxiliary_energy, @electric_auxiliary_energy_isdefaulted = XMLHelper.get_value_and_defaulted(heating_system, 'ElectricAuxiliaryEnergy', :float)
       @energy_star = XMLHelper.get_values(heating_system, 'ThirdPartyCertification').include?('Energy Star')
       @seed_id = XMLHelper.get_value(heating_system, 'extension/SeedId')
-      @fan_watts_per_cfm = to_float_or_nil(XMLHelper.get_value(heating_system, 'extension/FanPowerWattsPerCFM'))
-      @fan_watts_per_cfm_isdefaulted = get_software_defaulted(heating_system, 'extension/FanPowerWattsPerCFM') unless @fan_watts_per_cfm.nil?
-      @fan_watts = to_float_or_nil(XMLHelper.get_value(heating_system, 'extension/FanPowerWatts'))
-      @fan_watts_isdefaulted = get_software_defaulted(heating_system, 'extension/FanPowerWatts') unless @fan_watts.nil?
-      @shared_loop_watts = to_float_or_nil(XMLHelper.get_value(heating_system, 'extension/SharedLoopWatts'))
-      @fan_coil_watts = to_float_or_nil(XMLHelper.get_value(heating_system, 'extension/FanCoilWatts'))
-      @wlhp_heating_efficiency_cop = to_float_or_nil(XMLHelper.get_value(heating_system, "extension/WaterLoopHeatPump/AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value"))
+      @fan_watts_per_cfm, @fan_watts_per_cfm_isdefaulted = XMLHelper.get_value_and_defaulted(heating_system, 'extension/FanPowerWattsPerCFM', :float)
+      @fan_watts, @fan_watts_isdefaulted = XMLHelper.get_value_and_defaulted(heating_system, 'extension/FanPowerWatts', :float)
+      @shared_loop_watts = XMLHelper.get_value(heating_system, 'extension/SharedLoopWatts', :float)
+      @fan_coil_watts = XMLHelper.get_value(heating_system, 'extension/FanCoilWatts', :float)
+      @wlhp_heating_efficiency_cop = XMLHelper.get_value(heating_system, "extension/WaterLoopHeatPump/AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value", :float)
     end
   end
 
@@ -2794,32 +2747,29 @@ class HPXML < Object
 
       @id = HPXML::get_id(cooling_system)
       @distribution_system_idref = HPXML::get_idref(XMLHelper.get_element(cooling_system, 'DistributionSystem'))
-      @year_installed = to_integer_or_nil(XMLHelper.get_value(cooling_system, 'YearInstalled'))
-      @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(cooling_system, 'IsSharedSystem'))
-      @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(cooling_system, 'NumberofUnitsServed'))
+      @year_installed = XMLHelper.get_value(cooling_system, 'YearInstalled', :integer)
+      @is_shared_system = XMLHelper.get_value(cooling_system, 'IsSharedSystem', :boolean)
+      @number_of_units_served = XMLHelper.get_value(cooling_system, 'NumberofUnitsServed', :integer)
       @cooling_system_type = XMLHelper.get_value(cooling_system, 'CoolingSystemType')
       @cooling_system_fuel = XMLHelper.get_value(cooling_system, 'CoolingSystemFuel')
-      @cooling_capacity = to_float_or_nil(XMLHelper.get_value(cooling_system, 'CoolingCapacity'))
-      @compressor_type = XMLHelper.get_value(cooling_system, 'CompressorType')
-      @compressor_type_isdefaulted = get_software_defaulted(cooling_system, 'CompressorType') unless @compressor_type.nil?
-      @fraction_cool_load_served = to_float_or_nil(XMLHelper.get_value(cooling_system, 'FractionCoolLoadServed'))
+      @cooling_capacity = XMLHelper.get_value(cooling_system, 'CoolingCapacity', :float)
+      @compressor_type, @compressor_type_isdefaulted = XMLHelper.get_value_and_defaulted(cooling_system, 'CompressorType')
+      @fraction_cool_load_served = XMLHelper.get_value(cooling_system, 'FractionCoolLoadServed', :float)
       if [HVACTypeCentralAirConditioner, HVACTypeMiniSplitAirConditioner].include? @cooling_system_type
-        @cooling_efficiency_seer = to_float_or_nil(XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsSEER}']/Value"))
+        @cooling_efficiency_seer = XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsSEER}']/Value", :float)
       elsif [HVACTypeRoomAirConditioner].include? @cooling_system_type
-        @cooling_efficiency_eer = to_float_or_nil(XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsEER}']/Value"))
+        @cooling_efficiency_eer = XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsEER}']/Value", :float)
       elsif [HVACTypeChiller].include? @cooling_system_type
-        @cooling_efficiency_kw_per_ton = to_float_or_nil(XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsKwPerTon}']/Value"))
+        @cooling_efficiency_kw_per_ton = XMLHelper.get_value(cooling_system, "AnnualCoolingEfficiency[Units='#{UnitsKwPerTon}']/Value", :float)
       end
-      @cooling_shr = to_float_or_nil(XMLHelper.get_value(cooling_system, 'SensibleHeatFraction'))
-      @cooling_shr_isdefaulted = get_software_defaulted(cooling_system, 'SensibleHeatFraction') unless @cooling_shr.nil?
+      @cooling_shr, @cooling_shr_isdefaulted = XMLHelper.get_value_and_defaulted(cooling_system, 'SensibleHeatFraction', :float)
       @energy_star = XMLHelper.get_values(cooling_system, 'ThirdPartyCertification').include?('Energy Star')
       @seed_id = XMLHelper.get_value(cooling_system, 'extension/SeedId')
-      @fan_watts_per_cfm = to_float_or_nil(XMLHelper.get_value(cooling_system, 'extension/FanPowerWattsPerCFM'))
-      @fan_watts_per_cfm_isdefaulted = get_software_defaulted(cooling_system, 'extension/FanPowerWattsPerCFM') unless @fan_watts_per_cfm.nil?
-      @shared_loop_watts = to_float_or_nil(XMLHelper.get_value(cooling_system, 'extension/SharedLoopWatts'))
-      @fan_coil_watts = to_float_or_nil(XMLHelper.get_value(cooling_system, 'extension/FanCoilWatts'))
-      @wlhp_cooling_capacity = to_float_or_nil(XMLHelper.get_value(cooling_system, 'extension/WaterLoopHeatPump/CoolingCapacity'))
-      @wlhp_cooling_efficiency_eer = to_float_or_nil(XMLHelper.get_value(cooling_system, "extension/WaterLoopHeatPump/AnnualCoolingEfficiency[Units='#{UnitsEER}']/Value"))
+      @fan_watts_per_cfm, @fan_watts_per_cfm_isdefaulted = XMLHelper.get_value_and_defaulted(cooling_system, 'extension/FanPowerWattsPerCFM', :float)
+      @shared_loop_watts = XMLHelper.get_value(cooling_system, 'extension/SharedLoopWatts', :float)
+      @fan_coil_watts = XMLHelper.get_value(cooling_system, 'extension/FanCoilWatts', :float)
+      @wlhp_cooling_capacity = XMLHelper.get_value(cooling_system, 'extension/WaterLoopHeatPump/CoolingCapacity', :float)
+      @wlhp_cooling_efficiency_eer = XMLHelper.get_value(cooling_system, "extension/WaterLoopHeatPump/AnnualCoolingEfficiency[Units='#{UnitsEER}']/Value", :float)
     end
   end
 
@@ -2955,42 +2905,38 @@ class HPXML < Object
 
       @id = HPXML::get_id(heat_pump)
       @distribution_system_idref = HPXML::get_idref(XMLHelper.get_element(heat_pump, 'DistributionSystem'))
-      @year_installed = to_integer_or_nil(XMLHelper.get_value(heat_pump, 'YearInstalled'))
-      @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(heat_pump, 'IsSharedSystem'))
-      @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(heat_pump, 'NumberofUnitsServed'))
+      @year_installed = XMLHelper.get_value(heat_pump, 'YearInstalled', :integer)
+      @is_shared_system = XMLHelper.get_value(heat_pump, 'IsSharedSystem', :boolean)
+      @number_of_units_served = XMLHelper.get_value(heat_pump, 'NumberofUnitsServed', :integer)
       @heat_pump_type = XMLHelper.get_value(heat_pump, 'HeatPumpType')
       @heat_pump_fuel = XMLHelper.get_value(heat_pump, 'HeatPumpFuel')
-      @heating_capacity = to_float_or_nil(XMLHelper.get_value(heat_pump, 'HeatingCapacity'))
-      @heating_capacity_17F = to_float_or_nil(XMLHelper.get_value(heat_pump, 'HeatingCapacity17F'))
-      @cooling_capacity = to_float_or_nil(XMLHelper.get_value(heat_pump, 'CoolingCapacity'))
-      @compressor_type = XMLHelper.get_value(heat_pump, 'CompressorType')
-      @compressor_type_isdefaulted = get_software_defaulted(heat_pump, 'CompressorType') unless @compressor_type.nil?
-      @cooling_shr = to_float_or_nil(XMLHelper.get_value(heat_pump, 'CoolingSensibleHeatFraction'))
-      @cooling_shr_isdefaulted = get_software_defaulted(heat_pump, 'CoolingSensibleHeatFraction') unless @cooling_shr.nil?
+      @heating_capacity = XMLHelper.get_value(heat_pump, 'HeatingCapacity', :float)
+      @heating_capacity_17F = XMLHelper.get_value(heat_pump, 'HeatingCapacity17F', :float)
+      @cooling_capacity = XMLHelper.get_value(heat_pump, 'CoolingCapacity', :float)
+      @compressor_type, @compressor_type_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'CompressorType')
+      @cooling_shr, @cooling_shr_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'CoolingSensibleHeatFraction', :float)
       @backup_heating_fuel = XMLHelper.get_value(heat_pump, 'BackupSystemFuel')
-      @backup_heating_capacity = to_float_or_nil(XMLHelper.get_value(heat_pump, 'BackupHeatingCapacity'))
-      @backup_heating_efficiency_percent = to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='Percent']/Value"))
-      @backup_heating_efficiency_afue = to_float_or_nil(XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='#{UnitsAFUE}']/Value"))
-      @backup_heating_switchover_temp = to_float_or_nil(XMLHelper.get_value(heat_pump, 'BackupHeatingSwitchoverTemperature'))
-      @fraction_heat_load_served = to_float_or_nil(XMLHelper.get_value(heat_pump, 'FractionHeatLoadServed'))
-      @fraction_cool_load_served = to_float_or_nil(XMLHelper.get_value(heat_pump, 'FractionCoolLoadServed'))
+      @backup_heating_capacity = XMLHelper.get_value(heat_pump, 'BackupHeatingCapacity', :float)
+      @backup_heating_efficiency_percent = XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='Percent']/Value", :float)
+      @backup_heating_efficiency_afue = XMLHelper.get_value(heat_pump, "BackupAnnualHeatingEfficiency[Units='#{UnitsAFUE}']/Value", :float)
+      @backup_heating_switchover_temp = XMLHelper.get_value(heat_pump, 'BackupHeatingSwitchoverTemperature', :float)
+      @fraction_heat_load_served = XMLHelper.get_value(heat_pump, 'FractionHeatLoadServed', :float)
+      @fraction_cool_load_served = XMLHelper.get_value(heat_pump, 'FractionCoolLoadServed', :float)
       if [HVACTypeHeatPumpAirToAir, HVACTypeHeatPumpMiniSplit].include? @heat_pump_type
-        @cooling_efficiency_seer = to_float_or_nil(XMLHelper.get_value(heat_pump, "AnnualCoolingEfficiency[Units='#{UnitsSEER}']/Value"))
+        @cooling_efficiency_seer = XMLHelper.get_value(heat_pump, "AnnualCoolingEfficiency[Units='#{UnitsSEER}']/Value", :float)
       elsif [HVACTypeHeatPumpGroundToAir].include? @heat_pump_type
-        @cooling_efficiency_eer = to_float_or_nil(XMLHelper.get_value(heat_pump, "AnnualCoolingEfficiency[Units='#{UnitsEER}']/Value"))
+        @cooling_efficiency_eer = XMLHelper.get_value(heat_pump, "AnnualCoolingEfficiency[Units='#{UnitsEER}']/Value", :float)
       end
       if [HVACTypeHeatPumpAirToAir, HVACTypeHeatPumpMiniSplit].include? @heat_pump_type
-        @heating_efficiency_hspf = to_float_or_nil(XMLHelper.get_value(heat_pump, "AnnualHeatingEfficiency[Units='#{UnitsHSPF}']/Value"))
+        @heating_efficiency_hspf = XMLHelper.get_value(heat_pump, "AnnualHeatingEfficiency[Units='#{UnitsHSPF}']/Value", :float)
       elsif [HVACTypeHeatPumpGroundToAir].include? @heat_pump_type
-        @heating_efficiency_cop = to_float_or_nil(XMLHelper.get_value(heat_pump, "AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value"))
+        @heating_efficiency_cop = XMLHelper.get_value(heat_pump, "AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value", :float)
       end
       @energy_star = XMLHelper.get_values(heat_pump, 'ThirdPartyCertification').include?('Energy Star')
-      @pump_watts_per_ton = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/PumpPowerWattsPerTon'))
-      @pump_watts_per_ton_isdefaulted = get_software_defaulted(heat_pump, 'extension/PumpPowerWattsPerTon') unless @pump_watts_per_ton.nil?
-      @fan_watts_per_cfm = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/FanPowerWattsPerCFM'))
-      @fan_watts_per_cfm_isdefaulted = get_software_defaulted(heat_pump, 'extension/FanPowerWattsPerCFM') unless @fan_watts_per_cfm.nil?
+      @pump_watts_per_ton, @pump_watts_per_ton_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'extension/PumpPowerWattsPerTon', :float)
+      @fan_watts_per_cfm, @fan_watts_per_cfm_isdefaulted = XMLHelper.get_value_and_defaulted(heat_pump, 'extension/FanPowerWattsPerCFM', :float)
       @seed_id = XMLHelper.get_value(heat_pump, 'extension/SeedId')
-      @shared_loop_watts = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/SharedLoopWatts'))
+      @shared_loop_watts = XMLHelper.get_value(heat_pump, 'extension/SharedLoopWatts', :float)
     end
   end
 
@@ -3054,17 +3000,15 @@ class HPXML < Object
 
       @id = HPXML::get_id(hvac_control)
       @control_type = XMLHelper.get_value(hvac_control, 'ControlType')
-      @heating_setpoint_temp = to_float_or_nil(XMLHelper.get_value(hvac_control, 'SetpointTempHeatingSeason'))
-      @heating_setback_temp = to_float_or_nil(XMLHelper.get_value(hvac_control, 'SetbackTempHeatingSeason'))
-      @heating_setback_hours_per_week = to_integer_or_nil(XMLHelper.get_value(hvac_control, 'TotalSetbackHoursperWeekHeating'))
-      @heating_setback_start_hour = to_integer_or_nil(XMLHelper.get_value(hvac_control, 'extension/SetbackStartHourHeating'))
-      @heating_setback_start_hour_isdefaulted = get_software_defaulted(hvac_control, 'extension/SetbackStartHourHeating') unless @heating_setback_start_hour.nil?
-      @cooling_setpoint_temp = to_float_or_nil(XMLHelper.get_value(hvac_control, 'SetpointTempCoolingSeason'))
-      @cooling_setup_temp = to_float_or_nil(XMLHelper.get_value(hvac_control, 'SetupTempCoolingSeason'))
-      @cooling_setup_hours_per_week = to_integer_or_nil(XMLHelper.get_value(hvac_control, 'TotalSetupHoursperWeekCooling'))
-      @cooling_setup_start_hour = to_integer_or_nil(XMLHelper.get_value(hvac_control, 'extension/SetupStartHourCooling'))
-      @cooling_setup_start_hour_isdefaulted = get_software_defaulted(hvac_control, 'extension/SetupStartHourCooling') unless @cooling_setup_start_hour.nil?
-      @ceiling_fan_cooling_setpoint_temp_offset = to_float_or_nil(XMLHelper.get_value(hvac_control, 'extension/CeilingFanSetpointTempCoolingSeasonOffset'))
+      @heating_setpoint_temp = XMLHelper.get_value(hvac_control, 'SetpointTempHeatingSeason', :float)
+      @heating_setback_temp = XMLHelper.get_value(hvac_control, 'SetbackTempHeatingSeason', :float)
+      @heating_setback_hours_per_week = XMLHelper.get_value(hvac_control, 'TotalSetbackHoursperWeekHeating', :integer)
+      @heating_setback_start_hour, @heating_setback_start_hour_isdefaulted = XMLHelper.get_value_and_defaulted(hvac_control, 'extension/SetbackStartHourHeating', :integer)
+      @cooling_setpoint_temp = XMLHelper.get_value(hvac_control, 'SetpointTempCoolingSeason', :float)
+      @cooling_setup_temp = XMLHelper.get_value(hvac_control, 'SetupTempCoolingSeason', :float)
+      @cooling_setup_hours_per_week = XMLHelper.get_value(hvac_control, 'TotalSetupHoursperWeekCooling', :integer)
+      @cooling_setup_start_hour, @cooling_setup_start_hour_isdefaulted = XMLHelper.get_value_and_defaulted(hvac_control, 'extension/SetupStartHourCooling', :integer)
+      @ceiling_fan_cooling_setpoint_temp_offset = XMLHelper.get_value(hvac_control, 'extension/CeilingFanSetpointTempCoolingSeasonOffset', :float)
       @weekday_heating_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekdaySetpointTempsHeatingSeason')
       @weekend_heating_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekendSetpointTempsHeatingSeason')
       @weekday_cooling_setpoints = XMLHelper.get_value(hvac_control, 'extension/WeekdaySetpointTempsCoolingSeason')
@@ -3203,10 +3147,10 @@ class HPXML < Object
       if @distribution_system_type == 'Other'
         @distribution_system_type = XMLHelper.get_value(XMLHelper.get_element(hvac_distribution, 'DistributionSystemType'), 'Other')
       end
-      @annual_heating_dse = to_float_or_nil(XMLHelper.get_value(hvac_distribution, 'AnnualHeatingDistributionSystemEfficiency'))
-      @annual_cooling_dse = to_float_or_nil(XMLHelper.get_value(hvac_distribution, 'AnnualCoolingDistributionSystemEfficiency'))
-      @duct_system_sealed = to_boolean_or_nil(XMLHelper.get_value(hvac_distribution, 'HVACDistributionImprovement/DuctSystemSealed'))
-      @conditioned_floor_area_served = to_float_or_nil(XMLHelper.get_value(hvac_distribution, 'ConditionedFloorAreaServed'))
+      @annual_heating_dse = XMLHelper.get_value(hvac_distribution, 'AnnualHeatingDistributionSystemEfficiency', :float)
+      @annual_cooling_dse = XMLHelper.get_value(hvac_distribution, 'AnnualCoolingDistributionSystemEfficiency', :float)
+      @duct_system_sealed = XMLHelper.get_value(hvac_distribution, 'HVACDistributionImprovement/DuctSystemSealed', :boolean)
+      @conditioned_floor_area_served = XMLHelper.get_value(hvac_distribution, 'ConditionedFloorAreaServed', :float)
 
       air_distribution = XMLHelper.get_element(hvac_distribution, 'DistributionSystemType/AirDistribution')
       hydronic_distribution = XMLHelper.get_element(hvac_distribution, 'DistributionSystemType/HydronicDistribution')
@@ -3221,9 +3165,8 @@ class HPXML < Object
       if (not air_distribution.nil?) || (not hydronic_and_air_distribution.nil?)
         distribution = air_distribution
         distribution = hydronic_and_air_distribution if distribution.nil?
-        @number_of_return_registers = to_integer_or_nil(XMLHelper.get_value(distribution, 'NumberofReturnRegisters'))
-        @number_of_return_registers_isdefaulted = get_software_defaulted(distribution, 'NumberofReturnRegisters') unless @number_of_return_registers.nil?
-        @duct_leakage_to_outside_testing_exemption = to_boolean_or_nil(XMLHelper.get_value(distribution, 'extension/DuctLeakageToOutsideTestingExemption'))
+        @number_of_return_registers, @number_of_return_registers_isdefaulted = XMLHelper.get_value_and_defaulted(distribution, 'NumberofReturnRegisters', :integer)
+        @duct_leakage_to_outside_testing_exemption = XMLHelper.get_value(distribution, 'extension/DuctLeakageToOutsideTestingExemption', :boolean)
         @duct_leakage_measurements.from_oga(distribution)
         @ducts.from_oga(distribution)
       end
@@ -3279,7 +3222,7 @@ class HPXML < Object
       @duct_type = XMLHelper.get_value(duct_leakage_measurement, 'DuctType')
       @duct_leakage_test_method = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakageTestMethod')
       @duct_leakage_units = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/Units')
-      @duct_leakage_value = to_float_or_nil(XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/Value'))
+      @duct_leakage_value = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/Value', :float)
       @duct_leakage_total_or_to_outside = XMLHelper.get_value(duct_leakage_measurement, 'DuctLeakage/TotalOrToOutside')
     end
   end
@@ -3328,13 +3271,11 @@ class HPXML < Object
       return if duct.nil?
 
       @duct_type = XMLHelper.get_value(duct, 'DuctType')
-      @duct_insulation_r_value = to_float_or_nil(XMLHelper.get_value(duct, 'DuctInsulationRValue'))
+      @duct_insulation_r_value = XMLHelper.get_value(duct, 'DuctInsulationRValue', :float)
       @duct_insulation_material = XMLHelper.get_child_name(duct, 'DuctInsulationMaterial')
-      @duct_location = XMLHelper.get_value(duct, 'DuctLocation')
-      @duct_location_isdefaulted = get_software_defaulted(duct, 'DuctLocation') unless @duct_location.nil?
-      @duct_fraction_area = to_float_or_nil(XMLHelper.get_value(duct, 'FractionDuctArea'))
-      @duct_surface_area = to_float_or_nil(XMLHelper.get_value(duct, 'DuctSurfaceArea'))
-      @duct_surface_area_isdefaulted = get_software_defaulted(duct, 'DuctSurfaceArea') unless @duct_surface_area.nil?
+      @duct_location, @duct_location_isdefaulted = XMLHelper.get_value_and_defaulted(duct, 'DuctLocation')
+      @duct_fraction_area = XMLHelper.get_value(duct, 'FractionDuctArea', :float)
+      @duct_surface_area, @duct_surface_area_isdefaulted = XMLHelper.get_value_and_defaulted(duct, 'DuctSurfaceArea', :float)
     end
   end
 
@@ -3549,41 +3490,35 @@ class HPXML < Object
       return if ventilation_fan.nil?
 
       @id = HPXML::get_id(ventilation_fan)
-      @quantity = to_integer_or_nil(XMLHelper.get_value(ventilation_fan, 'Quantity'))
-      @quantity_isdefaulted = get_software_defaulted(ventilation_fan, 'Quantity') unless @quantity.nil?
+      @quantity, @quantity_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'Quantity', :integer)
       @fan_type = XMLHelper.get_value(ventilation_fan, 'FanType')
-      @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'IsSharedSystem'))
-      @is_shared_system_isdefaulted = get_software_defaulted(ventilation_fan, 'IsSharedSystem') unless @is_shared_system.nil?
-      @rated_flow_rate = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'RatedFlowRate'))
-      @rated_flow_rate_isdefaulted = get_software_defaulted(ventilation_fan, 'RatedFlowRate') unless @rated_flow_rate.nil?
-      @tested_flow_rate = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'TestedFlowRate'))
-      @flow_rate_not_tested = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/FlowRateNotTested'))
-      @fan_power = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'FanPower'))
-      @fan_power_isdefaulted = get_software_defaulted(ventilation_fan, 'FanPower') unless @fan_power.nil?
-      @fan_power_defaulted = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/FanPowerDefaulted'))
+      @is_shared_system, @is_shared_system_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'IsSharedSystem', :boolean)
+      @rated_flow_rate, @rated_flow_rate_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'RatedFlowRate', :float)
+      @tested_flow_rate = XMLHelper.get_value(ventilation_fan, 'TestedFlowRate', :float)
+      @flow_rate_not_tested = XMLHelper.get_value(ventilation_fan, 'extension/FlowRateNotTested', :boolean)
+      @fan_power, @fan_power_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'FanPower', :float)
+      @fan_power_defaulted = XMLHelper.get_value(ventilation_fan, 'extension/FanPowerDefaulted', :boolean)
       if @is_shared_system
-        @fraction_recirculation = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'FractionRecirculation'))
-        @in_unit_flow_rate = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/InUnitFlowRate'))
+        @fraction_recirculation = XMLHelper.get_value(ventilation_fan, 'FractionRecirculation', :float)
+        @in_unit_flow_rate = XMLHelper.get_value(ventilation_fan, 'extension/InUnitFlowRate', :float)
         @preheating_fuel = XMLHelper.get_value(ventilation_fan, 'extension/PreHeating/Fuel')
-        @preheating_efficiency_cop = to_float_or_nil(XMLHelper.get_value(ventilation_fan, "extension/PreHeating/AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value"))
-        @preheating_fraction_load_served = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/PreHeating/FractionVentilationHeatLoadServed'))
+        @preheating_efficiency_cop = XMLHelper.get_value(ventilation_fan, "extension/PreHeating/AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value", :float)
+        @preheating_fraction_load_served = XMLHelper.get_value(ventilation_fan, 'extension/PreHeating/FractionVentilationHeatLoadServed', :float)
         @precooling_fuel = XMLHelper.get_value(ventilation_fan, 'extension/PreCooling/Fuel')
-        @precooling_efficiency_cop = to_float_or_nil(XMLHelper.get_value(ventilation_fan, "extension/PreCooling/AnnualCoolingEfficiency[Units='#{UnitsCOP}']/Value"))
-        @precooling_fraction_load_served = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/PreCooling/FractionVentilationCoolLoadServed'))
+        @precooling_efficiency_cop = XMLHelper.get_value(ventilation_fan, "extension/PreCooling/AnnualCoolingEfficiency[Units='#{UnitsCOP}']/Value", :float)
+        @precooling_fraction_load_served = XMLHelper.get_value(ventilation_fan, 'extension/PreCooling/FractionVentilationCoolLoadServed', :float)
       end
-      @hours_in_operation = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'HoursInOperation'))
-      @hours_in_operation_isdefaulted = get_software_defaulted(ventilation_fan, 'HoursInOperation') unless @hours_in_operation.nil?
+      @hours_in_operation, @hours_in_operation_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'HoursInOperation', :float)
       @fan_location = XMLHelper.get_value(ventilation_fan, 'FanLocation')
-      @used_for_local_ventilation = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'UsedForLocalVentilation'))
-      @used_for_whole_building_ventilation = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'UsedForWholeBuildingVentilation'))
-      @used_for_seasonal_cooling_load_reduction = to_boolean_or_nil(XMLHelper.get_value(ventilation_fan, 'UsedForSeasonalCoolingLoadReduction'))
-      @total_recovery_efficiency = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'TotalRecoveryEfficiency'))
-      @total_recovery_efficiency_adjusted = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'AdjustedTotalRecoveryEfficiency'))
-      @sensible_recovery_efficiency = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'SensibleRecoveryEfficiency'))
-      @sensible_recovery_efficiency_adjusted = to_float_or_nil(XMLHelper.get_value(ventilation_fan, 'AdjustedSensibleRecoveryEfficiency'))
+      @used_for_local_ventilation = XMLHelper.get_value(ventilation_fan, 'UsedForLocalVentilation', :boolean)
+      @used_for_whole_building_ventilation = XMLHelper.get_value(ventilation_fan, 'UsedForWholeBuildingVentilation', :boolean)
+      @used_for_seasonal_cooling_load_reduction = XMLHelper.get_value(ventilation_fan, 'UsedForSeasonalCoolingLoadReduction', :boolean)
+      @total_recovery_efficiency = XMLHelper.get_value(ventilation_fan, 'TotalRecoveryEfficiency', :float)
+      @total_recovery_efficiency_adjusted = XMLHelper.get_value(ventilation_fan, 'AdjustedTotalRecoveryEfficiency', :float)
+      @sensible_recovery_efficiency = XMLHelper.get_value(ventilation_fan, 'SensibleRecoveryEfficiency', :float)
+      @sensible_recovery_efficiency_adjusted = XMLHelper.get_value(ventilation_fan, 'AdjustedSensibleRecoveryEfficiency', :float)
       @distribution_system_idref = HPXML::get_idref(XMLHelper.get_element(ventilation_fan, 'AttachedToHVACDistributionSystem'))
-      @start_hour = to_integer_or_nil(XMLHelper.get_value(ventilation_fan, 'extension/StartHour'))
-      @start_hour_isdefaulted = get_software_defaulted(ventilation_fan, 'extension/StartHour') unless @start_hour.nil?
+      @start_hour, @start_hour_isdefaulted = XMLHelper.get_value_and_defaulted(ventilation_fan, 'extension/StartHour', :integer)
     end
   end
 
@@ -3673,34 +3608,26 @@ class HPXML < Object
       return if water_heating_system.nil?
 
       @id = HPXML::get_id(water_heating_system)
-      @year_installed = to_integer_or_nil(XMLHelper.get_value(water_heating_system, 'YearInstalled'))
+      @year_installed = XMLHelper.get_value(water_heating_system, 'YearInstalled', :integer)
       @fuel_type = XMLHelper.get_value(water_heating_system, 'FuelType')
       @water_heater_type = XMLHelper.get_value(water_heating_system, 'WaterHeaterType')
-      @location = XMLHelper.get_value(water_heating_system, 'Location')
-      @location_isdefaulted = get_software_defaulted(water_heating_system, 'Location') unless @location.nil?
-      @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(water_heating_system, 'IsSharedSystem'))
-      @is_shared_system_isdefaulted = get_software_defaulted(water_heating_system, 'IsSharedSystem') unless @is_shared_system.nil?
-      @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(water_heating_system, 'NumberofUnitsServed'))
-      @performance_adjustment = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'PerformanceAdjustment'))
-      @performance_adjustment_isdefaulted = get_software_defaulted(water_heating_system, 'PerformanceAdjustment') unless @performance_adjustment.nil?
-      @tank_volume = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'TankVolume'))
-      @tank_volume_isdefaulted = get_software_defaulted(water_heating_system, 'TankVolume') unless @tank_volume.nil?
-      @fraction_dhw_load_served = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'FractionDHWLoadServed'))
-      @heating_capacity = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'HeatingCapacity'))
-      @heating_capacity_isdefaulted = get_software_defaulted(water_heating_system, 'HeatingCapacity') unless @heating_capacity.nil?
-      @energy_factor = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'EnergyFactor'))
-      @uniform_energy_factor = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'UniformEnergyFactor'))
-      @first_hour_rating = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'FirstHourRating'))
-      @recovery_efficiency = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'RecoveryEfficiency'))
-      @recovery_efficiency_isdefaulted = get_software_defaulted(water_heating_system, 'RecoveryEfficiency') unless @recovery_efficiency.nil?
-      @uses_desuperheater = to_boolean_or_nil(XMLHelper.get_value(water_heating_system, 'UsesDesuperheater'))
-      @jacket_r_value = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'WaterHeaterInsulation/Jacket/JacketRValue'))
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'Location')
+      @is_shared_system, @is_shared_system_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'IsSharedSystem', :boolean)
+      @number_of_units_served = XMLHelper.get_value(water_heating_system, 'NumberofUnitsServed', :integer)
+      @performance_adjustment, @performance_adjustment_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'PerformanceAdjustment', :float)
+      @tank_volume, @tank_volume_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'TankVolume', :float)
+      @fraction_dhw_load_served = XMLHelper.get_value(water_heating_system, 'FractionDHWLoadServed', :float)
+      @heating_capacity, @heating_capacity_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'HeatingCapacity', :float)
+      @energy_factor = XMLHelper.get_value(water_heating_system, 'EnergyFactor', :float)
+      @uniform_energy_factor = XMLHelper.get_value(water_heating_system, 'UniformEnergyFactor', :float)
+      @first_hour_rating = XMLHelper.get_value(water_heating_system, 'FirstHourRating', :float)
+      @recovery_efficiency, @recovery_efficiency_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'RecoveryEfficiency', :float)
+      @uses_desuperheater = XMLHelper.get_value(water_heating_system, 'UsesDesuperheater', :boolean)
+      @jacket_r_value = XMLHelper.get_value(water_heating_system, 'WaterHeaterInsulation/Jacket/JacketRValue', :float)
       @related_hvac_idref = HPXML::get_idref(XMLHelper.get_element(water_heating_system, 'RelatedHVACSystem'))
       @energy_star = XMLHelper.get_values(water_heating_system, 'ThirdPartyCertification').include?('Energy Star')
-      @standby_loss = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'StandbyLoss'))
-      @standby_loss_isdefaulted = get_software_defaulted(water_heating_system, 'StandbyLoss') unless @standby_loss.nil?
-      @temperature = to_float_or_nil(XMLHelper.get_value(water_heating_system, 'HotWaterTemperature'))
-      @temperature_isdefaulted = get_software_defaulted(water_heating_system, 'HotWaterTemperature') unless @temperature.nil?
+      @standby_loss, @standby_loss_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'StandbyLoss', :float)
+      @temperature, @temperature_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating_system, 'HotWaterTemperature', :float)
     end
   end
 
@@ -3781,27 +3708,22 @@ class HPXML < Object
 
       @id = HPXML::get_id(hot_water_distribution)
       @system_type = XMLHelper.get_child_name(hot_water_distribution, 'SystemType')
-      @pipe_r_value = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'PipeInsulation/PipeRValue'))
+      @pipe_r_value = XMLHelper.get_value(hot_water_distribution, 'PipeInsulation/PipeRValue', :float)
       if @system_type == 'Standard'
-        @standard_piping_length = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'SystemType/Standard/PipingLength'))
-        @standard_piping_length_isdefaulted = get_software_defaulted(hot_water_distribution, 'SystemType/Standard/PipingLength') unless @standard_piping_length.nil?
+        @standard_piping_length, @standard_piping_length_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Standard/PipingLength', :float)
       elsif @system_type == 'Recirculation'
         @recirculation_control_type = XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/ControlType')
-        @recirculation_piping_length = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/RecirculationPipingLoopLength'))
-        @recirculation_piping_length_isdefaulted = get_software_defaulted(hot_water_distribution, 'SystemType/Recirculation/RecirculationPipingLoopLength') unless @recirculation_piping_length.nil?
-        @recirculation_branch_piping_length = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/BranchPipingLoopLength'))
-        @recirculation_branch_piping_length_isdefaulted = get_software_defaulted(hot_water_distribution, 'SystemType/Recirculation/BranchPipingLoopLength') unless @recirculation_branch_piping_length.nil?
-        @recirculation_pump_power = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'SystemType/Recirculation/PumpPower'))
-        @recirculation_pump_power_isdefaulted = get_software_defaulted(hot_water_distribution, 'SystemType/Recirculation/PumpPower') unless @recirculation_pump_power.nil?
+        @recirculation_piping_length, @recirculation_piping_length_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Recirculation/RecirculationPipingLoopLength', :float)
+        @recirculation_branch_piping_length, @recirculation_branch_piping_length_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Recirculation/BranchPipingLoopLength', :float)
+        @recirculation_pump_power, @recirculation_pump_power_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'SystemType/Recirculation/PumpPower', :float)
       end
       @dwhr_facilities_connected = XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/FacilitiesConnected')
-      @dwhr_equal_flow = to_boolean_or_nil(XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/EqualFlow'))
-      @dwhr_efficiency = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/Efficiency'))
+      @dwhr_equal_flow = XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/EqualFlow', :boolean)
+      @dwhr_efficiency = XMLHelper.get_value(hot_water_distribution, 'DrainWaterHeatRecovery/Efficiency', :float)
       @has_shared_recirculation = XMLHelper.has_element(hot_water_distribution, 'extension/SharedRecirculation')
       if @has_shared_recirculation
-        @shared_recirculation_number_of_units_served = to_integer_or_nil(XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/NumberofUnitsServed'))
-        @shared_recirculation_pump_power = to_float_or_nil(XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/PumpPower'))
-        @shared_recirculation_pump_power_isdefaulted = get_software_defaulted(hot_water_distribution, 'extension/SharedRecirculation/PumpPower') unless @shared_recirculation_pump_power.nil?
+        @shared_recirculation_number_of_units_served = XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/NumberofUnitsServed', :integer)
+        @shared_recirculation_pump_power, @shared_recirculation_pump_power_isdefaulted = XMLHelper.get_value_and_defaulted(hot_water_distribution, 'extension/SharedRecirculation/PumpPower', :float)
         @shared_recirculation_control_type = XMLHelper.get_value(hot_water_distribution, 'extension/SharedRecirculation/ControlType')
       end
     end
@@ -3850,7 +3772,7 @@ class HPXML < Object
 
       @id = HPXML::get_id(water_fixture)
       @water_fixture_type = XMLHelper.get_value(water_fixture, 'WaterFixtureType')
-      @low_flow = to_boolean_or_nil(XMLHelper.get_value(water_fixture, 'LowFlow'))
+      @low_flow = XMLHelper.get_value(water_fixture, 'LowFlow', :boolean)
     end
   end
 
@@ -3876,8 +3798,7 @@ class HPXML < Object
       water_heating = XMLHelper.get_element(hpxml, 'Building/BuildingDetails/Systems/WaterHeating')
       return if water_heating.nil?
 
-      @water_fixtures_usage_multiplier = to_float_or_nil(XMLHelper.get_value(water_heating, 'extension/WaterFixturesUsageMultiplier'))
-      @water_fixtures_usage_multiplier_isdefaulted = get_software_defaulted(water_heating, 'extension/WaterFixturesUsageMultiplier') unless @water_fixtures_usage_multiplier.nil?
+      @water_fixtures_usage_multiplier, @water_fixtures_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(water_heating, 'extension/WaterFixturesUsageMultiplier', :float)
     end
   end
 
@@ -3950,17 +3871,16 @@ class HPXML < Object
 
       @id = HPXML::get_id(solar_thermal_system)
       @system_type = XMLHelper.get_value(solar_thermal_system, 'SystemType')
-      @collector_area = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'CollectorArea'))
+      @collector_area = XMLHelper.get_value(solar_thermal_system, 'CollectorArea', :float)
       @collector_loop_type = XMLHelper.get_value(solar_thermal_system, 'CollectorLoopType')
-      @collector_azimuth = to_integer_or_nil(XMLHelper.get_value(solar_thermal_system, 'CollectorAzimuth'))
+      @collector_azimuth = XMLHelper.get_value(solar_thermal_system, 'CollectorAzimuth', :integer)
       @collector_type = XMLHelper.get_value(solar_thermal_system, 'CollectorType')
-      @collector_tilt = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'CollectorTilt'))
-      @collector_frta = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'CollectorRatedOpticalEfficiency'))
-      @collector_frul = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'CollectorRatedThermalLosses'))
-      @storage_volume = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'StorageVolume'))
-      @storage_volume_isdefaulted = get_software_defaulted(solar_thermal_system, 'StorageVolume') unless @storage_volume.nil?
+      @collector_tilt = XMLHelper.get_value(solar_thermal_system, 'CollectorTilt', :float)
+      @collector_frta = XMLHelper.get_value(solar_thermal_system, 'CollectorRatedOpticalEfficiency', :float)
+      @collector_frul = XMLHelper.get_value(solar_thermal_system, 'CollectorRatedThermalLosses', :float)
+      @storage_volume, @storage_volume_isdefaulted = XMLHelper.get_value_and_defaulted(solar_thermal_system, 'StorageVolume', :float)
       @water_heating_system_idref = HPXML::get_idref(XMLHelper.get_element(solar_thermal_system, 'ConnectedTo'))
-      @solar_fraction = to_float_or_nil(XMLHelper.get_value(solar_thermal_system, 'SolarFraction'))
+      @solar_fraction = XMLHelper.get_value(solar_thermal_system, 'SolarFraction', :float)
     end
   end
 
@@ -4017,25 +3937,19 @@ class HPXML < Object
       return if pv_system.nil?
 
       @id = HPXML::get_id(pv_system)
-      @is_shared_system = to_boolean_or_nil(XMLHelper.get_value(pv_system, 'IsSharedSystem'))
-      @is_shared_system_isdefaulted = get_software_defaulted(pv_system, 'IsSharedSystem') unless @is_shared_system.nil?
-      @location = XMLHelper.get_value(pv_system, 'Location')
-      @location_isdefaulted = get_software_defaulted(pv_system, 'Location') unless @location.nil?
-      @module_type = XMLHelper.get_value(pv_system, 'ModuleType')
-      @module_type_isdefaulted = get_software_defaulted(pv_system, 'ModuleType') unless @module_type.nil?
-      @tracking = XMLHelper.get_value(pv_system, 'Tracking')
-      @tracking_isdefaulted = get_software_defaulted(pv_system, 'Tracking') unless @tracking.nil?
+      @is_shared_system, @is_shared_system_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'IsSharedSystem', :boolean)
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'Location')
+      @module_type, @module_type_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'ModuleType')
+      @tracking, @tracking_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'Tracking')
       @array_orientation = XMLHelper.get_value(pv_system, 'ArrayOrientation')
-      @array_azimuth = to_integer_or_nil(XMLHelper.get_value(pv_system, 'ArrayAzimuth'))
-      @array_tilt = to_float_or_nil(XMLHelper.get_value(pv_system, 'ArrayTilt'))
-      @max_power_output = to_float_or_nil(XMLHelper.get_value(pv_system, 'MaxPowerOutput'))
-      @inverter_efficiency = to_float_or_nil(XMLHelper.get_value(pv_system, 'InverterEfficiency'))
-      @inverter_efficiency_isdefaulted = get_software_defaulted(pv_system, 'InverterEfficiency') unless @inverter_efficiency.nil?
-      @system_losses_fraction = to_float_or_nil(XMLHelper.get_value(pv_system, 'SystemLossesFraction'))
-      @system_losses_fraction_isdefaulted = get_software_defaulted(pv_system, 'SystemLossesFraction') unless @system_losses_fraction.nil?
-      @number_of_panels = to_integer_or_nil(XMLHelper.get_value(pv_system, 'NumberOfPanels'))
-      @year_modules_manufactured = to_integer_or_nil(XMLHelper.get_value(pv_system, 'YearModulesManufactured'))
-      @number_of_bedrooms_served = to_integer_or_nil(XMLHelper.get_value(pv_system, 'extension/NumberofBedroomsServed'))
+      @array_azimuth = XMLHelper.get_value(pv_system, 'ArrayAzimuth', :integer)
+      @array_tilt = XMLHelper.get_value(pv_system, 'ArrayTilt', :float)
+      @max_power_output = XMLHelper.get_value(pv_system, 'MaxPowerOutput', :float)
+      @inverter_efficiency, @inverter_efficiency_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'InverterEfficiency', :float)
+      @system_losses_fraction, @system_losses_fraction_isdefaulted = XMLHelper.get_value_and_defaulted(pv_system, 'SystemLossesFraction', :float)
+      @number_of_panels = XMLHelper.get_value(pv_system, 'NumberOfPanels', :integer)
+      @year_modules_manufactured = XMLHelper.get_value(pv_system, 'YearModulesManufactured', :integer)
+      @number_of_bedrooms_served = XMLHelper.get_value(pv_system, 'extension/NumberofBedroomsServed', :integer)
     end
   end
 
@@ -4111,29 +4025,19 @@ class HPXML < Object
       return if clothes_washer.nil?
 
       @id = HPXML::get_id(clothes_washer)
-      @number_of_units = to_integer_or_nil(XMLHelper.get_value(clothes_washer, 'NumberofUnits'))
-      @is_shared_appliance = to_boolean_or_nil(XMLHelper.get_value(clothes_washer, 'IsSharedAppliance'))
-      @is_shared_appliance_isdefaulted = get_software_defaulted(clothes_washer, 'IsSharedAppliance') unless @is_shared_appliance.nil?
-      @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(clothes_washer, 'NumberofUnitsServed'))
-      @location = XMLHelper.get_value(clothes_washer, 'Location')
-      @location_isdefaulted = get_software_defaulted(clothes_washer, 'Location') unless @location.nil?
-      @modified_energy_factor = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'ModifiedEnergyFactor'))
-      @integrated_modified_energy_factor = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'IntegratedModifiedEnergyFactor'))
-      @integrated_modified_energy_factor_isdefaulted = get_software_defaulted(clothes_washer, 'IntegratedModifiedEnergyFactor') unless @integrated_modified_energy_factor.nil?
-      @rated_annual_kwh = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'RatedAnnualkWh'))
-      @rated_annual_kwh_isdefaulted = get_software_defaulted(clothes_washer, 'RatedAnnualkWh') unless @rated_annual_kwh.nil?
-      @label_electric_rate = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelElectricRate'))
-      @label_electric_rate_isdefaulted = get_software_defaulted(clothes_washer, 'LabelElectricRate') unless @label_electric_rate.nil?
-      @label_gas_rate = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelGasRate'))
-      @label_gas_rate_isdefaulted = get_software_defaulted(clothes_washer, 'LabelGasRate') unless @label_gas_rate.nil?
-      @label_annual_gas_cost = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelAnnualGasCost'))
-      @label_annual_gas_cost_isdefaulted = get_software_defaulted(clothes_washer, 'LabelAnnualGasCost') unless @label_annual_gas_cost.nil?
-      @label_usage = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'LabelUsage'))
-      @label_usage_isdefaulted = get_software_defaulted(clothes_washer, 'LabelUsage') unless @label_usage.nil?
-      @capacity = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'Capacity'))
-      @capacity_isdefaulted = get_software_defaulted(clothes_washer, 'Capacity') unless @capacity.nil?
-      @usage_multiplier = to_float_or_nil(XMLHelper.get_value(clothes_washer, 'extension/UsageMultiplier'))
-      @usage_multiplier_isdefaulted = get_software_defaulted(clothes_washer, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
+      @number_of_units = XMLHelper.get_value(clothes_washer, 'NumberofUnits', :integer)
+      @is_shared_appliance, @is_shared_appliance_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'IsSharedAppliance', :boolean)
+      @number_of_units_served = XMLHelper.get_value(clothes_washer, 'NumberofUnitsServed', :integer)
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'Location')
+      @modified_energy_factor = XMLHelper.get_value(clothes_washer, 'ModifiedEnergyFactor', :float)
+      @integrated_modified_energy_factor, @integrated_modified_energy_factor_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'IntegratedModifiedEnergyFactor', :float)
+      @rated_annual_kwh, @rated_annual_kwh_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'RatedAnnualkWh', :float)
+      @label_electric_rate, @label_electric_rate_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'LabelElectricRate', :float)
+      @label_gas_rate, @label_gas_rate_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'LabelGasRate', :float)
+      @label_annual_gas_cost, @label_annual_gas_cost_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'LabelAnnualGasCost', :float)
+      @label_usage, @label_usage_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'LabelUsage', :float)
+      @capacity, @capacity_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'Capacity', :float)
+      @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_washer, 'extension/UsageMultiplier', :float)
       @water_heating_system_idref = HPXML::get_idref(XMLHelper.get_element(clothes_washer, 'AttachedToWaterHeatingSystem'))
     end
   end
@@ -4191,24 +4095,17 @@ class HPXML < Object
       return if clothes_dryer.nil?
 
       @id = HPXML::get_id(clothes_dryer)
-      @number_of_units = to_integer_or_nil(XMLHelper.get_value(clothes_dryer, 'NumberofUnits'))
-      @is_shared_appliance = to_boolean_or_nil(XMLHelper.get_value(clothes_dryer, 'IsSharedAppliance'))
-      @is_shared_appliance_isdefaulted = get_software_defaulted(clothes_dryer, 'IsSharedAppliance') unless @is_shared_appliance.nil?
-      @number_of_units_served = to_integer_or_nil(XMLHelper.get_value(clothes_dryer, 'NumberofUnitsServed'))
-      @location = XMLHelper.get_value(clothes_dryer, 'Location')
-      @location_isdefaulted = get_software_defaulted(clothes_dryer, 'Location') unless @location.nil?
+      @number_of_units = XMLHelper.get_value(clothes_dryer, 'NumberofUnits', :integer)
+      @is_shared_appliance, @is_shared_appliance_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'IsSharedAppliance', :boolean)
+      @number_of_units_served = XMLHelper.get_value(clothes_dryer, 'NumberofUnitsServed', :integer)
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'Location')
       @fuel_type = XMLHelper.get_value(clothes_dryer, 'FuelType')
-      @energy_factor = to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'EnergyFactor'))
-      @combined_energy_factor = to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'CombinedEnergyFactor'))
-      @combined_energy_factor_isdefaulted = get_software_defaulted(clothes_dryer, 'CombinedEnergyFactor') unless @combined_energy_factor.nil?
-      @control_type = XMLHelper.get_value(clothes_dryer, 'ControlType')
-      @control_type_isdefaulted = get_software_defaulted(clothes_dryer, 'ControlType') unless @control_type.nil?
-      @usage_multiplier = to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'extension/UsageMultiplier'))
-      @usage_multiplier_isdefaulted = get_software_defaulted(clothes_dryer, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
-      @is_vented = to_boolean_or_nil(XMLHelper.get_value(clothes_dryer, 'extension/IsVented'))
-      @is_vented_isdefaulted = get_software_defaulted(clothes_dryer, 'extension/IsVented') unless @is_vented.nil?
-      @vented_flow_rate = to_float_or_nil(XMLHelper.get_value(clothes_dryer, 'extension/VentedFlowRate'))
-      @vented_flow_rate_isdefaulted = get_software_defaulted(clothes_dryer, 'extension/VentedFlowRate') unless @vented_flow_rate.nil?
+      @energy_factor = XMLHelper.get_value(clothes_dryer, 'EnergyFactor', :float)
+      @combined_energy_factor, @combined_energy_factor_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'CombinedEnergyFactor', :float)
+      @control_type, @control_type_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'ControlType')
+      @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'extension/UsageMultiplier', :float)
+      @is_vented, @is_vented_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'extension/IsVented', :boolean)
+      @vented_flow_rate, @vented_flow_rate_isdefaulted = XMLHelper.get_value_and_defaulted(clothes_dryer, 'extension/VentedFlowRate', :float)
     end
   end
 
@@ -4280,25 +4177,16 @@ class HPXML < Object
       return if dishwasher.nil?
 
       @id = HPXML::get_id(dishwasher)
-      @is_shared_appliance = to_boolean_or_nil(XMLHelper.get_value(dishwasher, 'IsSharedAppliance'))
-      @is_shared_appliance_isdefaulted = get_software_defaulted(dishwasher, 'IsSharedAppliance') unless @is_shared_appliance.nil?
-      @location = XMLHelper.get_value(dishwasher, 'Location')
-      @location_isdefaulted = get_software_defaulted(dishwasher, 'Location') unless @location.nil?
-      @rated_annual_kwh = to_float_or_nil(XMLHelper.get_value(dishwasher, 'RatedAnnualkWh'))
-      @rated_annual_kwh_isdefaulted = get_software_defaulted(dishwasher, 'RatedAnnualkWh') unless @rated_annual_kwh.nil?
-      @energy_factor = to_float_or_nil(XMLHelper.get_value(dishwasher, 'EnergyFactor'))
-      @place_setting_capacity = to_integer_or_nil(XMLHelper.get_value(dishwasher, 'PlaceSettingCapacity'))
-      @place_setting_capacity_isdefaulted = get_software_defaulted(dishwasher, 'PlaceSettingCapacity') unless @place_setting_capacity.nil?
-      @label_electric_rate = to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelElectricRate'))
-      @label_electric_rate_isdefaulted = get_software_defaulted(dishwasher, 'LabelElectricRate') unless @label_electric_rate.nil?
-      @label_gas_rate = to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelGasRate'))
-      @label_gas_rate_isdefaulted = get_software_defaulted(dishwasher, 'LabelGasRate') unless @label_gas_rate.nil?
-      @label_annual_gas_cost = to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelAnnualGasCost'))
-      @label_annual_gas_cost_isdefaulted = get_software_defaulted(dishwasher, 'LabelAnnualGasCost') unless @label_annual_gas_cost.nil?
-      @label_usage = to_float_or_nil(XMLHelper.get_value(dishwasher, 'LabelUsage'))
-      @label_usage_isdefaulted = get_software_defaulted(dishwasher, 'LabelUsage') unless @label_usage.nil?
-      @usage_multiplier = to_float_or_nil(XMLHelper.get_value(dishwasher, 'extension/UsageMultiplier'))
-      @usage_multiplier_isdefaulted = get_software_defaulted(dishwasher, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
+      @is_shared_appliance, @is_shared_appliance_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'IsSharedAppliance', :boolean)
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'Location')
+      @rated_annual_kwh, @rated_annual_kwh_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'RatedAnnualkWh', :float)
+      @energy_factor = XMLHelper.get_value(dishwasher, 'EnergyFactor', :float)
+      @place_setting_capacity, @place_setting_capacity_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'PlaceSettingCapacity', :integer)
+      @label_electric_rate, @label_electric_rate_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'LabelElectricRate', :float)
+      @label_gas_rate, @label_gas_rate_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'LabelGasRate', :float)
+      @label_annual_gas_cost, @label_annual_gas_cost_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'LabelAnnualGasCost', :float)
+      @label_usage, @label_usage_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'LabelUsage', :float)
+      @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(dishwasher, 'extension/UsageMultiplier', :float)
       @water_heating_system_idref = HPXML::get_idref(XMLHelper.get_element(dishwasher, 'AttachedToWaterHeatingSystem'))
     end
   end
@@ -4364,21 +4252,14 @@ class HPXML < Object
       return if refrigerator.nil?
 
       @id = HPXML::get_id(refrigerator)
-      @location = XMLHelper.get_value(refrigerator, 'Location')
-      @location_isdefaulted = get_software_defaulted(refrigerator, 'Location') unless @location.nil?
-      @rated_annual_kwh = to_float_or_nil(XMLHelper.get_value(refrigerator, 'RatedAnnualkWh'))
-      @rated_annual_kwh_isdefaulted = get_software_defaulted(refrigerator, 'RatedAnnualkWh') unless @rated_annual_kwh.nil?
-      @primary_indicator = to_boolean_or_nil(XMLHelper.get_value(refrigerator, 'PrimaryIndicator'))
-      @primary_indicator_isdefaulted = get_software_defaulted(refrigerator, 'PrimaryIndicator') unless @primary_indicator.nil?
-      @adjusted_annual_kwh = to_float_or_nil(XMLHelper.get_value(refrigerator, 'extension/AdjustedAnnualkWh'))
-      @usage_multiplier = to_float_or_nil(XMLHelper.get_value(refrigerator, 'extension/UsageMultiplier'))
-      @usage_multiplier_isdefaulted = get_software_defaulted(refrigerator, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
-      @weekday_fractions = XMLHelper.get_value(refrigerator, 'extension/WeekdayScheduleFractions')
-      @weekday_fractions_isdefaulted = get_software_defaulted(refrigerator, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
-      @weekend_fractions = XMLHelper.get_value(refrigerator, 'extension/WeekendScheduleFractions')
-      @weekend_fractions_isdefaulted = get_software_defaulted(refrigerator, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
-      @monthly_multipliers = XMLHelper.get_value(refrigerator, 'extension/MonthlyScheduleMultipliers')
-      @monthly_multipliers_isdefaulted = get_software_defaulted(refrigerator, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'Location')
+      @rated_annual_kwh, @rated_annual_kwh_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'RatedAnnualkWh', :float)
+      @primary_indicator, @primary_indicator_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'PrimaryIndicator', :boolean)
+      @adjusted_annual_kwh = XMLHelper.get_value(refrigerator, 'extension/AdjustedAnnualkWh', :float)
+      @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/UsageMultiplier', :float)
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/WeekdayScheduleFractions')
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/WeekendScheduleFractions')
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(refrigerator, 'extension/MonthlyScheduleMultipliers')
     end
   end
 
@@ -4430,19 +4311,13 @@ class HPXML < Object
       return if freezer.nil?
 
       @id = HPXML::get_id(freezer)
-      @location = XMLHelper.get_value(freezer, 'Location')
-      @location_isdefaulted = get_software_defaulted(freezer, 'Location') unless @location.nil?
-      @rated_annual_kwh = to_float_or_nil(XMLHelper.get_value(freezer, 'RatedAnnualkWh'))
-      @rated_annual_kwh_isdefaulted = get_software_defaulted(freezer, 'RatedAnnualkWh') unless @rated_annual_kwh.nil?
-      @adjusted_annual_kwh = to_float_or_nil(XMLHelper.get_value(freezer, 'extension/AdjustedAnnualkWh'))
-      @usage_multiplier = to_float_or_nil(XMLHelper.get_value(freezer, 'extension/UsageMultiplier'))
-      @usage_multiplier_isdefaulted = get_software_defaulted(freezer, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
-      @weekday_fractions = XMLHelper.get_value(freezer, 'extension/WeekdayScheduleFractions')
-      @weekday_fractions_isdefaulted = get_software_defaulted(freezer, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
-      @weekend_fractions = XMLHelper.get_value(freezer, 'extension/WeekendScheduleFractions')
-      @weekend_fractions_isdefaulted = get_software_defaulted(freezer, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
-      @monthly_multipliers = XMLHelper.get_value(freezer, 'extension/MonthlyScheduleMultipliers')
-      @monthly_multipliers_isdefaulted = get_software_defaulted(freezer, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'Location')
+      @rated_annual_kwh, @rated_annual_kwh_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'RatedAnnualkWh', :float)
+      @adjusted_annual_kwh = XMLHelper.get_value(freezer, 'extension/AdjustedAnnualkWh', :float)
+      @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/UsageMultiplier', :float)
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/WeekdayScheduleFractions')
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/WeekendScheduleFractions')
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(freezer, 'extension/MonthlyScheduleMultipliers')
     end
   end
 
@@ -4491,11 +4366,11 @@ class HPXML < Object
       return if dehumidifier.nil?
 
       @id = HPXML::get_id(dehumidifier)
-      @capacity = to_float_or_nil(XMLHelper.get_value(dehumidifier, 'Capacity'))
-      @energy_factor = to_float_or_nil(XMLHelper.get_value(dehumidifier, 'EnergyFactor'))
-      @integrated_energy_factor = to_float_or_nil(XMLHelper.get_value(dehumidifier, 'IntegratedEnergyFactor'))
-      @rh_setpoint = to_float_or_nil(XMLHelper.get_value(dehumidifier, 'DehumidistatSetpoint'))
-      @fraction_served = to_float_or_nil(XMLHelper.get_value(dehumidifier, 'FractionDehumidificationLoadServed'))
+      @capacity = XMLHelper.get_value(dehumidifier, 'Capacity', :float)
+      @energy_factor = XMLHelper.get_value(dehumidifier, 'EnergyFactor', :float)
+      @integrated_energy_factor = XMLHelper.get_value(dehumidifier, 'IntegratedEnergyFactor', :float)
+      @rh_setpoint = XMLHelper.get_value(dehumidifier, 'DehumidistatSetpoint', :float)
+      @fraction_served = XMLHelper.get_value(dehumidifier, 'FractionDehumidificationLoadServed', :float)
     end
   end
 
@@ -4547,19 +4422,13 @@ class HPXML < Object
       return if cooking_range.nil?
 
       @id = HPXML::get_id(cooking_range)
-      @location = XMLHelper.get_value(cooking_range, 'Location')
-      @location_isdefaulted = get_software_defaulted(cooking_range, 'Location') unless @location.nil?
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'Location')
       @fuel_type = XMLHelper.get_value(cooking_range, 'FuelType')
-      @is_induction = to_boolean_or_nil(XMLHelper.get_value(cooking_range, 'IsInduction'))
-      @is_induction_isdefaulted = get_software_defaulted(cooking_range, 'IsInduction') unless @is_induction.nil?
-      @usage_multiplier = to_float_or_nil(XMLHelper.get_value(cooking_range, 'extension/UsageMultiplier'))
-      @usage_multiplier_isdefaulted = get_software_defaulted(cooking_range, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
-      @weekday_fractions = XMLHelper.get_value(cooking_range, 'extension/WeekdayScheduleFractions')
-      @weekday_fractions_isdefaulted = get_software_defaulted(cooking_range, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
-      @weekend_fractions = XMLHelper.get_value(cooking_range, 'extension/WeekendScheduleFractions')
-      @weekend_fractions_isdefaulted = get_software_defaulted(cooking_range, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
-      @monthly_multipliers = XMLHelper.get_value(cooking_range, 'extension/MonthlyScheduleMultipliers')
-      @monthly_multipliers_isdefaulted = get_software_defaulted(cooking_range, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
+      @is_induction, @is_induction_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'IsInduction', :boolean)
+      @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/UsageMultiplier', :float)
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/WeekdayScheduleFractions')
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/WeekendScheduleFractions')
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(cooking_range, 'extension/MonthlyScheduleMultipliers')
     end
   end
 
@@ -4604,8 +4473,7 @@ class HPXML < Object
       return if oven.nil?
 
       @id = HPXML::get_id(oven)
-      @is_convection = to_boolean_or_nil(XMLHelper.get_value(oven, 'IsConvection'))
-      @is_convection_isdefaulted = get_software_defaulted(oven, 'IsConvection') unless @is_convection.nil?
+      @is_convection, @is_convection_isdefaulted = XMLHelper.get_value_and_defaulted(oven, 'IsConvection', :boolean)
     end
   end
 
@@ -4656,7 +4524,7 @@ class HPXML < Object
 
       @id = HPXML::get_id(lighting_group)
       @location = XMLHelper.get_value(lighting_group, 'Location')
-      @fraction_of_units_in_location = to_float_or_nil(XMLHelper.get_value(lighting_group, 'FractionofUnitsInLocation'))
+      @fraction_of_units_in_location = XMLHelper.get_value(lighting_group, 'FractionofUnitsInLocation', :float)
       @lighting_type = XMLHelper.get_child_name(lighting_group, 'LightingType')
     end
   end
@@ -4666,8 +4534,8 @@ class HPXML < Object
              :interior_weekday_fractions, :interior_weekend_fractions, :interior_monthly_multipliers,
              :garage_weekday_fractions, :garage_weekend_fractions, :garage_monthly_multipliers,
              :exterior_weekday_fractions, :exterior_weekend_fractions, :exterior_monthly_multipliers,
-             :holiday_exists, :holiday_kwh_per_day, :holiday_period_begin_month, :holiday_period_begin_day_of_month,
-             :holiday_period_end_month, :holiday_period_end_day_of_month, :holiday_weekday_fractions, :holiday_weekend_fractions]
+             :holiday_exists, :holiday_kwh_per_day, :holiday_period_begin_month, :holiday_period_begin_day,
+             :holiday_period_end_month, :holiday_period_end_day, :holiday_weekday_fractions, :holiday_weekend_fractions]
     attr_accessor(*ATTRS)
 
     def check_for_errors
@@ -4699,9 +4567,9 @@ class HPXML < Object
           XMLHelper.add_element(holiday_lighting_load, 'Value', to_float(@holiday_kwh_per_day), @holiday_kwh_per_day_isdefaulted)
         end
         XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginMonth', to_integer(@holiday_period_begin_month), @holiday_period_begin_month_isdefaulted) unless @holiday_period_begin_month.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginDayOfMonth', to_integer(@holiday_period_begin_day_of_month), @holiday_period_begin_day_of_month_isdefaulted) unless @holiday_period_begin_day_of_month.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodBeginDayOfMonth', to_integer(@holiday_period_begin_day), @holiday_period_begin_day_isdefaulted) unless @holiday_period_begin_day.nil?
         XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndMonth', to_integer(@holiday_period_end_month), @holiday_period_end_month_isdefaulted) unless @holiday_period_end_month.nil?
-        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndDayOfMonth', to_integer(@holiday_period_end_day_of_month), @holiday_period_end_day_of_month_isdefaulted) unless @holiday_period_end_day_of_month.nil?
+        XMLHelper.add_element(exterior_holiday_lighting, 'PeriodEndDayOfMonth', to_integer(@holiday_period_end_day), @holiday_period_end_day_isdefaulted) unless @holiday_period_end_day.nil?
         XMLHelper.add_element(exterior_holiday_lighting, 'WeekdayScheduleFractions', @holiday_weekday_fractions, @holiday_weekday_fractions_isdefaulted) unless @holiday_weekday_fractions.nil?
         XMLHelper.add_element(exterior_holiday_lighting, 'WeekendScheduleFractions', @holiday_weekend_fractions, @holiday_weekend_fractions_isdefaulted) unless @holiday_weekend_fractions.nil?
       end
@@ -4713,46 +4581,27 @@ class HPXML < Object
       lighting = XMLHelper.get_element(hpxml, 'Building/BuildingDetails/Lighting')
       return if lighting.nil?
 
-      @interior_usage_multiplier = to_float_or_nil(XMLHelper.get_value(lighting, 'extension/InteriorUsageMultiplier'))
-      @interior_usage_multiplier_isdefaulted = get_software_defaulted(lighting, 'extension/InteriorUsageMultiplier') unless @interior_usage_multiplier.nil?
-      @garage_usage_multiplier = to_float_or_nil(XMLHelper.get_value(lighting, 'extension/GarageUsageMultiplier'))
-      @garage_usage_multiplier_isdefaulted = get_software_defaulted(lighting, 'extension/GarageUsageMultiplier') unless @garage_usage_multiplier.nil?
-      @exterior_usage_multiplier = to_float_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorUsageMultiplier'))
-      @exterior_usage_multiplier_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorUsageMultiplier') unless @exterior_usage_multiplier.nil?
-      @interior_weekday_fractions = XMLHelper.get_value(lighting, 'extension/InteriorWeekdayScheduleFractions')
-      @interior_weekday_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/InteriorWeekdayScheduleFractions') unless @interior_weekday_fractions.nil?
-      @interior_weekend_fractions = XMLHelper.get_value(lighting, 'extension/InteriorWeekendScheduleFractions')
-      @interior_weekend_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/InteriorWeekendScheduleFractions') unless @interior_weekend_fractions.nil?
-      @interior_monthly_multipliers = XMLHelper.get_value(lighting, 'extension/InteriorMonthlyScheduleMultipliers')
-      @interior_monthly_multipliers_isdefaulted = get_software_defaulted(lighting, 'extension/InteriorMonthlyScheduleMultipliers') unless @interior_monthly_multipliers.nil?
-      @garage_weekday_fractions = XMLHelper.get_value(lighting, 'extension/GarageWeekdayScheduleFractions')
-      @garage_weekday_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/GarageWeekdayScheduleFractions') unless @garage_weekday_fractions.nil?
-      @garage_weekend_fractions = XMLHelper.get_value(lighting, 'extension/GarageWeekendScheduleFractions')
-      @garage_weekend_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/GarageWeekendScheduleFractions') unless @garage_weekend_fractions.nil?
-      @garage_monthly_multipliers = XMLHelper.get_value(lighting, 'extension/GarageMonthlyScheduleMultipliers')
-      @garage_monthly_multipliers_isdefaulted = get_software_defaulted(lighting, 'extension/GarageMonthlyScheduleMultipliers') unless @garage_monthly_multipliers.nil?
-      @exterior_weekday_fractions = XMLHelper.get_value(lighting, 'extension/ExteriorWeekdayScheduleFractions')
-      @exterior_weekday_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorWeekdayScheduleFractions') unless @exterior_weekday_fractions.nil?
-      @exterior_weekend_fractions = XMLHelper.get_value(lighting, 'extension/ExteriorWeekendScheduleFractions')
-      @exterior_weekend_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorWeekendScheduleFractions') unless @exterior_weekend_fractions.nil?
-      @exterior_monthly_multipliers = XMLHelper.get_value(lighting, 'extension/ExteriorMonthlyScheduleMultipliers')
-      @exterior_monthly_multipliers_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorMonthlyScheduleMultipliers') unless @exterior_monthly_multipliers.nil?
+      @interior_usage_multiplier, @interior_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorUsageMultiplier', :float)
+      @garage_usage_multiplier, @garage_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageUsageMultiplier', :float)
+      @exterior_usage_multiplier, @exterior_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorUsageMultiplier', :float)
+      @interior_weekday_fractions, @interior_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorWeekdayScheduleFractions')
+      @interior_weekend_fractions, @interior_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorWeekendScheduleFractions')
+      @interior_monthly_multipliers, @interior_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/InteriorMonthlyScheduleMultipliers')
+      @garage_weekday_fractions, @garage_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageWeekdayScheduleFractions')
+      @garage_weekend_fractions, @garage_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageWeekendScheduleFractions')
+      @garage_monthly_multipliers, @garage_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/GarageMonthlyScheduleMultipliers')
+      @exterior_weekday_fractions, @exterior_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorWeekdayScheduleFractions')
+      @exterior_weekend_fractions, @exterior_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorWeekendScheduleFractions')
+      @exterior_monthly_multipliers, @exterior_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorMonthlyScheduleMultipliers')
       if not XMLHelper.get_element(hpxml, 'Building/BuildingDetails/Lighting/extension/ExteriorHolidayLighting').nil?
         @holiday_exists = true
-        @holiday_kwh_per_day = to_float_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/Load[Units="kWh/day"]/Value'))
-        @holiday_kwh_per_day_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/Load[Units="kWh/day"]/Value') unless @holiday_kwh_per_day.nil?
-        @holiday_period_begin_month = to_integer_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginMonth'))
-        @holiday_period_begin_month_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginMonth') unless @holiday_period_begin_month.nil?
-        @holiday_period_begin_day_of_month = to_integer_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginDayOfMonth'))
-        @holiday_period_begin_day_of_month_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginDayOfMonth') unless @holiday_period_begin_day_of_month.nil?
-        @holiday_period_end_month = to_integer_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/PeriodEndMonth'))
-        @holiday_period_end_month_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodEndMonth') unless @holiday_period_end_month.nil?
-        @holiday_period_end_day_of_month = to_integer_or_nil(XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/PeriodEndDayOfMonth'))
-        @holiday_period_end_day_of_month_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodEndDayOfMonth') unless @holiday_period_end_day_of_month.nil?
-        @holiday_weekday_fractions = XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/WeekdayScheduleFractions')
-        @holiday_weekday_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekdayScheduleFractions') unless @holiday_weekday_fractions.nil?
-        @holiday_weekend_fractions = XMLHelper.get_value(lighting, 'extension/ExteriorHolidayLighting/WeekendScheduleFractions')
-        @holiday_weekend_fractions_isdefaulted = get_software_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekendScheduleFractions') unless @holiday_weekend_fractions.nil?
+        @holiday_kwh_per_day, @holiday_kwh_per_day_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/Load[Units="kWh/day"]/Value', :float)
+        @holiday_period_begin_month, @holiday_period_begin_month_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginMonth', :integer)
+        @holiday_period_begin_day, @holiday_period_begin_day_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodBeginDayOfMonth', :integer)
+        @holiday_period_end_month, @holiday_period_end_month_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodEndMonth', :integer)
+        @holiday_period_end_day, @holiday_period_end_day_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/PeriodEndDayOfMonth', :integer)
+        @holiday_weekday_fractions, @holiday_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekdayScheduleFractions')
+        @holiday_weekend_fractions, @holiday_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(lighting, 'extension/ExteriorHolidayLighting/WeekendScheduleFractions')
       else
         @holiday_exists = false
       end
@@ -4803,10 +4652,8 @@ class HPXML < Object
 
     def from_oga(ceiling_fan)
       @id = HPXML::get_id(ceiling_fan)
-      @efficiency = to_float_or_nil(XMLHelper.get_value(ceiling_fan, "Airflow[FanSpeed='medium']/Efficiency"))
-      @efficiency_isdefaulted = get_software_defaulted(ceiling_fan, "Airflow[FanSpeed='medium']/Efficiency") unless @efficiency.nil?
-      @quantity = to_integer_or_nil(XMLHelper.get_value(ceiling_fan, 'Quantity'))
-      @quantity_isdefaulted = get_software_defaulted(ceiling_fan, 'Quantity') unless @quantity.nil?
+      @efficiency, @efficiency_isdefaulted = XMLHelper.get_value_and_defaulted(ceiling_fan, "Airflow[FanSpeed='medium']/Efficiency", :float)
+      @quantity, @quantity_isdefaulted = XMLHelper.get_value_and_defaulted(ceiling_fan, 'Quantity', :integer)
     end
   end
 
@@ -4889,31 +4736,21 @@ class HPXML < Object
       @id = HPXML::get_id(pool)
       pool_pump = XMLHelper.get_element(pool, 'PoolPumps/PoolPump')
       @pump_id = HPXML::get_id(pool_pump)
-      @pump_kwh_per_year = to_float_or_nil(XMLHelper.get_value(pool_pump, "Load[Units='#{UnitsKwhPerYear}']/Value"))
-      @pump_kwh_per_year_isdefaulted = get_software_defaulted(pool_pump, "Load[Units='#{UnitsKwhPerYear}']/Value") unless @pump_kwh_per_year.nil?
-      @pump_usage_multiplier = to_float_or_nil(XMLHelper.get_value(pool_pump, 'extension/UsageMultiplier'))
-      @pump_usage_multiplier_isdefaulted = get_software_defaulted(pool_pump, 'extension/UsageMultiplier') unless @pump_usage_multiplier.nil?
-      @pump_weekday_fractions = XMLHelper.get_value(pool_pump, 'extension/WeekdayScheduleFractions')
-      @pump_weekday_fractions_isdefaulted = get_software_defaulted(pool_pump, 'extension/WeekdayScheduleFractions') unless @pump_weekday_fractions.nil?
-      @pump_weekend_fractions = XMLHelper.get_value(pool_pump, 'extension/WeekendScheduleFractions')
-      @pump_weekend_fractions_isdefaulted = get_software_defaulted(pool_pump, 'extension/WeekendScheduleFractions') unless @pump_weekend_fractions.nil?
-      @pump_monthly_multipliers = XMLHelper.get_value(pool_pump, 'extension/MonthlyScheduleMultipliers')
-      @pump_monthly_multipliers_isdefaulted = get_software_defaulted(pool_pump, 'extension/MonthlyScheduleMultipliers') unless @pump_monthly_multipliers.nil?
+      @pump_kwh_per_year, @pump_kwh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
+      @pump_usage_multiplier, @pump_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/UsageMultiplier', :float)
+      @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekdayScheduleFractions')
+      @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekendScheduleFractions')
+      @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/MonthlyScheduleMultipliers')
       heater = XMLHelper.get_element(pool, 'Heater')
       if not heater.nil?
         @heater_id = HPXML::get_id(heater)
         @heater_type = XMLHelper.get_value(heater, 'Type')
         @heater_load_units = XMLHelper.get_value(heater, 'Load/Units')
-        @heater_load_value = to_float_or_nil(XMLHelper.get_value(heater, 'Load/Value'))
-        @heater_load_value_isdefaulted = get_software_defaulted(heater, 'Load/Value') unless @heater_load_value.nil?
-        @heater_usage_multiplier = to_float_or_nil(XMLHelper.get_value(heater, 'extension/UsageMultiplier'))
-        @heater_usage_multiplier_isdefaulted = get_software_defaulted(heater, 'extension/UsageMultiplier') unless @heater_usage_multiplier.nil?
-        @heater_weekday_fractions = XMLHelper.get_value(heater, 'extension/WeekdayScheduleFractions')
-        @heater_weekday_fractions_isdefaulted = get_software_defaulted(heater, 'extension/WeekdayScheduleFractions') unless @heater_weekday_fractions.nil?
-        @heater_weekend_fractions = XMLHelper.get_value(heater, 'extension/WeekendScheduleFractions')
-        @heater_weekend_fractions_isdefaulted = get_software_defaulted(heater, 'extension/WeekendScheduleFractions') unless @heater_weekend_fractions.nil?
-        @heater_monthly_multipliers = XMLHelper.get_value(heater, 'extension/MonthlyScheduleMultipliers')
-        @heater_monthly_multipliers_isdefaulted = get_software_defaulted(heater, 'extension/MonthlyScheduleMultipliers') unless @heater_monthly_multipliers.nil?
+        @heater_load_value, @heater_load_value_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'Load/Value', :float)
+        @heater_usage_multiplier, @heater_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/UsageMultiplier', :float)
+        @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekdayScheduleFractions')
+        @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekendScheduleFractions')
+        @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/MonthlyScheduleMultipliers')
       end
     end
   end
@@ -4997,31 +4834,21 @@ class HPXML < Object
       @id = HPXML::get_id(hot_tub)
       hot_tub_pump = XMLHelper.get_element(hot_tub, 'HotTubPumps/HotTubPump')
       @pump_id = HPXML::get_id(hot_tub_pump)
-      @pump_kwh_per_year = to_float_or_nil(XMLHelper.get_value(hot_tub_pump, "Load[Units='#{UnitsKwhPerYear}']/Value"))
-      @pump_kwh_per_year_isdefaulted = get_software_defaulted(hot_tub_pump, "Load[Units='#{UnitsKwhPerYear}']/Value") unless @pump_kwh_per_year.nil?
-      @pump_usage_multiplier = to_float_or_nil(XMLHelper.get_value(hot_tub_pump, 'extension/UsageMultiplier'))
-      @pump_usage_multiplier_isdefaulted = get_software_defaulted(hot_tub_pump, 'extension/UsageMultiplier') unless @pump_usage_multiplier.nil?
-      @pump_weekday_fractions = XMLHelper.get_value(hot_tub_pump, 'extension/WeekdayScheduleFractions')
-      @pump_weekday_fractions_isdefaulted = get_software_defaulted(hot_tub_pump, 'extension/WeekdayScheduleFractions') unless @pump_weekday_fractions.nil?
-      @pump_weekend_fractions = XMLHelper.get_value(hot_tub_pump, 'extension/WeekendScheduleFractions')
-      @pump_weekend_fractions_isdefaulted = get_software_defaulted(hot_tub_pump, 'extension/WeekendScheduleFractions') unless @pump_weekend_fractions.nil?
-      @pump_monthly_multipliers = XMLHelper.get_value(hot_tub_pump, 'extension/MonthlyScheduleMultipliers')
-      @pump_monthly_multipliers_isdefaulted = get_software_defaulted(hot_tub_pump, 'extension/MonthlyScheduleMultipliers') unless @pump_monthly_multipliers.nil?
+      @pump_kwh_per_year, @pump_kwh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
+      @pump_usage_multiplier, @pump_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/UsageMultiplier', :float)
+      @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekdayScheduleFractions')
+      @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekendScheduleFractions')
+      @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/MonthlyScheduleMultipliers')
       heater = XMLHelper.get_element(hot_tub, 'Heater')
       if not heater.nil?
         @heater_id = HPXML::get_id(heater)
         @heater_type = XMLHelper.get_value(heater, 'Type')
         @heater_load_units = XMLHelper.get_value(heater, 'Load/Units')
-        @heater_load_value = to_float_or_nil(XMLHelper.get_value(heater, 'Load/Value'))
-        @heater_load_value_isdefaulted = get_software_defaulted(heater, 'Load/Value') unless @heater_load_value.nil?
-        @heater_usage_multiplier = to_float_or_nil(XMLHelper.get_value(heater, 'extension/UsageMultiplier'))
-        @heater_usage_multiplier_isdefaulted = get_software_defaulted(heater, 'extension/UsageMultiplier') unless @heater_usage_multiplier.nil?
-        @heater_weekday_fractions = XMLHelper.get_value(heater, 'extension/WeekdayScheduleFractions')
-        @heater_weekday_fractions_isdefaulted = get_software_defaulted(heater, 'extension/WeekdayScheduleFractions') unless @heater_weekday_fractions.nil?
-        @heater_weekend_fractions = XMLHelper.get_value(heater, 'extension/WeekendScheduleFractions')
-        @heater_weekend_fractions_isdefaulted = get_software_defaulted(heater, 'extension/WeekendScheduleFractions') unless @heater_weekend_fractions.nil?
-        @heater_monthly_multipliers = XMLHelper.get_value(heater, 'extension/MonthlyScheduleMultipliers')
-        @heater_monthly_multipliers_isdefaulted = get_software_defaulted(heater, 'extension/MonthlyScheduleMultipliers') unless @heater_monthly_multipliers.nil?
+        @heater_load_value, @heater_load_value_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'Load/Value', :float)
+        @heater_usage_multiplier, @heater_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/UsageMultiplier', :float)
+        @heater_weekday_fractions, @heater_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekdayScheduleFractions')
+        @heater_weekend_fractions, @heater_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/WeekendScheduleFractions')
+        @heater_monthly_multipliers, @heater_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(heater, 'extension/MonthlyScheduleMultipliers')
       end
     end
   end
@@ -5079,22 +4906,14 @@ class HPXML < Object
     def from_oga(plug_load)
       @id = HPXML::get_id(plug_load)
       @plug_load_type = XMLHelper.get_value(plug_load, 'PlugLoadType')
-      @location = XMLHelper.get_value(plug_load, 'Location')
-      @location_isdefaulted = get_software_defaulted(plug_load, 'Location') unless @location.nil?
-      @kWh_per_year = to_float_or_nil(XMLHelper.get_value(plug_load, "Load[Units='#{UnitsKwhPerYear}']/Value"))
-      @kWh_per_year_isdefaulted = get_software_defaulted(plug_load, "Load[Units='#{UnitsKwhPerYear}']/Value") unless @kWh_per_year.nil?
-      @frac_sensible = to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/FracSensible'))
-      @frac_sensible_isdefaulted = get_software_defaulted(plug_load, 'extension/FracSensible') unless @frac_sensible.nil?
-      @frac_latent = to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/FracLatent'))
-      @frac_latent_isdefaulted = get_software_defaulted(plug_load, 'extension/FracLatent') unless @frac_latent.nil?
-      @usage_multiplier = to_float_or_nil(XMLHelper.get_value(plug_load, 'extension/UsageMultiplier'))
-      @usage_multiplier_isdefaulted = get_software_defaulted(plug_load, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
-      @weekday_fractions = XMLHelper.get_value(plug_load, 'extension/WeekdayScheduleFractions')
-      @weekday_fractions_isdefaulted = get_software_defaulted(plug_load, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
-      @weekend_fractions = XMLHelper.get_value(plug_load, 'extension/WeekendScheduleFractions')
-      @weekend_fractions_isdefaulted = get_software_defaulted(plug_load, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
-      @monthly_multipliers = XMLHelper.get_value(plug_load, 'extension/MonthlyScheduleMultipliers')
-      @monthly_multipliers_isdefaulted = get_software_defaulted(plug_load, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'Location')
+      @kWh_per_year, @kWh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
+      @frac_sensible, @frac_sensible_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/FracSensible', :float)
+      @frac_latent, @frac_latent_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/FracLatent', :float)
+      @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/UsageMultiplier', :float)
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/WeekdayScheduleFractions')
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/WeekendScheduleFractions')
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(plug_load, 'extension/MonthlyScheduleMultipliers')
     end
   end
 
@@ -5152,23 +4971,15 @@ class HPXML < Object
     def from_oga(fuel_load)
       @id = HPXML::get_id(fuel_load)
       @fuel_load_type = XMLHelper.get_value(fuel_load, 'FuelLoadType')
-      @location = XMLHelper.get_value(fuel_load, 'Location')
-      @location_isdefaulted = get_software_defaulted(fuel_load, 'Location') unless @location.nil?
-      @therm_per_year = to_float_or_nil(XMLHelper.get_value(fuel_load, "Load[Units='#{UnitsThermPerYear}']/Value"))
-      @therm_per_year_isdefaulted = get_software_defaulted(fuel_load, "Load[Units='#{UnitsThermPerYear}']/Value") unless @therm_per_year.nil?
+      @location, @location_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'Location')
+      @therm_per_year, @therm_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, "Load[Units='#{UnitsThermPerYear}']/Value", :float)
       @fuel_type = XMLHelper.get_value(fuel_load, 'FuelType')
-      @frac_sensible = to_float_or_nil(XMLHelper.get_value(fuel_load, 'extension/FracSensible'))
-      @frac_sensible_isdefaulted = get_software_defaulted(fuel_load, 'extension/FracSensible') unless @frac_sensible.nil?
-      @frac_latent = to_float_or_nil(XMLHelper.get_value(fuel_load, 'extension/FracLatent'))
-      @frac_latent_isdefaulted = get_software_defaulted(fuel_load, 'extension/FracLatent') unless @frac_latent.nil?
-      @usage_multiplier = to_float_or_nil(XMLHelper.get_value(fuel_load, 'extension/UsageMultiplier'))
-      @usage_multiplier_isdefaulted = get_software_defaulted(fuel_load, 'extension/UsageMultiplier') unless @usage_multiplier.nil?
-      @weekday_fractions = XMLHelper.get_value(fuel_load, 'extension/WeekdayScheduleFractions')
-      @weekday_fractions_isdefaulted = get_software_defaulted(fuel_load, 'extension/WeekdayScheduleFractions') unless @weekday_fractions.nil?
-      @weekend_fractions = XMLHelper.get_value(fuel_load, 'extension/WeekendScheduleFractions')
-      @weekend_fractions_isdefaulted = get_software_defaulted(fuel_load, 'extension/WeekendScheduleFractions') unless @weekend_fractions.nil?
-      @monthly_multipliers = XMLHelper.get_value(fuel_load, 'extension/MonthlyScheduleMultipliers')
-      @monthly_multipliers_isdefaulted = get_software_defaulted(fuel_load, 'extension/MonthlyScheduleMultipliers') unless @monthly_multipliers.nil?
+      @frac_sensible, @frac_sensible_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/FracSensible', :float)
+      @frac_latent, @frac_latent_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/FracLatent', :float)
+      @usage_multiplier, @usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/UsageMultiplier', :float)
+      @weekday_fractions, @weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/WeekdayScheduleFractions')
+      @weekend_fractions, @weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/WeekendScheduleFractions')
+      @monthly_multipliers, @monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(fuel_load, 'extension/MonthlyScheduleMultipliers')
     end
   end
 
@@ -5445,63 +5256,4 @@ class HPXML < Object
   def self.get_idref(element)
     return XMLHelper.get_attribute_value(element, 'idref')
   end
-end
-
-def to_float(value)
-  begin
-    return Float(value)
-  rescue
-    fail "Cannot convert '#{value}' to float."
-  end
-end
-
-def to_integer(value)
-  begin
-    value = Float(value)
-  rescue
-    fail "Cannot convert '#{value}' to integer."
-  end
-  if value % 1 == 0
-    return Integer(value)
-  else
-    fail "Cannot convert '#{value}' to integer."
-  end
-end
-
-def to_boolean(value)
-  if value.is_a? TrueClass
-    return true
-  elsif value.is_a? FalseClass
-    return false
-  elsif (value.downcase.to_s == 'true') || (value == '1') || (value == 1)
-    return true
-  elsif (value.downcase.to_s == 'false') || (value == '0') || (value == 0)
-    return false
-  end
-
-  fail "Cannot convert '#{value}' to boolean."
-end
-
-def to_float_or_nil(value)
-  return if value.nil?
-
-  return to_float(value)
-end
-
-def to_integer_or_nil(value)
-  return if value.nil?
-
-  return to_integer(value)
-end
-
-def to_boolean_or_nil(value)
-  return if value.nil?
-
-  return to_boolean(value)
-end
-
-def get_software_defaulted(parent, element_name)
-  el = XMLHelper.get_element(parent, element_name)
-  is_defaulted = XMLHelper.get_attribute_value(el, 'dataSource') == 'software'
-  return is_defaulted
 end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -5027,11 +5027,13 @@ class HPXML < Object
 
           match = true
           surf.class::ATTRS.each do |attribute|
+            next if attribute.to_s.end_with? '_isdefaulted'
             next if attrs_to_ignore.include? attribute
             next if (surf_type == :foundation_walls) && (attribute == :azimuth) # Azimuth of foundation walls is irrelevant
             next if surf.send(attribute) == surf2.send(attribute)
 
             match = false
+            break
           end
           next unless match
 

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -135,9 +135,17 @@ class HPXMLDefaults
   end
 
   def self.apply_building_construction(hpxml, cfa, nbeds)
-    if hpxml.building_construction.conditioned_building_volume.nil?
+    if hpxml.building_construction.conditioned_building_volume.nil? && hpxml.building_construction.average_ceiling_height.nil?
+      hpxml.building_construction.average_ceiling_height = 8.0
+      hpxml.building_construction.average_ceiling_height_isdefaulted = true
       hpxml.building_construction.conditioned_building_volume = cfa * hpxml.building_construction.average_ceiling_height
       hpxml.building_construction.conditioned_building_volume_isdefaulted = true
+    elsif hpxml.building_construction.conditioned_building_volume.nil?
+      hpxml.building_construction.conditioned_building_volume = cfa * hpxml.building_construction.average_ceiling_height
+      hpxml.building_construction.conditioned_building_volume_isdefaulted = true
+    elsif hpxml.building_construction.average_ceiling_height.nil?
+      hpxml.building_construction.average_ceiling_height = hpxml.building_construction.conditioned_building_volume / cfa
+      hpxml.building_construction.average_ceiling_height_isdefaulted = true
     end
 
     if hpxml.building_construction.number_of_bathrooms.nil?
@@ -744,6 +752,12 @@ class HPXMLDefaults
     return if hpxml.hot_water_distributions.size == 0
 
     hot_water_distribution = hpxml.hot_water_distributions[0]
+
+    if hot_water_distribution.pipe_r_value.nil?
+      hot_water_distribution.pipe_r_value = 0.0
+      hot_water_distribution.pipe_r_value_isdefaulted = true
+    end
+
     if hot_water_distribution.system_type == HPXML::DHWDistTypeStandard
       if hot_water_distribution.standard_piping_length.nil?
         hot_water_distribution.standard_piping_length = HotWaterAndAppliances.get_default_std_pipe_length(has_uncond_bsmnt, cfa, ncfl)

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -45,17 +45,17 @@ class HPXMLDefaults
       hpxml.header.sim_begin_month = 1
       hpxml.header.sim_begin_month_isdefaulted = true
     end
-    if hpxml.header.sim_begin_day_of_month.nil?
-      hpxml.header.sim_begin_day_of_month = 1
-      hpxml.header.sim_begin_day_of_month_isdefaulted = true
+    if hpxml.header.sim_begin_day.nil?
+      hpxml.header.sim_begin_day = 1
+      hpxml.header.sim_begin_day_isdefaulted = true
     end
     if hpxml.header.sim_end_month.nil?
       hpxml.header.sim_end_month = 12
       hpxml.header.sim_end_month_isdefaulted = true
     end
-    if hpxml.header.sim_end_day_of_month.nil?
-      hpxml.header.sim_end_day_of_month = 31
-      hpxml.header.sim_end_day_of_month_isdefaulted = true
+    if hpxml.header.sim_end_day.nil?
+      hpxml.header.sim_end_day = 31
+      hpxml.header.sim_end_day_isdefaulted = true
     end
 
     if epw_file.startDateActualYear.is_initialized # AMY
@@ -82,26 +82,26 @@ class HPXMLDefaults
     end
 
     if hpxml.header.dst_enabled
-      if hpxml.header.dst_begin_month.nil? || hpxml.header.dst_begin_day_of_month.nil? || hpxml.header.dst_end_month.nil? || hpxml.header.dst_end_day_of_month.nil?
+      if hpxml.header.dst_begin_month.nil? || hpxml.header.dst_begin_day.nil? || hpxml.header.dst_end_month.nil? || hpxml.header.dst_end_day.nil?
         if epw_file.daylightSavingStartDate.is_initialized && epw_file.daylightSavingEndDate.is_initialized
           # Use weather file DST dates if available
           dst_start_date = epw_file.daylightSavingStartDate.get
           dst_end_date = epw_file.daylightSavingEndDate.get
           hpxml.header.dst_begin_month = dst_start_date.monthOfYear.value
-          hpxml.header.dst_begin_day_of_month = dst_start_date.dayOfMonth
+          hpxml.header.dst_begin_day = dst_start_date.dayOfMonth
           hpxml.header.dst_end_month = dst_end_date.monthOfYear.value
-          hpxml.header.dst_end_day_of_month = dst_end_date.dayOfMonth
+          hpxml.header.dst_end_day = dst_end_date.dayOfMonth
         else
           # Roughly average US dates according to https://en.wikipedia.org/wiki/Daylight_saving_time_in_the_United_States
           hpxml.header.dst_begin_month = 3
-          hpxml.header.dst_begin_day_of_month = 12
+          hpxml.header.dst_begin_day = 12
           hpxml.header.dst_end_month = 11
-          hpxml.header.dst_end_day_of_month = 5
+          hpxml.header.dst_end_day = 5
         end
         hpxml.header.dst_begin_month_isdefaulted = true
-        hpxml.header.dst_begin_day_of_month_isdefaulted = true
+        hpxml.header.dst_begin_day_isdefaulted = true
         hpxml.header.dst_end_month_isdefaulted = true
-        hpxml.header.dst_end_day_of_month_isdefaulted = true
+        hpxml.header.dst_end_day_isdefaulted = true
       end
     end
 
@@ -1092,14 +1092,14 @@ class HPXMLDefaults
       if hpxml.lighting.holiday_period_begin_month.nil?
         hpxml.lighting.holiday_period_begin_month = 11
         hpxml.lighting.holiday_period_begin_month_isdefaulted = true
-        hpxml.lighting.holiday_period_begin_day_of_month = 24
-        hpxml.lighting.holiday_period_begin_day_of_month_isdefaulted = true
+        hpxml.lighting.holiday_period_begin_day = 24
+        hpxml.lighting.holiday_period_begin_day_isdefaulted = true
       end
-      if hpxml.lighting.holiday_period_end_day_of_month.nil?
+      if hpxml.lighting.holiday_period_end_day.nil?
         hpxml.lighting.holiday_period_end_month = 1
         hpxml.lighting.holiday_period_end_month_isdefaulted = true
-        hpxml.lighting.holiday_period_end_day_of_month = 6
-        hpxml.lighting.holiday_period_end_day_of_month_isdefaulted = true
+        hpxml.lighting.holiday_period_end_day = 6
+        hpxml.lighting.holiday_period_end_day_isdefaulted = true
       end
       if hpxml.lighting.holiday_weekday_fractions.nil?
         hpxml.lighting.holiday_weekday_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -6,12 +6,12 @@ class HPXMLDefaults
     apply_site(hpxml)
     apply_building_occupancy(hpxml, nbeds)
     apply_building_construction(hpxml, cfa, nbeds)
+    apply_infiltration(hpxml)
     apply_attics(hpxml)
     apply_foundations(hpxml)
-    apply_infiltration(hpxml)
     apply_roofs(hpxml)
-    apply_walls(hpxml)
     apply_rim_joists(hpxml)
+    apply_walls(hpxml)
     apply_foundation_walls(hpxml)
     apply_slabs(hpxml)
     apply_windows(hpxml)
@@ -19,39 +19,68 @@ class HPXMLDefaults
     apply_hvac(hpxml)
     apply_hvac_control(hpxml)
     apply_hvac_distribution(hpxml, ncfl, ncfl_ag)
+    apply_ventilation_fans(hpxml)
     apply_water_heaters(hpxml, nbeds, eri_version)
     apply_hot_water_distribution(hpxml, cfa, ncfl, has_uncond_bsmnt)
     apply_water_fixtures(hpxml)
     apply_solar_thermal_systems(hpxml)
-    apply_ventilation_fans(hpxml)
-    apply_ceiling_fans(hpxml, nbeds)
-    apply_plug_loads(hpxml, cfa, nbeds)
-    apply_fuel_loads(hpxml, cfa, nbeds)
-    apply_pools_and_hot_tubs(hpxml, cfa, nbeds)
     apply_appliances(hpxml, nbeds, eri_version)
     apply_lighting(hpxml)
+    apply_ceiling_fans(hpxml, nbeds)
+    apply_pools_and_hot_tubs(hpxml, cfa, nbeds)
+    apply_plug_loads(hpxml, cfa, nbeds)
+    apply_fuel_loads(hpxml, cfa, nbeds)
     apply_pv_systems(hpxml)
   end
 
   private
 
   def self.apply_header(hpxml, epw_file, runner)
-    hpxml.header.timestep = 60 if hpxml.header.timestep.nil?
-
-    hpxml.header.sim_begin_month = 1 if hpxml.header.sim_begin_month.nil?
-    hpxml.header.sim_begin_day_of_month = 1 if hpxml.header.sim_begin_day_of_month.nil?
-    hpxml.header.sim_end_month = 12 if hpxml.header.sim_end_month.nil?
-    hpxml.header.sim_end_day_of_month = 31 if hpxml.header.sim_end_day_of_month.nil?
-    if epw_file.startDateActualYear.is_initialized # AMY
-      if not hpxml.header.sim_calendar_year.nil?
-        runner.registerWarning("Overriding Calendar Year (#{hpxml.header.sim_calendar_year}) with AMY year (#{epw_file.startDateActualYear.get}).") if hpxml.header.sim_calendar_year != epw_file.startDateActualYear.get
-      end
-      hpxml.header.sim_calendar_year = epw_file.startDateActualYear.get
-    else
-      hpxml.header.sim_calendar_year = 2007 if hpxml.header.sim_calendar_year.nil? # For consistency with SAM utility bill calculations
+    if hpxml.header.timestep.nil?
+      hpxml.header.timestep = 60
+      hpxml.header.timestep_isdefaulted = true
     end
 
-    hpxml.header.dst_enabled = true if hpxml.header.dst_enabled.nil? # Assume DST since it occurs in most US locations
+    if hpxml.header.sim_begin_month.nil?
+      hpxml.header.sim_begin_month = 1
+      hpxml.header.sim_begin_month_isdefaulted = true
+    end
+    if hpxml.header.sim_begin_day_of_month.nil?
+      hpxml.header.sim_begin_day_of_month = 1
+      hpxml.header.sim_begin_day_of_month_isdefaulted = true
+    end
+    if hpxml.header.sim_end_month.nil?
+      hpxml.header.sim_end_month = 12
+      hpxml.header.sim_end_month_isdefaulted = true
+    end
+    if hpxml.header.sim_end_day_of_month.nil?
+      hpxml.header.sim_end_day_of_month = 31
+      hpxml.header.sim_end_day_of_month_isdefaulted = true
+    end
+
+    if epw_file.startDateActualYear.is_initialized # AMY
+      if not hpxml.header.sim_calendar_year.nil?
+        if hpxml.header.sim_calendar_year != epw_file.startDateActualYear.get
+          runner.registerWarning("Overriding Calendar Year (#{hpxml.header.sim_calendar_year}) with AMY year (#{epw_file.startDateActualYear.get}).")
+          hpxml.header.sim_calendar_year = epw_file.startDateActualYear.get
+          hpxml.header.sim_calendar_year_isdefaulted = true
+        end
+      else
+        hpxml.header.sim_calendar_year = epw_file.startDateActualYear.get
+        hpxml.header.sim_calendar_year_isdefaulted = true
+      end
+    else
+      if hpxml.header.sim_calendar_year.nil?
+        hpxml.header.sim_calendar_year = 2007 # For consistency with SAM utility bill calculations
+        hpxml.header.sim_calendar_year_isdefaulted = true
+      end
+    end
+
+    if hpxml.header.dst_enabled.nil?
+      hpxml.header.dst_enabled = true # Assume DST since it occurs in most US locations
+      hpxml.header.dst_enabled_isdefaulted = true
+    end
+
     if hpxml.header.dst_enabled
       if hpxml.header.dst_begin_month.nil? || hpxml.header.dst_begin_day_of_month.nil? || hpxml.header.dst_end_month.nil? || hpxml.header.dst_end_day_of_month.nil?
         if epw_file.daylightSavingStartDate.is_initialized && epw_file.daylightSavingEndDate.is_initialized
@@ -69,29 +98,56 @@ class HPXMLDefaults
           hpxml.header.dst_end_month = 11
           hpxml.header.dst_end_day_of_month = 5
         end
+        hpxml.header.dst_begin_month_isdefaulted = true
+        hpxml.header.dst_begin_day_of_month_isdefaulted = true
+        hpxml.header.dst_end_month_isdefaulted = true
+        hpxml.header.dst_end_day_of_month_isdefaulted = true
       end
     end
 
-    hpxml.header.allow_increased_fixed_capacities = false if hpxml.header.allow_increased_fixed_capacities.nil?
-    hpxml.header.use_max_load_for_heat_pumps = true if hpxml.header.use_max_load_for_heat_pumps.nil?
+    if hpxml.header.allow_increased_fixed_capacities.nil?
+      hpxml.header.allow_increased_fixed_capacities = false
+      hpxml.header.allow_increased_fixed_capacities_isdefaulted = true
+    end
+    if hpxml.header.use_max_load_for_heat_pumps.nil?
+      hpxml.header.use_max_load_for_heat_pumps = true
+      hpxml.header.use_max_load_for_heat_pumps_isdefaulted = true
+    end
   end
 
   def self.apply_site(hpxml)
-    hpxml.site.site_type = HPXML::SiteTypeSuburban if hpxml.site.site_type.nil?
-    hpxml.site.shelter_coefficient = Airflow.get_default_shelter_coefficient() if hpxml.site.shelter_coefficient.nil?
+    if hpxml.site.site_type.nil?
+      hpxml.site.site_type = HPXML::SiteTypeSuburban
+      hpxml.site.site_type_isdefaulted = true
+    end
+
+    if hpxml.site.shelter_coefficient.nil?
+      hpxml.site.shelter_coefficient = Airflow.get_default_shelter_coefficient()
+      hpxml.site.shelter_coefficient_isdefaulted = true
+    end
   end
 
   def self.apply_building_occupancy(hpxml, nbeds)
-    hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(nbeds) if hpxml.building_occupancy.number_of_residents.nil?
+    if hpxml.building_occupancy.number_of_residents.nil?
+      hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(nbeds)
+      hpxml.building_occupancy.number_of_residents_isdefaulted = true
+    end
   end
 
   def self.apply_building_construction(hpxml, cfa, nbeds)
     if hpxml.building_construction.conditioned_building_volume.nil?
       hpxml.building_construction.conditioned_building_volume = cfa * hpxml.building_construction.average_ceiling_height
+      hpxml.building_construction.conditioned_building_volume_isdefaulted = true
     end
-    hpxml.building_construction.number_of_bathrooms = Float(Waterheater.get_default_num_bathrooms(nbeds)).to_i if hpxml.building_construction.number_of_bathrooms.nil?
+
+    if hpxml.building_construction.number_of_bathrooms.nil?
+      hpxml.building_construction.number_of_bathrooms = Float(Waterheater.get_default_num_bathrooms(nbeds)).to_i
+      hpxml.building_construction.number_of_bathrooms_isdefaulted = true
+    end
+
     if hpxml.building_construction.has_flue_or_chimney.nil?
       hpxml.building_construction.has_flue_or_chimney = false
+      hpxml.building_construction.has_flue_or_chimney_isdefaulted = true
       hpxml.heating_systems.each do |heating_system|
         if [HPXML::HVACTypeFurnace, HPXML::HVACTypeBoiler, HPXML::HVACTypeWallFurnace, HPXML::HVACTypeFloorFurnace, HPXML::HVACTypeStove, HPXML::HVACTypeFixedHeater].include? heating_system.heating_system_type
           if not heating_system.heating_efficiency_afue.nil?
@@ -119,6 +175,29 @@ class HPXMLDefaults
     end
   end
 
+  def self.apply_infiltration(hpxml)
+    measurements = []
+    infil_volume = nil
+    hpxml.air_infiltration_measurements.each do |measurement|
+      is_ach = ((measurement.unit_of_measure == HPXML::UnitsACH) && !measurement.house_pressure.nil?)
+      is_cfm = ((measurement.unit_of_measure == HPXML::UnitsCFM) && !measurement.house_pressure.nil?)
+      is_nach = (measurement.unit_of_measure == HPXML::UnitsACHNatural)
+      next unless (is_ach || is_cfm || is_nach)
+
+      measurements << measurement
+      next if measurement.infiltration_volume.nil?
+
+      infil_volume = measurement.infiltration_volume
+    end
+    if infil_volume.nil?
+      infil_volume = hpxml.building_construction.conditioned_building_volume
+      measurements.each do |measurement|
+        measurement.infiltration_volume = infil_volume
+        measurement.infiltration_volume_isdefaulted = true
+      end
+    end
+  end
+
   def self.apply_attics(hpxml)
     return unless hpxml.has_space_type(HPXML::LocationAtticVented)
 
@@ -135,6 +214,7 @@ class HPXMLDefaults
     end
     if vented_attic.vented_attic_sla.nil? && vented_attic.vented_attic_ach.nil?
       vented_attic.vented_attic_sla = Airflow.get_default_vented_attic_sla()
+      vented_attic.vented_attic_sla_isdefaulted = true
     end
   end
 
@@ -154,28 +234,7 @@ class HPXMLDefaults
     end
     if vented_crawl.vented_crawlspace_sla.nil?
       vented_crawl.vented_crawlspace_sla = Airflow.get_default_vented_crawl_sla()
-    end
-  end
-
-  def self.apply_infiltration(hpxml)
-    measurements = []
-    infil_volume = nil
-    hpxml.air_infiltration_measurements.each do |measurement|
-      is_ach = ((measurement.unit_of_measure == HPXML::UnitsACH) && !measurement.house_pressure.nil?)
-      is_cfm = ((measurement.unit_of_measure == HPXML::UnitsCFM) && !measurement.house_pressure.nil?)
-      is_nach = (measurement.unit_of_measure == HPXML::UnitsACHNatural)
-      next unless (is_ach || is_cfm || is_nach)
-
-      measurements << measurement
-      next if measurement.infiltration_volume.nil?
-
-      infil_volume = measurement.infiltration_volume
-    end
-    if infil_volume.nil?
-      infil_volume = hpxml.building_construction.conditioned_building_volume
-      measurements.each do |measurement|
-        measurement.infiltration_volume = infil_volume
-      end
+      vented_crawl.vented_crawlspace_sla_isdefaulted = true
     end
   end
 
@@ -183,35 +242,22 @@ class HPXMLDefaults
     hpxml.roofs.each do |roof|
       if roof.roof_type.nil?
         roof.roof_type = HPXML::RoofTypeAsphaltShingles
+        roof.roof_type_isdefaulted = true
       end
       if roof.emittance.nil?
         roof.emittance = 0.90
+        roof.emittance_isdefaulted = true
       end
       if roof.radiant_barrier.nil?
         roof.radiant_barrier = false
+        roof.radiant_barrier_isdefaulted = true
       end
       if roof.roof_color.nil?
         roof.roof_color = Constructions.get_default_roof_color(roof.roof_type, roof.solar_absorptance)
+        roof.roof_color_isdefaulted = true
       elsif roof.solar_absorptance.nil?
         roof.solar_absorptance = Constructions.get_default_roof_solar_absorptance(roof.roof_type, roof.roof_color)
-      end
-    end
-  end
-
-  def self.apply_walls(hpxml)
-    hpxml.walls.each do |wall|
-      next unless wall.is_exterior
-
-      if wall.emittance.nil?
-        wall.emittance = 0.90
-      end
-      if wall.siding.nil?
-        wall.siding = HPXML::SidingTypeWood
-      end
-      if wall.color.nil?
-        wall.color = Constructions.get_default_wall_color(wall.solar_absorptance)
-      elsif wall.solar_absorptance.nil?
-        wall.solar_absorptance = Constructions.get_default_wall_solar_absorptance(wall.color)
+        roof.solar_absorptance_isdefaulted = true
       end
     end
   end
@@ -222,14 +268,40 @@ class HPXMLDefaults
 
       if rim_joist.emittance.nil?
         rim_joist.emittance = 0.90
+        rim_joist.emittance_isdefaulted = true
       end
       if rim_joist.siding.nil?
         rim_joist.siding = HPXML::SidingTypeWood
+        rim_joist.siding_isdefaulted = true
       end
       if rim_joist.color.nil?
         rim_joist.color = Constructions.get_default_wall_color(rim_joist.solar_absorptance)
+        rim_joist.color_isdefaulted = true
       elsif rim_joist.solar_absorptance.nil?
         rim_joist.solar_absorptance = Constructions.get_default_wall_solar_absorptance(rim_joist.color)
+        rim_joist.solar_absorptance_isdefaulted = true
+      end
+    end
+  end
+
+  def self.apply_walls(hpxml)
+    hpxml.walls.each do |wall|
+      next unless wall.is_exterior
+
+      if wall.emittance.nil?
+        wall.emittance = 0.90
+        wall.emittance_isdefaulted = true
+      end
+      if wall.siding.nil?
+        wall.siding = HPXML::SidingTypeWood
+        wall.siding_isdefaulted = true
+      end
+      if wall.color.nil?
+        wall.color = Constructions.get_default_wall_color(wall.solar_absorptance)
+        wall.color_isdefaulted = true
+      elsif wall.solar_absorptance.nil?
+        wall.solar_absorptance = Constructions.get_default_wall_solar_absorptance(wall.color)
+        wall.solar_absorptance_isdefaulted = true
       end
     end
   end
@@ -238,6 +310,7 @@ class HPXMLDefaults
     hpxml.foundation_walls.each do |foundation_wall|
       if foundation_wall.thickness.nil?
         foundation_wall.thickness = 8.0
+        foundation_wall.thickness_isdefaulted = true
       end
     end
   end
@@ -246,22 +319,17 @@ class HPXMLDefaults
     hpxml.slabs.each do |slab|
       if slab.thickness.nil?
         slab.thickness = 4.0
+        slab.thickness_isdefaulted = true
       end
       conditioned_slab = [HPXML::LocationLivingSpace,
                           HPXML::LocationBasementConditioned].include?(slab.interior_adjacent_to)
       if slab.carpet_r_value.nil?
-        if conditioned_slab
-          slab.carpet_r_value = 2.0
-        else
-          slab.carpet_r_value = 0.0
-        end
+        slab.carpet_r_value = conditioned_slab ? 2.0 : 0.0
+        slab.carpet_r_value_isdefaulted = true
       end
       if slab.carpet_fraction.nil?
-        if conditioned_slab
-          slab.carpet_fraction = 0.8
-        else
-          slab.carpet_fraction = 0.0
-        end
+        slab.carpet_fraction = conditioned_slab ? 0.8 : 0.0
+        slab.carpet_fraction_isdefaulted = true
       end
     end
   end
@@ -271,12 +339,15 @@ class HPXMLDefaults
     hpxml.windows.each do |window|
       if window.interior_shading_factor_summer.nil?
         window.interior_shading_factor_summer = default_shade_summer
+        window.interior_shading_factor_summer_isdefaulted = true
       end
       if window.interior_shading_factor_winter.nil?
         window.interior_shading_factor_winter = default_shade_winter
+        window.interior_shading_factor_winter_isdefaulted = true
       end
       if window.fraction_operable.nil?
         window.fraction_operable = Airflow.get_default_fraction_of_windows_operable()
+        window.fraction_operable_isdefaulted = true
       end
     end
   end
@@ -285,9 +356,11 @@ class HPXMLDefaults
     hpxml.skylights.each do |skylight|
       if skylight.interior_shading_factor_summer.nil?
         skylight.interior_shading_factor_summer = 1.0
+        skylight.interior_shading_factor_summer_isdefaulted = true
       end
       if skylight.interior_shading_factor_winter.nil?
         skylight.interior_shading_factor_winter = 1.0
+        skylight.interior_shading_factor_winter_isdefaulted = true
       end
     end
   end
@@ -298,16 +371,21 @@ class HPXMLDefaults
       next unless cooling_system.compressor_type.nil?
 
       cooling_system.compressor_type = HVAC.get_default_compressor_type(cooling_system.cooling_system_type, cooling_system.cooling_efficiency_seer)
+      cooling_system.compressor_type_isdefaulted = true
     end
     hpxml.heat_pumps.each do |heat_pump|
       next unless heat_pump.compressor_type.nil?
 
       heat_pump.compressor_type = HVAC.get_default_compressor_type(heat_pump.heat_pump_type, heat_pump.cooling_efficiency_seer)
+      heat_pump.compressor_type_isdefaulted = true
     end
 
     # Default boiler EAE
     hpxml.heating_systems.each do |heating_system|
-      heating_system.electric_auxiliary_energy = HVAC.get_default_boiler_eae(heating_system)
+      if heating_system.electric_auxiliary_energy.nil?
+        heating_system.electric_auxiliary_energy_isdefaulted = true
+        heating_system.electric_auxiliary_energy = HVAC.get_default_boiler_eae(heating_system)
+      end
     end
 
     # Default AC/HP sensible heat ratio
@@ -322,10 +400,13 @@ class HPXMLDefaults
         elsif cooling_system.compressor_type == HPXML::HVACCompressorTypeVariableSpeed
           cooling_system.cooling_shr = 0.78
         end
+        cooling_system.cooling_shr_isdefaulted = true
       elsif cooling_system.cooling_system_type == HPXML::HVACTypeRoomAirConditioner
         cooling_system.cooling_shr = 0.65
+        cooling_system.cooling_shr_isdefaulted = true
       elsif cooling_system.cooling_system_type == HPXML::HVACTypeMiniSplitAirConditioner
         cooling_system.cooling_shr = 0.73
+        cooling_system.cooling_shr_isdefaulted = true
       end
     end
     hpxml.heat_pumps.each do |heat_pump|
@@ -339,10 +420,13 @@ class HPXMLDefaults
         elsif heat_pump.compressor_type == HPXML::HVACCompressorTypeVariableSpeed
           heat_pump.cooling_shr = 0.78
         end
+        heat_pump.cooling_shr_isdefaulted = true
       elsif heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpMiniSplit
         heat_pump.cooling_shr = 0.73
+        heat_pump.cooling_shr_isdefaulted = true
       elsif heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir
         heat_pump.cooling_shr = 0.732
+        heat_pump.cooling_shr_isdefaulted = true
       end
     end
 
@@ -352,6 +436,7 @@ class HPXMLDefaults
       next unless heat_pump.pump_watts_per_ton.nil?
 
       heat_pump.pump_watts_per_ton = HVAC.get_default_gshp_pump_power()
+      heat_pump.pump_watts_per_ton_isdefaulted = true
     end
 
     # Fan power
@@ -367,10 +452,12 @@ class HPXMLDefaults
           else
             heating_system.fan_watts_per_cfm = psc_watts_per_cfm
           end
+          heating_system.fan_watts_per_cfm_isdefaulted = true
         end
       elsif [HPXML::HVACTypeStove].include? heating_system.heating_system_type
         if heating_system.fan_watts.nil?
           heating_system.fan_watts = 40.0 # W
+          heating_system.fan_watts_isdefaulted = true
         end
       elsif [HPXML::HVACTypeWallFurnace,
              HPXML::HVACTypeFloorFurnace,
@@ -379,6 +466,7 @@ class HPXMLDefaults
              HPXML::HVACTypeFireplace].include? heating_system.heating_system_type
         if heating_system.fan_watts.nil?
           heating_system.fan_watts = 0.0 # W/cfm, assume no fan power
+          heating_system.fan_watts_isdefaulted = true
         end
       end
     end
@@ -387,18 +475,21 @@ class HPXMLDefaults
 
       if (not cooling_system.attached_heating_system.nil?) && (not cooling_system.attached_heating_system.fan_watts_per_cfm.nil?)
         cooling_system.fan_watts_per_cfm = cooling_system.attached_heating_system.fan_watts_per_cfm
+        cooling_system.fan_watts_per_cfm_isdefaulted = true
       elsif [HPXML::HVACTypeCentralAirConditioner].include? cooling_system.cooling_system_type
         if cooling_system.cooling_efficiency_seer > 13.5 # HEScore assumption
           cooling_system.fan_watts_per_cfm = ecm_watts_per_cfm
         else
           cooling_system.fan_watts_per_cfm = psc_watts_per_cfm
         end
+        cooling_system.fan_watts_per_cfm_isdefaulted = true
       elsif [HPXML::HVACTypeMiniSplitAirConditioner].include? cooling_system.cooling_system_type
         if not cooling_system.distribution_system.nil?
           cooling_system.fan_watts_per_cfm = mini_split_ducted_watts_per_cfm
         else
           cooling_system.fan_watts_per_cfm = mini_split_ductless_watts_per_cfm
         end
+        cooling_system.fan_watts_per_cfm_isdefaulted = true
       elsif [HPXML::HVACTypeEvaporativeCooler].include? cooling_system.cooling_system_type
         # Depends on airflow rate, so defaulted in hvac_sizing.rb
       end
@@ -412,18 +503,21 @@ class HPXMLDefaults
         else
           heat_pump.fan_watts_per_cfm = psc_watts_per_cfm
         end
+        heat_pump.fan_watts_per_cfm_isdefaulted = true
       elsif [HPXML::HVACTypeHeatPumpGroundToAir].include? heat_pump.heat_pump_type
         if heat_pump.heating_efficiency_cop > 8.75 / 3.2 # HEScore assumption
           heat_pump.fan_watts_per_cfm = ecm_watts_per_cfm
         else
           heat_pump.fan_watts_per_cfm = psc_watts_per_cfm
         end
+        heat_pump.fan_watts_per_cfm_isdefaulted = true
       elsif [HPXML::HVACTypeHeatPumpMiniSplit].include? heat_pump.heat_pump_type
         if not heat_pump.distribution_system.nil?
           heat_pump.fan_watts_per_cfm = mini_split_ducted_watts_per_cfm
         else
           heat_pump.fan_watts_per_cfm = mini_split_ductless_watts_per_cfm
         end
+        heat_pump.fan_watts_per_cfm_isdefaulted = true
       end
     end
 
@@ -467,12 +561,14 @@ class HPXMLDefaults
       if not hvac_control.heating_setback_temp.nil?
         if hvac_control.heating_setback_start_hour.nil?
           hvac_control.heating_setback_start_hour = 23 # 11 pm
+          hvac_control.heating_setback_start_hour_isdefaulted = true
         end
       end
 
       next unless not hvac_control.cooling_setup_temp.nil?
       if hvac_control.cooling_setup_start_hour.nil?
         hvac_control.cooling_setup_start_hour = 9 # 9 am
+        hvac_control.cooling_setup_start_hour_isdefaulted = true
       end
     end
   end
@@ -495,6 +591,7 @@ class HPXMLDefaults
       # Default return registers
       if hvac_distribution.number_of_return_registers.nil?
         hvac_distribution.number_of_return_registers = ncfl # Add 1 return register per conditioned floor if not provided
+        hvac_distribution.number_of_return_registers_isdefaulted = true
       end
 
       # Default ducts
@@ -519,10 +616,82 @@ class HPXMLDefaults
               hvac_distribution.ducts.add(duct_type: duct.duct_type,
                                           duct_insulation_r_value: duct.duct_insulation_r_value,
                                           duct_location: secondary_duct_location,
-                                          duct_surface_area: secondary_duct_area)
+                                          duct_location_isdefaulted: true,
+                                          duct_surface_area: secondary_duct_area,
+                                          duct_surface_area_isdefaulted: true)
             end
           end
+          duct.duct_surface_area_isdefaulted = true
+          duct.duct_location_isdefaulted = true
         end
+      end
+    end
+  end
+
+  def self.apply_ventilation_fans(hpxml)
+    # Default mech vent systems
+    hpxml.ventilation_fans.each do |vent_fan|
+      next unless vent_fan.used_for_whole_building_ventilation
+
+      if vent_fan.is_shared_system.nil?
+        vent_fan.is_shared_system = false
+        vent_fan.is_shared_system_isdefaulted = true
+      end
+      if vent_fan.hours_in_operation.nil?
+        vent_fan.hours_in_operation = (vent_fan.fan_type == HPXML::MechVentTypeCFIS) ? 8.0 : 24.0
+        vent_fan.hours_in_operation_isdefaulted = true
+      end
+    end
+
+    # Default kitchen fan
+    hpxml.ventilation_fans.each do |vent_fan|
+      next unless (vent_fan.used_for_local_ventilation && (vent_fan.fan_location == HPXML::LocationKitchen))
+
+      if vent_fan.quantity.nil?
+        vent_fan.quantity = 1
+        vent_fan.quantity_isdefaulted = true
+      end
+      if vent_fan.rated_flow_rate.nil?
+        vent_fan.rated_flow_rate = 100.0 # cfm, per BA HSP
+        vent_fan.rated_flow_rate_isdefaulted = true
+      end
+      if vent_fan.hours_in_operation.nil?
+        vent_fan.hours_in_operation = 1.0 # hrs/day, per BA HSP
+        vent_fan.hours_in_operation_isdefaulted = true
+      end
+      if vent_fan.fan_power.nil?
+        vent_fan.fan_power = 0.3 * vent_fan.rated_flow_rate # W, per BA HSP
+        vent_fan.fan_power_isdefaulted = true
+      end
+      if vent_fan.start_hour.nil?
+        vent_fan.start_hour = 18 # 6 pm, per BA HSP
+        vent_fan.start_hour_isdefaulted = true
+      end
+    end
+
+    # Default bath fans
+    hpxml.ventilation_fans.each do |vent_fan|
+      next unless (vent_fan.used_for_local_ventilation && (vent_fan.fan_location == HPXML::LocationBath))
+
+      if vent_fan.quantity.nil?
+        vent_fan.quantity = hpxml.building_construction.number_of_bathrooms
+        vent_fan.quantity_isdefaulted = true
+      end
+      if vent_fan.rated_flow_rate.nil?
+        vent_fan.rated_flow_rate = 50.0 # cfm, per BA HSP
+        vent_fan.rated_flow_rate_isdefaulted = true
+      end
+      if vent_fan.hours_in_operation.nil?
+        vent_fan.hours_in_operation = 1.0 # hrs/day, per BA HSP
+        vent_fan.hours_in_operation_isdefaulted = true
+      end
+      if vent_fan.fan_power.nil?
+        vent_fan.fan_power = 0.3 * vent_fan.rated_flow_rate # W, per BA HSP
+        vent_fan.fan_power_isdefaulted = true
+      end
+      if vent_fan.start_hour.nil?
+        vent_fan.start_hour = 7 # 7 am, per BA HSP
+        vent_fan.start_hour_isdefaulted = true
       end
     end
   end
@@ -531,12 +700,15 @@ class HPXMLDefaults
     hpxml.water_heating_systems.each do |water_heating_system|
       if water_heating_system.is_shared_system.nil?
         water_heating_system.is_shared_system = false
+        water_heating_system.is_shared_system_isdefaulted = true
       end
       if water_heating_system.temperature.nil?
         water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(eri_version)
+        water_heating_system.temperature_isdefaulted = true
       end
       if water_heating_system.performance_adjustment.nil?
         water_heating_system.performance_adjustment = Waterheater.get_default_performance_adjustment(water_heating_system)
+        water_heating_system.performance_adjustment_isdefaulted = true
       end
       if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeCombiStorage) && water_heating_system.standby_loss.nil?
         # Use equation fit from AHRI database
@@ -545,20 +717,25 @@ class HPXMLDefaults
         surface_area = Waterheater.calc_tank_areas(act_vol)[0]
         sqft_by_gal = surface_area / act_vol # sqft/gal
         water_heating_system.standby_loss = (2.9721 * sqft_by_gal - 0.4732).round(3) # linear equation assuming a constant u, F/hr
+        water_heating_system.standby_loss_isdefaulted = true
       end
       if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage)
         if water_heating_system.heating_capacity.nil?
           water_heating_system.heating_capacity = Waterheater.get_default_heating_capacity(water_heating_system.fuel_type, nbeds, hpxml.water_heating_systems.size, hpxml.building_construction.number_of_bathrooms) * 1000.0
+          water_heating_system.heating_capacity_isdefaulted = true
         end
         if water_heating_system.tank_volume.nil?
           water_heating_system.tank_volume = Waterheater.get_default_tank_volume(water_heating_system.fuel_type, nbeds, hpxml.building_construction.number_of_bathrooms)
+          water_heating_system.tank_volume_isdefaulted = true
         end
         if water_heating_system.recovery_efficiency.nil?
           water_heating_system.recovery_efficiency = Waterheater.get_default_recovery_efficiency(water_heating_system)
+          water_heating_system.recovery_efficiency_isdefaulted = true
         end
       end
       if water_heating_system.location.nil?
         water_heating_system.location = Waterheater.get_default_location(hpxml, hpxml.climate_and_risk_zones.iecc_zone)
+        water_heating_system.location_isdefaulted = true
       end
     end
   end
@@ -570,22 +747,27 @@ class HPXMLDefaults
     if hot_water_distribution.system_type == HPXML::DHWDistTypeStandard
       if hot_water_distribution.standard_piping_length.nil?
         hot_water_distribution.standard_piping_length = HotWaterAndAppliances.get_default_std_pipe_length(has_uncond_bsmnt, cfa, ncfl)
+        hot_water_distribution.standard_piping_length_isdefaulted = true
       end
     elsif hot_water_distribution.system_type == HPXML::DHWDistTypeRecirc
       if hot_water_distribution.recirculation_piping_length.nil?
         hot_water_distribution.recirculation_piping_length = HotWaterAndAppliances.get_default_recirc_loop_length(HotWaterAndAppliances.get_default_std_pipe_length(has_uncond_bsmnt, cfa, ncfl))
+        hot_water_distribution.recirculation_piping_length_isdefaulted = true
       end
       if hot_water_distribution.recirculation_branch_piping_length.nil?
         hot_water_distribution.recirculation_branch_piping_length = HotWaterAndAppliances.get_default_recirc_branch_loop_length()
+        hot_water_distribution.recirculation_branch_piping_length_isdefaulted = true
       end
       if hot_water_distribution.recirculation_pump_power.nil?
         hot_water_distribution.recirculation_pump_power = HotWaterAndAppliances.get_default_recirc_pump_power()
+        hot_water_distribution.recirculation_pump_power_isdefaulted = true
       end
     end
 
     if hot_water_distribution.has_shared_recirculation
       if hot_water_distribution.shared_recirculation_pump_power.nil?
         hot_water_distribution.shared_recirculation_pump_power = HotWaterAndAppliances.get_default_shared_recirc_pump_power()
+        hot_water_distribution.shared_recirculation_pump_power_isdefaulted = true
       end
     end
   end
@@ -593,6 +775,7 @@ class HPXMLDefaults
   def self.apply_water_fixtures(hpxml)
     if hpxml.water_heating.water_fixtures_usage_multiplier.nil?
       hpxml.water_heating.water_fixtures_usage_multiplier = 1.0
+      hpxml.water_heating.water_fixtures_usage_multiplier_isdefaulted = true
     end
   end
 
@@ -605,66 +788,326 @@ class HPXMLDefaults
     if not collector_area.nil? # Detailed solar water heater
       if solar_thermal_system.storage_volume.nil?
         solar_thermal_system.storage_volume = Waterheater.calc_default_solar_thermal_system_storage_volume(collector_area)
+        solar_thermal_system.storage_volume_isdefaulted = true
       end
     end
   end
 
-  def self.apply_ventilation_fans(hpxml)
-    # Default mech vent systems
-    hpxml.ventilation_fans.each do |vent_fan|
-      next unless vent_fan.used_for_whole_building_ventilation
-
-      if vent_fan.is_shared_system.nil?
-        vent_fan.is_shared_system = false
+  def self.apply_pv_systems(hpxml)
+    hpxml.pv_systems.each do |pv_system|
+      if pv_system.is_shared_system.nil?
+        pv_system.is_shared_system = false
+        pv_system.is_shared_system_isdefaulted = true
       end
-      if vent_fan.hours_in_operation.nil?
-        if vent_fan.fan_type == HPXML::MechVentTypeCFIS
-          vent_fan.hours_in_operation = 8.0
-        else
-          vent_fan.hours_in_operation = 24.0
+      if pv_system.location.nil?
+        pv_system.location = HPXML::LocationRoof
+        pv_system.location_isdefaulted = true
+      end
+      if pv_system.tracking.nil?
+        pv_system.tracking = HPXML::PVTrackingTypeFixed
+        pv_system.tracking_isdefaulted = true
+      end
+      if pv_system.module_type.nil?
+        pv_system.module_type = HPXML::PVModuleTypeStandard
+        pv_system.module_type_isdefaulted = true
+      end
+      if pv_system.inverter_efficiency.nil?
+        pv_system.inverter_efficiency = PV.get_default_inv_eff()
+        pv_system.inverter_efficiency_isdefaulted = true
+      end
+      if pv_system.system_losses_fraction.nil?
+        pv_system.system_losses_fraction = PV.get_default_system_losses(pv_system.year_modules_manufactured)
+        pv_system.system_losses_fraction_isdefaulted = true
+      end
+    end
+  end
+
+  def self.apply_appliances(hpxml, nbeds, eri_version)
+    # Default clothes washer
+    if hpxml.clothes_washers.size > 0
+      clothes_washer = hpxml.clothes_washers[0]
+      if clothes_washer.is_shared_appliance.nil?
+        clothes_washer.is_shared_appliance = false
+        clothes_washer.is_shared_appliance_isdefaulted = true
+      end
+      if clothes_washer.location.nil?
+        clothes_washer.location = HPXML::LocationLivingSpace
+        clothes_washer.location_isdefaulted = true
+      end
+      if clothes_washer.rated_annual_kwh.nil?
+        default_values = HotWaterAndAppliances.get_clothes_washer_default_values(eri_version)
+        clothes_washer.integrated_modified_energy_factor = default_values[:integrated_modified_energy_factor]
+        clothes_washer.integrated_modified_energy_factor_isdefaulted = true
+        clothes_washer.rated_annual_kwh = default_values[:rated_annual_kwh]
+        clothes_washer.rated_annual_kwh_isdefaulted = true
+        clothes_washer.label_electric_rate = default_values[:label_electric_rate]
+        clothes_washer.label_electric_rate_isdefaulted = true
+        clothes_washer.label_gas_rate = default_values[:label_gas_rate]
+        clothes_washer.label_gas_rate_isdefaulted = true
+        clothes_washer.label_annual_gas_cost = default_values[:label_annual_gas_cost]
+        clothes_washer.label_annual_gas_cost_isdefaulted = true
+        clothes_washer.capacity = default_values[:capacity]
+        clothes_washer.capacity_isdefaulted = true
+        clothes_washer.label_usage = default_values[:label_usage]
+        clothes_washer.label_usage_isdefaulted = true
+      end
+      if clothes_washer.usage_multiplier.nil?
+        clothes_washer.usage_multiplier = 1.0
+        clothes_washer.usage_multiplier_isdefaulted = true
+      end
+    end
+
+    # Default clothes dryer
+    if hpxml.clothes_dryers.size > 0
+      clothes_dryer = hpxml.clothes_dryers[0]
+      if clothes_dryer.is_shared_appliance.nil?
+        clothes_dryer.is_shared_appliance = false
+        clothes_dryer.is_shared_appliance_isdefaulted = true
+      end
+      if clothes_dryer.location.nil?
+        clothes_dryer.location = HPXML::LocationLivingSpace
+        clothes_dryer.location_isdefaulted = true
+      end
+      if clothes_dryer.control_type.nil?
+        default_values = HotWaterAndAppliances.get_clothes_dryer_default_values(eri_version, clothes_dryer.fuel_type)
+        clothes_dryer.control_type = default_values[:control_type]
+        clothes_dryer.control_type_isdefaulted = true
+        clothes_dryer.combined_energy_factor = default_values[:combined_energy_factor]
+        clothes_dryer.combined_energy_factor_isdefaulted = true
+      end
+      if clothes_dryer.usage_multiplier.nil?
+        clothes_dryer.usage_multiplier = 1.0
+        clothes_dryer.usage_multiplier_isdefaulted = true
+      end
+      if clothes_dryer.is_vented.nil?
+        clothes_dryer.is_vented = true
+        clothes_dryer.is_vented_isdefaulted = true
+      end
+      if clothes_dryer.is_vented && clothes_dryer.vented_flow_rate.nil?
+        clothes_dryer.vented_flow_rate = 100.0
+        clothes_dryer.vented_flow_rate_isdefaulted = true
+      end
+    end
+
+    # Default dishwasher
+    if hpxml.dishwashers.size > 0
+      dishwasher = hpxml.dishwashers[0]
+      if dishwasher.is_shared_appliance.nil?
+        dishwasher.is_shared_appliance = false
+        dishwasher.is_shared_appliance_isdefaulted = true
+      end
+      if dishwasher.location.nil?
+        dishwasher.location = HPXML::LocationLivingSpace
+        dishwasher.location_isdefaulted = true
+      end
+      if dishwasher.place_setting_capacity.nil?
+        default_values = HotWaterAndAppliances.get_dishwasher_default_values(eri_version)
+        dishwasher.rated_annual_kwh = default_values[:rated_annual_kwh]
+        dishwasher.rated_annual_kwh_isdefaulted = true
+        dishwasher.label_electric_rate = default_values[:label_electric_rate]
+        dishwasher.label_electric_rate_isdefaulted = true
+        dishwasher.label_gas_rate = default_values[:label_gas_rate]
+        dishwasher.label_gas_rate_isdefaulted = true
+        dishwasher.label_annual_gas_cost = default_values[:label_annual_gas_cost]
+        dishwasher.label_annual_gas_cost_isdefaulted = true
+        dishwasher.label_usage = default_values[:label_usage]
+        dishwasher.label_usage_isdefaulted = true
+        dishwasher.place_setting_capacity = default_values[:place_setting_capacity]
+        dishwasher.place_setting_capacity_isdefaulted = true
+      end
+      if dishwasher.usage_multiplier.nil?
+        dishwasher.usage_multiplier = 1.0
+        dishwasher.usage_multiplier_isdefaulted = true
+      end
+    end
+
+    # Default refrigerators
+    if hpxml.refrigerators.size == 1
+      hpxml.refrigerators[0].primary_indicator = true
+      hpxml.refrigerators[0].primary_indicator_isdefaulted = true
+    end
+    hpxml.refrigerators.each do |refrigerator|
+      if not refrigerator.primary_indicator # extra refrigerator
+        if refrigerator.location.nil?
+          refrigerator.location = HotWaterAndAppliances.get_default_extra_refrigerator_and_freezer_locations(hpxml)
+          refrigerator.location_isdefaulted = true
+        end
+        if refrigerator.adjusted_annual_kwh.nil? && refrigerator.rated_annual_kwh.nil?
+          default_values = HotWaterAndAppliances.get_extra_refrigerator_default_values
+          refrigerator.rated_annual_kwh = default_values[:rated_annual_kwh]
+          refrigerator.rated_annual_kwh_isdefaulted = true
+        end
+      else # primary refrigerator
+        if refrigerator.location.nil?
+          refrigerator.location = HPXML::LocationLivingSpace
+          refrigerator.location_isdefaulted = true
+        end
+        if refrigerator.adjusted_annual_kwh.nil? && refrigerator.rated_annual_kwh.nil?
+          default_values = HotWaterAndAppliances.get_refrigerator_default_values(nbeds)
+          refrigerator.rated_annual_kwh = default_values[:rated_annual_kwh]
+          refrigerator.rated_annual_kwh_isdefaulted = true
         end
       end
-    end
-
-    # Default kitchen fan
-    hpxml.ventilation_fans.each do |vent_fan|
-      next unless (vent_fan.used_for_local_ventilation && (vent_fan.fan_location == HPXML::LocationKitchen))
-
-      if vent_fan.quantity.nil?
-        vent_fan.quantity = 1
+      if refrigerator.usage_multiplier.nil?
+        refrigerator.usage_multiplier = 1.0
+        refrigerator.usage_multiplier_isdefaulted = true
       end
-      if vent_fan.rated_flow_rate.nil?
-        vent_fan.rated_flow_rate = 100.0 # cfm, per BA HSP
+      if refrigerator.weekday_fractions.nil?
+        refrigerator.weekday_fractions = '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041'
+        refrigerator.weekday_fractions_isdefaulted = true
       end
-      if vent_fan.hours_in_operation.nil?
-        vent_fan.hours_in_operation = 1.0 # hrs/day, per BA HSP
+      if refrigerator.weekend_fractions.nil?
+        refrigerator.weekend_fractions = '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041'
+        refrigerator.weekend_fractions_isdefaulted = true
       end
-      if vent_fan.fan_power.nil?
-        vent_fan.fan_power = 0.3 * vent_fan.rated_flow_rate # W, per BA HSP
-      end
-      if vent_fan.start_hour.nil?
-        vent_fan.start_hour = 18 # 6 pm, per BA HSP
+      if refrigerator.monthly_multipliers.nil?
+        refrigerator.monthly_multipliers = '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837'
+        refrigerator.monthly_multipliers_isdefaulted = true
       end
     end
 
-    # Default bath fans
-    hpxml.ventilation_fans.each do |vent_fan|
-      next unless (vent_fan.used_for_local_ventilation && (vent_fan.fan_location == HPXML::LocationBath))
+    # Default freezer
+    hpxml.freezers.each do |freezer|
+      if freezer.location.nil?
+        freezer.location = HotWaterAndAppliances.get_default_extra_refrigerator_and_freezer_locations(hpxml)
+        freezer.location_isdefaulted = true
+      end
+      if freezer.adjusted_annual_kwh.nil? && freezer.rated_annual_kwh.nil?
+        default_values = HotWaterAndAppliances.get_freezer_default_values
+        freezer.rated_annual_kwh = default_values[:rated_annual_kwh]
+        freezer.rated_annual_kwh_isdefaulted = true
+      end
+      if freezer.usage_multiplier.nil?
+        freezer.usage_multiplier = 1.0
+        freezer.usage_multiplier_isdefaulted = true
+      end
+      if freezer.weekday_fractions.nil?
+        freezer.weekday_fractions = '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041'
+        freezer.weekday_fractions_isdefaulted = true
+      end
+      if freezer.weekend_fractions.nil?
+        freezer.weekend_fractions = '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041'
+        freezer.weekend_fractions_isdefaulted = true
+      end
+      if freezer.monthly_multipliers.nil?
+        freezer.monthly_multipliers = '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837'
+        freezer.monthly_multipliers_isdefaulted = true
+      end
+    end
 
-      if vent_fan.quantity.nil?
-        vent_fan.quantity = hpxml.building_construction.number_of_bathrooms
+    # Default cooking range
+    if hpxml.cooking_ranges.size > 0
+      cooking_range = hpxml.cooking_ranges[0]
+      if cooking_range.location.nil?
+        cooking_range.location = HPXML::LocationLivingSpace
+        cooking_range.location_isdefaulted = true
       end
-      if vent_fan.rated_flow_rate.nil?
-        vent_fan.rated_flow_rate = 50.0 # cfm, per BA HSP
+      if cooking_range.is_induction.nil?
+        default_values = HotWaterAndAppliances.get_range_oven_default_values()
+        cooking_range.is_induction = default_values[:is_induction]
+        cooking_range.is_induction_isdefaulted = true
       end
-      if vent_fan.hours_in_operation.nil?
-        vent_fan.hours_in_operation = 1.0 # hrs/day, per BA HSP
+      if cooking_range.usage_multiplier.nil?
+        cooking_range.usage_multiplier = 1.0
+        cooking_range.usage_multiplier_isdefaulted = true
       end
-      if vent_fan.fan_power.nil?
-        vent_fan.fan_power = 0.3 * vent_fan.rated_flow_rate # W, per BA HSP
+      if cooking_range.weekday_fractions.nil?
+        cooking_range.weekday_fractions = '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011'
+        cooking_range.weekday_fractions_isdefaulted = true
       end
-      if vent_fan.start_hour.nil?
-        vent_fan.start_hour = 7 # 7 am, per BA HSP
+      if cooking_range.weekend_fractions.nil?
+        cooking_range.weekend_fractions = '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011'
+        cooking_range.weekend_fractions_isdefaulted = true
+      end
+      if cooking_range.monthly_multipliers.nil?
+        cooking_range.monthly_multipliers = '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097'
+        cooking_range.monthly_multipliers_isdefaulted = true
+      end
+    end
+
+    # Default oven
+    if hpxml.ovens.size > 0
+      oven = hpxml.ovens[0]
+      if oven.is_convection.nil?
+        default_values = HotWaterAndAppliances.get_range_oven_default_values()
+        oven.is_convection = default_values[:is_convection]
+        oven.is_convection_isdefaulted = true
+      end
+    end
+  end
+
+  def self.apply_lighting(hpxml)
+    if hpxml.lighting.interior_usage_multiplier.nil?
+      hpxml.lighting.interior_usage_multiplier = 1.0
+      hpxml.lighting.interior_usage_multiplier_isdefaulted = true
+    end
+    if hpxml.lighting.garage_usage_multiplier.nil?
+      hpxml.lighting.garage_usage_multiplier = 1.0
+      hpxml.lighting.garage_usage_multiplier_isdefaulted = true
+    end
+    if hpxml.lighting.exterior_usage_multiplier.nil?
+      hpxml.lighting.exterior_usage_multiplier = 1.0
+      hpxml.lighting.exterior_usage_multiplier_isdefaulted = true
+    end
+    # Schedules from T24 2016 Residential ACM Appendix C Table 8 Exterior Lighting Hourly Multiplier (Weekdays and weekends)
+    default_exterior_lighting_weekday_fractions = '0.046, 0.046, 0.046, 0.046, 0.046, 0.037, 0.035, 0.034, 0.033, 0.028, 0.022, 0.015, 0.012, 0.011, 0.011, 0.012, 0.019, 0.037, 0.049, 0.065, 0.091, 0.105, 0.091, 0.063'
+    default_exterior_lighting_weekend_fractions = '0.046, 0.046, 0.045, 0.045, 0.046, 0.045, 0.044, 0.041, 0.036, 0.03, 0.024, 0.016, 0.012, 0.011, 0.011, 0.012, 0.019, 0.038, 0.048, 0.06, 0.083, 0.098, 0.085, 0.059'
+    default_exterior_lighting_monthly_multipliers = '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248'
+    if hpxml.has_space_type(HPXML::LocationGarage)
+      if hpxml.lighting.garage_weekday_fractions.nil?
+        hpxml.lighting.garage_weekday_fractions = default_exterior_lighting_weekday_fractions
+        hpxml.lighting.garage_weekday_fractions_isdefaulted = true
+      end
+      if hpxml.lighting.garage_weekend_fractions.nil?
+        hpxml.lighting.garage_weekend_fractions = default_exterior_lighting_weekend_fractions
+        hpxml.lighting.garage_weekend_fractions_isdefaulted = true
+      end
+      if hpxml.lighting.garage_monthly_multipliers.nil?
+        hpxml.lighting.garage_monthly_multipliers = default_exterior_lighting_monthly_multipliers
+        hpxml.lighting.garage_monthly_multipliers_isdefaulted = true
+      end
+    end
+    if hpxml.lighting.exterior_weekday_fractions.nil?
+      hpxml.lighting.exterior_weekday_fractions = default_exterior_lighting_weekday_fractions
+      hpxml.lighting.exterior_weekday_fractions_isdefaulted = true
+    end
+    if hpxml.lighting.exterior_weekend_fractions.nil?
+      hpxml.lighting.exterior_weekend_fractions = default_exterior_lighting_weekend_fractions
+      hpxml.lighting.exterior_weekend_fractions_isdefaulted = true
+    end
+    if hpxml.lighting.exterior_monthly_multipliers.nil?
+      hpxml.lighting.exterior_monthly_multipliers = default_exterior_lighting_monthly_multipliers
+      hpxml.lighting.exterior_monthly_multipliers_isdefaulted = true
+    end
+    if hpxml.lighting.holiday_exists
+      if hpxml.lighting.holiday_kwh_per_day.nil?
+        # From LA100 repo (2017)
+        if hpxml.building_construction.residential_facility_type == HPXML::ResidentialTypeSFD
+          hpxml.lighting.holiday_kwh_per_day = 1.1
+        else # Multifamily and others
+          hpxml.lighting.holiday_kwh_per_day = 0.55
+        end
+        hpxml.lighting.holiday_kwh_per_day_isdefaulted = true
+      end
+      if hpxml.lighting.holiday_period_begin_month.nil?
+        hpxml.lighting.holiday_period_begin_month = 11
+        hpxml.lighting.holiday_period_begin_month_isdefaulted = true
+        hpxml.lighting.holiday_period_begin_day_of_month = 24
+        hpxml.lighting.holiday_period_begin_day_of_month_isdefaulted = true
+      end
+      if hpxml.lighting.holiday_period_end_day_of_month.nil?
+        hpxml.lighting.holiday_period_end_month = 1
+        hpxml.lighting.holiday_period_end_month_isdefaulted = true
+        hpxml.lighting.holiday_period_end_day_of_month = 6
+        hpxml.lighting.holiday_period_end_day_of_month_isdefaulted = true
+      end
+      if hpxml.lighting.holiday_weekday_fractions.nil?
+        hpxml.lighting.holiday_weekday_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
+        hpxml.lighting.holiday_weekday_fractions_isdefaulted = true
+      end
+      if hpxml.lighting.holiday_weekend_fractions.nil?
+        hpxml.lighting.holiday_weekend_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
+        hpxml.lighting.holiday_weekend_fractions_isdefaulted = true
       end
     end
   end
@@ -676,9 +1119,103 @@ class HPXMLDefaults
     if ceiling_fan.efficiency.nil?
       medium_cfm = 3000.0
       ceiling_fan.efficiency = medium_cfm / HVAC.get_default_ceiling_fan_power()
+      ceiling_fan.efficiency_isdefaulted = true
     end
     if ceiling_fan.quantity.nil?
       ceiling_fan.quantity = HVAC.get_default_ceiling_fan_quantity(nbeds)
+      ceiling_fan.quantity_isdefaulted = true
+    end
+  end
+
+  def self.apply_pools_and_hot_tubs(hpxml, cfa, nbeds)
+    hpxml.pools.each do |pool|
+      if pool.pump_kwh_per_year.nil?
+        pool.pump_kwh_per_year = MiscLoads.get_pool_pump_default_values(cfa, nbeds)
+        pool.pump_kwh_per_year_isdefaulted = true
+      end
+      if pool.heater_load_value.nil?
+        default_heater_load_units, default_heater_load_value = MiscLoads.get_pool_heater_default_values(cfa, nbeds, pool.heater_type)
+        pool.heater_load_units = default_heater_load_units
+        pool.heater_load_value = default_heater_load_value
+        pool.heater_load_value_isdefaulted = true
+      end
+      if pool.heater_usage_multiplier.nil?
+        pool.heater_usage_multiplier = 1.0
+        pool.heater_usage_multiplier_isdefaulted = true
+      end
+      if pool.pump_usage_multiplier.nil?
+        pool.pump_usage_multiplier = 1.0
+        pool.pump_usage_multiplier_isdefaulted = true
+      end
+      if pool.pump_weekday_fractions.nil?
+        pool.pump_weekday_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
+        pool.pump_weekday_fractions_isdefaulted = true
+      end
+      if pool.pump_weekend_fractions.nil?
+        pool.pump_weekend_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
+        pool.pump_weekend_fractions_isdefaulted = true
+      end
+      if pool.pump_monthly_multipliers.nil?
+        pool.pump_monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
+        pool.pump_monthly_multipliers_isdefaulted = true
+      end
+      if pool.heater_weekday_fractions.nil?
+        pool.heater_weekday_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
+        pool.heater_weekday_fractions_isdefaulted = true
+      end
+      if pool.heater_weekend_fractions.nil?
+        pool.heater_weekend_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
+        pool.heater_weekend_fractions_isdefaulted = true
+      end
+      if pool.heater_monthly_multipliers.nil?
+        pool.heater_monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
+        pool.heater_monthly_multipliers_isdefaulted = true
+      end
+    end
+
+    hpxml.hot_tubs.each do |hot_tub|
+      if hot_tub.pump_kwh_per_year.nil?
+        hot_tub.pump_kwh_per_year = MiscLoads.get_hot_tub_pump_default_values(cfa, nbeds)
+        hot_tub.pump_kwh_per_year_isdefaulted = true
+      end
+      if hot_tub.heater_load_value.nil?
+        default_heater_load_units, default_heater_load_value = MiscLoads.get_hot_tub_heater_default_values(cfa, nbeds, hot_tub.heater_type)
+        hot_tub.heater_load_units = default_heater_load_units
+        hot_tub.heater_load_value = default_heater_load_value
+        hot_tub.heater_load_value_isdefaulted = true
+      end
+      if hot_tub.heater_usage_multiplier.nil?
+        hot_tub.heater_usage_multiplier = 1.0
+        hot_tub.heater_usage_multiplier_isdefaulted = true
+      end
+      if hot_tub.pump_usage_multiplier.nil?
+        hot_tub.pump_usage_multiplier = 1.0
+        hot_tub.pump_usage_multiplier_isdefaulted = true
+      end
+      if hot_tub.pump_weekday_fractions.nil?
+        hot_tub.pump_weekday_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
+        hot_tub.pump_weekday_fractions_isdefaulted = true
+      end
+      if hot_tub.pump_weekend_fractions.nil?
+        hot_tub.pump_weekend_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
+        hot_tub.pump_weekend_fractions_isdefaulted = true
+      end
+      if hot_tub.pump_monthly_multipliers.nil?
+        hot_tub.pump_monthly_multipliers = '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921'
+        hot_tub.pump_monthly_multipliers_isdefaulted = true
+      end
+      if hot_tub.heater_weekday_fractions.nil?
+        hot_tub.heater_weekday_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
+        hot_tub.heater_weekday_fractions_isdefaulted = true
+      end
+      if hot_tub.heater_weekend_fractions.nil?
+        hot_tub.heater_weekend_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
+        hot_tub.heater_weekend_fractions_isdefaulted = true
+      end
+      if hot_tub.heater_monthly_multipliers.nil?
+        hot_tub.heater_monthly_multipliers = '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837'
+        hot_tub.heater_monthly_multipliers_isdefaulted = true
+      end
     end
   end
 
@@ -688,97 +1225,126 @@ class HPXMLDefaults
         default_annual_kwh, default_sens_frac, default_lat_frac = MiscLoads.get_residual_mels_default_values(cfa)
         if plug_load.kWh_per_year.nil?
           plug_load.kWh_per_year = default_annual_kwh
+          plug_load.kWh_per_year_isdefaulted = true
         end
         if plug_load.frac_sensible.nil?
           plug_load.frac_sensible = default_sens_frac
+          plug_load.frac_sensible_isdefaulted = true
         end
         if plug_load.frac_latent.nil?
           plug_load.frac_latent = default_lat_frac
+          plug_load.frac_latent_isdefaulted = true
         end
         if plug_load.location.nil?
           plug_load.location = HPXML::LocationInterior
+          plug_load.location_isdefaulted = true
         end
         if plug_load.weekday_fractions.nil?
           plug_load.weekday_fractions = '0.035, 0.033, 0.032, 0.031, 0.032, 0.033, 0.037, 0.042, 0.043, 0.043, 0.043, 0.044, 0.045, 0.045, 0.044, 0.046, 0.048, 0.052, 0.053, 0.05, 0.047, 0.045, 0.04, 0.036'
+          plug_load.weekday_fractions_isdefaulted = true
         end
         if plug_load.weekend_fractions.nil?
           plug_load.weekend_fractions = '0.035, 0.033, 0.032, 0.031, 0.032, 0.033, 0.037, 0.042, 0.043, 0.043, 0.043, 0.044, 0.045, 0.045, 0.044, 0.046, 0.048, 0.052, 0.053, 0.05, 0.047, 0.045, 0.04, 0.036'
+          plug_load.weekend_fractions_isdefaulted = true
         end
         if plug_load.monthly_multipliers.nil?
           plug_load.monthly_multipliers = '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248'
+          plug_load.monthly_multipliers_isdefaulted = true
         end
       elsif plug_load.plug_load_type == HPXML::PlugLoadTypeTelevision
         default_annual_kwh, default_sens_frac, default_lat_frac = MiscLoads.get_televisions_default_values(cfa, nbeds)
         if plug_load.kWh_per_year.nil?
           plug_load.kWh_per_year = default_annual_kwh
+          plug_load.kWh_per_year_isdefaulted = true
         end
         if plug_load.frac_sensible.nil?
           plug_load.frac_sensible = default_sens_frac
+          plug_load.frac_sensible_isdefaulted = true
         end
         if plug_load.frac_latent.nil?
           plug_load.frac_latent = default_lat_frac
+          plug_load.frac_latent_isdefaulted = true
         end
         if plug_load.location.nil?
           plug_load.location = HPXML::LocationInterior
+          plug_load.location_isdefaulted = true
         end
         if plug_load.weekday_fractions.nil?
           plug_load.weekday_fractions = '0.037, 0.018, 0.009, 0.007, 0.011, 0.018, 0.029, 0.040, 0.049, 0.058, 0.065, 0.072, 0.076, 0.086, 0.091, 0.102, 0.127, 0.156, 0.210, 0.294, 0.363, 0.344, 0.208, 0.090'
+          plug_load.weekday_fractions_isdefaulted = true
         end
         if plug_load.weekend_fractions.nil?
           plug_load.weekend_fractions = '0.044, 0.022, 0.012, 0.008, 0.011, 0.014, 0.024, 0.043, 0.071, 0.094, 0.112, 0.123, 0.132, 0.156, 0.178, 0.196, 0.206, 0.213, 0.251, 0.330, 0.388, 0.358, 0.226, 0.103'
+          plug_load.weekend_fractions_isdefaulted = true
         end
         if plug_load.monthly_multipliers.nil?
           plug_load.monthly_multipliers = '1.137, 1.129, 0.961, 0.969, 0.961, 0.993, 0.996, 0.96, 0.993, 0.867, 0.86, 1.137'
+          plug_load.monthly_multipliers_isdefaulted = true
         end
       elsif plug_load.plug_load_type == HPXML::PlugLoadTypeElectricVehicleCharging
         default_annual_kwh = MiscLoads.get_electric_vehicle_charging_default_values
         if plug_load.kWh_per_year.nil?
           plug_load.kWh_per_year = default_annual_kwh
+          plug_load.kWh_per_year_isdefaulted = true
         end
         if plug_load.frac_sensible.nil?
           plug_load.frac_sensible = 0.0
+          plug_load.frac_sensible_isdefaulted = true
         end
         if plug_load.frac_latent.nil?
           plug_load.frac_latent = 0.0
+          plug_load.frac_latent_isdefaulted = true
         end
         if plug_load.location.nil?
           plug_load.location = HPXML::LocationExterior
+          plug_load.location_isdefaulted = true
         end
         if plug_load.weekday_fractions.nil?
           plug_load.weekday_fractions = '0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042'
+          plug_load.weekday_fractions_isdefaulted = true
         end
         if plug_load.weekend_fractions.nil?
           plug_load.weekend_fractions = '0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042'
+          plug_load.weekend_fractions_isdefaulted = true
         end
         if plug_load.monthly_multipliers.nil?
           plug_load.monthly_multipliers = '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1'
+          plug_load.monthly_multipliers_isdefaulted = true
         end
       elsif plug_load.plug_load_type == HPXML::PlugLoadTypeWellPump
         default_annual_kwh = MiscLoads.get_well_pump_default_values(cfa, nbeds)
         if plug_load.kWh_per_year.nil?
           plug_load.kWh_per_year = default_annual_kwh
+          plug_load.kWh_per_year_isdefaulted = true
         end
         if plug_load.frac_sensible.nil?
           plug_load.frac_sensible = 0.0
+          plug_load.frac_sensible_isdefaulted = true
         end
         if plug_load.frac_latent.nil?
           plug_load.frac_latent = 0.0
+          plug_load.frac_latent_isdefaulted = true
         end
         if plug_load.location.nil?
           plug_load.location = HPXML::LocationExterior
+          plug_load.location_isdefaulted = true
         end
         if plug_load.weekday_fractions.nil?
           plug_load.weekday_fractions = '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065'
+          plug_load.weekday_fractions_isdefaulted = true
         end
         if plug_load.weekend_fractions.nil?
           plug_load.weekend_fractions = '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065'
+          plug_load.weekend_fractions_isdefaulted = true
         end
         if plug_load.monthly_multipliers.nil?
           plug_load.monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
+          plug_load.monthly_multipliers_isdefaulted = true
         end
       end
       if plug_load.usage_multiplier.nil?
         plug_load.usage_multiplier = 1.0
+        plug_load.usage_multiplier_isdefaulted = true
       end
     end
   end
@@ -788,393 +1354,94 @@ class HPXMLDefaults
       if fuel_load.fuel_load_type == HPXML::FuelLoadTypeGrill
         if fuel_load.therm_per_year.nil?
           fuel_load.therm_per_year = MiscLoads.get_gas_grill_default_values(cfa, nbeds)
+          fuel_load.therm_per_year_isdefaulted = true
         end
         if fuel_load.frac_sensible.nil?
           fuel_load.frac_sensible = 0.0
+          fuel_load.frac_sensible_isdefaulted = true
         end
         if fuel_load.frac_latent.nil?
           fuel_load.frac_latent = 0.0
+          fuel_load.frac_latent_isdefaulted = true
         end
         if fuel_load.location.nil?
           fuel_load.location = HPXML::LocationExterior
+          fuel_load.location_isdefaulted = true
         end
         if fuel_load.weekday_fractions.nil?
           fuel_load.weekday_fractions = '0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007'
+          fuel_load.weekday_fractions_isdefaulted = true
         end
         if fuel_load.weekend_fractions.nil?
           fuel_load.weekend_fractions = '0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007'
+          fuel_load.weekend_fractions_isdefaulted = true
         end
         if fuel_load.monthly_multipliers.nil?
           fuel_load.monthly_multipliers = '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097'
+          fuel_load.monthly_multipliers_isdefaulted = true
         end
       elsif fuel_load.fuel_load_type == HPXML::FuelLoadTypeLighting
         if fuel_load.therm_per_year.nil?
           fuel_load.therm_per_year = MiscLoads.get_gas_lighting_default_values(cfa, nbeds)
+          fuel_load.therm_per_year_isdefaulted = true
         end
         if fuel_load.frac_sensible.nil?
           fuel_load.frac_sensible = 0.0
+          fuel_load.frac_sensible_isdefaulted = true
         end
         if fuel_load.frac_latent.nil?
           fuel_load.frac_latent = 0.0
+          fuel_load.frac_latent_isdefaulted = true
         end
         if fuel_load.location.nil?
           fuel_load.location = HPXML::LocationExterior
+          fuel_load.location_isdefaulted = true
         end
         if fuel_load.weekday_fractions.nil?
           fuel_load.weekday_fractions = '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065'
+          fuel_load.weekday_fractions_isdefaulted = true
         end
         if fuel_load.weekend_fractions.nil?
           fuel_load.weekend_fractions = '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065'
+          fuel_load.weekend_fractions_isdefaulted = true
         end
         if fuel_load.monthly_multipliers.nil?
           fuel_load.monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
+          fuel_load.monthly_multipliers_isdefaulted = true
         end
       elsif fuel_load.fuel_load_type == HPXML::FuelLoadTypeFireplace
         if fuel_load.therm_per_year.nil?
           fuel_load.therm_per_year = MiscLoads.get_gas_fireplace_default_values(cfa, nbeds)
+          fuel_load.therm_per_year_isdefaulted = true
         end
         if fuel_load.frac_sensible.nil?
           fuel_load.frac_sensible = 0.5
+          fuel_load.frac_sensible_isdefaulted = true
         end
         if fuel_load.frac_latent.nil?
           fuel_load.frac_latent = 0.1
+          fuel_load.frac_latent_isdefaulted = true
         end
         if fuel_load.location.nil?
           fuel_load.location = HPXML::LocationInterior
+          fuel_load.location_isdefaulted = true
         end
         if fuel_load.weekday_fractions.nil?
           fuel_load.weekday_fractions = '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065'
+          fuel_load.weekday_fractions_isdefaulted = true
         end
         if fuel_load.weekend_fractions.nil?
           fuel_load.weekend_fractions = '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065'
+          fuel_load.weekend_fractions_isdefaulted = true
         end
         if fuel_load.monthly_multipliers.nil?
           fuel_load.monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
+          fuel_load.monthly_multipliers_isdefaulted = true
         end
       end
       if fuel_load.usage_multiplier.nil?
         fuel_load.usage_multiplier = 1.0
-      end
-    end
-  end
-
-  def self.apply_pools_and_hot_tubs(hpxml, cfa, nbeds)
-    hpxml.pools.each do |pool|
-      if pool.pump_kwh_per_year.nil?
-        pool.pump_kwh_per_year = MiscLoads.get_pool_pump_default_values(cfa, nbeds)
-      end
-      if pool.heater_load_value.nil?
-        default_heater_load_units, default_heater_load_value = MiscLoads.get_pool_heater_default_values(cfa, nbeds, pool.heater_type)
-        pool.heater_load_units = default_heater_load_units
-        pool.heater_load_value = default_heater_load_value
-      end
-      if pool.heater_usage_multiplier.nil?
-        pool.heater_usage_multiplier = 1.0
-      end
-      if pool.pump_usage_multiplier.nil?
-        pool.pump_usage_multiplier = 1.0
-      end
-      if pool.pump_weekday_fractions.nil?
-        pool.pump_weekday_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
-      end
-      if pool.pump_weekend_fractions.nil?
-        pool.pump_weekend_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
-      end
-      if pool.pump_monthly_multipliers.nil?
-        pool.pump_monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
-      end
-      if pool.heater_weekday_fractions.nil?
-        pool.heater_weekday_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
-      end
-      if pool.heater_weekend_fractions.nil?
-        pool.heater_weekend_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
-      end
-      if pool.heater_monthly_multipliers.nil?
-        pool.heater_monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
-      end
-    end
-
-    hpxml.hot_tubs.each do |hot_tub|
-      if hot_tub.pump_kwh_per_year.nil?
-        hot_tub.pump_kwh_per_year = MiscLoads.get_hot_tub_pump_default_values(cfa, nbeds)
-      end
-      if hot_tub.heater_load_value.nil?
-        default_heater_load_units, default_heater_load_value = MiscLoads.get_hot_tub_heater_default_values(cfa, nbeds, hot_tub.heater_type)
-        hot_tub.heater_load_units = default_heater_load_units
-        hot_tub.heater_load_value = default_heater_load_value
-      end
-      if hot_tub.heater_usage_multiplier.nil?
-        hot_tub.heater_usage_multiplier = 1.0
-      end
-      if hot_tub.pump_usage_multiplier.nil?
-        hot_tub.pump_usage_multiplier = 1.0
-      end
-      if hot_tub.pump_weekday_fractions.nil?
-        hot_tub.pump_weekday_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
-      end
-      if hot_tub.pump_weekend_fractions.nil?
-        hot_tub.pump_weekend_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
-      end
-      if hot_tub.pump_monthly_multipliers.nil?
-        hot_tub.pump_monthly_multipliers = '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921'
-      end
-      if hot_tub.heater_weekday_fractions.nil?
-        hot_tub.heater_weekday_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
-      end
-      if hot_tub.heater_weekend_fractions.nil?
-        hot_tub.heater_weekend_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
-      end
-      if hot_tub.heater_monthly_multipliers.nil?
-        hot_tub.heater_monthly_multipliers = '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837'
-      end
-    end
-  end
-
-  def self.apply_appliances(hpxml, nbeds, eri_version)
-    # Default clothes washer
-    if hpxml.clothes_washers.size > 0
-      clothes_washer = hpxml.clothes_washers[0]
-      if clothes_washer.is_shared_appliance.nil?
-        clothes_washer.is_shared_appliance = false
-      end
-      if clothes_washer.location.nil?
-        clothes_washer.location = HPXML::LocationLivingSpace
-      end
-      if clothes_washer.rated_annual_kwh.nil?
-        default_values = HotWaterAndAppliances.get_clothes_washer_default_values(eri_version)
-        clothes_washer.integrated_modified_energy_factor = default_values[:integrated_modified_energy_factor]
-        clothes_washer.rated_annual_kwh = default_values[:rated_annual_kwh]
-        clothes_washer.label_electric_rate = default_values[:label_electric_rate]
-        clothes_washer.label_gas_rate = default_values[:label_gas_rate]
-        clothes_washer.label_annual_gas_cost = default_values[:label_annual_gas_cost]
-        clothes_washer.capacity = default_values[:capacity]
-        clothes_washer.label_usage = default_values[:label_usage]
-      end
-      if clothes_washer.usage_multiplier.nil?
-        clothes_washer.usage_multiplier = 1.0
-      end
-    end
-
-    # Default clothes dryer
-    if hpxml.clothes_dryers.size > 0
-      clothes_dryer = hpxml.clothes_dryers[0]
-      if clothes_dryer.is_shared_appliance.nil?
-        clothes_dryer.is_shared_appliance = false
-      end
-      if clothes_dryer.location.nil?
-        clothes_dryer.location = HPXML::LocationLivingSpace
-      end
-      if clothes_dryer.control_type.nil?
-        default_values = HotWaterAndAppliances.get_clothes_dryer_default_values(eri_version, clothes_dryer.fuel_type)
-        clothes_dryer.control_type = default_values[:control_type]
-        clothes_dryer.combined_energy_factor = default_values[:combined_energy_factor]
-      end
-      if clothes_dryer.usage_multiplier.nil?
-        clothes_dryer.usage_multiplier = 1.0
-      end
-      if clothes_dryer.is_vented.nil?
-        clothes_dryer.is_vented = true
-      end
-      if clothes_dryer.is_vented && clothes_dryer.vented_flow_rate.nil?
-        clothes_dryer.vented_flow_rate = 100.0
-      end
-    end
-
-    # Default dishwasher
-    if hpxml.dishwashers.size > 0
-      dishwasher = hpxml.dishwashers[0]
-      if dishwasher.is_shared_appliance.nil?
-        dishwasher.is_shared_appliance = false
-      end
-      if dishwasher.location.nil?
-        dishwasher.location = HPXML::LocationLivingSpace
-      end
-      if dishwasher.place_setting_capacity.nil?
-        default_values = HotWaterAndAppliances.get_dishwasher_default_values(eri_version)
-        dishwasher.rated_annual_kwh = default_values[:rated_annual_kwh]
-        dishwasher.label_electric_rate = default_values[:label_electric_rate]
-        dishwasher.label_gas_rate = default_values[:label_gas_rate]
-        dishwasher.label_annual_gas_cost = default_values[:label_annual_gas_cost]
-        dishwasher.label_usage = default_values[:label_usage]
-        dishwasher.place_setting_capacity = default_values[:place_setting_capacity]
-      end
-      if dishwasher.usage_multiplier.nil?
-        dishwasher.usage_multiplier = 1.0
-      end
-    end
-
-    # Default refrigerators
-    if hpxml.refrigerators.size == 1
-      hpxml.refrigerators[0].primary_indicator = true
-    end
-    hpxml.refrigerators.each do |refrigerator|
-      if not refrigerator.primary_indicator # extra refrigerator
-        if refrigerator.location.nil?
-          refrigerator.location = HotWaterAndAppliances.get_default_extra_refrigerator_and_freezer_locations(hpxml)
-        end
-        if refrigerator.adjusted_annual_kwh.nil? && refrigerator.rated_annual_kwh.nil?
-          default_values = HotWaterAndAppliances.get_extra_refrigerator_default_values
-          refrigerator.rated_annual_kwh = default_values[:rated_annual_kwh]
-        end
-      else # primary refrigerator
-        if refrigerator.location.nil?
-          refrigerator.location = HPXML::LocationLivingSpace
-        end
-        if refrigerator.adjusted_annual_kwh.nil? && refrigerator.rated_annual_kwh.nil?
-          default_values = HotWaterAndAppliances.get_refrigerator_default_values(nbeds)
-          refrigerator.rated_annual_kwh = default_values[:rated_annual_kwh]
-        end
-      end
-      if refrigerator.usage_multiplier.nil?
-        refrigerator.usage_multiplier = 1.0
-      end
-      if refrigerator.weekday_fractions.nil?
-        refrigerator.weekday_fractions = '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041'
-      end
-      if refrigerator.weekend_fractions.nil?
-        refrigerator.weekend_fractions = '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041'
-      end
-      if refrigerator.monthly_multipliers.nil?
-        refrigerator.monthly_multipliers = '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837'
-      end
-    end
-
-    # Default freezer
-    hpxml.freezers.each do |freezer|
-      if freezer.location.nil?
-        freezer.location = HotWaterAndAppliances.get_default_extra_refrigerator_and_freezer_locations(hpxml)
-      end
-      if freezer.adjusted_annual_kwh.nil? && freezer.rated_annual_kwh.nil?
-        default_values = HotWaterAndAppliances.get_freezer_default_values
-        freezer.rated_annual_kwh = default_values[:rated_annual_kwh]
-      end
-      if freezer.usage_multiplier.nil?
-        freezer.usage_multiplier = 1.0
-      end
-      if freezer.weekday_fractions.nil?
-        freezer.weekday_fractions = '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041'
-      end
-      if freezer.weekend_fractions.nil?
-        freezer.weekend_fractions = '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041'
-      end
-      if freezer.monthly_multipliers.nil?
-        freezer.monthly_multipliers = '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837'
-      end
-    end
-
-    # Default cooking range
-    if hpxml.cooking_ranges.size > 0
-      cooking_range = hpxml.cooking_ranges[0]
-      if cooking_range.location.nil?
-        cooking_range.location = HPXML::LocationLivingSpace
-      end
-      if cooking_range.is_induction.nil?
-        default_values = HotWaterAndAppliances.get_range_oven_default_values()
-        cooking_range.is_induction = default_values[:is_induction]
-      end
-      if cooking_range.usage_multiplier.nil?
-        cooking_range.usage_multiplier = 1.0
-      end
-      if cooking_range.weekday_fractions.nil?
-        cooking_range.weekday_fractions = '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011'
-      end
-      if cooking_range.weekend_fractions.nil?
-        cooking_range.weekend_fractions = '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011'
-      end
-      if cooking_range.monthly_multipliers.nil?
-        cooking_range.monthly_multipliers = '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097'
-      end
-    end
-
-    # Default oven
-    if hpxml.ovens.size > 0
-      oven = hpxml.ovens[0]
-      if oven.is_convection.nil?
-        default_values = HotWaterAndAppliances.get_range_oven_default_values()
-        oven.is_convection = default_values[:is_convection]
-      end
-    end
-  end
-
-  def self.apply_lighting(hpxml)
-    if hpxml.lighting.interior_usage_multiplier.nil?
-      hpxml.lighting.interior_usage_multiplier = 1.0
-    end
-    if hpxml.lighting.garage_usage_multiplier.nil?
-      hpxml.lighting.garage_usage_multiplier = 1.0
-    end
-    if hpxml.lighting.exterior_usage_multiplier.nil?
-      hpxml.lighting.exterior_usage_multiplier = 1.0
-    end
-    # Schedules from T24 2016 Residential ACM Appendix C Table 8 Exterior Lighting Hourly Multiplier (Weekdays and weekends)
-    default_exterior_lighting_weekday_fractions = '0.046, 0.046, 0.046, 0.046, 0.046, 0.037, 0.035, 0.034, 0.033, 0.028, 0.022, 0.015, 0.012, 0.011, 0.011, 0.012, 0.019, 0.037, 0.049, 0.065, 0.091, 0.105, 0.091, 0.063'
-    default_exterior_lighting_weekend_fractions = '0.046, 0.046, 0.045, 0.045, 0.046, 0.045, 0.044, 0.041, 0.036, 0.03, 0.024, 0.016, 0.012, 0.011, 0.011, 0.012, 0.019, 0.038, 0.048, 0.06, 0.083, 0.098, 0.085, 0.059'
-    default_exterior_lighting_monthly_multipliers = '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248'
-    if hpxml.has_space_type(HPXML::LocationGarage)
-      if hpxml.lighting.garage_weekday_fractions.nil?
-        hpxml.lighting.garage_weekday_fractions = default_exterior_lighting_weekday_fractions
-      end
-      if hpxml.lighting.garage_weekend_fractions.nil?
-        hpxml.lighting.garage_weekend_fractions = default_exterior_lighting_weekend_fractions
-      end
-      if hpxml.lighting.garage_monthly_multipliers.nil?
-        hpxml.lighting.garage_monthly_multipliers = default_exterior_lighting_monthly_multipliers
-      end
-    end
-    if hpxml.lighting.exterior_weekday_fractions.nil?
-      hpxml.lighting.exterior_weekday_fractions = default_exterior_lighting_weekday_fractions
-    end
-    if hpxml.lighting.exterior_weekend_fractions.nil?
-      hpxml.lighting.exterior_weekend_fractions = default_exterior_lighting_weekend_fractions
-    end
-    if hpxml.lighting.exterior_monthly_multipliers.nil?
-      hpxml.lighting.exterior_monthly_multipliers = default_exterior_lighting_monthly_multipliers
-    end
-    if hpxml.lighting.holiday_exists
-      if hpxml.lighting.holiday_kwh_per_day.nil?
-        # From LA100 repo (2017)
-        if hpxml.building_construction.residential_facility_type == HPXML::ResidentialTypeSFD
-          hpxml.lighting.holiday_kwh_per_day = 1.1
-        else # Multifamily and others
-          hpxml.lighting.holiday_kwh_per_day = 0.55
-        end
-      end
-      if hpxml.lighting.holiday_period_begin_month.nil?
-        hpxml.lighting.holiday_period_begin_month = 11
-        hpxml.lighting.holiday_period_begin_day_of_month = 24
-      end
-      if hpxml.lighting.holiday_period_end_day_of_month.nil?
-        hpxml.lighting.holiday_period_end_month = 1
-        hpxml.lighting.holiday_period_end_day_of_month = 6
-      end
-      if hpxml.lighting.holiday_weekday_fractions.nil?
-        hpxml.lighting.holiday_weekday_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
-      end
-      if hpxml.lighting.holiday_weekend_fractions.nil?
-        hpxml.lighting.holiday_weekend_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
-      end
-    end
-  end
-
-  def self.apply_pv_systems(hpxml)
-    hpxml.pv_systems.each do |pv_system|
-      if pv_system.is_shared_system.nil?
-        pv_system.is_shared_system = false
-      end
-      if pv_system.location.nil?
-        pv_system.location = HPXML::LocationRoof
-      end
-      if pv_system.tracking.nil?
-        pv_system.tracking = HPXML::PVTrackingTypeFixed
-      end
-      if pv_system.module_type.nil?
-        pv_system.module_type = HPXML::PVModuleTypeStandard
-      end
-      if pv_system.inverter_efficiency.nil?
-        pv_system.inverter_efficiency = PV.get_default_inv_eff()
-      end
-      if pv_system.system_losses_fraction.nil?
-        pv_system.system_losses_fraction = PV.get_default_system_losses(pv_system.year_modules_manufactured)
+        fuel_load.usage_multiplier_isdefaulted = true
       end
     end
   end

--- a/HPXMLtoOpenStudio/resources/lighting.rb
+++ b/HPXMLtoOpenStudio/resources/lighting.rb
@@ -47,7 +47,7 @@ class Lighting
       garage_sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameGarageLighting + ' schedule', lighting.garage_weekday_fractions, lighting.garage_weekend_fractions, lighting.garage_monthly_multipliers, Constants.ScheduleTypeLimitsFraction)
     end
     if not lighting.holiday_kwh_per_day.nil?
-      exterior_holiday_sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameLightingExteriorHoliday + ' schedule', lighting.holiday_weekday_fractions, lighting.holiday_weekend_fractions, lighting.exterior_monthly_multipliers, Constants.ScheduleTypeLimitsFraction, true, lighting.holiday_period_begin_month, lighting.holiday_period_begin_day_of_month, lighting.holiday_period_end_month, lighting.holiday_period_end_day_of_month)
+      exterior_holiday_sch = MonthWeekdayWeekendSchedule.new(model, Constants.ObjectNameLightingExteriorHoliday + ' schedule', lighting.holiday_weekday_fractions, lighting.holiday_weekend_fractions, lighting.exterior_monthly_multipliers, Constants.ScheduleTypeLimitsFraction, true, lighting.holiday_period_begin_month, lighting.holiday_period_begin_day, lighting.holiday_period_end_month, lighting.holiday_period_end_day)
     end
 
     # Add lighting to each conditioned space

--- a/HPXMLtoOpenStudio/resources/location.rb
+++ b/HPXMLtoOpenStudio/resources/location.rb
@@ -58,8 +58,8 @@ class Location
     return unless hpxml.header.dst_enabled
 
     month_names = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-    dst_start_date = "#{month_names[hpxml.header.dst_begin_month - 1]} #{hpxml.header.dst_begin_day_of_month}"
-    dst_end_date = "#{month_names[hpxml.header.dst_end_month - 1]} #{hpxml.header.dst_end_day_of_month}"
+    dst_start_date = "#{month_names[hpxml.header.dst_begin_month - 1]} #{hpxml.header.dst_begin_day}"
+    dst_end_date = "#{month_names[hpxml.header.dst_end_month - 1]} #{hpxml.header.dst_end_day}"
 
     run_period_control_daylight_saving_time = model.getRunPeriodControlDaylightSavingTime
     run_period_control_daylight_saving_time.setStartDate(dst_start_date)

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -178,7 +178,7 @@ class MonthWeekdayWeekendSchedule
   # monthly_values can either be a comma-separated string of 12 numbers or a 12-element array of numbers.
   def initialize(model, sch_name, weekday_hourly_values, weekend_hourly_values, monthly_values,
                  schedule_type_limits_name = nil, normalize_values = true, begin_month = 1,
-                 begin_day_of_month = 1, end_month = 12, end_day_of_month = 31)
+                 begin_day = 1, end_month = 12, end_day = 31)
     @model = model
     @sch_name = sch_name
     @schedule = nil
@@ -187,9 +187,9 @@ class MonthWeekdayWeekendSchedule
     @monthly_values = validateValues(monthly_values, 12, 'monthly')
     @schedule_type_limits_name = schedule_type_limits_name
     @begin_month = begin_month
-    @begin_day_of_month = begin_day_of_month
+    @begin_day = begin_day
     @end_month = end_month
-    @end_day_of_month = end_day_of_month
+    @end_day = end_day
 
     if normalize_values
       @weekday_hourly_values = normalizeSumToOne(@weekday_hourly_values)
@@ -311,7 +311,7 @@ class MonthWeekdayWeekendSchedule
     end
 
     num_days_in_each_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    num_days_in_each_month[@end_month] = @end_day_of_month
+    num_days_in_each_month[@end_month] = @end_day
     num_days_in_each_month.each_index do |i|
       num_days_in_each_month[i] += leap_offset if i == 2
     end
@@ -320,7 +320,7 @@ class MonthWeekdayWeekendSchedule
       orig_day_startm[i] += leap_offset if i > 2
     end
     day_startm = orig_day_startm.map(&:clone)
-    day_startm[@begin_month] = orig_day_startm[@begin_month] + @begin_day_of_month - 1
+    day_startm[@begin_month] = orig_day_startm[@begin_month] + @begin_day - 1
     day_endm = [orig_day_startm, num_days_in_each_month].transpose.map { |i| (i != [0, 0]) ? i.reduce(:+) - 1 : 0 }
     time = []
     for h in 1..24

--- a/HPXMLtoOpenStudio/resources/simcontrols.rb
+++ b/HPXMLtoOpenStudio/resources/simcontrols.rb
@@ -26,8 +26,8 @@ class SimControls
 
     run_period = model.getRunPeriod
     run_period.setBeginMonth(header.sim_begin_month)
-    run_period.setBeginDayOfMonth(header.sim_begin_day_of_month)
+    run_period.setBeginDayOfMonth(header.sim_begin_day)
     run_period.setEndMonth(header.sim_end_month)
-    run_period.setEndDayOfMonth(header.sim_end_day_of_month)
+    run_period.setEndDayOfMonth(header.sim_end_day)
   end
 end

--- a/HPXMLtoOpenStudio/resources/xmlhelper.rb
+++ b/HPXMLtoOpenStudio/resources/xmlhelper.rb
@@ -3,20 +3,23 @@
 class XMLHelper
   # Adds the child element with 'element_name' and sets its value. Returns the
   # child element.
-  def self.add_element(parent, element_name, value = nil)
+  def self.add_element(parent, element_name, value = nil, defaulted = false)
     added = Oga::XML::Element.new(name: element_name)
     parent.children << added
     if not value.nil?
       added.inner_text = value.to_s
+    end
+    if defaulted
+      XMLHelper.add_attribute(added, 'dataSource', 'software')
     end
     return added
   end
 
   # Adds the child element with 'element_name' to a single extension element and
   # sets its value. Returns the extension element.
-  def self.add_extension(parent, element_name, value)
+  def self.add_extension(parent, element_name, value, defaulted = false)
     extension = XMLHelper.create_elements_as_needed(parent, ['extension'])
-    return XMLHelper.add_element(extension, element_name, value)
+    return XMLHelper.add_element(extension, element_name, value, defaulted)
   end
 
   # Creates a hierarchy of elements under the parent element based on the supplied

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -48,7 +48,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.header.allow_increased_fixed_capacities = true
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_header_values(hpxml_default, 30, 2, 2, 11, 11, 2008, false, 3, 3, 10, 10, false, true)
+    _test_default_header_values(hpxml_default, false, 30, 2, 2, 11, 11, 2008, false, 3, 3, 10, 10, false, true)
 
     # Test defaults - DST not in weather file
     hpxml.header.timestep = nil
@@ -66,7 +66,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.header.allow_increased_fixed_capacities = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_header_values(hpxml_default, 60, 1, 1, 12, 31, 2007, true, 3, 12, 11, 5, true, false)
+    _test_default_header_values(hpxml_default, true, 60, 1, 1, 12, 31, 2007, true, 3, 12, 11, 5, true, false)
 
     # Test defaults - DST in weather file
     hpxml = _create_hpxml('base-location-AMY-2012.xml')
@@ -85,7 +85,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.header.allow_increased_fixed_capacities = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_header_values(hpxml_default, 60, 1, 1, 12, 31, 2012, true, 3, 11, 11, 4, true, false)
+    _test_default_header_values(hpxml_default, true, 60, 1, 1, 12, 31, 2012, true, 3, 11, 11, 4, true, false)
   end
 
   def test_site
@@ -95,14 +95,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.site.shelter_coefficient = 0.3
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_site_values(hpxml_default, HPXML::SiteTypeRural, 0.3)
+    _test_default_site_values(hpxml_default, false, HPXML::SiteTypeRural, 0.3)
 
     # Test defaults
     hpxml.site.site_type = nil
     hpxml.site.shelter_coefficient = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_site_values(hpxml_default, HPXML::SiteTypeSuburban, 0.5)
+    _test_default_site_values(hpxml_default, true, HPXML::SiteTypeSuburban, 0.5)
   end
 
   def test_occupancy
@@ -111,13 +111,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.building_occupancy.number_of_residents = 1
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_occupancy_values(hpxml_default, 1)
+    _test_default_occupancy_values(hpxml_default, false, 1)
 
     # Test defaults
     hpxml.building_occupancy.number_of_residents = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_occupancy_values(hpxml_default, 3)
+    _test_default_occupancy_values(hpxml_default, true, 3)
   end
 
   def test_building_construction
@@ -126,7 +126,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.building_construction.number_of_bathrooms = 4.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_building_construction_values(hpxml_default, 21600, true, 4)
+    _test_default_building_construction_values(hpxml_default, false, 21600, true, 4)
 
     # Test defaults w/ average ceiling height
     hpxml.building_construction.conditioned_building_volume = nil
@@ -135,37 +135,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.building_construction.number_of_bathrooms = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_building_construction_values(hpxml_default, 27000, false, 2)
-  end
-
-  def test_attics
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-atticroof-vented.xml')
-    hpxml.attics[0].vented_attic_sla = 0.001
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_attic_values(hpxml_default, 0.001)
-
-    # Test defaults
-    hpxml.attics[0].vented_attic_sla = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_attic_values(hpxml_default, 1.0 / 300.0)
-  end
-
-  def test_foundations
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-foundation-vented-crawlspace.xml')
-    hpxml.foundations[0].vented_crawlspace_sla = 0.001
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_foundation_values(hpxml_default, 0.001)
-
-    # Test defaults
-    hpxml.foundations[0].vented_crawlspace_sla = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_foundation_values(hpxml_default, 1.0 / 150.0)
+    _test_default_building_construction_values(hpxml_default, true, 27000, false, 2)
   end
 
   def test_infiltration
@@ -174,20 +144,50 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.air_infiltration_measurements[0].infiltration_volume = 25000
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_infiltration_values(hpxml_default, 25000)
+    _test_default_infiltration_values(hpxml_default, false, 25000)
 
     # Test defaults w/ conditioned basement
     hpxml.air_infiltration_measurements[0].infiltration_volume = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_infiltration_values(hpxml_default, 2700 * 8)
+    _test_default_infiltration_values(hpxml_default, true, 2700 * 8)
 
     # Test defaults w/o conditioned basement
     hpxml = _create_hpxml('base-foundation-slab.xml')
     hpxml.air_infiltration_measurements[0].infiltration_volume = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_infiltration_values(hpxml_default, 1350 * 8)
+    _test_default_infiltration_values(hpxml_default, true, 1350 * 8)
+  end
+
+  def test_attics
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-atticroof-vented.xml')
+    hpxml.attics[0].vented_attic_sla = 0.001
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_attic_values(hpxml_default, false, 0.001)
+
+    # Test defaults
+    hpxml.attics[0].vented_attic_sla = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_attic_values(hpxml_default, true, 1.0 / 300.0)
+  end
+
+  def test_foundations
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-foundation-vented-crawlspace.xml')
+    hpxml.foundations[0].vented_crawlspace_sla = 0.001
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_foundation_values(hpxml_default, false, 0.001)
+
+    # Test defaults
+    hpxml.foundations[0].vented_crawlspace_sla = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_foundation_values(hpxml_default, true, 1.0 / 150.0)
   end
 
   def test_roofs
@@ -199,38 +199,24 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.roofs[0].emittance = 0.88
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_roof_values(hpxml_default, HPXML::RoofTypeMetal, 0.77, HPXML::ColorDark, 0.88, true)
+    _test_default_roof_values(hpxml_default, false, HPXML::RoofTypeMetal, 0.77, HPXML::ColorDark, 0.88, true)
 
-    # Test defaults
+    # Test defaults w/ RoofColor
     hpxml.roofs[0].roof_type = nil
     hpxml.roofs[0].solar_absorptance = nil
     hpxml.roofs[0].roof_color = HPXML::ColorLight
     hpxml.roofs[0].emittance = nil
-    hpxml.roofs[0].radiant_barrier = false
+    hpxml.roofs[0].radiant_barrier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_roof_values(hpxml_default, HPXML::RoofTypeAsphaltShingles, 0.75, HPXML::ColorLight, 0.90, false)
-  end
+    _test_default_roof_values(hpxml_default, true, HPXML::RoofTypeAsphaltShingles, 0.75, HPXML::ColorLight, 0.90, false)
 
-  def test_walls
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base.xml')
-    hpxml.walls[0].siding = HPXML::SidingTypeFiberCement
-    hpxml.walls[0].solar_absorptance = 0.66
-    hpxml.walls[0].color = HPXML::ColorDark
-    hpxml.walls[0].emittance = 0.88
+    # Test defaults w/ SolarAbsorptance
+    hpxml.roofs[0].solar_absorptance = 0.99
+    hpxml.roofs[0].roof_color = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_wall_values(hpxml_default, HPXML::SidingTypeFiberCement, 0.66, HPXML::ColorDark, 0.88)
-
-    # Test defaults
-    hpxml.walls[0].siding = nil
-    hpxml.walls[0].solar_absorptance = nil
-    hpxml.walls[0].color = HPXML::ColorLight
-    hpxml.walls[0].emittance = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_wall_values(hpxml_default, HPXML::SidingTypeWood, 0.5, HPXML::ColorLight, 0.90)
+    _test_default_roof_values(hpxml_default, true, HPXML::RoofTypeAsphaltShingles, 0.99, HPXML::ColorDark, 0.90, false)
   end
 
   def test_rim_joists
@@ -242,16 +228,51 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.rim_joists[0].emittance = 0.88
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeBrick, 0.55, HPXML::ColorLight, 0.88)
+    _test_default_rim_joist_values(hpxml_default, false, HPXML::SidingTypeBrick, 0.55, HPXML::ColorLight, 0.88)
 
-    # Test defaults
+    # Test defaults w/ Color
     hpxml.rim_joists[0].siding = nil
     hpxml.rim_joists[0].solar_absorptance = nil
     hpxml.rim_joists[0].color = HPXML::ColorDark
     hpxml.rim_joists[0].emittance = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeWood, 0.95, HPXML::ColorDark, 0.90)
+    _test_default_rim_joist_values(hpxml_default, true, HPXML::SidingTypeWood, 0.95, HPXML::ColorDark, 0.90)
+
+    # Test defaults w/ SolarAbsorptance
+    hpxml.rim_joists[0].solar_absorptance = 0.99
+    hpxml.rim_joists[0].color = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_rim_joist_values(hpxml_default, true, HPXML::SidingTypeWood, 0.99, HPXML::ColorDark, 0.90)
+  end
+
+  def test_walls
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.walls[0].siding = HPXML::SidingTypeFiberCement
+    hpxml.walls[0].solar_absorptance = 0.66
+    hpxml.walls[0].color = HPXML::ColorDark
+    hpxml.walls[0].emittance = 0.88
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_wall_values(hpxml_default, false, HPXML::SidingTypeFiberCement, 0.66, HPXML::ColorDark, 0.88)
+
+    # Test defaults W/ Color
+    hpxml.walls[0].siding = nil
+    hpxml.walls[0].solar_absorptance = nil
+    hpxml.walls[0].color = HPXML::ColorLight
+    hpxml.walls[0].emittance = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_wall_values(hpxml_default, true, HPXML::SidingTypeWood, 0.5, HPXML::ColorLight, 0.90)
+
+    # Test defaults W/ SolarAbsorptance
+    hpxml.walls[0].solar_absorptance = 0.99
+    hpxml.walls[0].color = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_wall_values(hpxml_default, true, HPXML::SidingTypeWood, 0.99, HPXML::ColorDark, 0.90)
   end
 
   def test_foundation_walls
@@ -260,13 +281,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.foundation_walls[0].thickness = 7.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_foundation_wall_values(hpxml_default, 7.0)
+    _test_default_foundation_wall_values(hpxml_default, false, 7.0)
 
     # Test defaults
     hpxml.foundation_walls[0].thickness = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_foundation_wall_values(hpxml_default, 8.0)
+    _test_default_foundation_wall_values(hpxml_default, true, 8.0)
   end
 
   def test_slabs
@@ -277,7 +298,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.slabs[0].carpet_fraction = 0.5
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_slab_values(hpxml_default, 7.0, 1.1, 0.5)
+    _test_default_slab_values(hpxml_default, false, 7.0, 1.1, 0.5)
 
     # Test defaults
     hpxml.slabs[0].thickness = nil
@@ -285,7 +306,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.slabs[0].carpet_fraction = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_slab_values(hpxml_default, 4.0, 2.0, 0.8)
+    _test_default_slab_values(hpxml_default, true, 4.0, 2.0, 0.8)
   end
 
   def test_windows
@@ -299,7 +320,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     n_windows = hpxml_default.windows.size
-    _test_default_window_values(hpxml_default, [0.66] * n_windows, [0.77] * n_windows, [0.5] * n_windows)
+    _test_default_window_values(hpxml_default, false, [0.66] * n_windows, [0.77] * n_windows, [0.5] * n_windows)
 
     # Test defaults
     hpxml.windows.each do |window|
@@ -310,7 +331,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     n_windows = hpxml_default.windows.size
-    _test_default_window_values(hpxml_default, [0.7] * n_windows, [0.85] * n_windows, [0.67] * n_windows)
+    _test_default_window_values(hpxml_default, true, [0.7] * n_windows, [0.85] * n_windows, [0.67] * n_windows)
   end
 
   def test_skylights
@@ -323,7 +344,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     n_skylights = hpxml_default.skylights.size
-    _test_default_skylight_values(hpxml_default, [0.66] * n_skylights, [0.77] * n_skylights)
+    _test_default_skylight_values(hpxml_default, false, [0.66] * n_skylights, [0.77] * n_skylights)
 
     # Test defaults
     hpxml.skylights.each do |skylight|
@@ -333,7 +354,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     n_skylights = hpxml_default.skylights.size
-    _test_default_skylight_values(hpxml_default, [1.0] * n_skylights, [1.0] * n_skylights)
+    _test_default_skylight_values(hpxml_default, true, [1.0] * n_skylights, [1.0] * n_skylights)
   end
 
   def test_central_air_conditioners
@@ -344,7 +365,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.cooling_systems[0].fan_watts_per_cfm = 0.66
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_central_air_conditioner_values(hpxml_default, 0.88, HPXML::HVACCompressorTypeVariableSpeed, 0.66)
+    _test_default_central_air_conditioner_values(hpxml_default, false, 0.88, HPXML::HVACCompressorTypeVariableSpeed, 0.66)
 
     # Test defaults
     hpxml.cooling_systems[0].cooling_shr = nil
@@ -352,7 +373,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.cooling_systems[0].fan_watts_per_cfm = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_central_air_conditioner_values(hpxml_default, 0.73, HPXML::HVACCompressorTypeSingleStage, 0.5)
+    _test_default_central_air_conditioner_values(hpxml_default, true, 0.73, HPXML::HVACCompressorTypeSingleStage, 0.5)
   end
 
   def test_room_air_conditioners
@@ -361,13 +382,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.cooling_systems[0].cooling_shr = 0.88
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_room_air_conditioner_values(hpxml_default, 0.88)
+    _test_default_room_air_conditioner_values(hpxml_default, false, 0.88)
 
     # Test defaults
     hpxml.cooling_systems[0].cooling_shr = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_room_air_conditioner_values(hpxml_default, 0.65)
+    _test_default_room_air_conditioner_values(hpxml_default, true, 0.65)
   end
 
   def test_mini_split_air_conditioners
@@ -377,14 +398,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.cooling_systems[0].fan_watts_per_cfm = 0.66
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mini_split_air_conditioner_values(hpxml_default, 0.78, 0.66)
+    _test_default_mini_split_air_conditioner_values(hpxml_default, false, 0.78, 0.66)
 
     # Test defaults
     hpxml.cooling_systems[0].cooling_shr = nil
     hpxml.cooling_systems[0].fan_watts_per_cfm = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mini_split_air_conditioner_values(hpxml_default, 0.73, 0.18)
+    _test_default_mini_split_air_conditioner_values(hpxml_default, true, 0.73, 0.18)
   end
 
   def test_furnaces
@@ -393,13 +414,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].fan_watts_per_cfm = 0.66
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_furnace_values(hpxml_default, 0.66)
+    _test_default_furnace_values(hpxml_default, false, 0.66)
 
     # Test defaults
     hpxml.heating_systems[0].fan_watts_per_cfm = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_furnace_values(hpxml_default, 0.375)
+    _test_default_furnace_values(hpxml_default, true, 0.375)
   end
 
   def test_wall_furnaces
@@ -408,13 +429,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].fan_watts = 22
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_wall_furnace_values(hpxml_default, 22)
+    _test_default_wall_furnace_values(hpxml_default, false, 22)
 
     # Test defaults
     hpxml.heating_systems[0].fan_watts = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_wall_furnace_values(hpxml_default, 0)
+    _test_default_wall_furnace_values(hpxml_default, true, 0)
   end
 
   def test_floor_furnaces
@@ -423,13 +444,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].fan_watts = 22
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_floor_furnace_values(hpxml_default, 22)
+    _test_default_floor_furnace_values(hpxml_default, false, 22)
 
     # Test defaults
     hpxml.heating_systems[0].fan_watts = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_floor_furnace_values(hpxml_default, 0)
+    _test_default_floor_furnace_values(hpxml_default, true, 0)
   end
 
   def test_boilers
@@ -438,13 +459,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].electric_auxiliary_energy = 99.9
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_boiler_values(hpxml_default, 99.9)
+    _test_default_boiler_values(hpxml_default, false, 99.9)
 
     # Test defaults w/ in-unit boiler
     hpxml.heating_systems[0].electric_auxiliary_energy = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_boiler_values(hpxml_default, 170.0)
+    _test_default_boiler_values(hpxml_default, true, 170.0)
 
     # Test inputs not overridden by defaults (shared boiler)
     hpxml = _create_hpxml('base-hvac-shared-boiler-only-baseboard.xml')
@@ -452,13 +473,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].electric_auxiliary_energy = 99.9
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_boiler_values(hpxml_default, 99.9)
+    _test_default_boiler_values(hpxml_default, false, 99.9)
 
     # Test defaults w/ shared boiler
     hpxml.heating_systems[0].electric_auxiliary_energy = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_boiler_values(hpxml_default, 220.0)
+    _test_default_boiler_values(hpxml_default, true, 220.0)
   end
 
   def test_stoves
@@ -467,13 +488,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].fan_watts = 22
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_stove_values(hpxml_default, 22)
+    _test_default_stove_values(hpxml_default, false, 22)
 
     # Test defaults
     hpxml.heating_systems[0].fan_watts = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_stove_values(hpxml_default, 40)
+    _test_default_stove_values(hpxml_default, true, 40)
   end
 
   def test_portable_heaters
@@ -482,13 +503,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].fan_watts = 22
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_portable_heater_values(hpxml_default, 22)
+    _test_default_portable_heater_values(hpxml_default, false, 22)
 
     # Test defaults
     hpxml.heating_systems[0].fan_watts = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_portable_heater_values(hpxml_default, 0)
+    _test_default_portable_heater_values(hpxml_default, true, 0)
   end
 
   def test_fixed_heaters
@@ -497,13 +518,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].fan_watts = 22
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_fixed_heater_values(hpxml_default, 22)
+    _test_default_fixed_heater_values(hpxml_default, false, 22)
 
     # Test defaults
     hpxml.heating_systems[0].fan_watts = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_fixed_heater_values(hpxml_default, 0)
+    _test_default_fixed_heater_values(hpxml_default, true, 0)
   end
 
   def test_fireplaces
@@ -512,13 +533,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heating_systems[0].fan_watts = 22
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_fireplace_values(hpxml_default, 22)
+    _test_default_fireplace_values(hpxml_default, false, 22)
 
     # Test defaults
     hpxml.heating_systems[0].fan_watts = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_fireplace_values(hpxml_default, 0)
+    _test_default_fireplace_values(hpxml_default, true, 0)
   end
 
   def test_air_source_heat_pumps
@@ -529,7 +550,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heat_pumps[0].fan_watts_per_cfm = 0.66
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_air_to_air_heat_pump_values(hpxml_default, 0.88, HPXML::HVACCompressorTypeVariableSpeed, 0.66)
+    _test_default_air_to_air_heat_pump_values(hpxml_default, false, 0.88, HPXML::HVACCompressorTypeVariableSpeed, 0.66)
 
     # Test defaults
     hpxml.heat_pumps[0].cooling_shr = nil
@@ -537,7 +558,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heat_pumps[0].fan_watts_per_cfm = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_air_to_air_heat_pump_values(hpxml_default, 0.73, HPXML::HVACCompressorTypeSingleStage, 0.5)
+    _test_default_air_to_air_heat_pump_values(hpxml_default, true, 0.73, HPXML::HVACCompressorTypeSingleStage, 0.5)
   end
 
   def test_mini_split_heat_pumps
@@ -547,14 +568,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heat_pumps[0].fan_watts_per_cfm = 0.66
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mini_split_heat_pump_values(hpxml_default, 0.78, 0.66)
+    _test_default_mini_split_heat_pump_values(hpxml_default, false, 0.78, 0.66)
 
     # Test defaults
     hpxml.heat_pumps[0].cooling_shr = nil
     hpxml.heat_pumps[0].fan_watts_per_cfm = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mini_split_heat_pump_values(hpxml_default, 0.73, 0.18)
+    _test_default_mini_split_heat_pump_values(hpxml_default, true, 0.73, 0.18)
   end
 
   def test_ground_to_air_heat_pumps
@@ -564,14 +585,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.heat_pumps[0].fan_watts_per_cfm = 0.99
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_ground_to_air_heat_pump_values(hpxml_default, 9.9, 0.99)
+    _test_default_ground_to_air_heat_pump_values(hpxml_default, false, 9.9, 0.99)
 
     # Test defaults
     hpxml.heat_pumps[0].pump_watts_per_ton = nil
     hpxml.heat_pumps[0].fan_watts_per_cfm = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_ground_to_air_heat_pump_values(hpxml_default, 30.0, 0.375)
+    _test_default_ground_to_air_heat_pump_values(hpxml_default, true, 30.0, 0.375)
   end
 
   def test_hvac_controls
@@ -581,19 +602,20 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.hvac_controls[0].cooling_setup_start_hour = 12
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_hvac_control_values(hpxml_default, 12, 12)
+    _test_default_hvac_control_values(hpxml_default, false, 12, 12)
 
     # Test defaults
     hpxml.hvac_controls[0].heating_setback_start_hour = nil
     hpxml.hvac_controls[0].cooling_setup_start_hour = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_hvac_control_values(hpxml_default, 23, 9)
+    _test_default_hvac_control_values(hpxml_default, true, 23, 9)
   end
 
   def test_hvac_distribution
     # Test inputs not overridden by defaults
     hpxml = _create_hpxml('base.xml')
+    hpxml.hvac_distributions[0].number_of_return_registers = hpxml.building_construction.number_of_conditioned_floors
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['attic - unvented']
@@ -601,9 +623,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_supply_areas = [150.0]
     expected_return_areas = [50.0]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, false, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ conditioned basement
+    hpxml.hvac_distributions[0].number_of_return_registers = nil
     hpxml.hvac_distributions.each do |hvac_distribution|
       hvac_distribution.ducts.each do |duct|
         duct.duct_location = nil
@@ -617,7 +640,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_supply_areas = [729.0]
     expected_return_areas = [270.0]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, true, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ multiple foundations
     hpxml = _create_hpxml('base-foundation-multiple.xml')
@@ -634,7 +657,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_supply_areas = [364.5]
     expected_return_areas = [67.5]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, true, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ foundation exposed to ambient
     hpxml = _create_hpxml('base-foundation-ambient.xml')
@@ -651,7 +674,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_supply_areas = [364.5]
     expected_return_areas = [67.5]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, true, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ building/unit adjacent to other housing unit
     hpxml = _create_hpxml('base-enclosure-other-housing-unit.xml')
@@ -668,7 +691,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_supply_areas = [364.5]
     expected_return_areas = [67.5]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, true, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ 2-story building
     hpxml = _create_hpxml('base-enclosure-2stories.xml')
@@ -685,7 +708,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_supply_areas = [820.13, 273.38]
     expected_return_areas = [455.63, 151.88]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, true, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ 1-story building & multiple HVAC systems
     hpxml = _create_hpxml('base-hvac-multiple.xml')
@@ -702,7 +725,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_supply_areas = [91.125, 91.125] * hpxml_default.hvac_distributions.size
     expected_return_areas = [33.75, 33.75] * hpxml_default.hvac_distributions.size
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, true, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
 
     # Test defaults w/ 2-story building & multiple HVAC systems
     hpxml = _create_hpxml('base-hvac-multiple.xml')
@@ -720,206 +743,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_supply_areas = [68.34, 68.34, 22.78, 22.78] * hpxml_default.hvac_distributions.size
     expected_return_areas = [25.31, 25.31, 8.44, 8.44] * hpxml_default.hvac_distributions.size
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
-  end
-
-  def test_storage_water_heaters
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base.xml')
-    hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFA
-    hpxml.water_heating_systems.each do |wh|
-      wh.is_shared_system = true
-      wh.number_of_units_served = 2
-      wh.heating_capacity = 15000.0
-      wh.tank_volume = 40.0
-      wh.recovery_efficiency = 0.95
-    end
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_storage_water_heater_values(hpxml_default, [true, 15000.0, 40.0, 0.95])
-
-    # Test defaults w/ 3-bedroom house & electric storage water heater
-    hpxml.water_heating_systems.each do |water_heating_system|
-      water_heating_system.is_shared_system = nil
-      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage
-
-      water_heating_system.heating_capacity = nil
-      water_heating_system.tank_volume = nil
-      water_heating_system.recovery_efficiency = nil
-    end
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_storage_water_heater_values(hpxml_default, [false, 18766.7, 50.0, 0.98])
-
-    # Test defaults w/ 5-bedroom house & electric storage water heater
-    hpxml = _create_hpxml('base-enclosure-beds-5.xml')
-    hpxml.water_heating_systems.each do |water_heating_system|
-      water_heating_system.is_shared_system = nil
-      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage
-
-      water_heating_system.heating_capacity = nil
-      water_heating_system.tank_volume = nil
-      water_heating_system.recovery_efficiency = nil
-    end
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_storage_water_heater_values(hpxml_default, [false, 18766.7, 66.0, 0.98])
-
-    # Test defaults w/ 3-bedroom house & 2 storage water heaters (1 electric and 1 natural gas)
-    hpxml = _create_hpxml('base-dhw-multiple.xml')
-    hpxml.water_heating_systems.each do |water_heating_system|
-      water_heating_system.is_shared_system = nil
-      next unless water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage
-
-      water_heating_system.heating_capacity = nil
-      water_heating_system.tank_volume = nil
-      water_heating_system.recovery_efficiency = nil
-    end
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_storage_water_heater_values(hpxml_default, [false, 15354.6, 50.0, 0.98],
-                                              [false, 36000.0, 40.0, 0.756])
-  end
-
-  def test_tankless_water_heaters
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-dhw-tankless-gas.xml')
-    hpxml.water_heating_systems[0].performance_adjustment = 0.88
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_tankless_water_heater_values(hpxml_default, [0.88])
-
-    # Test defaults w/ EF
-    hpxml.water_heating_systems[0].performance_adjustment = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_tankless_water_heater_values(hpxml_default, [0.92])
-
-    # Test defaults w/ UEF
-    hpxml.water_heating_systems[0].energy_factor = nil
-    hpxml.water_heating_systems[0].uniform_energy_factor = 0.93
-    hpxml.water_heating_systems[0].first_hour_rating = 5.7
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_tankless_water_heater_values(hpxml_default, [0.94])
-  end
-
-  def test_hot_water_distribution
-    # Test inputs not overridden by defaults -- standard
-    hpxml = _create_hpxml('base.xml')
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_standard_distribution_values(hpxml_default, 50.0)
-
-    # Test inputs not overridden by defaults -- recirculation
-    hpxml = _create_hpxml('base-dhw-recirc-demand.xml')
-    hpxml.hot_water_distributions[0].recirculation_pump_power = 65.0
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_recirc_distribution_values(hpxml_default, 50.0, 50.0, 65.0)
-
-    # Test inputs not overridden by defaults -- shared recirculation
-    hpxml = _create_hpxml('base-dhw-shared-water-heater-recirc.xml')
-    hpxml.hot_water_distributions[0].shared_recirculation_pump_power = 333.0
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_shared_recirc_distribution_values(hpxml_default, 333.0)
-
-    # Test defaults w/ conditioned basement
-    hpxml = _create_hpxml('base.xml')
-    hpxml.hot_water_distributions[0].standard_piping_length = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_standard_distribution_values(hpxml_default, 93.48)
-
-    # Test defaults w/ unconditioned basement
-    hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
-    hpxml.hot_water_distributions[0].standard_piping_length = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_standard_distribution_values(hpxml_default, 88.48)
-
-    # Test defaults w/ 2-story building
-    hpxml = _create_hpxml('base-enclosure-2stories.xml')
-    hpxml.hot_water_distributions[0].standard_piping_length = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_standard_distribution_values(hpxml_default, 103.48)
-
-    # Test defaults w/ recirculation & conditioned basement
-    hpxml = _create_hpxml('base-dhw-recirc-demand.xml')
-    hpxml.hot_water_distributions[0].recirculation_piping_length = nil
-    hpxml.hot_water_distributions[0].recirculation_branch_piping_length = nil
-    hpxml.hot_water_distributions[0].recirculation_pump_power = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_recirc_distribution_values(hpxml_default, 166.96, 10.0, 50.0)
-
-    # Test defaults w/ recirculation & unconditioned basement
-    hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
-    hpxml.hot_water_distributions.clear
-    hpxml.hot_water_distributions.add(id: 'HotWaterDistribution',
-                                      system_type: HPXML::DHWDistTypeRecirc,
-                                      recirculation_control_type: HPXML::DHWRecirControlTypeSensor,
-                                      pipe_r_value: 3.0)
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_recirc_distribution_values(hpxml_default, 156.96, 10.0, 50.0)
-
-    # Test defaults w/ recirculation & 2-story building
-    hpxml = _create_hpxml('base-enclosure-2stories.xml')
-    hpxml.hot_water_distributions.clear
-    hpxml.hot_water_distributions.add(id: 'HotWaterDistribution',
-                                      system_type: HPXML::DHWDistTypeRecirc,
-                                      recirculation_control_type: HPXML::DHWRecirControlTypeSensor,
-                                      pipe_r_value: 3.0)
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_recirc_distribution_values(hpxml_default, 186.96, 10.0, 50.0)
-
-    # Test defaults w/ shared recirculation
-    hpxml = _create_hpxml('base-dhw-shared-water-heater-recirc.xml')
-    hpxml.hot_water_distributions[0].shared_recirculation_pump_power = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_shared_recirc_distribution_values(hpxml_default, 220.0)
-  end
-
-  def test_water_fixtures
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base.xml')
-    hpxml.water_heating.water_fixtures_usage_multiplier = 2.0
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_water_fixture_values(hpxml_default, 2.0)
-
-    # Test defaults
-    hpxml.water_heating.water_fixtures_usage_multiplier = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_water_fixture_values(hpxml_default, 1.0)
-  end
-
-  def test_solar_thermal_systems
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-dhw-solar-direct-flat-plate.xml')
-    hpxml.solar_thermal_systems[0].storage_volume = 55.0
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_solar_thermal_values(hpxml_default, 55.0)
-
-    # Test defaults w/ collector area of 40 sqft
-    hpxml.solar_thermal_systems[0].storage_volume = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_solar_thermal_values(hpxml_default, 60.0)
-
-    # Test defaults w/ collector area of 100 sqft
-    hpxml.solar_thermal_systems[0].collector_area = 100.0
-    hpxml.solar_thermal_systems[0].storage_volume = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_solar_thermal_values(hpxml_default, 150.0)
+    _test_default_duct_values(hpxml_default, true, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
   end
 
   def test_mech_ventilation_fans
@@ -933,7 +757,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     vent_fan.hours_in_operation = 22.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mech_vent_values(hpxml_default, true, 22.0)
+    _test_default_mech_vent_values(hpxml_default, false, true, 22.0)
 
     # Test defaults
     vent_fan.rated_flow_rate = nil
@@ -945,21 +769,23 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     vent_fan.hours_in_operation = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mech_vent_values(hpxml_default, false, 24.0)
+    _test_default_mech_vent_values(hpxml_default, true, false, 24.0)
 
     # Test inputs not overridden by defaults w/ CFIS
     hpxml = _create_hpxml('base-mechvent-cfis.xml')
     vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+    vent_fan.is_shared_system = false
     vent_fan.hours_in_operation = 12.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mech_vent_values(hpxml_default, false, 12.0)
+    _test_default_mech_vent_values(hpxml_default, false, false, 12.0)
 
     # Test defaults w/ CFIS
+    vent_fan.is_shared_system = nil
     vent_fan.hours_in_operation = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mech_vent_values(hpxml_default, false, 8.0)
+    _test_default_mech_vent_values(hpxml_default, true, false, 8.0)
   end
 
   def test_local_ventilation_fans
@@ -979,8 +805,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     bath_fan.hours_in_operation = 3
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_kitchen_fan_values(hpxml_default, 2, 300, 2, 20, 12)
-    _test_default_bath_fan_values(hpxml_default, 3, 80, 3, 33, 6)
+    _test_default_kitchen_fan_values(hpxml_default, false, 2, 300, 2, 20, 12)
+    _test_default_bath_fan_values(hpxml_default, false, 3, 80, 3, 33, 6)
 
     # Test defaults
     kitchen_fan.rated_flow_rate = nil
@@ -995,266 +821,254 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     bath_fan.hours_in_operation = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_kitchen_fan_values(hpxml_default, 1, 100, 1, 30, 18)
-    _test_default_bath_fan_values(hpxml_default, 2, 50, 1, 15, 7)
+    _test_default_kitchen_fan_values(hpxml_default, true, 1, 100, 1, 30, 18)
+    _test_default_bath_fan_values(hpxml_default, true, 2, 50, 1, 15, 7)
   end
 
-  def test_clothes_dryer_exhaust
+  def test_storage_water_heaters
     # Test inputs not overridden by defaults
-    hpxml_name = 'base.xml'
-    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
-    clothes_dryer = hpxml.clothes_dryers[0]
-    clothes_dryer.is_vented = true
-    clothes_dryer.vented_flow_rate = 200
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_clothes_dryer_exhaust_values(hpxml_default, true, 200)
-
-    clothes_dryer.is_vented = false
-    clothes_dryer.vented_flow_rate = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_clothes_dryer_exhaust_values(hpxml_default, false, nil)
-
-    # Test defaults
-    clothes_dryer.is_vented = nil
-    clothes_dryer.vented_flow_rate = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_clothes_dryer_exhaust_values(hpxml_default, true, 100)
-  end
-
-  def test_ceiling_fans
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-lighting-ceiling-fans.xml')
-    hpxml.ceiling_fans[0].quantity = 2
-    hpxml.ceiling_fans[0].efficiency = 100
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_ceiling_fan_values(hpxml_default, 2, 100)
-
-    # Test defaults
-    hpxml.ceiling_fans.each do |ceiling_fan|
-      ceiling_fan.quantity = nil
-      ceiling_fan.efficiency = nil
+    hpxml = _create_hpxml('base.xml')
+    hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFA
+    hpxml.water_heating_systems.each do |wh|
+      wh.is_shared_system = true
+      wh.number_of_units_served = 2
+      wh.heating_capacity = 15000.0
+      wh.tank_volume = 40.0
+      wh.recovery_efficiency = 0.95
+      wh.location = HPXML::LocationLivingSpace
+      wh.temperature = 111
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_ceiling_fan_values(hpxml_default, 4, 70.4)
-  end
+    _test_default_storage_water_heater_values(hpxml_default, false,
+                                              [true, 15000.0, 40.0, 0.95, HPXML::LocationLivingSpace, 111])
 
-  def test_pools
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
-    pool = hpxml.pools[0]
-    pool.heater_load_units = HPXML::UnitsKwhPerYear
-    pool.heater_load_value = 1000
-    pool.pump_kwh_per_year = 3000
-    pool.heater_weekday_fractions = ConstantDaySchedule
-    pool.heater_weekend_fractions = ConstantDaySchedule
-    pool.heater_monthly_multipliers = ConstantMonthSchedule
-    pool.pump_weekday_fractions = ConstantDaySchedule
-    pool.pump_weekend_fractions = ConstantDaySchedule
-    pool.pump_monthly_multipliers = ConstantMonthSchedule
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_pool_heater_values(hpxml_default, HPXML::UnitsKwhPerYear, 1000, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-    _test_default_pool_pump_values(hpxml_default, 3000, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-
-    # Test defaults
-    pool = hpxml.pools[0]
-    pool.heater_load_units = nil
-    pool.heater_load_value = nil
-    pool.pump_kwh_per_year = nil
-    pool.heater_weekday_fractions = nil
-    pool.heater_weekend_fractions = nil
-    pool.heater_monthly_multipliers = nil
-    pool.pump_weekday_fractions = nil
-    pool.pump_weekend_fractions = nil
-    pool.pump_monthly_multipliers = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_pool_heater_values(hpxml_default, HPXML::UnitsThermPerYear, 236, '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
-    _test_default_pool_pump_values(hpxml_default, 2496, '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
-
-    # Test defaults 2
-    hpxml = _create_hpxml('base-misc-loads-large-uncommon2.xml')
-    pool = hpxml.pools[0]
-    pool.heater_load_units = nil
-    pool.heater_load_value = nil
-    pool.pump_kwh_per_year = nil
-    pool.heater_weekday_fractions = nil
-    pool.heater_weekend_fractions = nil
-    pool.heater_monthly_multipliers = nil
-    pool.pump_weekday_fractions = nil
-    pool.pump_weekend_fractions = nil
-    pool.pump_monthly_multipliers = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_pool_heater_values(hpxml_default, nil, nil, nil, nil, nil)
-    _test_default_pool_pump_values(hpxml_default, 2496, '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
-  end
-
-  def test_hot_tubs
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
-    hot_tub = hpxml.hot_tubs[0]
-    hot_tub.heater_load_units = HPXML::UnitsThermPerYear
-    hot_tub.heater_load_value = 1000
-    hot_tub.pump_kwh_per_year = 3000
-    hot_tub.heater_weekday_fractions = ConstantDaySchedule
-    hot_tub.heater_weekend_fractions = ConstantDaySchedule
-    hot_tub.heater_monthly_multipliers = ConstantMonthSchedule
-    hot_tub.pump_weekday_fractions = ConstantDaySchedule
-    hot_tub.pump_weekend_fractions = ConstantDaySchedule
-    hot_tub.pump_monthly_multipliers = ConstantMonthSchedule
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_hot_tub_heater_values(hpxml_default, HPXML::UnitsThermPerYear, 1000, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-    _test_default_hot_tub_pump_values(hpxml_default, 3000, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-
-    # Test defaults
-    hot_tub = hpxml.hot_tubs[0]
-    hot_tub.heater_load_units = nil
-    hot_tub.heater_load_value = nil
-    hot_tub.pump_kwh_per_year = nil
-    hot_tub.heater_weekday_fractions = nil
-    hot_tub.heater_weekend_fractions = nil
-    hot_tub.heater_monthly_multipliers = nil
-    hot_tub.pump_weekday_fractions = nil
-    hot_tub.pump_weekend_fractions = nil
-    hot_tub.pump_monthly_multipliers = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_hot_tub_heater_values(hpxml_default, HPXML::UnitsKwhPerYear, 1125, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-    _test_default_hot_tub_pump_values(hpxml_default, 1111, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921')
-
-    # Test defaults 2
-    hpxml = _create_hpxml('base-misc-loads-large-uncommon2.xml')
-    hot_tub = hpxml.hot_tubs[0]
-    hot_tub.heater_load_units = nil
-    hot_tub.heater_load_value = nil
-    hot_tub.pump_kwh_per_year = nil
-    hot_tub.heater_weekday_fractions = nil
-    hot_tub.heater_weekend_fractions = nil
-    hot_tub.heater_monthly_multipliers = nil
-    hot_tub.pump_weekday_fractions = nil
-    hot_tub.pump_weekend_fractions = nil
-    hot_tub.pump_monthly_multipliers = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_hot_tub_heater_values(hpxml_default, HPXML::UnitsKwhPerYear, 225, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-    _test_default_hot_tub_pump_values(hpxml_default, 1111, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921')
-  end
-
-  def test_plug_loads
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
-    tv_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeTelevision }[0]
-    tv_pl.kWh_per_year = 1000
-    tv_pl.frac_sensible = 0.6
-    tv_pl.frac_latent = 0.3
-    tv_pl.location = HPXML::LocationExterior
-    tv_pl.weekday_fractions = ConstantDaySchedule
-    tv_pl.weekend_fractions = ConstantDaySchedule
-    tv_pl.monthly_multipliers = ConstantMonthSchedule
-    other_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeOther }[0]
-    other_pl.kWh_per_year = 2000
-    other_pl.frac_sensible = 0.5
-    other_pl.frac_latent = 0.4
-    other_pl.location = HPXML::LocationExterior
-    other_pl.weekday_fractions = ConstantDaySchedule
-    other_pl.weekend_fractions = ConstantDaySchedule
-    other_pl.monthly_multipliers = ConstantMonthSchedule
-    veh_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeElectricVehicleCharging }[0]
-    veh_pl.kWh_per_year = 4000
-    veh_pl.frac_sensible = 0.4
-    veh_pl.frac_latent = 0.5
-    veh_pl.location = HPXML::LocationInterior
-    veh_pl.weekday_fractions = ConstantDaySchedule
-    veh_pl.weekend_fractions = ConstantDaySchedule
-    veh_pl.monthly_multipliers = ConstantMonthSchedule
-    wellpump_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeWellPump }[0]
-    wellpump_pl.kWh_per_year = 3000
-    wellpump_pl.frac_sensible = 0.3
-    wellpump_pl.frac_latent = 0.6
-    wellpump_pl.location = HPXML::LocationInterior
-    wellpump_pl.weekday_fractions = ConstantDaySchedule
-    wellpump_pl.weekend_fractions = ConstantDaySchedule
-    wellpump_pl.monthly_multipliers = ConstantMonthSchedule
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeTelevision, 1000, 0.6, 0.3, HPXML::LocationExterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeOther, 2000, 0.5, 0.4, HPXML::LocationExterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeElectricVehicleCharging, 4000, 0.4, 0.5, HPXML::LocationInterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeWellPump, 3000, 0.3, 0.6, HPXML::LocationInterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-
-    # Test defaults
-    hpxml.plug_loads.each do |plug_load|
-      plug_load.kWh_per_year = nil
-      plug_load.frac_sensible = nil
-      plug_load.frac_latent = nil
-      plug_load.location = nil
-      plug_load.weekday_fractions = nil
-      plug_load.weekend_fractions = nil
-      plug_load.monthly_multipliers = nil
+    # Test defaults w/ 3-bedroom house & electric storage water heater
+    hpxml.water_heating_systems.each do |wh|
+      wh.is_shared_system = nil
+      wh.heating_capacity = nil
+      wh.tank_volume = nil
+      wh.recovery_efficiency = nil
+      wh.location = nil
+      wh.temperature = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeTelevision, 620, 1.0, 0.0, HPXML::LocationInterior, '0.037, 0.018, 0.009, 0.007, 0.011, 0.018, 0.029, 0.040, 0.049, 0.058, 0.065, 0.072, 0.076, 0.086, 0.091, 0.102, 0.127, 0.156, 0.210, 0.294, 0.363, 0.344, 0.208, 0.090', '0.044, 0.022, 0.012, 0.008, 0.011, 0.014, 0.024, 0.043, 0.071, 0.094, 0.112, 0.123, 0.132, 0.156, 0.178, 0.196, 0.206, 0.213, 0.251, 0.330, 0.388, 0.358, 0.226, 0.103', '1.137, 1.129, 0.961, 0.969, 0.961, 0.993, 0.996, 0.96, 0.993, 0.867, 0.86, 1.137')
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeOther, 2457, 0.855, 0.045, HPXML::LocationInterior, '0.035, 0.033, 0.032, 0.031, 0.032, 0.033, 0.037, 0.042, 0.043, 0.043, 0.043, 0.044, 0.045, 0.045, 0.044, 0.046, 0.048, 0.052, 0.053, 0.05, 0.047, 0.045, 0.04, 0.036', '0.035, 0.033, 0.032, 0.031, 0.032, 0.033, 0.037, 0.042, 0.043, 0.043, 0.043, 0.044, 0.045, 0.045, 0.044, 0.046, 0.048, 0.052, 0.053, 0.05, 0.047, 0.045, 0.04, 0.036', '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248')
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeElectricVehicleCharging, 1667, 0.0, 0.0, HPXML::LocationExterior, '0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042', '0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
-    _test_default_plug_load_values(hpxml_default, HPXML::PlugLoadTypeWellPump, 441, 0.0, 0.0, HPXML::LocationExterior, '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
-  end
+    _test_default_storage_water_heater_values(hpxml_default, true,
+                                              [false, 18766.7, 50.0, 0.98, HPXML::LocationBasementConditioned, 125])
 
-  def test_fuel_loads
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
-    gg_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeGrill }[0]
-    gg_fl.therm_per_year = 1000
-    gg_fl.frac_sensible = 0.6
-    gg_fl.frac_latent = 0.3
-    gg_fl.location = HPXML::LocationInterior
-    gg_fl.weekday_fractions = ConstantDaySchedule
-    gg_fl.weekend_fractions = ConstantDaySchedule
-    gg_fl.monthly_multipliers = ConstantMonthSchedule
-    gl_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeLighting }[0]
-    gl_fl.therm_per_year = 2000
-    gl_fl.frac_sensible = 0.5
-    gl_fl.frac_latent = 0.4
-    gl_fl.location = HPXML::LocationInterior
-    gl_fl.weekday_fractions = ConstantDaySchedule
-    gl_fl.weekend_fractions = ConstantDaySchedule
-    gl_fl.monthly_multipliers = ConstantMonthSchedule
-    gf_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeFireplace }[0]
-    gf_fl.therm_per_year = 3000
-    gf_fl.frac_sensible = 0.4
-    gf_fl.frac_latent = 0.5
-    gf_fl.location = HPXML::LocationExterior
-    gf_fl.weekday_fractions = ConstantDaySchedule
-    gf_fl.weekend_fractions = ConstantDaySchedule
-    gf_fl.monthly_multipliers = ConstantMonthSchedule
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeGrill, 1000, 0.6, 0.3, HPXML::LocationInterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeLighting, 2000, 0.5, 0.4, HPXML::LocationInterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeFireplace, 3000, 0.4, 0.5, HPXML::LocationExterior, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-
-    # Test defaults
-    hpxml.fuel_loads.each do |fuel_load|
-      fuel_load.therm_per_year = nil
-      fuel_load.frac_sensible = nil
-      fuel_load.frac_latent = nil
-      fuel_load.location = nil
-      fuel_load.weekday_fractions = nil
-      fuel_load.weekend_fractions = nil
-      fuel_load.monthly_multipliers = nil
+    # Test defaults w/ 5-bedroom house & electric storage water heater
+    hpxml = _create_hpxml('base-enclosure-beds-5.xml')
+    hpxml.water_heating_systems.each do |wh|
+      wh.is_shared_system = nil
+      wh.heating_capacity = nil
+      wh.tank_volume = nil
+      wh.recovery_efficiency = nil
+      wh.location = nil
+      wh.temperature = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeGrill, 33, 0.0, 0.0, HPXML::LocationExterior, '0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007', '0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeLighting, 20, 0.0, 0.0, HPXML::LocationExterior, '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
-    _test_default_fuel_load_values(hpxml_default, HPXML::FuelLoadTypeFireplace, 67, 0.5, 0.1, HPXML::LocationInterior, '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
+    _test_default_storage_water_heater_values(hpxml_default, true,
+                                              [false, 18766.7, 66.0, 0.98, HPXML::LocationBasementConditioned, 125])
+
+    # Test defaults w/ 3-bedroom house & 2 storage water heaters (1 electric and 1 natural gas)
+    hpxml = _create_hpxml('base-dhw-multiple.xml')
+    hpxml.water_heating_systems.each do |wh|
+      wh.is_shared_system = nil
+      next unless wh.water_heater_type == HPXML::WaterHeaterTypeStorage
+
+      wh.heating_capacity = nil
+      wh.tank_volume = nil
+      wh.recovery_efficiency = nil
+      wh.location = nil
+      wh.temperature = nil
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_storage_water_heater_values(hpxml_default, true,
+                                              [false, 15354.6, 50.0, 0.98, HPXML::LocationBasementConditioned, 125],
+                                              [false, 36000.0, 40.0, 0.756, HPXML::LocationBasementConditioned, 125])
+  end
+
+  def test_tankless_water_heaters
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-dhw-tankless-gas.xml')
+    hpxml.water_heating_systems[0].performance_adjustment = 0.88
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_tankless_water_heater_values(hpxml_default, false, [0.88])
+
+    # Test defaults w/ EF
+    hpxml.water_heating_systems[0].performance_adjustment = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_tankless_water_heater_values(hpxml_default, true, [0.92])
+
+    # Test defaults w/ UEF
+    hpxml.water_heating_systems[0].energy_factor = nil
+    hpxml.water_heating_systems[0].uniform_energy_factor = 0.93
+    hpxml.water_heating_systems[0].first_hour_rating = 5.7
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_tankless_water_heater_values(hpxml_default, true, [0.94])
+  end
+
+  def test_hot_water_distribution
+    # Test inputs not overridden by defaults -- standard
+    hpxml = _create_hpxml('base.xml')
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_standard_distribution_values(hpxml_default, false, 50.0)
+
+    # Test inputs not overridden by defaults -- recirculation
+    hpxml = _create_hpxml('base-dhw-recirc-demand.xml')
+    hpxml.hot_water_distributions[0].recirculation_pump_power = 65.0
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_recirc_distribution_values(hpxml_default, false, 50.0, 50.0, 65.0)
+
+    # Test inputs not overridden by defaults -- shared recirculation
+    hpxml = _create_hpxml('base-dhw-shared-water-heater-recirc.xml')
+    hpxml.hot_water_distributions[0].shared_recirculation_pump_power = 333.0
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_shared_recirc_distribution_values(hpxml_default, false, 333.0)
+
+    # Test defaults w/ conditioned basement
+    hpxml = _create_hpxml('base.xml')
+    hpxml.hot_water_distributions[0].standard_piping_length = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_standard_distribution_values(hpxml_default, true, 93.48)
+
+    # Test defaults w/ unconditioned basement
+    hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
+    hpxml.hot_water_distributions[0].standard_piping_length = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_standard_distribution_values(hpxml_default, true, 88.48)
+
+    # Test defaults w/ 2-story building
+    hpxml = _create_hpxml('base-enclosure-2stories.xml')
+    hpxml.hot_water_distributions[0].standard_piping_length = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_standard_distribution_values(hpxml_default, true, 103.48)
+
+    # Test defaults w/ recirculation & conditioned basement
+    hpxml = _create_hpxml('base-dhw-recirc-demand.xml')
+    hpxml.hot_water_distributions[0].recirculation_piping_length = nil
+    hpxml.hot_water_distributions[0].recirculation_branch_piping_length = nil
+    hpxml.hot_water_distributions[0].recirculation_pump_power = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_recirc_distribution_values(hpxml_default, true, 166.96, 10.0, 50.0)
+
+    # Test defaults w/ recirculation & unconditioned basement
+    hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
+    hpxml.hot_water_distributions.clear
+    hpxml.hot_water_distributions.add(id: 'HotWaterDistribution',
+                                      system_type: HPXML::DHWDistTypeRecirc,
+                                      recirculation_control_type: HPXML::DHWRecirControlTypeSensor,
+                                      pipe_r_value: 3.0)
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_recirc_distribution_values(hpxml_default, true, 156.96, 10.0, 50.0)
+
+    # Test defaults w/ recirculation & 2-story building
+    hpxml = _create_hpxml('base-enclosure-2stories.xml')
+    hpxml.hot_water_distributions.clear
+    hpxml.hot_water_distributions.add(id: 'HotWaterDistribution',
+                                      system_type: HPXML::DHWDistTypeRecirc,
+                                      recirculation_control_type: HPXML::DHWRecirControlTypeSensor,
+                                      pipe_r_value: 3.0)
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_recirc_distribution_values(hpxml_default, true, 186.96, 10.0, 50.0)
+
+    # Test defaults w/ shared recirculation
+    hpxml = _create_hpxml('base-dhw-shared-water-heater-recirc.xml')
+    hpxml.hot_water_distributions[0].shared_recirculation_pump_power = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_shared_recirc_distribution_values(hpxml_default, true, 220.0)
+  end
+
+  def test_water_fixtures
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.water_heating.water_fixtures_usage_multiplier = 2.0
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_water_fixture_values(hpxml_default, false, 2.0)
+
+    # Test defaults
+    hpxml.water_heating.water_fixtures_usage_multiplier = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_water_fixture_values(hpxml_default, true, 1.0)
+  end
+
+  def test_solar_thermal_systems
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-dhw-solar-direct-flat-plate.xml')
+    hpxml.solar_thermal_systems[0].storage_volume = 55.0
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_solar_thermal_values(hpxml_default, false, 55.0)
+
+    # Test defaults w/ collector area of 40 sqft
+    hpxml.solar_thermal_systems[0].storage_volume = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_solar_thermal_values(hpxml_default, true, 60.0)
+
+    # Test defaults w/ collector area of 100 sqft
+    hpxml.solar_thermal_systems[0].collector_area = 100.0
+    hpxml.solar_thermal_systems[0].storage_volume = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_solar_thermal_values(hpxml_default, true, 150.0)
+  end
+
+  def test_pv_systems
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-pv.xml')
+    hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFA
+    hpxml.pv_systems.each do |pv|
+      pv.is_shared_system = true
+      pv.number_of_bedrooms_served = 20
+      pv.inverter_efficiency = 0.90
+      pv.system_losses_fraction = 0.20
+      pv.location = HPXML::LocationGround
+      pv.tracking = HPXML::PVTrackingType1Axis
+      pv.module_type = HPXML::PVModuleTypePremium
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_pv_system_values(hpxml_default, false, 0.90, 0.20, true, HPXML::LocationGround, HPXML::PVTrackingType1Axis, HPXML::PVModuleTypePremium)
+
+    # Test defaults w/o year modules manufactured
+    hpxml.pv_systems.each do |pv|
+      pv.is_shared_system = nil
+      pv.inverter_efficiency = nil
+      pv.system_losses_fraction = nil
+      pv.location = nil
+      pv.tracking = nil
+      pv.module_type = nil
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_pv_system_values(hpxml_default, true, 0.96, 0.14, false, HPXML::LocationRoof, HPXML::PVTrackingTypeFixed, HPXML::PVModuleTypeStandard)
+
+    # Test defaults w/ year modules manufactured
+    hpxml.pv_systems.each do |pv|
+      pv.year_modules_manufactured = 2010
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_pv_system_values(hpxml_default, true, 0.96, 0.182, false, HPXML::LocationRoof, HPXML::PVTrackingTypeFixed, HPXML::PVModuleTypeStandard)
   end
 
   def test_clothes_washers
@@ -1270,7 +1084,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.clothes_washers[0].water_heating_system_idref = hpxml.water_heating_systems[0].id
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_washer_values(hpxml_default, true, HPXML::LocationBasementConditioned, 1.21, 380.0, 0.12, 1.09, 27.0, 3.2, 6.0, 1.5)
+    _test_default_clothes_washer_values(hpxml_default, false, true, HPXML::LocationBasementConditioned, 1.21, 380.0, 0.12, 1.09, 27.0, 3.2, 6.0, 1.5)
 
     # Test defaults
     hpxml.clothes_washers[0].is_shared_appliance = nil
@@ -1285,7 +1099,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.clothes_washers[0].usage_multiplier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_washer_values(hpxml_default, false, HPXML::LocationLivingSpace, 1.0, 400.0, 0.12, 1.09, 27.0, 3.0, 6.0, 1.0)
+    _test_default_clothes_washer_values(hpxml_default, true, false, HPXML::LocationLivingSpace, 1.0, 400.0, 0.12, 1.09, 27.0, 3.0, 6.0, 1.0)
 
     # Test defaults before 301-2019 Addendum A
     hpxml = _create_hpxml('base.xml')
@@ -1302,7 +1116,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.clothes_washers[0].usage_multiplier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_washer_values(hpxml_default, false, HPXML::LocationLivingSpace, 0.331, 704.0, 0.08, 0.58, 23.0, 2.874, 999, 1.0)
+    _test_default_clothes_washer_values(hpxml_default, true, false, HPXML::LocationLivingSpace, 0.331, 704.0, 0.08, 0.58, 23.0, 2.874, 999, 1.0)
   end
 
   def test_clothes_dryers
@@ -1319,36 +1133,62 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.clothes_dryers[0].usage_multiplier = 1.1
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_dryer_values(hpxml_default, true, HPXML::LocationBasementConditioned, HPXML::ClothesDryerControlTypeMoisture, 3.33, 1.1)
+    _test_default_clothes_dryer_values(hpxml_default, false, true, HPXML::LocationBasementConditioned, HPXML::ClothesDryerControlTypeMoisture, 3.33, 1.1)
 
     # Test defaults w/ electric clothes dryer
     hpxml.clothes_dryers[0].location = nil
-    hpxml.clothes_dryers[0].is_shared_appliance = false
+    hpxml.clothes_dryers[0].is_shared_appliance = nil
     hpxml.clothes_dryers[0].control_type = nil
     hpxml.clothes_dryers[0].combined_energy_factor = nil
     hpxml.clothes_dryers[0].usage_multiplier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_dryer_values(hpxml_default, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 3.01, 1.0)
+    _test_default_clothes_dryer_values(hpxml_default, true, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 3.01, 1.0)
 
     # Test defaults w/ gas clothes dryer
     hpxml.clothes_dryers[0].fuel_type = HPXML::FuelTypeNaturalGas
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_dryer_values(hpxml_default, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 3.01, 1.0)
+    _test_default_clothes_dryer_values(hpxml_default, true, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 3.01, 1.0)
 
     # Test defaults w/ electric clothes dryer before 301-2019 Addendum A
     hpxml.header.eri_calculation_version = '2019'
     hpxml.clothes_dryers[0].fuel_type = HPXML::FuelTypeElectricity
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_dryer_values(hpxml_default, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 2.62, 1.0)
+    _test_default_clothes_dryer_values(hpxml_default, true, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 2.62, 1.0)
 
     # Test defaults w/ gas clothes dryer before 301-2019 Addendum A
     hpxml.clothes_dryers[0].fuel_type = HPXML::FuelTypeNaturalGas
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_clothes_dryer_values(hpxml_default, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 2.32, 1.0)
+    _test_default_clothes_dryer_values(hpxml_default, true, false, HPXML::LocationLivingSpace, HPXML::ClothesDryerControlTypeTimer, 2.32, 1.0)
+  end
+
+  def test_clothes_dryer_exhaust
+    # Test inputs not overridden by defaults w/ vented dryer
+    hpxml_name = 'base.xml'
+    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    clothes_dryer = hpxml.clothes_dryers[0]
+    clothes_dryer.is_vented = true
+    clothes_dryer.vented_flow_rate = 200
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_clothes_dryer_exhaust_values(hpxml_default, false, true, 200)
+
+    # Test inputs not overridden by defaults w/ unvented dryer
+    clothes_dryer.is_vented = false
+    clothes_dryer.vented_flow_rate = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_clothes_dryer_exhaust_values(hpxml_default, false, false, nil)
+
+    # Test defaults
+    clothes_dryer.is_vented = nil
+    clothes_dryer.vented_flow_rate = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_clothes_dryer_exhaust_values(hpxml_default, true, true, 100)
   end
 
   def test_dishwashers
@@ -1364,7 +1204,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.dishwashers[0].water_heating_system_idref = hpxml.water_heating_systems[0].id
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_dishwasher_values(hpxml_default, true, HPXML::LocationBasementConditioned, 307.0, 0.12, 1.09, 22.32, 4.0, 12, 1.3)
+    _test_default_dishwasher_values(hpxml_default, false, true, HPXML::LocationBasementConditioned, 307.0, 0.12, 1.09, 22.32, 4.0, 12, 1.3)
 
     # Test defaults
     hpxml.dishwashers[0].is_shared_appliance = nil
@@ -1378,13 +1218,13 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.dishwashers[0].usage_multiplier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_dishwasher_values(hpxml_default, false, HPXML::LocationLivingSpace, 467.0, 0.12, 1.09, 33.12, 4.0, 12, 1.0)
+    _test_default_dishwasher_values(hpxml_default, true, false, HPXML::LocationLivingSpace, 467.0, 0.12, 1.09, 33.12, 4.0, 12, 1.0)
 
     # Test defaults before 301-2019 Addendum A
     hpxml.header.eri_calculation_version = '2019'
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_dishwasher_values(hpxml_default, false, HPXML::LocationLivingSpace, 467.0, 999, 999, 999, 999, 12, 1.0)
+    _test_default_dishwasher_values(hpxml_default, true, false, HPXML::LocationLivingSpace, 467.0, 999, 999, 999, 999, 12, 1.0)
   end
 
   def test_refrigerators
@@ -1397,7 +1237,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.refrigerators[0].monthly_multipliers = ConstantMonthSchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_refrigerator_values(hpxml_default, HPXML::LocationBasementConditioned, 650.0, 1.2, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_refrigerator_values(hpxml_default, false, HPXML::LocationBasementConditioned, 650.0, 1.2, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
 
     # Test defaults
     hpxml.refrigerators[0].location = nil
@@ -1408,72 +1248,20 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.refrigerators[0].monthly_multipliers = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 691.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+    _test_default_refrigerator_values(hpxml_default, true, HPXML::LocationLivingSpace, 691.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
 
     # Test defaults w/ refrigerator in 5-bedroom house
     hpxml.building_construction.number_of_bedrooms = 5
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 727.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+    _test_default_refrigerator_values(hpxml_default, true, HPXML::LocationLivingSpace, 727.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
 
     # Test defaults before 301-2019 Addendum A
     hpxml.header.eri_calculation_version = '2019'
     hpxml.building_construction.number_of_bedrooms = 3
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_refrigerator_values(hpxml_default, HPXML::LocationLivingSpace, 691.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
-  end
-
-  def test_cooking_ranges
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base.xml')
-    hpxml.cooking_ranges[0].location = HPXML::LocationBasementConditioned
-    hpxml.cooking_ranges[0].is_induction = true
-    hpxml.cooking_ranges[0].usage_multiplier = 1.1
-    hpxml.cooking_ranges[0].weekday_fractions = ConstantDaySchedule
-    hpxml.cooking_ranges[0].weekend_fractions = ConstantDaySchedule
-    hpxml.cooking_ranges[0].monthly_multipliers = ConstantMonthSchedule
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_cooking_range_values(hpxml_default, HPXML::LocationBasementConditioned, true, 1.1, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
-
-    # Test defaults
-    hpxml.cooking_ranges[0].location = nil
-    hpxml.cooking_ranges[0].is_induction = nil
-    hpxml.cooking_ranges[0].usage_multiplier = nil
-    hpxml.cooking_ranges[0].weekday_fractions = nil
-    hpxml.cooking_ranges[0].weekend_fractions = nil
-    hpxml.cooking_ranges[0].monthly_multipliers = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_cooking_range_values(hpxml_default, HPXML::LocationLivingSpace, false, 1.0, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
-
-    # Test defaults before 301-2019 Addendum A
-    hpxml.header.eri_calculation_version = '2019'
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_cooking_range_values(hpxml_default, HPXML::LocationLivingSpace, false, 1.0, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
-  end
-
-  def test_ovens
-    # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base.xml')
-    hpxml.ovens[0].is_convection = true
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_oven_values(hpxml_default, true)
-
-    # Test defaults
-    hpxml.ovens[0].is_convection = nil
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_oven_values(hpxml_default, false)
-
-    # Test defaults before 301-2019 Addendum A
-    hpxml.header.eri_calculation_version = '2019'
-    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
-    hpxml_default = _test_measure()
-    _test_default_oven_values(hpxml_default, false)
+    _test_default_refrigerator_values(hpxml_default, true, HPXML::LocationLivingSpace, 691.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
   end
 
   def test_extra_refrigerators
@@ -1489,7 +1277,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_extra_refrigerators_values(hpxml_default, HPXML::LocationBasementConditioned, 333.0, 1.5, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_extra_refrigerators_values(hpxml_default, false, HPXML::LocationBasementConditioned, 333.0, 1.5, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
 
     # Test defaults
     hpxml.refrigerators.each do |refrigerator|
@@ -1502,7 +1290,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_extra_refrigerators_values(hpxml_default, HPXML::LocationGarage, 244.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+    _test_default_extra_refrigerators_values(hpxml_default, true, HPXML::LocationGarage, 244.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
   end
 
   def test_freezers
@@ -1518,7 +1306,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_freezers_values(hpxml_default, HPXML::LocationBasementConditioned, 333.0, 1.5, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_freezers_values(hpxml_default, false, HPXML::LocationBasementConditioned, 333.0, 1.5, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
 
     # Test defaults
     hpxml.freezers.each do |freezer|
@@ -1531,7 +1319,59 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_freezers_values(hpxml_default, HPXML::LocationGarage, 320.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+    _test_default_freezers_values(hpxml_default, true, HPXML::LocationGarage, 320.0, 1.0, '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+  end
+
+  def test_cooking_ranges
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.cooking_ranges[0].location = HPXML::LocationBasementConditioned
+    hpxml.cooking_ranges[0].is_induction = true
+    hpxml.cooking_ranges[0].usage_multiplier = 1.1
+    hpxml.cooking_ranges[0].weekday_fractions = ConstantDaySchedule
+    hpxml.cooking_ranges[0].weekend_fractions = ConstantDaySchedule
+    hpxml.cooking_ranges[0].monthly_multipliers = ConstantMonthSchedule
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_cooking_range_values(hpxml_default, false, HPXML::LocationBasementConditioned, true, 1.1, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    hpxml.cooking_ranges[0].location = nil
+    hpxml.cooking_ranges[0].is_induction = nil
+    hpxml.cooking_ranges[0].usage_multiplier = nil
+    hpxml.cooking_ranges[0].weekday_fractions = nil
+    hpxml.cooking_ranges[0].weekend_fractions = nil
+    hpxml.cooking_ranges[0].monthly_multipliers = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_cooking_range_values(hpxml_default, true, HPXML::LocationLivingSpace, false, 1.0, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
+
+    # Test defaults before 301-2019 Addendum A
+    hpxml.header.eri_calculation_version = '2019'
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_cooking_range_values(hpxml_default, true, HPXML::LocationLivingSpace, false, 1.0, '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
+  end
+
+  def test_ovens
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.ovens[0].is_convection = true
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_oven_values(hpxml_default, false, true)
+
+    # Test defaults
+    hpxml.ovens[0].is_convection = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_oven_values(hpxml_default, true, false)
+
+    # Test defaults before 301-2019 Addendum A
+    hpxml.header.eri_calculation_version = '2019'
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_oven_values(hpxml_default, true, false)
   end
 
   def test_lighting
@@ -1559,7 +1399,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.lighting.holiday_weekend_fractions = ConstantDaySchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_lighting_values(hpxml_default, 2.0, 2.0, 2.0,
+    _test_default_lighting_values(hpxml_default, false, 2.0, 2.0, 2.0,
                                   { int_wk_sch: ConstantDaySchedule,
                                     int_wknd_sch: ConstantDaySchedule,
                                     int_month_mult: ConstantMonthSchedule,
@@ -1593,7 +1433,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.lighting.holiday_exists = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_lighting_values(hpxml_default, 1.0, 1.0, 1.0,
+    _test_default_lighting_values(hpxml_default, true, 1.0, 1.0, 1.0,
                                   { ext_wk_sch: '0.046, 0.046, 0.046, 0.046, 0.046, 0.037, 0.035, 0.034, 0.033, 0.028, 0.022, 0.015, 0.012, 0.011, 0.011, 0.012, 0.019, 0.037, 0.049, 0.065, 0.091, 0.105, 0.091, 0.063',
                                     ext_wknd_sch: '0.046, 0.046, 0.045, 0.045, 0.046, 0.045, 0.044, 0.041, 0.036, 0.03, 0.024, 0.016, 0.012, 0.011, 0.011, 0.012, 0.019, 0.038, 0.048, 0.06, 0.083, 0.098, 0.085, 0.059',
                                     ext_month_mult: '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248' })
@@ -1605,7 +1445,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.lighting.exterior_usage_multiplier = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_lighting_values(hpxml_default, 1.0, 1.0, 1.0,
+    _test_default_lighting_values(hpxml_default, true, 1.0, 1.0, 1.0,
                                   { ext_wk_sch: '0.046, 0.046, 0.046, 0.046, 0.046, 0.037, 0.035, 0.034, 0.033, 0.028, 0.022, 0.015, 0.012, 0.011, 0.011, 0.012, 0.019, 0.037, 0.049, 0.065, 0.091, 0.105, 0.091, 0.063',
                                     ext_wknd_sch: '0.046, 0.046, 0.045, 0.045, 0.046, 0.045, 0.044, 0.041, 0.036, 0.03, 0.024, 0.016, 0.012, 0.011, 0.011, 0.012, 0.019, 0.038, 0.048, 0.06, 0.083, 0.098, 0.085, 0.059',
                                     ext_month_mult: '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248',
@@ -1614,49 +1454,258 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
                                     grg_month_mult: '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248' })
   end
 
-  def test_pv_systems
+  def test_ceiling_fans
     # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base-pv.xml')
-    hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFA
-    hpxml.pv_systems.each do |pv|
-      pv.is_shared_system = true
-      pv.number_of_bedrooms_served = 20
-      pv.inverter_efficiency = 0.90
-      pv.system_losses_fraction = 0.20
-      pv.location = HPXML::LocationGround
-      pv.tracking = HPXML::PVTrackingType1Axis
-      pv.module_type = HPXML::PVModuleTypePremium
-    end
+    hpxml = _create_hpxml('base-lighting-ceiling-fans.xml')
+    hpxml.ceiling_fans[0].quantity = 2
+    hpxml.ceiling_fans[0].efficiency = 100
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    expected_interver_efficiency = [0.90, 0.90]
-    expected_system_loss_frac = [0.20, 0.20]
-    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, true, HPXML::LocationGround, HPXML::PVTrackingType1Axis, HPXML::PVModuleTypePremium)
+    _test_default_ceiling_fan_values(hpxml_default, false, 2, 100)
 
-    # Test defaults w/o year modules manufactured
-    hpxml.pv_systems.each do |pv|
-      pv.is_shared_system = nil
-      pv.inverter_efficiency = nil
-      pv.system_losses_fraction = nil
-      pv.location = nil
-      pv.tracking = nil
-      pv.module_type = nil
+    # Test defaults
+    hpxml.ceiling_fans.each do |ceiling_fan|
+      ceiling_fan.quantity = nil
+      ceiling_fan.efficiency = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    expected_interver_efficiency = [0.96, 0.96]
-    expected_system_loss_frac = [0.14, 0.14]
-    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, false, HPXML::LocationRoof, HPXML::PVTrackingTypeFixed, HPXML::PVModuleTypeStandard)
+    _test_default_ceiling_fan_values(hpxml_default, true, 4, 70.4)
+  end
 
-    # Test defaults w/ year modules manufactured
-    hpxml.pv_systems.each do |pv|
-      pv.year_modules_manufactured = 2010
+  def test_pools
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
+    pool = hpxml.pools[0]
+    pool.heater_load_units = HPXML::UnitsKwhPerYear
+    pool.heater_load_value = 1000
+    pool.heater_usage_multiplier = 1.4
+    pool.heater_weekday_fractions = ConstantDaySchedule
+    pool.heater_weekend_fractions = ConstantDaySchedule
+    pool.heater_monthly_multipliers = ConstantMonthSchedule
+    pool.pump_kwh_per_year = 3000
+    pool.pump_usage_multiplier = 1.3
+    pool.pump_weekday_fractions = ConstantDaySchedule
+    pool.pump_weekend_fractions = ConstantDaySchedule
+    pool.pump_monthly_multipliers = ConstantMonthSchedule
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_pool_heater_values(hpxml_default, false, HPXML::UnitsKwhPerYear, 1000, 1.4, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_pool_pump_values(hpxml_default, false, 3000, 1.3, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    pool = hpxml.pools[0]
+    pool.heater_load_units = nil
+    pool.heater_load_value = nil
+    pool.heater_usage_multiplier = nil
+    pool.heater_weekday_fractions = nil
+    pool.heater_weekend_fractions = nil
+    pool.heater_monthly_multipliers = nil
+    pool.pump_kwh_per_year = nil
+    pool.pump_usage_multiplier = nil
+    pool.pump_weekday_fractions = nil
+    pool.pump_weekend_fractions = nil
+    pool.pump_monthly_multipliers = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_pool_heater_values(hpxml_default, true, HPXML::UnitsThermPerYear, 236, 1.0, '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
+    _test_default_pool_pump_values(hpxml_default, true, 2496, 1.0, '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
+
+    # Test defaults 2
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon2.xml')
+    pool = hpxml.pools[0]
+    pool.heater_load_units = nil
+    pool.heater_load_value = nil
+    pool.heater_usage_multiplier = nil
+    pool.heater_weekday_fractions = nil
+    pool.heater_weekend_fractions = nil
+    pool.heater_monthly_multipliers = nil
+    pool.pump_kwh_per_year = nil
+    pool.pump_usage_multiplier = nil
+    pool.pump_weekday_fractions = nil
+    pool.pump_weekend_fractions = nil
+    pool.pump_monthly_multipliers = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_pool_heater_values(hpxml_default, true, nil, nil, nil, nil, nil, nil)
+    _test_default_pool_pump_values(hpxml_default, true, 2496, 1.0, '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
+  end
+
+  def test_hot_tubs
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
+    hot_tub = hpxml.hot_tubs[0]
+    hot_tub.heater_load_units = HPXML::UnitsThermPerYear
+    hot_tub.heater_load_value = 1000
+    hot_tub.heater_usage_multiplier = 0.8
+    hot_tub.heater_weekday_fractions = ConstantDaySchedule
+    hot_tub.heater_weekend_fractions = ConstantDaySchedule
+    hot_tub.heater_monthly_multipliers = ConstantMonthSchedule
+    hot_tub.pump_kwh_per_year = 3000
+    hot_tub.pump_usage_multiplier = 0.7
+    hot_tub.pump_weekday_fractions = ConstantDaySchedule
+    hot_tub.pump_weekend_fractions = ConstantDaySchedule
+    hot_tub.pump_monthly_multipliers = ConstantMonthSchedule
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_hot_tub_heater_values(hpxml_default, false, HPXML::UnitsThermPerYear, 1000, 0.8, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_hot_tub_pump_values(hpxml_default, false, 3000, 0.7, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    hot_tub = hpxml.hot_tubs[0]
+    hot_tub.heater_load_units = nil
+    hot_tub.heater_load_value = nil
+    hot_tub.heater_usage_multiplier = nil
+    hot_tub.heater_weekday_fractions = nil
+    hot_tub.heater_weekend_fractions = nil
+    hot_tub.heater_monthly_multipliers = nil
+    hot_tub.pump_kwh_per_year = nil
+    hot_tub.pump_usage_multiplier = nil
+    hot_tub.pump_weekday_fractions = nil
+    hot_tub.pump_weekend_fractions = nil
+    hot_tub.pump_monthly_multipliers = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_hot_tub_heater_values(hpxml_default, true, HPXML::UnitsKwhPerYear, 1125, 1.0, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+    _test_default_hot_tub_pump_values(hpxml_default, true, 1111, 1.0, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921')
+
+    # Test defaults 2
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon2.xml')
+    hot_tub = hpxml.hot_tubs[0]
+    hot_tub.heater_load_units = nil
+    hot_tub.heater_load_value = nil
+    hot_tub.heater_usage_multiplier = nil
+    hot_tub.heater_weekday_fractions = nil
+    hot_tub.heater_weekend_fractions = nil
+    hot_tub.heater_monthly_multipliers = nil
+    hot_tub.pump_kwh_per_year = nil
+    hot_tub.pump_usage_multiplier = nil
+    hot_tub.pump_weekday_fractions = nil
+    hot_tub.pump_weekend_fractions = nil
+    hot_tub.pump_monthly_multipliers = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_hot_tub_heater_values(hpxml_default, true, HPXML::UnitsKwhPerYear, 225, 1.0, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+    _test_default_hot_tub_pump_values(hpxml_default, true, 1111, 1.0, '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024', '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921')
+  end
+
+  def test_plug_loads
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
+    tv_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeTelevision }[0]
+    tv_pl.kWh_per_year = 1000
+    tv_pl.usage_multiplier = 1.1
+    tv_pl.frac_sensible = 0.6
+    tv_pl.frac_latent = 0.3
+    tv_pl.location = HPXML::LocationExterior
+    tv_pl.weekday_fractions = ConstantDaySchedule
+    tv_pl.weekend_fractions = ConstantDaySchedule
+    tv_pl.monthly_multipliers = ConstantMonthSchedule
+    other_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeOther }[0]
+    other_pl.kWh_per_year = 2000
+    other_pl.usage_multiplier = 1.2
+    other_pl.frac_sensible = 0.5
+    other_pl.frac_latent = 0.4
+    other_pl.location = HPXML::LocationExterior
+    other_pl.weekday_fractions = ConstantDaySchedule
+    other_pl.weekend_fractions = ConstantDaySchedule
+    other_pl.monthly_multipliers = ConstantMonthSchedule
+    veh_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeElectricVehicleCharging }[0]
+    veh_pl.kWh_per_year = 4000
+    veh_pl.usage_multiplier = 1.3
+    veh_pl.frac_sensible = 0.4
+    veh_pl.frac_latent = 0.5
+    veh_pl.location = HPXML::LocationInterior
+    veh_pl.weekday_fractions = ConstantDaySchedule
+    veh_pl.weekend_fractions = ConstantDaySchedule
+    veh_pl.monthly_multipliers = ConstantMonthSchedule
+    wellpump_pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == HPXML::PlugLoadTypeWellPump }[0]
+    wellpump_pl.kWh_per_year = 3000
+    wellpump_pl.usage_multiplier = 1.4
+    wellpump_pl.frac_sensible = 0.3
+    wellpump_pl.frac_latent = 0.6
+    wellpump_pl.location = HPXML::LocationInterior
+    wellpump_pl.weekday_fractions = ConstantDaySchedule
+    wellpump_pl.weekend_fractions = ConstantDaySchedule
+    wellpump_pl.monthly_multipliers = ConstantMonthSchedule
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_plug_load_values(hpxml_default, false, HPXML::PlugLoadTypeTelevision, 1000, 0.6, 0.3, HPXML::LocationExterior, 1.1, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_plug_load_values(hpxml_default, false, HPXML::PlugLoadTypeOther, 2000, 0.5, 0.4, HPXML::LocationExterior, 1.2, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_plug_load_values(hpxml_default, false, HPXML::PlugLoadTypeElectricVehicleCharging, 4000, 0.4, 0.5, HPXML::LocationInterior, 1.3, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_plug_load_values(hpxml_default, false, HPXML::PlugLoadTypeWellPump, 3000, 0.3, 0.6, HPXML::LocationInterior, 1.4, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    hpxml.plug_loads.each do |plug_load|
+      plug_load.kWh_per_year = nil
+      plug_load.usage_multiplier = nil
+      plug_load.frac_sensible = nil
+      plug_load.frac_latent = nil
+      plug_load.location = nil
+      plug_load.weekday_fractions = nil
+      plug_load.weekend_fractions = nil
+      plug_load.monthly_multipliers = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    expected_interver_efficiency = [0.96, 0.96]
-    expected_system_loss_frac = [0.182, 0.182]
-    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, false, HPXML::LocationRoof, HPXML::PVTrackingTypeFixed, HPXML::PVModuleTypeStandard)
+    _test_default_plug_load_values(hpxml_default, true, HPXML::PlugLoadTypeTelevision, 620, 1.0, 0.0, HPXML::LocationInterior, 1.0, '0.037, 0.018, 0.009, 0.007, 0.011, 0.018, 0.029, 0.040, 0.049, 0.058, 0.065, 0.072, 0.076, 0.086, 0.091, 0.102, 0.127, 0.156, 0.210, 0.294, 0.363, 0.344, 0.208, 0.090', '0.044, 0.022, 0.012, 0.008, 0.011, 0.014, 0.024, 0.043, 0.071, 0.094, 0.112, 0.123, 0.132, 0.156, 0.178, 0.196, 0.206, 0.213, 0.251, 0.330, 0.388, 0.358, 0.226, 0.103', '1.137, 1.129, 0.961, 0.969, 0.961, 0.993, 0.996, 0.96, 0.993, 0.867, 0.86, 1.137')
+    _test_default_plug_load_values(hpxml_default, true, HPXML::PlugLoadTypeOther, 2457, 0.855, 0.045, HPXML::LocationInterior, 1.0, '0.035, 0.033, 0.032, 0.031, 0.032, 0.033, 0.037, 0.042, 0.043, 0.043, 0.043, 0.044, 0.045, 0.045, 0.044, 0.046, 0.048, 0.052, 0.053, 0.05, 0.047, 0.045, 0.04, 0.036', '0.035, 0.033, 0.032, 0.031, 0.032, 0.033, 0.037, 0.042, 0.043, 0.043, 0.043, 0.044, 0.045, 0.045, 0.044, 0.046, 0.048, 0.052, 0.053, 0.05, 0.047, 0.045, 0.04, 0.036', '1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248')
+    _test_default_plug_load_values(hpxml_default, true, HPXML::PlugLoadTypeElectricVehicleCharging, 1667, 0.0, 0.0, HPXML::LocationExterior, 1.0, '0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042', '0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042, 0.042', '1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1')
+    _test_default_plug_load_values(hpxml_default, true, HPXML::PlugLoadTypeWellPump, 441, 0.0, 0.0, HPXML::LocationExterior, 1.0, '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
+  end
+
+  def test_fuel_loads
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-misc-loads-large-uncommon.xml')
+    gg_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeGrill }[0]
+    gg_fl.therm_per_year = 1000
+    gg_fl.usage_multiplier = 0.9
+    gg_fl.frac_sensible = 0.6
+    gg_fl.frac_latent = 0.3
+    gg_fl.location = HPXML::LocationInterior
+    gg_fl.weekday_fractions = ConstantDaySchedule
+    gg_fl.weekend_fractions = ConstantDaySchedule
+    gg_fl.monthly_multipliers = ConstantMonthSchedule
+    gl_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeLighting }[0]
+    gl_fl.therm_per_year = 2000
+    gl_fl.usage_multiplier = 0.8
+    gl_fl.frac_sensible = 0.5
+    gl_fl.frac_latent = 0.4
+    gl_fl.location = HPXML::LocationInterior
+    gl_fl.weekday_fractions = ConstantDaySchedule
+    gl_fl.weekend_fractions = ConstantDaySchedule
+    gl_fl.monthly_multipliers = ConstantMonthSchedule
+    gf_fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == HPXML::FuelLoadTypeFireplace }[0]
+    gf_fl.therm_per_year = 3000
+    gf_fl.usage_multiplier = 0.7
+    gf_fl.frac_sensible = 0.4
+    gf_fl.frac_latent = 0.5
+    gf_fl.location = HPXML::LocationExterior
+    gf_fl.weekday_fractions = ConstantDaySchedule
+    gf_fl.weekend_fractions = ConstantDaySchedule
+    gf_fl.monthly_multipliers = ConstantMonthSchedule
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_fuel_load_values(hpxml_default, false, HPXML::FuelLoadTypeGrill, 1000, 0.6, 0.3, HPXML::LocationInterior, 0.9, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_fuel_load_values(hpxml_default, false, HPXML::FuelLoadTypeLighting, 2000, 0.5, 0.4, HPXML::LocationInterior, 0.8, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_fuel_load_values(hpxml_default, false, HPXML::FuelLoadTypeFireplace, 3000, 0.4, 0.5, HPXML::LocationExterior, 0.7, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+
+    # Test defaults
+    hpxml.fuel_loads.each do |fuel_load|
+      fuel_load.therm_per_year = nil
+      fuel_load.usage_multiplier = nil
+      fuel_load.frac_sensible = nil
+      fuel_load.frac_latent = nil
+      fuel_load.location = nil
+      fuel_load.weekday_fractions = nil
+      fuel_load.weekend_fractions = nil
+      fuel_load.monthly_multipliers = nil
+    end
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_fuel_load_values(hpxml_default, true, HPXML::FuelLoadTypeGrill, 33, 0.0, 0.0, HPXML::LocationExterior, 1.0, '0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007', '0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007', '1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097')
+    _test_default_fuel_load_values(hpxml_default, true, HPXML::FuelLoadTypeLighting, 20, 0.0, 0.0, HPXML::LocationExterior, 1.0, '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
+    _test_default_fuel_load_values(hpxml_default, true, HPXML::FuelLoadTypeFireplace, 67, 0.5, 0.1, HPXML::LocationInterior, 1.0, '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065', '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
   end
 
   def _test_measure()
@@ -1694,610 +1743,1041 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     return hpxml_default
   end
 
-  def _test_default_header_values(hpxml, tstep, sim_begin_month, sim_begin_day, sim_end_month, sim_end_day, sim_calendar_year,
+  def _test_default_header_values(hpxml, isdefaulted, tstep, sim_begin_month, sim_begin_day, sim_end_month, sim_end_day, sim_calendar_year,
                                   dst_enabled, dst_begin_month, dst_begin_day_of_month, dst_end_month, dst_end_day_of_month,
                                   use_max_load_for_heat_pumps, allow_increased_fixed_capacities)
     assert_equal(tstep, hpxml.header.timestep)
+    assert_equal(isdefaulted, hpxml.header.timestep_isdefaulted)
+
     assert_equal(sim_begin_month, hpxml.header.sim_begin_month)
+    assert_equal(isdefaulted, hpxml.header.sim_begin_month_isdefaulted)
+
     assert_equal(sim_begin_day, hpxml.header.sim_begin_day_of_month)
+    assert_equal(isdefaulted, hpxml.header.sim_begin_day_of_month_isdefaulted)
+
     assert_equal(sim_end_month, hpxml.header.sim_end_month)
+    assert_equal(isdefaulted, hpxml.header.sim_end_month_isdefaulted)
+
     assert_equal(sim_end_day, hpxml.header.sim_end_day_of_month)
+    assert_equal(isdefaulted, hpxml.header.sim_end_day_of_month_isdefaulted)
+
     assert_equal(sim_calendar_year, hpxml.header.sim_calendar_year)
+    assert_equal(isdefaulted, hpxml.header.sim_calendar_year_isdefaulted)
+
     assert_equal(dst_enabled, hpxml.header.dst_enabled)
+    assert_equal(isdefaulted, hpxml.header.dst_enabled_isdefaulted)
+
     assert_equal(dst_begin_month, hpxml.header.dst_begin_month)
+    assert_equal(isdefaulted, hpxml.header.dst_begin_month_isdefaulted)
+
     assert_equal(dst_begin_day_of_month, hpxml.header.dst_begin_day_of_month)
+    assert_equal(isdefaulted, hpxml.header.dst_begin_day_of_month_isdefaulted)
+
     assert_equal(dst_end_month, hpxml.header.dst_end_month)
+    assert_equal(isdefaulted, hpxml.header.dst_end_month_isdefaulted)
+
     assert_equal(dst_end_day_of_month, hpxml.header.dst_end_day_of_month)
+    assert_equal(isdefaulted, hpxml.header.dst_end_day_of_month_isdefaulted)
+
     assert_equal(use_max_load_for_heat_pumps, hpxml.header.use_max_load_for_heat_pumps)
+    assert_equal(isdefaulted, hpxml.header.use_max_load_for_heat_pumps_isdefaulted)
+
     assert_equal(allow_increased_fixed_capacities, hpxml.header.allow_increased_fixed_capacities)
+    assert_equal(isdefaulted, hpxml.header.allow_increased_fixed_capacities_isdefaulted)
   end
 
-  def _test_default_site_values(hpxml, site_type, shelter_coefficient)
+  def _test_default_site_values(hpxml, isdefaulted, site_type, shelter_coefficient)
     assert_equal(site_type, hpxml.site.site_type)
+    assert_equal(isdefaulted, hpxml.site.site_type_isdefaulted)
+
     assert_equal(shelter_coefficient, hpxml.site.shelter_coefficient)
+    assert_equal(isdefaulted, hpxml.site.shelter_coefficient_isdefaulted)
   end
 
-  def _test_default_occupancy_values(hpxml, num_occupants)
+  def _test_default_occupancy_values(hpxml, isdefaulted, num_occupants)
     assert_equal(num_occupants, hpxml.building_occupancy.number_of_residents)
+    assert_equal(isdefaulted, hpxml.building_occupancy.number_of_residents_isdefaulted)
   end
 
-  def _test_default_central_air_conditioner_values(hpxml, shr, compressor_type, fan_watts_per_cfm)
+  def _test_default_building_construction_values(hpxml, isdefaulted, building_volume, has_flue_or_chimney, n_bathrooms)
+    assert_equal(building_volume, hpxml.building_construction.conditioned_building_volume)
+    assert_equal(isdefaulted, hpxml.building_construction.conditioned_building_volume_isdefaulted)
+
+    assert_equal(has_flue_or_chimney, hpxml.building_construction.has_flue_or_chimney)
+    assert_equal(isdefaulted, hpxml.building_construction.has_flue_or_chimney_isdefaulted)
+
+    assert_equal(n_bathrooms, hpxml.building_construction.number_of_bathrooms)
+    assert_equal(isdefaulted, hpxml.building_construction.number_of_bathrooms_isdefaulted)
+  end
+
+  def _test_default_infiltration_values(hpxml, isdefaulted, volume)
+    air_infiltration_measurement = hpxml.air_infiltration_measurements[0]
+
+    assert_equal(volume, air_infiltration_measurement.infiltration_volume)
+    assert_equal(isdefaulted, air_infiltration_measurement.infiltration_volume_isdefaulted)
+  end
+
+  def _test_default_attic_values(hpxml, isdefaulted, sla)
+    attic = hpxml.attics[0]
+
+    assert_equal(sla, attic.vented_attic_sla)
+    assert_equal(isdefaulted, attic.vented_attic_sla_isdefaulted)
+  end
+
+  def _test_default_foundation_values(hpxml, isdefaulted, sla)
+    foundation = hpxml.foundations[0]
+
+    assert_equal(sla, foundation.vented_crawlspace_sla)
+    assert_equal(isdefaulted, foundation.vented_crawlspace_sla_isdefaulted)
+  end
+
+  def _test_default_roof_values(hpxml, isdefaulted, roof_type, solar_absorptance, roof_color, emittance, radiant_barrier)
+    roof = hpxml.roofs[0]
+
+    assert_equal(roof_type, roof.roof_type)
+    assert_equal(isdefaulted, roof.roof_type_isdefaulted)
+
+    assert_equal(solar_absorptance, roof.solar_absorptance)
+    assert_equal(roof_color, roof.roof_color)
+    if isdefaulted
+      assert_equal(isdefaulted, roof.solar_absorptance_isdefaulted || roof.roof_color_isdefaulted)
+    else
+      assert_equal(isdefaulted, roof.solar_absorptance_isdefaulted)
+      assert_equal(isdefaulted, roof.roof_color_isdefaulted)
+    end
+
+    assert_equal(emittance, roof.emittance)
+    assert_equal(isdefaulted, roof.emittance_isdefaulted)
+
+    assert_equal(radiant_barrier, roof.radiant_barrier)
+    assert_equal(isdefaulted, roof.radiant_barrier_isdefaulted)
+  end
+
+  def _test_default_rim_joist_values(hpxml, isdefaulted, siding, solar_absorptance, color, emittance)
+    rim_joist = hpxml.rim_joists[0]
+
+    assert_equal(siding, rim_joist.siding)
+    assert_equal(isdefaulted, rim_joist.siding_isdefaulted)
+
+    assert_equal(solar_absorptance, rim_joist.solar_absorptance)
+    assert_equal(color, rim_joist.color)
+    if isdefaulted
+      assert_equal(isdefaulted, rim_joist.solar_absorptance_isdefaulted || rim_joist.color_isdefaulted)
+    else
+      assert_equal(isdefaulted, rim_joist.solar_absorptance_isdefaulted)
+      assert_equal(isdefaulted, rim_joist.color_isdefaulted)
+    end
+
+    assert_equal(emittance, rim_joist.emittance)
+    assert_equal(isdefaulted, rim_joist.emittance_isdefaulted)
+  end
+
+  def _test_default_wall_values(hpxml, isdefaulted, siding, solar_absorptance, color, emittance)
+    wall = hpxml.walls[0]
+
+    assert_equal(siding, wall.siding)
+    assert_equal(isdefaulted, wall.siding_isdefaulted)
+
+    assert_equal(solar_absorptance, wall.solar_absorptance)
+    assert_equal(color, wall.color)
+    if isdefaulted
+      assert_equal(isdefaulted, wall.solar_absorptance_isdefaulted || wall.color_isdefaulted)
+    else
+      assert_equal(isdefaulted, wall.solar_absorptance_isdefaulted)
+      assert_equal(isdefaulted, wall.color_isdefaulted)
+    end
+
+    assert_equal(emittance, wall.emittance)
+    assert_equal(isdefaulted, wall.emittance_isdefaulted)
+  end
+
+  def _test_default_foundation_wall_values(hpxml, isdefaulted, thickness)
+    foundation_wall = hpxml.foundation_walls[0]
+
+    assert_equal(thickness, foundation_wall.thickness)
+    assert_equal(isdefaulted, foundation_wall.thickness_isdefaulted)
+  end
+
+  def _test_default_slab_values(hpxml, isdefaulted, thickness, carpet_r_value, carpet_fraction)
+    slab = hpxml.slabs[0]
+
+    assert_equal(thickness, slab.thickness)
+    assert_equal(isdefaulted, slab.thickness_isdefaulted)
+
+    assert_equal(carpet_r_value, slab.carpet_r_value)
+    assert_equal(isdefaulted, slab.carpet_r_value_isdefaulted)
+
+    assert_equal(carpet_fraction, slab.carpet_fraction)
+    assert_equal(isdefaulted, slab.carpet_fraction_isdefaulted)
+  end
+
+  def _test_default_window_values(hpxml, isdefaulted, summer_shade_coeffs, winter_shade_coeffs, fraction_operable)
+    assert_equal(summer_shade_coeffs.size, hpxml.windows.size)
+    hpxml.windows.each_with_index do |window, idx|
+      assert_equal(summer_shade_coeffs[idx], window.interior_shading_factor_summer)
+      assert_equal(isdefaulted, window.interior_shading_factor_summer_isdefaulted)
+
+      assert_equal(winter_shade_coeffs[idx], window.interior_shading_factor_winter)
+      assert_equal(isdefaulted, window.interior_shading_factor_winter_isdefaulted)
+
+      assert_equal(fraction_operable[idx], window.fraction_operable)
+      assert_equal(isdefaulted, window.fraction_operable_isdefaulted)
+    end
+  end
+
+  def _test_default_skylight_values(hpxml, isdefaulted, summer_shade_coeffs, winter_shade_coeffs)
+    assert_equal(summer_shade_coeffs.size, hpxml.skylights.size)
+    hpxml.skylights.each_with_index do |skylight, idx|
+      assert_equal(summer_shade_coeffs[idx], skylight.interior_shading_factor_summer)
+      assert_equal(isdefaulted, skylight.interior_shading_factor_summer_isdefaulted)
+
+      assert_equal(winter_shade_coeffs[idx], skylight.interior_shading_factor_winter)
+      assert_equal(isdefaulted, skylight.interior_shading_factor_winter_isdefaulted)
+    end
+  end
+
+  def _test_default_central_air_conditioner_values(hpxml, isdefaulted, shr, compressor_type, fan_watts_per_cfm)
     cooling_system = hpxml.cooling_systems[0]
+
     assert_equal(shr, cooling_system.cooling_shr)
+    assert_equal(isdefaulted, cooling_system.cooling_shr_isdefaulted)
+
     assert_equal(compressor_type, cooling_system.compressor_type)
+    assert_equal(isdefaulted, cooling_system.compressor_type_isdefaulted)
+
     assert_equal(fan_watts_per_cfm, cooling_system.fan_watts_per_cfm)
+    assert_equal(isdefaulted, cooling_system.fan_watts_per_cfm_isdefaulted)
   end
 
-  def _test_default_room_air_conditioner_values(hpxml, shr)
+  def _test_default_room_air_conditioner_values(hpxml, isdefaulted, shr)
     cooling_system = hpxml.cooling_systems[0]
+
     assert_equal(shr, cooling_system.cooling_shr)
+    assert_equal(isdefaulted, cooling_system.cooling_shr_isdefaulted)
   end
 
-  def _test_default_mini_split_air_conditioner_values(hpxml, shr, fan_watts_per_cfm)
+  def _test_default_mini_split_air_conditioner_values(hpxml, isdefaulted, shr, fan_watts_per_cfm)
     cooling_system = hpxml.cooling_systems[0]
+
     assert_equal(shr, cooling_system.cooling_shr)
+    assert_equal(isdefaulted, cooling_system.cooling_shr_isdefaulted)
+
     assert_equal(fan_watts_per_cfm, cooling_system.fan_watts_per_cfm)
+    assert_equal(isdefaulted, cooling_system.fan_watts_per_cfm_isdefaulted)
   end
 
-  def _test_default_furnace_values(hpxml, fan_watts_per_cfm)
+  def _test_default_furnace_values(hpxml, isdefaulted, fan_watts_per_cfm)
     heating_system = hpxml.heating_systems[0]
+
     assert_equal(fan_watts_per_cfm, heating_system.fan_watts_per_cfm)
+    assert_equal(isdefaulted, heating_system.fan_watts_per_cfm_isdefaulted)
   end
 
-  def _test_default_wall_furnace_values(hpxml, fan_watts)
+  def _test_default_wall_furnace_values(hpxml, isdefaulted, fan_watts)
     heating_system = hpxml.heating_systems[0]
+
     assert_equal(fan_watts, heating_system.fan_watts)
+    assert_equal(isdefaulted, heating_system.fan_watts_isdefaulted)
   end
 
-  def _test_default_floor_furnace_values(hpxml, fan_watts)
+  def _test_default_floor_furnace_values(hpxml, isdefaulted, fan_watts)
     heating_system = hpxml.heating_systems[0]
+
     assert_equal(fan_watts, heating_system.fan_watts)
+    assert_equal(isdefaulted, heating_system.fan_watts_isdefaulted)
   end
 
-  def _test_default_stove_values(hpxml, fan_watts)
+  def _test_default_stove_values(hpxml, isdefaulted, fan_watts)
     heating_system = hpxml.heating_systems[0]
+
     assert_equal(fan_watts, heating_system.fan_watts)
+    assert_equal(isdefaulted, heating_system.fan_watts_isdefaulted)
   end
 
-  def _test_default_portable_heater_values(hpxml, fan_watts)
+  def _test_default_portable_heater_values(hpxml, isdefaulted, fan_watts)
     heating_system = hpxml.heating_systems[0]
+
     assert_equal(fan_watts, heating_system.fan_watts)
+    assert_equal(isdefaulted, heating_system.fan_watts_isdefaulted)
   end
 
-  def _test_default_fixed_heater_values(hpxml, fan_watts)
+  def _test_default_fixed_heater_values(hpxml, isdefaulted, fan_watts)
     heating_system = hpxml.heating_systems[0]
+
     assert_equal(fan_watts, heating_system.fan_watts)
+    assert_equal(isdefaulted, heating_system.fan_watts_isdefaulted)
   end
 
-  def _test_default_fireplace_values(hpxml, fan_watts)
+  def _test_default_fireplace_values(hpxml, isdefaulted, fan_watts)
     heating_system = hpxml.heating_systems[0]
+
     assert_equal(fan_watts, heating_system.fan_watts)
+    assert_equal(isdefaulted, heating_system.fan_watts_isdefaulted)
   end
 
-  def _test_default_boiler_values(hpxml, eae)
+  def _test_default_boiler_values(hpxml, isdefaulted, eae)
     heating_system = hpxml.heating_systems[0]
+
     assert_equal(eae, heating_system.electric_auxiliary_energy)
+    assert_equal(isdefaulted, heating_system.electric_auxiliary_energy_isdefaulted)
   end
 
-  def _test_default_air_to_air_heat_pump_values(hpxml, shr, compressor_type, fan_watts_per_cfm)
+  def _test_default_air_to_air_heat_pump_values(hpxml, isdefaulted, shr, compressor_type, fan_watts_per_cfm)
     heat_pump = hpxml.heat_pumps[0]
+
     assert_equal(shr, heat_pump.cooling_shr)
+    assert_equal(isdefaulted, heat_pump.cooling_shr_isdefaulted)
+
     assert_equal(compressor_type, heat_pump.compressor_type)
+    assert_equal(isdefaulted, heat_pump.compressor_type_isdefaulted)
+
     assert_equal(fan_watts_per_cfm, heat_pump.fan_watts_per_cfm)
+    assert_equal(isdefaulted, heat_pump.fan_watts_per_cfm_isdefaulted)
   end
 
-  def _test_default_mini_split_heat_pump_values(hpxml, shr, fan_watts_per_cfm)
+  def _test_default_mini_split_heat_pump_values(hpxml, isdefaulted, shr, fan_watts_per_cfm)
     heat_pump = hpxml.heat_pumps[0]
+
     assert_equal(shr, heat_pump.cooling_shr)
+    assert_equal(isdefaulted, heat_pump.cooling_shr_isdefaulted)
+
     assert_equal(fan_watts_per_cfm, heat_pump.fan_watts_per_cfm)
+    assert_equal(isdefaulted, heat_pump.fan_watts_per_cfm_isdefaulted)
   end
 
-  def _test_default_ground_to_air_heat_pump_values(hpxml, pump_watts_per_ton, fan_watts_per_cfm)
+  def _test_default_ground_to_air_heat_pump_values(hpxml, isdefaulted, pump_watts_per_ton, fan_watts_per_cfm)
     heat_pump = hpxml.heat_pumps[0]
+
     assert_equal(pump_watts_per_ton, heat_pump.pump_watts_per_ton)
+    assert_equal(isdefaulted, heat_pump.pump_watts_per_ton_isdefaulted)
+
     assert_equal(fan_watts_per_cfm, heat_pump.fan_watts_per_cfm)
+    assert_equal(isdefaulted, heat_pump.fan_watts_per_cfm_isdefaulted)
   end
 
-  def _test_default_hvac_control_values(hpxml, htg_setback_start_hr, clg_setup_start_hr)
+  def _test_default_hvac_control_values(hpxml, isdefaulted, htg_setback_start_hr, clg_setup_start_hr)
     hvac_control = hpxml.hvac_controls[0]
+
     assert_equal(htg_setback_start_hr, hvac_control.heating_setback_start_hour)
+    assert_equal(isdefaulted, hvac_control.heating_setback_start_hour_isdefaulted)
+
     assert_equal(clg_setup_start_hr, hvac_control.cooling_setup_start_hour)
+    assert_equal(isdefaulted, hvac_control.cooling_setup_start_hour_isdefaulted)
   end
 
-  def _test_default_duct_values(hpxml, supply_locations, return_locations, supply_areas, return_areas, n_return_registers)
+  def _test_default_duct_values(hpxml, isdefaulted, supply_locations, return_locations, supply_areas, return_areas, n_return_registers)
     supply_duct_idx = 0
     return_duct_idx = 0
     hpxml.hvac_distributions.each do |hvac_distribution|
       next unless [HPXML::HVACDistributionTypeAir, HPXML::HVACDistributionTypeHydronicAndAir].include? hvac_distribution.distribution_system_type
 
       assert_equal(n_return_registers, hvac_distribution.number_of_return_registers)
+      assert_equal(isdefaulted, hvac_distribution.number_of_return_registers_isdefaulted)
+
       hvac_distribution.ducts.each do |duct|
         if duct.duct_type == HPXML::DuctTypeSupply
           assert_equal(supply_locations[supply_duct_idx], duct.duct_location)
+          assert_equal(isdefaulted, duct.duct_location_isdefaulted)
+
           assert_in_epsilon(supply_areas[supply_duct_idx], duct.duct_surface_area, 0.01)
+          assert_equal(isdefaulted, duct.duct_surface_area_isdefaulted)
+
           supply_duct_idx += 1
         elsif duct.duct_type == HPXML::DuctTypeReturn
           assert_equal(return_locations[return_duct_idx], duct.duct_location)
+          assert_equal(isdefaulted, duct.duct_location_isdefaulted)
+
           assert_in_epsilon(return_areas[return_duct_idx], duct.duct_surface_area, 0.01)
+          assert_equal(isdefaulted, duct.duct_surface_area_isdefaulted)
+
           return_duct_idx += 1
         end
       end
     end
   end
 
-  def _test_default_pv_system_values(hpxml, interver_efficiency, system_loss_frac, is_shared_system, location, tracking, module_type)
-    assert_equal(interver_efficiency.size, hpxml.pv_systems.size)
+  def _test_default_mech_vent_values(hpxml, isdefaulted, is_shared_system, hours_in_operation)
+    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+
+    assert_equal(is_shared_system, vent_fan.is_shared_system)
+    assert_equal(isdefaulted, vent_fan.is_shared_system_isdefaulted)
+
+    assert_equal(hours_in_operation, vent_fan.hours_in_operation)
+    assert_equal(isdefaulted, vent_fan.hours_in_operation_isdefaulted)
+  end
+
+  def _test_default_kitchen_fan_values(hpxml, isdefaulted, quantity, rated_flow_rate, hours_in_operation, fan_power, start_hour)
+    kitchen_fan = hpxml.ventilation_fans.select { |f| f.used_for_local_ventilation && f.fan_location == HPXML::LocationKitchen }[0]
+
+    assert_equal(quantity, kitchen_fan.quantity)
+    assert_equal(isdefaulted, kitchen_fan.quantity_isdefaulted)
+
+    assert_equal(rated_flow_rate, kitchen_fan.rated_flow_rate)
+    assert_equal(isdefaulted, kitchen_fan.rated_flow_rate_isdefaulted)
+
+    assert_equal(hours_in_operation, kitchen_fan.hours_in_operation)
+    assert_equal(isdefaulted, kitchen_fan.hours_in_operation_isdefaulted)
+
+    assert_equal(fan_power, kitchen_fan.fan_power)
+    assert_equal(isdefaulted, kitchen_fan.fan_power_isdefaulted)
+
+    assert_equal(start_hour, kitchen_fan.start_hour)
+    assert_equal(isdefaulted, kitchen_fan.start_hour_isdefaulted)
+  end
+
+  def _test_default_bath_fan_values(hpxml, isdefaulted, quantity, rated_flow_rate, hours_in_operation, fan_power, start_hour)
+    bath_fan = hpxml.ventilation_fans.select { |f| f.used_for_local_ventilation && f.fan_location == HPXML::LocationBath }[0]
+
+    assert_equal(quantity, bath_fan.quantity)
+    assert_equal(isdefaulted, bath_fan.quantity_isdefaulted)
+
+    assert_equal(rated_flow_rate, bath_fan.rated_flow_rate)
+    assert_equal(isdefaulted, bath_fan.rated_flow_rate_isdefaulted)
+
+    assert_equal(hours_in_operation, bath_fan.hours_in_operation)
+    assert_equal(isdefaulted, bath_fan.hours_in_operation_isdefaulted)
+
+    assert_equal(fan_power, bath_fan.fan_power)
+    assert_equal(isdefaulted, bath_fan.fan_power_isdefaulted)
+
+    assert_equal(start_hour, bath_fan.start_hour)
+    assert_equal(isdefaulted, bath_fan.start_hour_isdefaulted)
+  end
+
+  def _test_default_storage_water_heater_values(hpxml, isdefaulted, *expected_wh_values)
+    storage_water_heaters = hpxml.water_heating_systems.select { |w| w.water_heater_type == HPXML::WaterHeaterTypeStorage }
+    assert_equal(expected_wh_values.size, storage_water_heaters.size)
+    storage_water_heaters.each_with_index do |wh_system, idx|
+      is_shared, heating_capacity, tank_volume, recovery_efficiency, location = expected_wh_values[idx]
+
+      assert_equal(is_shared, wh_system.is_shared_system)
+      assert_equal(isdefaulted, wh_system.is_shared_system_isdefaulted)
+
+      assert_in_epsilon(heating_capacity, wh_system.heating_capacity, 0.01)
+      assert_equal(isdefaulted, wh_system.heating_capacity_isdefaulted)
+
+      assert_equal(tank_volume, wh_system.tank_volume)
+      assert_equal(isdefaulted, wh_system.tank_volume_isdefaulted)
+
+      assert_in_epsilon(recovery_efficiency, wh_system.recovery_efficiency, 0.01)
+      assert_equal(isdefaulted, wh_system.recovery_efficiency_isdefaulted)
+
+      assert_equal(location, wh_system.location)
+      assert_equal(isdefaulted, wh_system.location_isdefaulted)
+    end
+  end
+
+  def _test_default_tankless_water_heater_values(hpxml, isdefaulted, *expected_wh_values)
+    tankless_water_heaters = hpxml.water_heating_systems.select { |w| w.water_heater_type == HPXML::WaterHeaterTypeTankless }
+    assert_equal(expected_wh_values.size, tankless_water_heaters.size)
+    tankless_water_heaters.each_with_index do |wh_system, idx|
+      performance_adjustment, = expected_wh_values[idx]
+
+      assert_equal(performance_adjustment, wh_system.performance_adjustment)
+      assert_equal(isdefaulted, wh_system.performance_adjustment_isdefaulted)
+    end
+  end
+
+  def _test_default_standard_distribution_values(hpxml, isdefaulted, piping_length)
+    hot_water_distribution = hpxml.hot_water_distributions[0]
+
+    assert_in_epsilon(piping_length, hot_water_distribution.standard_piping_length, 0.01)
+    assert_equal(isdefaulted, hot_water_distribution.standard_piping_length_isdefaulted)
+  end
+
+  def _test_default_recirc_distribution_values(hpxml, isdefaulted, piping_length, branch_piping_length, pump_power)
+    hot_water_distribution = hpxml.hot_water_distributions[0]
+
+    assert_in_epsilon(piping_length, hot_water_distribution.recirculation_piping_length, 0.01)
+    assert_equal(isdefaulted, hot_water_distribution.recirculation_piping_length_isdefaulted)
+
+    assert_in_epsilon(branch_piping_length, hot_water_distribution.recirculation_branch_piping_length, 0.01)
+    assert_equal(isdefaulted, hot_water_distribution.recirculation_branch_piping_length_isdefaulted)
+
+    assert_in_epsilon(pump_power, hot_water_distribution.recirculation_pump_power, 0.01)
+    assert_equal(isdefaulted, hot_water_distribution.recirculation_pump_power_isdefaulted)
+  end
+
+  def _test_default_shared_recirc_distribution_values(hpxml, isdefaulted, pump_power)
+    hot_water_distribution = hpxml.hot_water_distributions[0]
+
+    assert_in_epsilon(pump_power, hot_water_distribution.shared_recirculation_pump_power, 0.01)
+    assert_equal(isdefaulted, hot_water_distribution.shared_recirculation_pump_power_isdefaulted)
+  end
+
+  def _test_default_water_fixture_values(hpxml, isdefaulted, usage_multiplier)
+    assert_equal(usage_multiplier, hpxml.water_heating.water_fixtures_usage_multiplier)
+    assert_equal(isdefaulted, hpxml.water_heating.water_fixtures_usage_multiplier_isdefaulted)
+  end
+
+  def _test_default_solar_thermal_values(hpxml, isdefaulted, storage_volume)
+    solar_thermal_system = hpxml.solar_thermal_systems[0]
+
+    assert_equal(storage_volume, solar_thermal_system.storage_volume)
+    assert_equal(isdefaulted, solar_thermal_system.storage_volume_isdefaulted)
+  end
+
+  def _test_default_pv_system_values(hpxml, isdefaulted, interver_efficiency, system_loss_frac, is_shared_system, location, tracking, module_type)
     hpxml.pv_systems.each_with_index do |pv, idx|
       assert_equal(is_shared_system, pv.is_shared_system)
-      assert_equal(interver_efficiency[idx], pv.inverter_efficiency)
-      assert_in_epsilon(system_loss_frac[idx], pv.system_losses_fraction, 0.01)
+      assert_equal(isdefaulted, pv.is_shared_system_isdefaulted)
+
+      assert_equal(interver_efficiency, pv.inverter_efficiency)
+      assert_equal(isdefaulted, pv.inverter_efficiency_isdefaulted)
+
+      assert_in_epsilon(system_loss_frac, pv.system_losses_fraction, 0.01)
+      assert_equal(isdefaulted, pv.system_losses_fraction_isdefaulted)
+
       assert_equal(location, pv.location)
+      assert_equal(isdefaulted, pv.location_isdefaulted)
+
       assert_equal(tracking, pv.tracking)
+      assert_equal(isdefaulted, pv.tracking_isdefaulted)
+
       assert_equal(module_type, pv.module_type)
+      assert_equal(isdefaulted, pv.module_type_isdefaulted)
     end
   end
 
-  def _test_default_building_construction_values(hpxml, building_volume, has_flue_or_chimney, n_bathrooms)
-    assert_equal(building_volume, hpxml.building_construction.conditioned_building_volume)
-    assert_equal(has_flue_or_chimney, hpxml.building_construction.has_flue_or_chimney)
-    assert_equal(n_bathrooms, hpxml.building_construction.number_of_bathrooms)
-  end
-
-  def _test_default_attic_values(hpxml, sla)
-    attic = hpxml.attics[0]
-    assert_equal(sla, attic.vented_attic_sla)
-  end
-
-  def _test_default_foundation_values(hpxml, sla)
-    foundation = hpxml.foundations[0]
-    assert_equal(sla, foundation.vented_crawlspace_sla)
-  end
-
-  def _test_default_infiltration_values(hpxml, volume)
-    air_infiltration_measurement = hpxml.air_infiltration_measurements[0]
-    assert_equal(volume, air_infiltration_measurement.infiltration_volume)
-  end
-
-  def _test_default_roof_values(hpxml, roof_type, solar_absorptance, roof_color, emittance, radiant_barrier)
-    roof = hpxml.roofs[0]
-    assert_equal(roof_type, roof.roof_type)
-    assert_equal(solar_absorptance, roof.solar_absorptance)
-    assert_equal(roof_color, roof.roof_color)
-    assert_equal(emittance, roof.emittance)
-    assert_equal(radiant_barrier, roof.radiant_barrier)
-  end
-
-  def _test_default_wall_values(hpxml, siding, solar_absorptance, color, emittance)
-    wall = hpxml.walls[0]
-    assert_equal(siding, wall.siding)
-    assert_equal(solar_absorptance, wall.solar_absorptance)
-    assert_equal(color, wall.color)
-    assert_equal(emittance, wall.emittance)
-  end
-
-  def _test_default_rim_joist_values(hpxml, siding, solar_absorptance, color, emittance)
-    rim_joist = hpxml.rim_joists[0]
-    assert_equal(siding, rim_joist.siding)
-    assert_equal(solar_absorptance, rim_joist.solar_absorptance)
-    assert_equal(color, rim_joist.color)
-    assert_equal(emittance, rim_joist.emittance)
-  end
-
-  def _test_default_foundation_wall_values(hpxml, thickness)
-    foundation_wall = hpxml.foundation_walls[0]
-    assert_equal(thickness, foundation_wall.thickness)
-  end
-
-  def _test_default_slab_values(hpxml, thickness, carpet_r_value, carpet_fraction)
-    slab = hpxml.slabs[0]
-    assert_equal(thickness, slab.thickness)
-    assert_equal(carpet_r_value, slab.carpet_r_value)
-    assert_equal(carpet_fraction, slab.carpet_fraction)
-  end
-
-  def _test_default_window_values(hpxml, summer_shade_coeffs, winter_shade_coeffs, fraction_operable)
-    assert_equal(summer_shade_coeffs.size, hpxml.windows.size)
-    hpxml.windows.each_with_index do |window, idx|
-      assert_equal(summer_shade_coeffs[idx], window.interior_shading_factor_summer)
-      assert_equal(winter_shade_coeffs[idx], window.interior_shading_factor_winter)
-      assert_equal(fraction_operable[idx], window.fraction_operable)
-    end
-  end
-
-  def _test_default_skylight_values(hpxml, summer_shade_coeffs, winter_shade_coeffs)
-    assert_equal(summer_shade_coeffs.size, hpxml.skylights.size)
-    hpxml.skylights.each_with_index do |skylight, idx|
-      assert_equal(summer_shade_coeffs[idx], skylight.interior_shading_factor_summer)
-      assert_equal(winter_shade_coeffs[idx], skylight.interior_shading_factor_winter)
-    end
-  end
-
-  def _test_default_clothes_washer_values(hpxml, is_shared, location, imef, rated_annual_kwh, label_electric_rate, label_gas_rate, label_annual_gas_cost, capacity, label_usage, usage_multiplier)
+  def _test_default_clothes_washer_values(hpxml, isdefaulted, is_shared, location, imef, rated_annual_kwh, label_electric_rate, label_gas_rate, label_annual_gas_cost, capacity, label_usage, usage_multiplier)
     clothes_washer = hpxml.clothes_washers[0]
+
     assert_equal(is_shared, clothes_washer.is_shared_appliance)
+    assert_equal(isdefaulted, clothes_washer.is_shared_appliance_isdefaulted)
+
     assert_equal(location, clothes_washer.location)
+    assert_equal(isdefaulted, clothes_washer.location_isdefaulted)
+
     assert_equal(imef, clothes_washer.integrated_modified_energy_factor)
+    assert_equal(isdefaulted, clothes_washer.integrated_modified_energy_factor_isdefaulted)
+
     assert_equal(rated_annual_kwh, clothes_washer.rated_annual_kwh)
+    assert_equal(isdefaulted, clothes_washer.rated_annual_kwh_isdefaulted)
+
     assert_equal(label_electric_rate, clothes_washer.label_electric_rate)
+    assert_equal(isdefaulted, clothes_washer.label_electric_rate_isdefaulted)
+
     assert_equal(label_gas_rate, clothes_washer.label_gas_rate)
+    assert_equal(isdefaulted, clothes_washer.label_gas_rate_isdefaulted)
+
     assert_equal(label_annual_gas_cost, clothes_washer.label_annual_gas_cost)
+    assert_equal(isdefaulted, clothes_washer.label_annual_gas_cost_isdefaulted)
+
     assert_equal(capacity, clothes_washer.capacity)
+    assert_equal(isdefaulted, clothes_washer.capacity_isdefaulted)
+
     assert_equal(label_usage, clothes_washer.label_usage)
+    assert_equal(isdefaulted, clothes_washer.label_usage_isdefaulted)
+
     assert_equal(usage_multiplier, clothes_washer.usage_multiplier)
+    assert_equal(isdefaulted, clothes_washer.usage_multiplier_isdefaulted)
   end
 
-  def _test_default_clothes_dryer_values(hpxml, is_shared, location, control_type, cef, usage_multiplier)
+  def _test_default_clothes_dryer_values(hpxml, isdefaulted, is_shared, location, control_type, cef, usage_multiplier)
     clothes_dryer = hpxml.clothes_dryers[0]
+
     assert_equal(is_shared, clothes_dryer.is_shared_appliance)
+    assert_equal(isdefaulted, clothes_dryer.is_shared_appliance_isdefaulted)
+
     assert_equal(location, clothes_dryer.location)
+    assert_equal(isdefaulted, clothes_dryer.location_isdefaulted)
+
     assert_equal(control_type, clothes_dryer.control_type)
+    assert_equal(isdefaulted, clothes_dryer.control_type_isdefaulted)
+
     assert_equal(cef, clothes_dryer.combined_energy_factor)
+    assert_equal(isdefaulted, clothes_dryer.combined_energy_factor_isdefaulted)
+
     assert_equal(usage_multiplier, clothes_dryer.usage_multiplier)
+    assert_equal(isdefaulted, clothes_dryer.usage_multiplier_isdefaulted)
   end
 
-  def _test_default_dishwasher_values(hpxml, is_shared, location, rated_annual_kwh, label_electric_rate, label_gas_rate, label_annual_gas_cost, label_usage, place_setting_capacity, usage_multiplier)
+  def _test_default_clothes_dryer_exhaust_values(hpxml, isdefaulted, is_vented, vented_flow_rate)
+    clothes_dryer = hpxml.clothes_dryers[0]
+
+    assert_equal(is_vented, clothes_dryer.is_vented)
+    assert_equal(isdefaulted, clothes_dryer.is_vented_isdefaulted)
+
+    if vented_flow_rate.nil?
+      assert_nil(clothes_dryer.vented_flow_rate)
+    else
+      assert_equal(vented_flow_rate, clothes_dryer.vented_flow_rate)
+      assert_equal(isdefaulted, clothes_dryer.vented_flow_rate_isdefaulted)
+    end
+  end
+
+  def _test_default_dishwasher_values(hpxml, isdefaulted, is_shared, location, rated_annual_kwh, label_electric_rate, label_gas_rate, label_annual_gas_cost, label_usage, place_setting_capacity, usage_multiplier)
     dishwasher = hpxml.dishwashers[0]
+
     assert_equal(is_shared, dishwasher.is_shared_appliance)
+    assert_equal(isdefaulted, dishwasher.is_shared_appliance_isdefaulted)
+
     assert_equal(location, dishwasher.location)
+    assert_equal(isdefaulted, dishwasher.location_isdefaulted)
+
     assert_equal(rated_annual_kwh, dishwasher.rated_annual_kwh)
+    assert_equal(isdefaulted, dishwasher.rated_annual_kwh_isdefaulted)
+
     assert_equal(label_electric_rate, dishwasher.label_electric_rate)
+    assert_equal(isdefaulted, dishwasher.label_electric_rate_isdefaulted)
+
     assert_equal(label_gas_rate, dishwasher.label_gas_rate)
+    assert_equal(isdefaulted, dishwasher.label_gas_rate_isdefaulted)
+
     assert_equal(label_annual_gas_cost, dishwasher.label_annual_gas_cost)
+    assert_equal(isdefaulted, dishwasher.label_annual_gas_cost_isdefaulted)
+
     assert_equal(label_usage, dishwasher.label_usage)
+    assert_equal(isdefaulted, dishwasher.label_usage_isdefaulted)
+
     assert_equal(place_setting_capacity, dishwasher.place_setting_capacity)
+    assert_equal(isdefaulted, dishwasher.place_setting_capacity_isdefaulted)
+
     assert_equal(usage_multiplier, dishwasher.usage_multiplier)
+    assert_equal(isdefaulted, dishwasher.usage_multiplier_isdefaulted)
   end
 
-  def _test_default_refrigerator_values(hpxml, location, rated_annual_kwh, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_refrigerator_values(hpxml, isdefaulted, location, rated_annual_kwh, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     hpxml.refrigerators.each do |refrigerator|
       next unless refrigerator.primary_indicator
 
       assert_equal(location, refrigerator.location)
+      assert_equal(isdefaulted, refrigerator.location_isdefaulted)
+
       assert_equal(rated_annual_kwh, refrigerator.rated_annual_kwh)
+      assert_equal(isdefaulted, refrigerator.rated_annual_kwh_isdefaulted)
+
       assert_equal(usage_multiplier, refrigerator.usage_multiplier)
+      assert_equal(isdefaulted, refrigerator.usage_multiplier_isdefaulted)
+
       if weekday_sch.nil?
         assert_nil(refrigerator.weekday_fractions)
       else
         assert_equal(weekday_sch, refrigerator.weekday_fractions)
+        assert_equal(isdefaulted, refrigerator.weekday_fractions_isdefaulted)
       end
+
       if weekend_sch.nil?
         assert_nil(refrigerator.weekend_fractions)
       else
         assert_equal(weekend_sch, refrigerator.weekend_fractions)
+        assert_equal(isdefaulted, refrigerator.weekend_fractions_isdefaulted)
       end
+
       if monthly_mults.nil?
         assert_nil(refrigerator.monthly_multipliers)
       else
         assert_equal(monthly_mults, refrigerator.monthly_multipliers)
+        assert_equal(isdefaulted, refrigerator.monthly_multipliers_isdefaulted)
       end
     end
   end
 
-  def _test_default_extra_refrigerators_values(hpxml, location, rated_annual_kwh, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_extra_refrigerators_values(hpxml, isdefaulted, location, rated_annual_kwh, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     hpxml.refrigerators.each do |refrigerator|
       next if refrigerator.primary_indicator
 
       assert_equal(location, refrigerator.location)
+      assert_equal(isdefaulted, refrigerator.location_isdefaulted)
+
       assert_in_epsilon(rated_annual_kwh, refrigerator.rated_annual_kwh, 0.01)
+      assert_equal(isdefaulted, refrigerator.rated_annual_kwh_isdefaulted)
+
       assert_equal(usage_multiplier, refrigerator.usage_multiplier)
+      assert_equal(isdefaulted, refrigerator.usage_multiplier_isdefaulted)
+
       if weekday_sch.nil?
         assert_nil(refrigerator.weekday_fractions)
       else
         assert_equal(weekday_sch, refrigerator.weekday_fractions)
+        assert_equal(isdefaulted, refrigerator.weekday_fractions_isdefaulted)
       end
+
       if weekend_sch.nil?
         assert_nil(refrigerator.weekend_fractions)
       else
         assert_equal(weekend_sch, refrigerator.weekend_fractions)
+        assert_equal(isdefaulted, refrigerator.weekend_fractions_isdefaulted)
       end
+
       if monthly_mults.nil?
         assert_nil(refrigerator.monthly_multipliers)
       else
         assert_equal(monthly_mults, refrigerator.monthly_multipliers)
+        assert_equal(isdefaulted, refrigerator.monthly_multipliers_isdefaulted)
       end
     end
   end
 
-  def _test_default_freezers_values(hpxml, location, rated_annual_kwh, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_freezers_values(hpxml, isdefaulted, location, rated_annual_kwh, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     hpxml.freezers.each do |freezer|
       assert_equal(location, freezer.location)
+      assert_equal(isdefaulted, freezer.location_isdefaulted)
+
       assert_in_epsilon(rated_annual_kwh, freezer.rated_annual_kwh, 0.01)
+      assert_equal(isdefaulted, freezer.rated_annual_kwh_isdefaulted)
+
       assert_equal(usage_multiplier, freezer.usage_multiplier)
+      assert_equal(isdefaulted, freezer.usage_multiplier_isdefaulted)
+
       if weekday_sch.nil?
         assert_nil(freezer.weekday_fractions)
       else
         assert_equal(weekday_sch, freezer.weekday_fractions)
+        assert_equal(isdefaulted, freezer.weekday_fractions_isdefaulted)
       end
+
       if weekend_sch.nil?
         assert_nil(freezer.weekend_fractions)
       else
         assert_equal(weekend_sch, freezer.weekend_fractions)
+        assert_equal(isdefaulted, freezer.weekend_fractions_isdefaulted)
       end
+
       if monthly_mults.nil?
         assert_nil(freezer.monthly_multipliers)
       else
         assert_equal(monthly_mults, freezer.monthly_multipliers)
+        assert_equal(isdefaulted, freezer.monthly_multipliers_isdefaulted)
       end
     end
   end
 
-  def _test_default_cooking_range_values(hpxml, location, is_induction, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_cooking_range_values(hpxml, isdefaulted, location, is_induction, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     cooking_range = hpxml.cooking_ranges[0]
+
     assert_equal(location, cooking_range.location)
+    assert_equal(isdefaulted, cooking_range.location_isdefaulted)
+
     assert_equal(is_induction, cooking_range.is_induction)
+    assert_equal(isdefaulted, cooking_range.is_induction_isdefaulted)
+
     assert_equal(usage_multiplier, cooking_range.usage_multiplier)
+    assert_equal(isdefaulted, cooking_range.usage_multiplier_isdefaulted)
+
     if weekday_sch.nil?
       assert_nil(cooking_range.weekday_fractions)
     else
       assert_equal(weekday_sch, cooking_range.weekday_fractions)
+      assert_equal(isdefaulted, cooking_range.weekday_fractions_isdefaulted)
     end
+
     if weekend_sch.nil?
       assert_nil(cooking_range.weekend_fractions)
     else
       assert_equal(weekend_sch, cooking_range.weekend_fractions)
+      assert_equal(isdefaulted, cooking_range.weekend_fractions_isdefaulted)
     end
+
     if monthly_mults.nil?
       assert_nil(cooking_range.monthly_multipliers)
     else
       assert_equal(monthly_mults, cooking_range.monthly_multipliers)
+      assert_equal(isdefaulted, cooking_range.monthly_multipliers_isdefaulted)
     end
   end
 
-  def _test_default_oven_values(hpxml, is_convection)
+  def _test_default_oven_values(hpxml, isdefaulted, is_convection)
     oven = hpxml.ovens[0]
+
     assert_equal(is_convection, oven.is_convection)
+    assert_equal(isdefaulted, oven.is_convection_isdefaulted)
   end
 
-  def _test_default_lighting_values(hpxml, interior_usage_multiplier, garage_usage_multiplier, exterior_usage_multiplier, schedules = {})
+  def _test_default_lighting_values(hpxml, isdefaulted, interior_usage_multiplier, garage_usage_multiplier, exterior_usage_multiplier, schedules = {})
     assert_equal(interior_usage_multiplier, hpxml.lighting.interior_usage_multiplier)
+    assert_equal(isdefaulted, hpxml.lighting.interior_usage_multiplier_isdefaulted)
+
     assert_equal(garage_usage_multiplier, hpxml.lighting.garage_usage_multiplier)
+    assert_equal(isdefaulted, hpxml.lighting.garage_usage_multiplier_isdefaulted)
+
     assert_equal(exterior_usage_multiplier, hpxml.lighting.exterior_usage_multiplier)
+    assert_equal(isdefaulted, hpxml.lighting.exterior_usage_multiplier_isdefaulted)
+
     if not schedules[:grg_wk_sch].nil?
       assert_equal(schedules[:grg_wk_sch], hpxml.lighting.garage_weekday_fractions)
+      assert_equal(isdefaulted, hpxml.lighting.garage_weekday_fractions_isdefaulted)
     else
       assert_nil(hpxml.lighting.garage_weekday_fractions)
     end
+
     if not schedules[:grg_wknd_sch].nil?
       assert_equal(schedules[:grg_wknd_sch], hpxml.lighting.garage_weekend_fractions)
+      assert_equal(isdefaulted, hpxml.lighting.garage_weekend_fractions_isdefaulted)
     else
       assert_nil(hpxml.lighting.garage_weekend_fractions)
     end
+
     if not schedules[:grg_month_mult].nil?
       assert_equal(schedules[:grg_month_mult], hpxml.lighting.garage_monthly_multipliers)
+      assert_equal(isdefaulted, hpxml.lighting.garage_monthly_multipliers_isdefaulted)
     else
       assert_nil(hpxml.lighting.garage_monthly_multipliers)
     end
+
     if not schedules[:ext_wk_sch].nil?
       assert_equal(schedules[:ext_wk_sch], hpxml.lighting.exterior_weekday_fractions)
+      assert_equal(isdefaulted, hpxml.lighting.exterior_weekday_fractions_isdefaulted)
     else
       assert_nil(hpxml.lighting.exterior_weekday_fractions)
     end
+
     if not schedules[:ext_wknd_sch].nil?
       assert_equal(schedules[:ext_wknd_sch], hpxml.lighting.exterior_weekend_fractions)
+      assert_equal(isdefaulted, hpxml.lighting.exterior_weekend_fractions_isdefaulted)
     else
       assert_nil(hpxml.lighting.exterior_weekday_fractions)
     end
+
     if not schedules[:ext_month_mult].nil?
       assert_equal(schedules[:ext_month_mult], hpxml.lighting.exterior_monthly_multipliers)
+      assert_equal(isdefaulted, hpxml.lighting.exterior_monthly_multipliers_isdefaulted)
     else
       assert_nil(hpxml.lighting.exterior_monthly_multipliers)
     end
+
     if not schedules[:hol_kwh_per_day].nil?
       assert_equal(schedules[:hol_kwh_per_day], hpxml.lighting.holiday_kwh_per_day)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_kwh_per_day_isdefaulted)
     else
       assert_nil(hpxml.lighting.holiday_kwh_per_day)
     end
+
     if not schedules[:hol_begin_month].nil?
       assert_equal(schedules[:hol_begin_month], hpxml.lighting.holiday_period_begin_month)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_period_begin_month_isdefaulted)
     else
       assert_nil(hpxml.lighting.holiday_period_begin_month)
     end
+
     if not schedules[:hol_begin_day_of_month].nil?
       assert_equal(schedules[:hol_begin_day_of_month], hpxml.lighting.holiday_period_begin_day_of_month)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_period_begin_day_of_month_isdefaulted)
     else
       assert_nil(hpxml.lighting.holiday_period_begin_day_of_month)
     end
+
     if not schedules[:hol_end_month].nil?
       assert_equal(schedules[:hol_end_month], hpxml.lighting.holiday_period_end_month)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_period_end_month_isdefaulted)
     else
       assert_nil(hpxml.lighting.holiday_period_end_month)
     end
+
     if not schedules[:hol_end_day_of_month].nil?
       assert_equal(schedules[:hol_end_day_of_month], hpxml.lighting.holiday_period_end_day_of_month)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_period_end_day_of_month_isdefaulted)
     else
       assert_nil(hpxml.lighting.holiday_period_end_day_of_month)
     end
+
     if not schedules[:hol_wk_sch].nil?
       assert_equal(schedules[:hol_wk_sch], hpxml.lighting.holiday_weekday_fractions)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_weekday_fractions_isdefaulted)
     else
       assert_nil(hpxml.lighting.holiday_weekday_fractions)
     end
+
     if not schedules[:hol_wknd_sch].nil?
       assert_equal(schedules[:hol_wknd_sch], hpxml.lighting.holiday_weekend_fractions)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_weekend_fractions_isdefaulted)
     else
       assert_nil(hpxml.lighting.holiday_weekend_fractions)
     end
   end
 
-  def _test_default_standard_distribution_values(hpxml, piping_length)
-    hot_water_distribution = hpxml.hot_water_distributions[0]
-    assert_in_epsilon(piping_length, hot_water_distribution.standard_piping_length, 0.01)
+  def _test_default_ceiling_fan_values(hpxml, isdefaulted, quantity, efficiency)
+    ceiling_fan = hpxml.ceiling_fans[0]
+
+    assert_equal(quantity, ceiling_fan.quantity)
+    assert_equal(isdefaulted, ceiling_fan.quantity_isdefaulted)
+
+    assert_in_epsilon(efficiency, ceiling_fan.efficiency, 0.01)
+    assert_equal(isdefaulted, ceiling_fan.efficiency_isdefaulted)
   end
 
-  def _test_default_recirc_distribution_values(hpxml, piping_length, branch_piping_length, pump_power)
-    hot_water_distribution = hpxml.hot_water_distributions[0]
-    assert_in_epsilon(piping_length, hot_water_distribution.recirculation_piping_length, 0.01)
-    assert_in_epsilon(branch_piping_length, hot_water_distribution.recirculation_branch_piping_length, 0.01)
-    assert_in_epsilon(pump_power, hot_water_distribution.recirculation_pump_power, 0.01)
-  end
-
-  def _test_default_shared_recirc_distribution_values(hpxml, pump_power)
-    hot_water_distribution = hpxml.hot_water_distributions[0]
-    assert_in_epsilon(pump_power, hot_water_distribution.shared_recirculation_pump_power, 0.01)
-  end
-
-  def _test_default_water_fixture_values(hpxml, usage_multiplier)
-    assert_equal(usage_multiplier, hpxml.water_heating.water_fixtures_usage_multiplier)
-  end
-
-  def _test_default_solar_thermal_values(hpxml, storage_volume)
-    assert_in_epsilon(storage_volume, hpxml.solar_thermal_systems[0].storage_volume)
-  end
-
-  def _test_default_mech_vent_values(hpxml, is_shared_system, hours_in_operation)
-    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
-    assert_equal(is_shared_system, vent_fan.is_shared_system)
-    assert_equal(hours_in_operation, vent_fan.hours_in_operation)
-  end
-
-  def _test_default_kitchen_fan_values(hpxml, quantity, rated_flow_rate, hours_in_operation, fan_power, start_hour)
-    kitchen_fan = hpxml.ventilation_fans.select { |f| f.used_for_local_ventilation && f.fan_location == HPXML::LocationKitchen }[0]
-    assert_equal(quantity, kitchen_fan.quantity)
-    assert_equal(rated_flow_rate, kitchen_fan.rated_flow_rate)
-    assert_equal(hours_in_operation, kitchen_fan.hours_in_operation)
-    assert_equal(fan_power, kitchen_fan.fan_power)
-    assert_equal(start_hour, kitchen_fan.start_hour)
-  end
-
-  def _test_default_bath_fan_values(hpxml, quantity, rated_flow_rate, hours_in_operation, fan_power, start_hour)
-    bath_fan = hpxml.ventilation_fans.select { |f| f.used_for_local_ventilation && f.fan_location == HPXML::LocationBath }[0]
-    assert_equal(quantity, bath_fan.quantity)
-    assert_equal(rated_flow_rate, bath_fan.rated_flow_rate)
-    assert_equal(hours_in_operation, bath_fan.hours_in_operation)
-    assert_equal(fan_power, bath_fan.fan_power)
-    assert_equal(start_hour, bath_fan.start_hour)
-  end
-
-  def _test_default_clothes_dryer_exhaust_values(hpxml, is_vented, vented_flow_rate)
-    clothes_dryer = hpxml.clothes_dryers[0]
-    assert_equal(is_vented, clothes_dryer.is_vented)
-    if vented_flow_rate.nil?
-      assert_nil(clothes_dryer.vented_flow_rate)
-    else
-      assert_equal(vented_flow_rate, clothes_dryer.vented_flow_rate)
-    end
-  end
-
-  def _test_default_ceiling_fan_values(hpxml, quantity, efficiency)
-    assert_equal(quantity, hpxml.ceiling_fans[0].quantity)
-    assert_in_epsilon(efficiency, hpxml.ceiling_fans[0].efficiency, 0.01)
-  end
-
-  def _test_default_pool_heater_values(hpxml, load_units, load_value, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_pool_heater_values(hpxml, isdefaulted, load_units, load_value, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     pool = hpxml.pools[0]
+
     if load_units.nil?
       assert_nil(pool.heater_load_units)
     else
       assert_equal(load_units, pool.heater_load_units)
     end
+
     if load_value.nil?
       assert_nil(pool.heater_load_value)
     else
-      assert_in_epsilon(load_value, pool.heater_load_value.to_f, 0.01)
+      assert_in_epsilon(load_value, pool.heater_load_value, 0.01)
+      assert_equal(isdefaulted, pool.heater_load_value_isdefaulted)
     end
+
+    if usage_multiplier.nil?
+      assert_nil(pool.heater_usage_multiplier)
+    else
+      assert_equal(usage_multiplier, pool.heater_usage_multiplier)
+      assert_equal(isdefaulted, pool.heater_usage_multiplier_isdefaulted)
+    end
+
     if weekday_sch.nil?
       assert_nil(pool.heater_weekday_fractions)
     else
       assert_equal(weekday_sch, pool.heater_weekday_fractions)
+      assert_equal(isdefaulted, pool.heater_weekday_fractions_isdefaulted)
     end
+
     if weekend_sch.nil?
       assert_nil(pool.heater_weekend_fractions)
     else
       assert_equal(weekend_sch, pool.heater_weekend_fractions)
+      assert_equal(isdefaulted, pool.heater_weekend_fractions_isdefaulted)
     end
+
     if monthly_mults.nil?
       assert_nil(pool.heater_monthly_multipliers)
     else
       assert_equal(monthly_mults, pool.heater_monthly_multipliers)
+      assert_equal(isdefaulted, pool.heater_monthly_multipliers_isdefaulted)
     end
   end
 
-  def _test_default_pool_pump_values(hpxml, kWh_per_year, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_pool_pump_values(hpxml, isdefaulted, kWh_per_year, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     pool = hpxml.pools[0]
+
     assert_in_epsilon(kWh_per_year, pool.pump_kwh_per_year, 0.01)
+    assert_equal(isdefaulted, pool.pump_kwh_per_year_isdefaulted)
+
+    assert_equal(usage_multiplier, pool.pump_usage_multiplier)
+    assert_equal(isdefaulted, pool.pump_usage_multiplier_isdefaulted)
+
     assert_equal(weekday_sch, pool.pump_weekday_fractions)
+    assert_equal(isdefaulted, pool.pump_weekday_fractions_isdefaulted)
+
     assert_equal(weekend_sch, pool.pump_weekend_fractions)
+    assert_equal(isdefaulted, pool.pump_weekend_fractions_isdefaulted)
+
     assert_equal(monthly_mults, pool.pump_monthly_multipliers)
+    assert_equal(isdefaulted, pool.pump_monthly_multipliers_isdefaulted)
   end
 
-  def _test_default_hot_tub_heater_values(hpxml, load_units, load_value, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_hot_tub_heater_values(hpxml, isdefaulted, load_units, load_value, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     hot_tub = hpxml.hot_tubs[0]
+
     if load_units.nil?
       assert_nil(hot_tub.heater_load_units)
     else
       assert_equal(load_units, hot_tub.heater_load_units)
     end
+
     if load_value.nil?
       assert_nil(hot_tub.heater_load_value)
     else
-      assert_in_epsilon(load_value, hot_tub.heater_load_value.to_f, 0.01)
+      assert_in_epsilon(load_value, hot_tub.heater_load_value, 0.01)
+      assert_equal(isdefaulted, hot_tub.heater_load_value_isdefaulted)
     end
+
+    if usage_multiplier.nil?
+      assert_nil(hot_tub.heater_usage_multiplier)
+    else
+      assert_equal(usage_multiplier, hot_tub.heater_usage_multiplier)
+      assert_equal(isdefaulted, hot_tub.heater_usage_multiplier_isdefaulted)
+    end
+
     if weekday_sch.nil?
       assert_nil(hot_tub.heater_weekday_fractions)
     else
       assert_equal(weekday_sch, hot_tub.heater_weekday_fractions)
+      assert_equal(isdefaulted, hot_tub.heater_weekday_fractions_isdefaulted)
     end
+
     if weekend_sch.nil?
       assert_nil(hot_tub.heater_weekend_fractions)
     else
       assert_equal(weekend_sch, hot_tub.heater_weekend_fractions)
+      assert_equal(isdefaulted, hot_tub.heater_weekend_fractions_isdefaulted)
     end
+
     if monthly_mults.nil?
       assert_nil(hot_tub.heater_monthly_multipliers)
     else
       assert_equal(monthly_mults, hot_tub.heater_monthly_multipliers)
+      assert_equal(isdefaulted, hot_tub.heater_monthly_multipliers_isdefaulted)
     end
   end
 
-  def _test_default_hot_tub_pump_values(hpxml, kWh_per_year, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_hot_tub_pump_values(hpxml, isdefaulted, kWh_per_year, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     hot_tub = hpxml.hot_tubs[0]
+
     assert_in_epsilon(kWh_per_year, hot_tub.pump_kwh_per_year, 0.01)
+    assert_equal(isdefaulted, hot_tub.pump_kwh_per_year_isdefaulted)
+
+    assert_equal(usage_multiplier, hot_tub.pump_usage_multiplier)
+    assert_equal(isdefaulted, hot_tub.pump_usage_multiplier_isdefaulted)
+
     assert_equal(weekday_sch, hot_tub.pump_weekday_fractions)
+    assert_equal(isdefaulted, hot_tub.pump_weekday_fractions_isdefaulted)
+
     assert_equal(weekend_sch, hot_tub.pump_weekend_fractions)
+    assert_equal(isdefaulted, hot_tub.pump_weekend_fractions_isdefaulted)
+
     assert_equal(monthly_mults, hot_tub.pump_monthly_multipliers)
+    assert_equal(isdefaulted, hot_tub.pump_monthly_multipliers_isdefaulted)
   end
 
-  def _test_default_plug_load_values(hpxml, load_type, kWh_per_year, frac_sensible, frac_latent, location, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_plug_load_values(hpxml, isdefaulted, load_type, kWh_per_year, frac_sensible, frac_latent, location, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     pl = hpxml.plug_loads.select { |pl| pl.plug_load_type == load_type }[0]
+
     assert_in_epsilon(kWh_per_year, pl.kWh_per_year, 0.01)
+    assert_equal(isdefaulted, pl.kWh_per_year_isdefaulted)
+
+    assert_equal(usage_multiplier, pl.usage_multiplier)
+    assert_equal(isdefaulted, pl.usage_multiplier_isdefaulted)
+
     assert_in_epsilon(frac_sensible, pl.frac_sensible, 0.01)
+    assert_equal(isdefaulted, pl.frac_sensible_isdefaulted)
+
     assert_in_epsilon(frac_latent, pl.frac_latent, 0.01)
+    assert_equal(isdefaulted, pl.frac_latent_isdefaulted)
+
     assert_equal(location, pl.location)
+    assert_equal(isdefaulted, pl.location_isdefaulted)
+
     assert_equal(weekday_sch, pl.weekday_fractions)
+    assert_equal(isdefaulted, pl.weekday_fractions_isdefaulted)
+
     assert_equal(weekend_sch, pl.weekend_fractions)
+    assert_equal(isdefaulted, pl.weekend_fractions_isdefaulted)
+
     assert_equal(monthly_mults, pl.monthly_multipliers)
+    assert_equal(isdefaulted, pl.monthly_multipliers_isdefaulted)
   end
 
-  def _test_default_fuel_load_values(hpxml, load_type, therm_per_year, frac_sensible, frac_latent, location, weekday_sch, weekend_sch, monthly_mults)
+  def _test_default_fuel_load_values(hpxml, isdefaulted, load_type, therm_per_year, frac_sensible, frac_latent, location, usage_multiplier, weekday_sch, weekend_sch, monthly_mults)
     fl = hpxml.fuel_loads.select { |fl| fl.fuel_load_type == load_type }[0]
+
     assert_in_epsilon(therm_per_year, fl.therm_per_year, 0.01)
+    assert_equal(isdefaulted, fl.therm_per_year_isdefaulted)
+
+    assert_equal(usage_multiplier, fl.usage_multiplier)
+    assert_equal(isdefaulted, fl.usage_multiplier_isdefaulted)
+
     assert_in_epsilon(frac_sensible, fl.frac_sensible, 0.01)
+    assert_equal(isdefaulted, fl.frac_sensible_isdefaulted)
+
     assert_in_epsilon(frac_latent, fl.frac_latent, 0.01)
+    assert_equal(isdefaulted, fl.frac_latent_isdefaulted)
+
     assert_equal(location, fl.location)
+    assert_equal(isdefaulted, fl.location_isdefaulted)
+
     assert_equal(weekday_sch, fl.weekday_fractions)
+    assert_equal(isdefaulted, fl.weekday_fractions_isdefaulted)
+
     assert_equal(weekend_sch, fl.weekend_fractions)
+    assert_equal(isdefaulted, fl.weekend_fractions_isdefaulted)
+
     assert_equal(monthly_mults, fl.monthly_multipliers)
-  end
-
-  def _test_default_storage_water_heater_values(hpxml, *expected_wh_values)
-    storage_water_heaters = hpxml.water_heating_systems.select { |w| w.water_heater_type == HPXML::WaterHeaterTypeStorage }
-    assert_equal(expected_wh_values.size, storage_water_heaters.size)
-    storage_water_heaters.each_with_index do |wh_system, idx|
-      is_shared, heating_capacity, tank_volume, recovery_efficiency = expected_wh_values[idx]
-      assert_equal(is_shared, wh_system.is_shared_system)
-      assert_in_epsilon(heating_capacity, wh_system.heating_capacity, 0.01)
-      assert_equal(tank_volume, wh_system.tank_volume)
-      assert_in_epsilon(recovery_efficiency, wh_system.recovery_efficiency, 0.01)
-    end
-  end
-
-  def _test_default_tankless_water_heater_values(hpxml, *expected_wh_values)
-    tankless_water_heaters = hpxml.water_heating_systems.select { |w| w.water_heater_type == HPXML::WaterHeaterTypeTankless }
-    assert_equal(expected_wh_values.size, tankless_water_heaters.size)
-    tankless_water_heaters.each_with_index do |wh_system, idx|
-      performance_adjustment, = expected_wh_values[idx]
-      assert_equal(performance_adjustment, wh_system.performance_adjustment)
-    end
+    assert_equal(isdefaulted, fl.monthly_multipliers_isdefaulted)
   end
 
   def _create_hpxml(hpxml_name)

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -123,19 +123,35 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
   def test_building_construction
     # Test inputs not overridden by defaults
     hpxml = _create_hpxml('base-enclosure-infil-flue.xml')
-    hpxml.building_construction.number_of_bathrooms = 4.0
+    hpxml.building_construction.number_of_bathrooms = 4
+    hpxml.building_construction.conditioned_building_volume = 20000
+    hpxml.building_construction.average_ceiling_height = 7
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_building_construction_values(hpxml_default, false, 21600, true, 4)
+    _test_default_building_construction_values(hpxml_default, false, 20000, 7, true, 4)
 
-    # Test defaults w/ average ceiling height
+    # Test defaults
     hpxml.building_construction.conditioned_building_volume = nil
-    hpxml.building_construction.average_ceiling_height = 10
+    hpxml.building_construction.average_ceiling_height = nil
     hpxml.building_construction.has_flue_or_chimney = nil
     hpxml.building_construction.number_of_bathrooms = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_building_construction_values(hpxml_default, true, 27000, false, 2)
+    _test_default_building_construction_values(hpxml_default, true, 21600, 8, false, 2)
+
+    # Test defaults w/ average ceiling height
+    hpxml.building_construction.conditioned_building_volume = nil
+    hpxml.building_construction.average_ceiling_height = 10
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_building_construction_values(hpxml_default, true, 27000, 10, false, 2)
+
+    # Test defaults w/ average ceiling height
+    hpxml.building_construction.conditioned_building_volume = 27000
+    hpxml.building_construction.average_ceiling_height = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_building_construction_values(hpxml_default, true, 27000, 10, false, 2)
   end
 
   def test_infiltration
@@ -917,16 +933,18 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
   def test_hot_water_distribution
     # Test inputs not overridden by defaults -- standard
     hpxml = _create_hpxml('base.xml')
+    hpxml.hot_water_distributions[0].pipe_r_value = 2.5
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_standard_distribution_values(hpxml_default, false, 50.0)
+    _test_default_standard_distribution_values(hpxml_default, false, 50.0, 2.5)
 
     # Test inputs not overridden by defaults -- recirculation
     hpxml = _create_hpxml('base-dhw-recirc-demand.xml')
     hpxml.hot_water_distributions[0].recirculation_pump_power = 65.0
+    hpxml.hot_water_distributions[0].pipe_r_value = 2.5
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_recirc_distribution_values(hpxml_default, false, 50.0, 50.0, 65.0)
+    _test_default_recirc_distribution_values(hpxml_default, false, 50.0, 50.0, 65.0, 2.5)
 
     # Test inputs not overridden by defaults -- shared recirculation
     hpxml = _create_hpxml('base-dhw-shared-water-heater-recirc.xml')
@@ -938,54 +956,56 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     # Test defaults w/ conditioned basement
     hpxml = _create_hpxml('base.xml')
     hpxml.hot_water_distributions[0].standard_piping_length = nil
+    hpxml.hot_water_distributions[0].pipe_r_value = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_standard_distribution_values(hpxml_default, true, 93.48)
+    _test_default_standard_distribution_values(hpxml_default, true, 93.48, 0.0)
 
     # Test defaults w/ unconditioned basement
     hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
     hpxml.hot_water_distributions[0].standard_piping_length = nil
+    hpxml.hot_water_distributions[0].pipe_r_value = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_standard_distribution_values(hpxml_default, true, 88.48)
+    _test_default_standard_distribution_values(hpxml_default, true, 88.48, 0.0)
 
     # Test defaults w/ 2-story building
     hpxml = _create_hpxml('base-enclosure-2stories.xml')
     hpxml.hot_water_distributions[0].standard_piping_length = nil
+    hpxml.hot_water_distributions[0].pipe_r_value = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_standard_distribution_values(hpxml_default, true, 103.48)
+    _test_default_standard_distribution_values(hpxml_default, true, 103.48, 0.0)
 
     # Test defaults w/ recirculation & conditioned basement
     hpxml = _create_hpxml('base-dhw-recirc-demand.xml')
     hpxml.hot_water_distributions[0].recirculation_piping_length = nil
     hpxml.hot_water_distributions[0].recirculation_branch_piping_length = nil
     hpxml.hot_water_distributions[0].recirculation_pump_power = nil
+    hpxml.hot_water_distributions[0].pipe_r_value = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_recirc_distribution_values(hpxml_default, true, 166.96, 10.0, 50.0)
+    _test_default_recirc_distribution_values(hpxml_default, true, 166.96, 10.0, 50.0, 0.0)
 
     # Test defaults w/ recirculation & unconditioned basement
     hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
     hpxml.hot_water_distributions.clear
     hpxml.hot_water_distributions.add(id: 'HotWaterDistribution',
                                       system_type: HPXML::DHWDistTypeRecirc,
-                                      recirculation_control_type: HPXML::DHWRecirControlTypeSensor,
-                                      pipe_r_value: 3.0)
+                                      recirculation_control_type: HPXML::DHWRecirControlTypeSensor)
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_recirc_distribution_values(hpxml_default, true, 156.96, 10.0, 50.0)
+    _test_default_recirc_distribution_values(hpxml_default, true, 156.96, 10.0, 50.0, 0.0)
 
     # Test defaults w/ recirculation & 2-story building
     hpxml = _create_hpxml('base-enclosure-2stories.xml')
     hpxml.hot_water_distributions.clear
     hpxml.hot_water_distributions.add(id: 'HotWaterDistribution',
                                       system_type: HPXML::DHWDistTypeRecirc,
-                                      recirculation_control_type: HPXML::DHWRecirControlTypeSensor,
-                                      pipe_r_value: 3.0)
+                                      recirculation_control_type: HPXML::DHWRecirControlTypeSensor)
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_recirc_distribution_values(hpxml_default, true, 186.96, 10.0, 50.0)
+    _test_default_recirc_distribution_values(hpxml_default, true, 186.96, 10.0, 50.0, 0.0)
 
     # Test defaults w/ shared recirculation
     hpxml = _create_hpxml('base-dhw-shared-water-heater-recirc.xml')
@@ -1799,9 +1819,15 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_equal(isdefaulted, hpxml.building_occupancy.number_of_residents_isdefaulted)
   end
 
-  def _test_default_building_construction_values(hpxml, isdefaulted, building_volume, has_flue_or_chimney, n_bathrooms)
+  def _test_default_building_construction_values(hpxml, isdefaulted, building_volume, average_ceiling_height, has_flue_or_chimney, n_bathrooms)
     assert_equal(building_volume, hpxml.building_construction.conditioned_building_volume)
-    assert_equal(isdefaulted, hpxml.building_construction.conditioned_building_volume_isdefaulted)
+    assert_equal(average_ceiling_height, hpxml.building_construction.average_ceiling_height)
+    if isdefaulted
+      assert_equal(isdefaulted, hpxml.building_construction.conditioned_building_volume_isdefaulted || hpxml.building_construction.average_ceiling_height_isdefaulted)
+    else
+      assert_equal(isdefaulted, hpxml.building_construction.conditioned_building_volume_isdefaulted)
+      assert_equal(isdefaulted, hpxml.building_construction.average_ceiling_height_isdefaulted)
+    end
 
     assert_equal(has_flue_or_chimney, hpxml.building_construction.has_flue_or_chimney)
     assert_equal(isdefaulted, hpxml.building_construction.has_flue_or_chimney_isdefaulted)
@@ -2178,14 +2204,17 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
   end
 
-  def _test_default_standard_distribution_values(hpxml, isdefaulted, piping_length)
+  def _test_default_standard_distribution_values(hpxml, isdefaulted, piping_length, pipe_r_value)
     hot_water_distribution = hpxml.hot_water_distributions[0]
 
     assert_in_epsilon(piping_length, hot_water_distribution.standard_piping_length, 0.01)
     assert_equal(isdefaulted, hot_water_distribution.standard_piping_length_isdefaulted)
+
+    assert_equal(pipe_r_value, hot_water_distribution.pipe_r_value)
+    assert_equal(isdefaulted, hot_water_distribution.pipe_r_value_isdefaulted)
   end
 
-  def _test_default_recirc_distribution_values(hpxml, isdefaulted, piping_length, branch_piping_length, pump_power)
+  def _test_default_recirc_distribution_values(hpxml, isdefaulted, piping_length, branch_piping_length, pump_power, pipe_r_value)
     hot_water_distribution = hpxml.hot_water_distributions[0]
 
     assert_in_epsilon(piping_length, hot_water_distribution.recirculation_piping_length, 0.01)
@@ -2196,6 +2225,9 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
     assert_in_epsilon(pump_power, hot_water_distribution.recirculation_pump_power, 0.01)
     assert_equal(isdefaulted, hot_water_distribution.recirculation_pump_power_isdefaulted)
+
+    assert_equal(pipe_r_value, hot_water_distribution.pipe_r_value)
+    assert_equal(isdefaulted, hot_water_distribution.pipe_r_value_isdefaulted)
   end
 
   def _test_default_shared_recirc_distribution_values(hpxml, isdefaulted, pump_power)

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -35,15 +35,15 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml = _create_hpxml('base.xml')
     hpxml.header.timestep = 30
     hpxml.header.sim_begin_month = 2
-    hpxml.header.sim_begin_day_of_month = 2
+    hpxml.header.sim_begin_day = 2
     hpxml.header.sim_end_month = 11
-    hpxml.header.sim_end_day_of_month = 11
+    hpxml.header.sim_end_day = 11
     hpxml.header.sim_calendar_year = 2008
     hpxml.header.dst_enabled = false
     hpxml.header.dst_begin_month = 3
-    hpxml.header.dst_begin_day_of_month = 3
+    hpxml.header.dst_begin_day = 3
     hpxml.header.dst_end_month = 10
-    hpxml.header.dst_end_day_of_month = 10
+    hpxml.header.dst_end_day = 10
     hpxml.header.use_max_load_for_heat_pumps = false
     hpxml.header.allow_increased_fixed_capacities = true
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -53,15 +53,15 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     # Test defaults - DST not in weather file
     hpxml.header.timestep = nil
     hpxml.header.sim_begin_month = nil
-    hpxml.header.sim_begin_day_of_month = nil
+    hpxml.header.sim_begin_day = nil
     hpxml.header.sim_end_month = nil
-    hpxml.header.sim_end_day_of_month = nil
+    hpxml.header.sim_end_day = nil
     hpxml.header.sim_calendar_year = nil
     hpxml.header.dst_enabled = nil
     hpxml.header.dst_begin_month = nil
-    hpxml.header.dst_begin_day_of_month = nil
+    hpxml.header.dst_begin_day = nil
     hpxml.header.dst_end_month = nil
-    hpxml.header.dst_end_day_of_month = nil
+    hpxml.header.dst_end_day = nil
     hpxml.header.use_max_load_for_heat_pumps = nil
     hpxml.header.allow_increased_fixed_capacities = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -72,15 +72,15 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml = _create_hpxml('base-location-AMY-2012.xml')
     hpxml.header.timestep = nil
     hpxml.header.sim_begin_month = nil
-    hpxml.header.sim_begin_day_of_month = nil
+    hpxml.header.sim_begin_day = nil
     hpxml.header.sim_end_month = nil
-    hpxml.header.sim_end_day_of_month = nil
+    hpxml.header.sim_end_day = nil
     hpxml.header.sim_calendar_year = nil
     hpxml.header.dst_enabled = nil
     hpxml.header.dst_begin_month = nil
-    hpxml.header.dst_begin_day_of_month = nil
+    hpxml.header.dst_begin_day = nil
     hpxml.header.dst_end_month = nil
-    hpxml.header.dst_end_day_of_month = nil
+    hpxml.header.dst_end_day = nil
     hpxml.header.use_max_load_for_heat_pumps = nil
     hpxml.header.allow_increased_fixed_capacities = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -1392,9 +1392,9 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.lighting.holiday_exists = true
     hpxml.lighting.holiday_kwh_per_day = 0.7
     hpxml.lighting.holiday_period_begin_month = 11
-    hpxml.lighting.holiday_period_begin_day_of_month = 19
+    hpxml.lighting.holiday_period_begin_day = 19
     hpxml.lighting.holiday_period_end_month = 12
-    hpxml.lighting.holiday_period_end_day_of_month = 31
+    hpxml.lighting.holiday_period_end_day = 31
     hpxml.lighting.holiday_weekday_fractions = ConstantDaySchedule
     hpxml.lighting.holiday_weekend_fractions = ConstantDaySchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -1411,9 +1411,9 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
                                     grg_month_mult: ConstantMonthSchedule,
                                     hol_kwh_per_day: 0.7,
                                     hol_begin_month: 11,
-                                    hol_begin_day_of_month: 19,
+                                    hol_begin_day: 19,
                                     hol_end_month: 12,
-                                    hol_end_day_of_month: 31,
+                                    hol_end_day: 31,
                                     hol_wk_sch: ConstantDaySchedule,
                                     hol_wknd_sch: ConstantDaySchedule })
 
@@ -1744,7 +1744,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
   end
 
   def _test_default_header_values(hpxml, isdefaulted, tstep, sim_begin_month, sim_begin_day, sim_end_month, sim_end_day, sim_calendar_year,
-                                  dst_enabled, dst_begin_month, dst_begin_day_of_month, dst_end_month, dst_end_day_of_month,
+                                  dst_enabled, dst_begin_month, dst_begin_day, dst_end_month, dst_end_day,
                                   use_max_load_for_heat_pumps, allow_increased_fixed_capacities)
     assert_equal(tstep, hpxml.header.timestep)
     assert_equal(isdefaulted, hpxml.header.timestep_isdefaulted)
@@ -1752,14 +1752,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_equal(sim_begin_month, hpxml.header.sim_begin_month)
     assert_equal(isdefaulted, hpxml.header.sim_begin_month_isdefaulted)
 
-    assert_equal(sim_begin_day, hpxml.header.sim_begin_day_of_month)
-    assert_equal(isdefaulted, hpxml.header.sim_begin_day_of_month_isdefaulted)
+    assert_equal(sim_begin_day, hpxml.header.sim_begin_day)
+    assert_equal(isdefaulted, hpxml.header.sim_begin_day_isdefaulted)
 
     assert_equal(sim_end_month, hpxml.header.sim_end_month)
     assert_equal(isdefaulted, hpxml.header.sim_end_month_isdefaulted)
 
-    assert_equal(sim_end_day, hpxml.header.sim_end_day_of_month)
-    assert_equal(isdefaulted, hpxml.header.sim_end_day_of_month_isdefaulted)
+    assert_equal(sim_end_day, hpxml.header.sim_end_day)
+    assert_equal(isdefaulted, hpxml.header.sim_end_day_isdefaulted)
 
     assert_equal(sim_calendar_year, hpxml.header.sim_calendar_year)
     assert_equal(isdefaulted, hpxml.header.sim_calendar_year_isdefaulted)
@@ -1770,14 +1770,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_equal(dst_begin_month, hpxml.header.dst_begin_month)
     assert_equal(isdefaulted, hpxml.header.dst_begin_month_isdefaulted)
 
-    assert_equal(dst_begin_day_of_month, hpxml.header.dst_begin_day_of_month)
-    assert_equal(isdefaulted, hpxml.header.dst_begin_day_of_month_isdefaulted)
+    assert_equal(dst_begin_day, hpxml.header.dst_begin_day)
+    assert_equal(isdefaulted, hpxml.header.dst_begin_day_isdefaulted)
 
     assert_equal(dst_end_month, hpxml.header.dst_end_month)
     assert_equal(isdefaulted, hpxml.header.dst_end_month_isdefaulted)
 
-    assert_equal(dst_end_day_of_month, hpxml.header.dst_end_day_of_month)
-    assert_equal(isdefaulted, hpxml.header.dst_end_day_of_month_isdefaulted)
+    assert_equal(dst_end_day, hpxml.header.dst_end_day)
+    assert_equal(isdefaulted, hpxml.header.dst_end_day_isdefaulted)
 
     assert_equal(use_max_load_for_heat_pumps, hpxml.header.use_max_load_for_heat_pumps)
     assert_equal(isdefaulted, hpxml.header.use_max_load_for_heat_pumps_isdefaulted)
@@ -2550,11 +2550,11 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
       assert_nil(hpxml.lighting.holiday_period_begin_month)
     end
 
-    if not schedules[:hol_begin_day_of_month].nil?
-      assert_equal(schedules[:hol_begin_day_of_month], hpxml.lighting.holiday_period_begin_day_of_month)
-      assert_equal(isdefaulted, hpxml.lighting.holiday_period_begin_day_of_month_isdefaulted)
+    if not schedules[:hol_begin_day].nil?
+      assert_equal(schedules[:hol_begin_day], hpxml.lighting.holiday_period_begin_day)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_period_begin_day_isdefaulted)
     else
-      assert_nil(hpxml.lighting.holiday_period_begin_day_of_month)
+      assert_nil(hpxml.lighting.holiday_period_begin_day)
     end
 
     if not schedules[:hol_end_month].nil?
@@ -2564,11 +2564,11 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
       assert_nil(hpxml.lighting.holiday_period_end_month)
     end
 
-    if not schedules[:hol_end_day_of_month].nil?
-      assert_equal(schedules[:hol_end_day_of_month], hpxml.lighting.holiday_period_end_day_of_month)
-      assert_equal(isdefaulted, hpxml.lighting.holiday_period_end_day_of_month_isdefaulted)
+    if not schedules[:hol_end_day].nil?
+      assert_equal(schedules[:hol_end_day], hpxml.lighting.holiday_period_end_day)
+      assert_equal(isdefaulted, hpxml.lighting.holiday_period_end_day_isdefaulted)
     else
-      assert_nil(hpxml.lighting.holiday_period_end_day_of_month)
+      assert_nil(hpxml.lighting.holiday_period_end_day)
     end
 
     if not schedules[:hol_wk_sch].nil?

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -192,21 +192,24 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def test_roofs
     # Test inputs not overridden by defaults
-    hpxml = _create_hpxml('base.xml')
+    hpxml = _create_hpxml('base-atticroof-radiant-barrier.xml')
     hpxml.roofs[0].roof_type = HPXML::RoofTypeMetal
     hpxml.roofs[0].solar_absorptance = 0.77
     hpxml.roofs[0].roof_color = HPXML::ColorDark
+    hpxml.roofs[0].emittance = 0.88
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_roof_values(hpxml_default, HPXML::RoofTypeMetal, 0.77, HPXML::ColorDark)
+    _test_default_roof_values(hpxml_default, HPXML::RoofTypeMetal, 0.77, HPXML::ColorDark, 0.88, true)
 
     # Test defaults
     hpxml.roofs[0].roof_type = nil
     hpxml.roofs[0].solar_absorptance = nil
     hpxml.roofs[0].roof_color = HPXML::ColorLight
+    hpxml.roofs[0].emittance = nil
+    hpxml.roofs[0].radiant_barrier = false
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_roof_values(hpxml_default, HPXML::RoofTypeAsphaltShingles, 0.75, HPXML::ColorLight)
+    _test_default_roof_values(hpxml_default, HPXML::RoofTypeAsphaltShingles, 0.75, HPXML::ColorLight, 0.90, false)
   end
 
   def test_walls
@@ -215,17 +218,19 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.walls[0].siding = HPXML::SidingTypeFiberCement
     hpxml.walls[0].solar_absorptance = 0.66
     hpxml.walls[0].color = HPXML::ColorDark
+    hpxml.walls[0].emittance = 0.88
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_wall_values(hpxml_default, HPXML::SidingTypeFiberCement, 0.66, HPXML::ColorDark)
+    _test_default_wall_values(hpxml_default, HPXML::SidingTypeFiberCement, 0.66, HPXML::ColorDark, 0.88)
 
     # Test defaults
     hpxml.walls[0].siding = nil
     hpxml.walls[0].solar_absorptance = nil
     hpxml.walls[0].color = HPXML::ColorLight
+    hpxml.walls[0].emittance = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_wall_values(hpxml_default, HPXML::SidingTypeWood, 0.5, HPXML::ColorLight)
+    _test_default_wall_values(hpxml_default, HPXML::SidingTypeWood, 0.5, HPXML::ColorLight, 0.90)
   end
 
   def test_rim_joists
@@ -234,17 +239,53 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.rim_joists[0].siding = HPXML::SidingTypeBrick
     hpxml.rim_joists[0].solar_absorptance = 0.55
     hpxml.rim_joists[0].color = HPXML::ColorLight
+    hpxml.rim_joists[0].emittance = 0.88
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeBrick, 0.55, HPXML::ColorLight)
+    _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeBrick, 0.55, HPXML::ColorLight, 0.88)
 
     # Test defaults
     hpxml.rim_joists[0].siding = nil
     hpxml.rim_joists[0].solar_absorptance = nil
     hpxml.rim_joists[0].color = HPXML::ColorDark
+    hpxml.rim_joists[0].emittance = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeWood, 0.95, HPXML::ColorDark)
+    _test_default_rim_joist_values(hpxml_default, HPXML::SidingTypeWood, 0.95, HPXML::ColorDark, 0.90)
+  end
+
+  def test_foundation_walls
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.foundation_walls[0].thickness = 7.0
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_foundation_wall_values(hpxml_default, 7.0)
+
+    # Test defaults
+    hpxml.foundation_walls[0].thickness = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_foundation_wall_values(hpxml_default, 8.0)
+  end
+
+  def test_slabs
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base.xml')
+    hpxml.slabs[0].thickness = 7.0
+    hpxml.slabs[0].carpet_r_value = 1.1
+    hpxml.slabs[0].carpet_fraction = 0.5
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_slab_values(hpxml_default, 7.0, 1.1, 0.5)
+
+    # Test defaults
+    hpxml.slabs[0].thickness = nil
+    hpxml.slabs[0].carpet_r_value = nil
+    hpxml.slabs[0].carpet_fraction = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_slab_values(hpxml_default, 4.0, 2.0, 0.8)
   end
 
   def test_windows
@@ -531,6 +572,23 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_ground_to_air_heat_pump_values(hpxml_default, 30.0, 0.375)
+  end
+
+  def test_hvac_controls
+    # Test inputs not overridden by defaults
+    hpxml = _create_hpxml('base-hvac-programmable-thermostat.xml')
+    hpxml.hvac_controls[0].heating_setback_start_hour = 12
+    hpxml.hvac_controls[0].cooling_setup_start_hour = 12
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_hvac_control_values(hpxml_default, 12, 12)
+
+    # Test defaults
+    hpxml.hvac_controls[0].heating_setback_start_hour = nil
+    hpxml.hvac_controls[0].cooling_setup_start_hour = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_hvac_control_values(hpxml_default, 23, 9)
   end
 
   def test_hvac_distribution
@@ -872,9 +930,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     vent_fan.is_shared_system = true
     vent_fan.fraction_recirculation = 0.0
     vent_fan.in_unit_flow_rate = 10.0
+    vent_fan.hours_in_operation = 22.0
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mech_vent_values(hpxml_default, true)
+    _test_default_mech_vent_values(hpxml_default, true, 22.0)
 
     # Test defaults
     vent_fan.rated_flow_rate = nil
@@ -883,9 +942,24 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     vent_fan.is_shared_system = nil
     vent_fan.fraction_recirculation = nil
     vent_fan.in_unit_flow_rate = nil
+    vent_fan.hours_in_operation = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_mech_vent_values(hpxml_default, false)
+    _test_default_mech_vent_values(hpxml_default, false, 24.0)
+
+    # Test inputs not overridden by defaults w/ CFIS
+    hpxml = _create_hpxml('base-mechvent-cfis.xml')
+    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+    vent_fan.hours_in_operation = 12.0
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_mech_vent_values(hpxml_default, false, 12.0)
+
+    # Test defaults w/ CFIS
+    vent_fan.hours_in_operation = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_mech_vent_values(hpxml_default, false, 8.0)
   end
 
   def test_local_ventilation_fans
@@ -1549,24 +1623,30 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
       pv.number_of_bedrooms_served = 20
       pv.inverter_efficiency = 0.90
       pv.system_losses_fraction = 0.20
+      pv.location = HPXML::LocationGround
+      pv.tracking = HPXML::PVTrackingType1Axis
+      pv.module_type = HPXML::PVModuleTypePremium
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_interver_efficiency = [0.90, 0.90]
     expected_system_loss_frac = [0.20, 0.20]
-    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, true)
+    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, true, HPXML::LocationGround, HPXML::PVTrackingType1Axis, HPXML::PVModuleTypePremium)
 
     # Test defaults w/o year modules manufactured
     hpxml.pv_systems.each do |pv|
       pv.is_shared_system = nil
       pv.inverter_efficiency = nil
       pv.system_losses_fraction = nil
+      pv.location = nil
+      pv.tracking = nil
+      pv.module_type = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_interver_efficiency = [0.96, 0.96]
     expected_system_loss_frac = [0.14, 0.14]
-    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, false)
+    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, false, HPXML::LocationRoof, HPXML::PVTrackingTypeFixed, HPXML::PVModuleTypeStandard)
 
     # Test defaults w/ year modules manufactured
     hpxml.pv_systems.each do |pv|
@@ -1576,7 +1656,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml_default = _test_measure()
     expected_interver_efficiency = [0.96, 0.96]
     expected_system_loss_frac = [0.182, 0.182]
-    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, false)
+    _test_default_pv_system_values(hpxml_default, expected_interver_efficiency, expected_system_loss_frac, false, HPXML::LocationRoof, HPXML::PVTrackingTypeFixed, HPXML::PVModuleTypeStandard)
   end
 
   def _test_measure()
@@ -1718,6 +1798,12 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_equal(fan_watts_per_cfm, heat_pump.fan_watts_per_cfm)
   end
 
+  def _test_default_hvac_control_values(hpxml, htg_setback_start_hr, clg_setup_start_hr)
+    hvac_control = hpxml.hvac_controls[0]
+    assert_equal(htg_setback_start_hr, hvac_control.heating_setback_start_hour)
+    assert_equal(clg_setup_start_hr, hvac_control.cooling_setup_start_hour)
+  end
+
   def _test_default_duct_values(hpxml, supply_locations, return_locations, supply_areas, return_areas, n_return_registers)
     supply_duct_idx = 0
     return_duct_idx = 0
@@ -1739,12 +1825,15 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
   end
 
-  def _test_default_pv_system_values(hpxml, interver_efficiency, system_loss_frac, is_shared_system)
+  def _test_default_pv_system_values(hpxml, interver_efficiency, system_loss_frac, is_shared_system, location, tracking, module_type)
     assert_equal(interver_efficiency.size, hpxml.pv_systems.size)
     hpxml.pv_systems.each_with_index do |pv, idx|
       assert_equal(is_shared_system, pv.is_shared_system)
       assert_equal(interver_efficiency[idx], pv.inverter_efficiency)
       assert_in_epsilon(system_loss_frac[idx], pv.system_losses_fraction, 0.01)
+      assert_equal(location, pv.location)
+      assert_equal(tracking, pv.tracking)
+      assert_equal(module_type, pv.module_type)
     end
   end
 
@@ -1769,25 +1858,41 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_equal(volume, air_infiltration_measurement.infiltration_volume)
   end
 
-  def _test_default_roof_values(hpxml, roof_type, solar_absorptance, roof_color)
+  def _test_default_roof_values(hpxml, roof_type, solar_absorptance, roof_color, emittance, radiant_barrier)
     roof = hpxml.roofs[0]
     assert_equal(roof_type, roof.roof_type)
     assert_equal(solar_absorptance, roof.solar_absorptance)
     assert_equal(roof_color, roof.roof_color)
+    assert_equal(emittance, roof.emittance)
+    assert_equal(radiant_barrier, roof.radiant_barrier)
   end
 
-  def _test_default_wall_values(hpxml, siding, solar_absorptance, color)
+  def _test_default_wall_values(hpxml, siding, solar_absorptance, color, emittance)
     wall = hpxml.walls[0]
     assert_equal(siding, wall.siding)
     assert_equal(solar_absorptance, wall.solar_absorptance)
     assert_equal(color, wall.color)
+    assert_equal(emittance, wall.emittance)
   end
 
-  def _test_default_rim_joist_values(hpxml, siding, solar_absorptance, color)
+  def _test_default_rim_joist_values(hpxml, siding, solar_absorptance, color, emittance)
     rim_joist = hpxml.rim_joists[0]
     assert_equal(siding, rim_joist.siding)
     assert_equal(solar_absorptance, rim_joist.solar_absorptance)
     assert_equal(color, rim_joist.color)
+    assert_equal(emittance, rim_joist.emittance)
+  end
+
+  def _test_default_foundation_wall_values(hpxml, thickness)
+    foundation_wall = hpxml.foundation_walls[0]
+    assert_equal(thickness, foundation_wall.thickness)
+  end
+
+  def _test_default_slab_values(hpxml, thickness, carpet_r_value, carpet_fraction)
+    slab = hpxml.slabs[0]
+    assert_equal(thickness, slab.thickness)
+    assert_equal(carpet_r_value, slab.carpet_r_value)
+    assert_equal(carpet_fraction, slab.carpet_fraction)
   end
 
   def _test_default_window_values(hpxml, summer_shade_coeffs, winter_shade_coeffs, fraction_operable)
@@ -2039,9 +2144,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_in_epsilon(storage_volume, hpxml.solar_thermal_systems[0].storage_volume)
   end
 
-  def _test_default_mech_vent_values(hpxml, is_shared_system)
+  def _test_default_mech_vent_values(hpxml, is_shared_system, hours_in_operation)
     vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
     assert_equal(is_shared_system, vent_fan.is_shared_system)
+    assert_equal(hours_in_operation, vent_fan.hours_in_operation)
   end
 
   def _test_default_kitchen_fan_values(hpxml, quantity, rated_flow_rate, hours_in_operation, fan_power, start_hour)

--- a/HPXMLtoOpenStudio/tests/test_location.rb
+++ b/HPXMLtoOpenStudio/tests/test_location.rb
@@ -18,10 +18,10 @@ class HPXMLtoOpenStudioLocationTest < MiniTest::Test
     start_date = run_period_control_daylight_saving_time.startDate
     end_date = run_period_control_daylight_saving_time.endDate
     begin_month = start_date.monthOfYear.value
-    begin_day_of_month = start_date.dayOfMonth
+    begin_day = start_date.dayOfMonth
     end_month = end_date.monthOfYear.value
-    end_day_of_month = end_date.dayOfMonth
-    return begin_month, begin_day_of_month, end_month, end_day_of_month
+    end_day = end_date.dayOfMonth
+    return begin_month, begin_day, end_month, end_day
   end
 
   def test_dst_default
@@ -30,11 +30,11 @@ class HPXMLtoOpenStudioLocationTest < MiniTest::Test
     model, hpxml = _test_measure(args_hash)
 
     assert_equal(1, model.getObjectsByType('OS:RunPeriodControl:DaylightSavingTime'.to_IddObjectType).size)
-    begin_month, begin_day_of_month, end_month, end_day_of_month = get_daylight_saving_month_and_days(model)
+    begin_month, begin_day, end_month, end_day = get_daylight_saving_month_and_days(model)
     assert_equal(3, begin_month)
-    assert_equal(12, begin_day_of_month)
+    assert_equal(12, begin_day)
     assert_equal(11, end_month)
-    assert_equal(5, end_day_of_month)
+    assert_equal(5, end_day)
   end
 
   def test_dst_custom
@@ -43,11 +43,11 @@ class HPXMLtoOpenStudioLocationTest < MiniTest::Test
     model, hpxml = _test_measure(args_hash)
 
     assert_equal(1, model.getObjectsByType('OS:RunPeriodControl:DaylightSavingTime'.to_IddObjectType).size)
-    begin_month, begin_day_of_month, end_month, end_day_of_month = get_daylight_saving_month_and_days(model)
+    begin_month, begin_day, end_month, end_day = get_daylight_saving_month_and_days(model)
     assert_equal(3, begin_month)
-    assert_equal(10, begin_day_of_month)
+    assert_equal(10, begin_day)
     assert_equal(11, end_month)
-    assert_equal(6, end_day_of_month)
+    assert_equal(6, end_day)
   end
 
   def test_dst_disabled

--- a/HPXMLtoOpenStudio/tests/test_simcontrols.rb
+++ b/HPXMLtoOpenStudio/tests/test_simcontrols.rb
@@ -16,10 +16,10 @@ class HPXMLtoOpenStudioSimControlsTest < MiniTest::Test
   def get_run_period_month_and_days(model)
     run_period = model.getRunPeriod
     begin_month = run_period.getBeginMonth
-    begin_day_of_month = run_period.getBeginDayOfMonth
+    begin_day = run_period.getBeginDayOfMonth
     end_month = run_period.getEndMonth
-    end_day_of_month = run_period.getEndDayOfMonth
-    return begin_month, begin_day_of_month, end_month, end_day_of_month
+    end_day = run_period.getEndDayOfMonth
+    return begin_month, begin_day, end_month, end_day
   end
 
   def test_run_period_year
@@ -27,11 +27,11 @@ class HPXMLtoOpenStudioSimControlsTest < MiniTest::Test
     args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base.xml'))
     model, hpxml = _test_measure(args_hash)
 
-    begin_month, begin_day_of_month, end_month, end_day_of_month = get_run_period_month_and_days(model)
+    begin_month, begin_day, end_month, end_day = get_run_period_month_and_days(model)
     assert_equal(1, begin_month)
-    assert_equal(1, begin_day_of_month)
+    assert_equal(1, begin_day)
     assert_equal(12, end_month)
-    assert_equal(31, end_day_of_month)
+    assert_equal(31, end_day)
   end
 
   def test_run_period_1month
@@ -39,11 +39,11 @@ class HPXMLtoOpenStudioSimControlsTest < MiniTest::Test
     args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-simcontrol-runperiod-1-month.xml'))
     model, hpxml = _test_measure(args_hash)
 
-    begin_month, begin_day_of_month, end_month, end_day_of_month = get_run_period_month_and_days(model)
+    begin_month, begin_day, end_month, end_day = get_run_period_month_and_days(model)
     assert_equal(1, begin_month)
-    assert_equal(1, begin_day_of_month)
+    assert_equal(1, begin_day)
     assert_equal(1, end_month)
-    assert_equal(31, end_day_of_month)
+    assert_equal(31, end_day)
   end
 
   def test_timestep_1hour

--- a/tasks.rb
+++ b/tasks.rb
@@ -555,18 +555,18 @@ def set_hpxml_header(hpxml_file, hpxml)
   elsif ['base-simcontrol-daylight-saving-custom.xml'].include? hpxml_file
     hpxml.header.dst_enabled = true
     hpxml.header.dst_begin_month = 3
-    hpxml.header.dst_begin_day_of_month = 10
+    hpxml.header.dst_begin_day = 10
     hpxml.header.dst_end_month = 11
-    hpxml.header.dst_end_day_of_month = 6
+    hpxml.header.dst_end_day = 6
   elsif ['base-simcontrol-daylight-saving-disabled.xml'].include? hpxml_file
     hpxml.header.dst_enabled = false
   elsif ['base-simcontrol-timestep-10-mins.xml'].include? hpxml_file
     hpxml.header.timestep = 10
   elsif ['base-simcontrol-runperiod-1-month.xml'].include? hpxml_file
     hpxml.header.sim_begin_month = 1
-    hpxml.header.sim_begin_day_of_month = 1
+    hpxml.header.sim_begin_day = 1
     hpxml.header.sim_end_month = 1
-    hpxml.header.sim_end_day_of_month = 31
+    hpxml.header.sim_end_day = 31
   elsif ['base-hvac-undersized-allow-increased-fixed-capacities.xml'].include? hpxml_file
     hpxml.header.allow_increased_fixed_capacities = true
   elsif hpxml_file.include? 'manual-s-oversize-allowances.xml'
@@ -577,10 +577,10 @@ def set_hpxml_header(hpxml_file, hpxml)
     hpxml.header.timestep = 45
   elsif ['invalid_files/invalid-runperiod.xml'].include? hpxml_file
     hpxml.header.sim_end_month = 4
-    hpxml.header.sim_end_day_of_month = 31
+    hpxml.header.sim_end_day = 31
   elsif ['invalid_files/invalid-daylight-saving.xml'].include? hpxml_file
     hpxml.header.dst_end_month = 4
-    hpxml.header.dst_end_day_of_month = 31
+    hpxml.header.dst_end_day = 31
   elsif ['base-misc-defaults.xml'].include? hpxml_file
     hpxml.header.timestep = nil
   elsif ['invalid_files/invalid-input-parameters.xml'].include? hpxml_file
@@ -4894,9 +4894,9 @@ def set_hpxml_lighting_schedule(hpxml_file, hpxml)
     hpxml.lighting.holiday_exists = true
     hpxml.lighting.holiday_kwh_per_day = 1.1
     hpxml.lighting.holiday_period_begin_month = 11
-    hpxml.lighting.holiday_period_begin_day_of_month = 24
+    hpxml.lighting.holiday_period_begin_day = 24
     hpxml.lighting.holiday_period_end_month = 1
-    hpxml.lighting.holiday_period_end_day_of_month = 6
+    hpxml.lighting.holiday_period_end_day = 6
     hpxml.lighting.holiday_weekday_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
     hpxml.lighting.holiday_weekend_fractions = '0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008, 0.098, 0.168, 0.194, 0.284, 0.192, 0.037, 0.019'
   end

--- a/tasks.rb
+++ b/tasks.rb
@@ -5104,7 +5104,7 @@ def create_schematron_hpxml_validator(hpxml_docs)
   hpxml_validator = XMLHelper.create_doc(version = '1.0', encoding = 'UTF-8')
   root = XMLHelper.add_element(hpxml_validator, 'sch:schema')
   XMLHelper.add_attribute(root, 'xmlns:sch', 'http://purl.oclc.org/dsdl/schematron')
-  XMLHelper.add_element(root, 'sch:title', 'HPXML Schematron Validator: HPXML.xsd')
+  XMLHelper.add_element(root, 'sch:title', 'HPXML Schematron Validator: HPXML.xsd', :string)
   name_space = XMLHelper.add_element(root, 'sch:ns')
   XMLHelper.add_attribute(name_space, 'uri', 'http://hpxmlonline.com/2019/10')
   XMLHelper.add_attribute(name_space, 'prefix', 'h')
@@ -5189,27 +5189,27 @@ def create_schematron_hpxml_validator(hpxml_docs)
     end
 
     if not hpxml_data_type[:enums].empty?
-      assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be \"#{hpxml_data_type[:enums].join('" or "')}\"")
+      assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be \"#{hpxml_data_type[:enums].join('" or "')}\"", :string)
       XMLHelper.add_attribute(assertion, 'role', 'ERROR')
       XMLHelper.add_attribute(assertion, 'test', "#{element_name}[#{hpxml_data_type[:enums].map { |e| "text()=\"#{e}\"" }.join(' or ')}] or not(#{element_name})")
     else
       if hpxml_data_type[:min_inclusive]
-        assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be greater than or equal to #{hpxml_data_type[:min_inclusive]}")
+        assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be greater than or equal to #{hpxml_data_type[:min_inclusive]}", :string)
         XMLHelper.add_attribute(assertion, 'role', 'ERROR')
         XMLHelper.add_attribute(assertion, 'test', "number(#{element_name}) &gt;= #{hpxml_data_type[:min_inclusive]} or not(#{element_name})")
       end
       if hpxml_data_type[:max_inclusive]
-        assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be less than or equal to #{hpxml_data_type[:max_inclusive]}")
+        assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be less than or equal to #{hpxml_data_type[:max_inclusive]}", :string)
         XMLHelper.add_attribute(assertion, 'role', 'ERROR')
         XMLHelper.add_attribute(assertion, 'test', "number(#{element_name}) &lt;= #{hpxml_data_type[:max_inclusive]} or not(#{element_name})")
       end
       if hpxml_data_type[:min_exclusive]
-        assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be greater than #{hpxml_data_type[:min_exclusive]}")
+        assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be greater than #{hpxml_data_type[:min_exclusive]}", :string)
         XMLHelper.add_attribute(assertion, 'role', 'ERROR')
         XMLHelper.add_attribute(assertion, 'test', "number(#{element_name}) &gt; #{hpxml_data_type[:min_exclusive]} or not(#{element_name})")
       end
       if hpxml_data_type[:max_exclusive]
-        assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be less than #{hpxml_data_type[:max_exclusive]}")
+        assertion = XMLHelper.add_element(rule, 'sch:assert', "Expected #{element_name.gsub('h:', '')} to be less than #{hpxml_data_type[:max_exclusive]}", :string)
         XMLHelper.add_attribute(assertion, 'role', 'ERROR')
         XMLHelper.add_attribute(assertion, 'test', "number(#{element_name}) &lt; #{hpxml_data_type[:max_exclusive]} or not(#{element_name})")
       end


### PR DESCRIPTION
## Pull Request Description

Changed from required to optional:
- `BuildingConstruction/AverageCeilingHeight` (default: calculated as CV/CFA, else 8.0)
- `Roof/Emittance` (default: 0.90)
- `Roof/RadiantBarrier` (default: false)
- `Wall/Emittance` (default: 0.90)
- `RimJoist/Emittance` (default: 0.90)
- `FoundationWall/Thickness` (default: 8.0 inches)
- `Slab/Thickness` (default: 4.0 inches)
- `Slab/extension/CarpetFraction` (default: 0.8 if adjacent to conditioned space, else 0.0)
- `Slab/extension/CarpetRValue` (default: 2.0 if adjacent to conditioned space, else 0.0)
- `HVACControl/extension/SetbackStartHourHeating` (default: 23 (11pm))
- `HVACControl/extension/SetupStartHourCooling` (default: 9 (9am))
- `VentilationFan[UsedForWholeBuildingVentilation="true"]/HoursInOperation` (default: 24 if not CFIS, else 8)
- `HotWaterDistribution/PipeInsulation/PipeRValue` (default: 0.0)
- `PVSystem/Location` (default: roof)
- `PVSystem/ModuleType` (default: standard)
- `PVSystem/Tracking` (default: fixed)

Also adds `dataSource="software"` attribute to in.xml for any defaulted elements.

## Checklist

Not all may apply:

- [x] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
