### PR TITLE
DSE values as fractions

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b632ed3a-3c50-4fed-a540-69c538028d90</version_id>
-  <version_modified>20201215T000042Z</version_modified>
+  <version_id>6c749d72-1968-444d-a033-fa79a05bcd7a</version_id>
+  <version_modified>20201215T205425Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -316,12 +316,6 @@
       <checksum>1A6416EF</checksum>
     </file>
     <file>
-      <filename>BaseElements.xsd</filename>
-      <filetype>xsd</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B7D212FC</checksum>
-    </file>
-    <file>
       <filename>HPXMLDataTypes.xsd</filename>
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
@@ -424,12 +418,6 @@
       <checksum>216063F8</checksum>
     </file>
     <file>
-      <filename>HPXMLvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7FDAF453</checksum>
-    </file>
-    <file>
       <filename>test_hotwater_appliance.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -517,6 +505,18 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>7D19E7A5</checksum>
+    </file>
+    <file>
+      <filename>BaseElements.xsd</filename>
+      <filetype>xsd</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>206E1C74</checksum>
+    </file>
+    <file>
+      <filename>HPXMLvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>A8E978A1</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/BaseElements.xsd
+++ b/HPXMLtoOpenStudio/resources/BaseElements.xsd
@@ -1288,18 +1288,14 @@
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLDouble">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="Fraction">
 										<xs:annotation>
-											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation
-												3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use
-												History.</xs:documentation>
+											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLDouble">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="Fraction">
 										<xs:annotation>
-											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation
-												3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use
-												History.</xs:documentation>
+											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="HVACDistributionImprovement" type="HVACDistributionImprovementInfo"/>

--- a/HPXMLtoOpenStudio/resources/HPXMLvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/HPXMLvalidator.xml
@@ -265,6 +265,10 @@
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:HVAC/h:HVACDistribution'>
       <sch:assert role='ERROR' test='number(h:ConditionedFloorAreaServed) &gt; 0 or not(h:ConditionedFloorAreaServed)'>Expected ConditionedFloorAreaServed to be greater than 0</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AnnualHeatingDistributionSystemEfficiency) &gt;= 0 or not(h:AnnualHeatingDistributionSystemEfficiency)'>Expected AnnualHeatingDistributionSystemEfficiency to be greater than or equal to 0</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AnnualHeatingDistributionSystemEfficiency) &lt;= 1 or not(h:AnnualHeatingDistributionSystemEfficiency)'>Expected AnnualHeatingDistributionSystemEfficiency to be less than or equal to 1</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AnnualCoolingDistributionSystemEfficiency) &gt;= 0 or not(h:AnnualCoolingDistributionSystemEfficiency)'>Expected AnnualCoolingDistributionSystemEfficiency to be greater than or equal to 0</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AnnualCoolingDistributionSystemEfficiency) &lt;= 1 or not(h:AnnualCoolingDistributionSystemEfficiency)'>Expected AnnualCoolingDistributionSystemEfficiency to be less than or equal to 1</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:MechanicalVentilation/h:VentilationFans/h:VentilationFan'>
       <sch:assert role='ERROR' test='number(h:Quantity) &gt; 0 or not(h:Quantity)'>Expected Quantity to be greater than 0</sch:assert>


### PR DESCRIPTION
## Pull Request Description

Ensures `AnnualHeatingDistributionSystemEfficiency` and `AnnualCoolingDistributionSystemEfficiency` values are fractions (0-1) instead of percentages (0-100), similar to other elements in HPXML.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
