### PR TITLE
Fix possible neighbor shading error

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -1637,6 +1637,7 @@ class OSModel
     floor_surface.setSpace(create_or_get_space(model, spaces, HPXML::LocationLivingSpace))
     floor_surface.setOutsideBoundaryCondition('Adiabatic')
     floor_surface.additionalProperties.setFeature('SurfaceType', 'InferredFloor')
+    floor_surface.additionalProperties.setFeature('Tilt', 0.0)
 
     # Add ceiling surface
     ceiling_surface = OpenStudio::Model::Surface.new(add_ceiling_polygon(-floor_width, -floor_length, z_origin), model)
@@ -1648,6 +1649,7 @@ class OSModel
     ceiling_surface.setSpace(create_or_get_space(model, spaces, HPXML::LocationLivingSpace))
     ceiling_surface.setOutsideBoundaryCondition('Adiabatic')
     ceiling_surface.additionalProperties.setFeature('SurfaceType', 'InferredCeiling')
+    ceiling_surface.additionalProperties.setFeature('Tilt', 0.0)
 
     if not @cond_bsmnt_surfaces.empty?
       # assuming added ceiling is in conditioned basement

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -453,7 +453,7 @@ class OSModel
     azimuth_lengths = {}
     model.getSurfaces.sort.each do |surface|
       next unless ['wall', 'roofceiling'].include? surface.surfaceType.downcase
-      next unless ['outdoors', 'foundation'].include? surface.outsideBoundaryCondition.downcase
+      next unless ['outdoors', 'foundation', 'adiabatic'].include? surface.outsideBoundaryCondition.downcase
       next if surface.additionalProperties.getFeatureAsDouble('Tilt').get <= 0 # skip flat roofs
 
       surfaces << surface
@@ -803,10 +803,23 @@ class OSModel
     vertices << OpenStudio::Point3d.new(x / 2, y / 2, z)
     vertices << OpenStudio::Point3d.new(x / 2, 0 - y / 2, z)
 
-    return vertices
+    # Rotate about the z axis
+    # This is not strictly needed, but will make the floor edges
+    # parallel to the walls for a better geometry rendering.
+    azimuth_rad = UnitConversions.convert(@default_azimuths[0], 'deg', 'rad')
+    m = OpenStudio::Matrix.new(4, 4, 0)
+    m[0, 0] = Math::cos(-azimuth_rad)
+    m[1, 1] = Math::cos(-azimuth_rad)
+    m[0, 1] = -Math::sin(-azimuth_rad)
+    m[1, 0] = Math::sin(-azimuth_rad)
+    m[2, 2] = 1
+    m[3, 3] = 1
+    transformation = OpenStudio::Transformation.new(m)
+
+    return transformation * vertices
   end
 
-  def self.add_wall_polygon(x, y, z, azimuth = 0, offsets = [0] * 4, subsurface_area = 0)
+  def self.add_wall_polygon(x, y, z, azimuth, offsets = [0] * 4, subsurface_area = 0)
     x = UnitConversions.convert(x, 'ft', 'm')
     y = UnitConversions.convert(y, 'ft', 'm')
     z = UnitConversions.convert(z, 'ft', 'm')
@@ -844,7 +857,7 @@ class OSModel
     return transformation * vertices
   end
 
-  def self.add_roof_polygon(x, y, z, azimuth = 0, tilt = 0.5)
+  def self.add_roof_polygon(x, y, z, azimuth, tilt)
     x = UnitConversions.convert(x, 'ft', 'm')
     y = UnitConversions.convert(y, 'ft', 'm')
     z = UnitConversions.convert(z, 'ft', 'm')
@@ -960,7 +973,7 @@ class OSModel
         if roof.pitch > 0
           azimuths = @default_azimuths # Model as four directions for average exterior incident solar
         else
-          azimuths = [90] # Arbitrary azimuth for flat roof
+          azimuths = [@default_azimuths[0]] # Arbitrary azimuth for flat roof
         end
       else
         azimuths = [roof.azimuth]

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -1231,6 +1231,7 @@ class OSModel
         surface = OpenStudio::Model::Surface.new(add_floor_polygon(length, width, z_origin), model)
         surface.additionalProperties.setFeature('SurfaceType', 'Floor')
       end
+      surface.additionalProperties.setFeature('Tilt', 0.0)
       set_surface_interior(model, spaces, surface, frame_floor)
       set_surface_exterior(model, spaces, surface, frame_floor)
       surface.setName(frame_floor.id)

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>724d4b85-154f-465d-808a-1ae988488682</version_id>
-  <version_modified>20201205T201129Z</version_modified>
+  <version_id>f0812b1b-475c-45d8-b471-d3a5c01a51ad</version_id>
+  <version_modified>20201206T004413Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -504,7 +504,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>6859105D</checksum>
+      <checksum>943ADAA3</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>1fb7389d-05ce-4a3c-b3a3-e54df96630fc</version_id>
-  <version_modified>20201204T023712Z</version_modified>
+  <version_id>f9d57ed2-32be-406c-9c5c-abc26151e00e</version_id>
+  <version_modified>20201205T195129Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -493,7 +493,7 @@
       <filename>test_water_heater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>BE6AB0B7</checksum>
+      <checksum>00FF316C</checksum>
     </file>
     <file>
       <version>
@@ -504,7 +504,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>A869BAD1</checksum>
+      <checksum>201BF9FB</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f9d57ed2-32be-406c-9c5c-abc26151e00e</version_id>
-  <version_modified>20201205T195129Z</version_modified>
+  <version_id>724d4b85-154f-465d-808a-1ae988488682</version_id>
+  <version_modified>20201205T201129Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -504,7 +504,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>201BF9FB</checksum>
+      <checksum>6859105D</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Fixes possible "A neighbor building has an azimuth (XXX) not equal to the azimuth of any wall" error if the neighbor is in the same direction as the SFA/MF dwelling unit's adiabatic side. Closes #547.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
