### PR TITLE
Water heater RE defaulting

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f0b6ac5d-0fda-49ad-b60d-5d655f439e3b</version_id>
-  <version_modified>20201210T010745Z</version_modified>
+  <version_id>77e80ae9-c905-4a9b-a875-61aae03507fd</version_id>
+  <version_modified>20201210T224144Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -370,12 +370,6 @@
       <checksum>E4CE9FD0</checksum>
     </file>
     <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>8CC67A4B</checksum>
-    </file>
-    <file>
       <filename>simcontrols.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -507,16 +501,22 @@
       <checksum>2129504F</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D6372E4F</checksum>
-    </file>
-    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>0CCBFD45</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>53B38353</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C2A8C48B</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -20,7 +20,7 @@ class HPXMLDefaults
     apply_hvac_control(hpxml)
     apply_hvac_distribution(hpxml, ncfl, ncfl_ag)
     apply_ventilation_fans(hpxml)
-    apply_water_heaters(hpxml, nbeds, eri_version)
+    apply_water_heaters(hpxml, nbeds, eri_version, runner)
     apply_hot_water_distribution(hpxml, cfa, ncfl, has_uncond_bsmnt)
     apply_water_fixtures(hpxml)
     apply_solar_thermal_systems(hpxml)
@@ -706,7 +706,7 @@ class HPXMLDefaults
     end
   end
 
-  def self.apply_water_heaters(hpxml, nbeds, eri_version)
+  def self.apply_water_heaters(hpxml, nbeds, eri_version, runner)
     hpxml.water_heating_systems.each do |water_heating_system|
       if water_heating_system.is_shared_system.nil?
         water_heating_system.is_shared_system = false
@@ -739,7 +739,7 @@ class HPXMLDefaults
           water_heating_system.tank_volume_isdefaulted = true
         end
         if water_heating_system.recovery_efficiency.nil?
-          water_heating_system.recovery_efficiency = Waterheater.get_default_recovery_efficiency(water_heating_system)
+          water_heating_system.recovery_efficiency = Waterheater.get_default_recovery_efficiency(runner, water_heating_system)
           water_heating_system.recovery_efficiency_isdefaulted = true
         end
       end

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -1181,7 +1181,7 @@ class Waterheater
     end
   end
 
-  def self.get_default_recovery_efficiency(water_heating_system)
+  def self.get_default_recovery_efficiency(runner, water_heating_system)
     # Water Heater Recovery Efficiency by fuel and energy factor
     if water_heating_system.fuel_type == HPXML::FuelTypeElectricity
       return 0.98
@@ -1192,10 +1192,15 @@ class Waterheater
         ef = calc_ef_from_uef(water_heating_system)
       end
       if ef >= 0.75
-        return 0.778114 * ef + 0.276679
+        re = 0.778114 * ef + 0.276679
       else
-        return 0.252117 * ef + 0.607997
+        re = 0.252117 * ef + 0.607997
       end
+      if re > 0.99
+        runner.registerWarning("Defaulted recovery efficiency (RE = #{re.round(3)}) for water heater '#{water_heating_system.id}' exceeds 0.99, this may indicate incorrect inputs. Proceeding using RE = 0.99.")
+        re = 0.99
+      end
+      return re
     end
   end
 


### PR DESCRIPTION
## Pull Request Description

For situations where a water heater doesn't have Recovery Efficiency (RE) provided, and is defaulted to a value > 0.99 based on our AHRI regression, we now provide a warning and continue the simulation using RE = 0.99. Previously the simulation incurred errors.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
