### PR TITLE
Ability to skip validation for performance

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -117,6 +117,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     begin
       if skip_validation
         stron_paths = []
+        runner.registerWarning('Skipping HPXML input validation. This should only be used if the HPXML file has already been validated.')
       else
         stron_paths = [File.join(File.dirname(__FILE__), 'resources', 'HPXMLvalidator.xml'),
                        File.join(File.dirname(__FILE__), 'resources', 'EPvalidator.xml')]

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -66,7 +66,13 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
 
     arg = OpenStudio::Measure::OSArgument.makeBoolArgument('debug', false)
     arg.setDisplayName('Debug Mode?')
-    arg.setDescription('If enabled: 1) Writes in.osm file, 2) Writes in.xml HPXML file with defaults populated, 3) Generates additional log output, and 4) Creates all EnergyPlus output files. Any files written will be in the output path specified above.')
+    arg.setDescription('If true: 1) Writes in.osm file, 2) Writes in.xml HPXML file with defaults populated, 3) Generates additional log output, and 4) Creates all EnergyPlus output files. Any files written will be in the output path specified above.')
+    arg.setDefaultValue(false)
+    args << arg
+
+    arg = OpenStudio::Measure::OSArgument.makeBoolArgument('skip_validation', false)
+    arg.setDisplayName('Skip Validation?')
+    arg.setDescription('If true, bypasses HPXML input validation for faster performance. WARNING: This should only be used if the supplied HPXML file has already been validated against the Schema & Schematron documents.')
     arg.setDefaultValue(false)
     args << arg
 
@@ -90,6 +96,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     hpxml_path = runner.getStringArgumentValue('hpxml_path', user_arguments)
     output_dir = runner.getOptionalStringArgumentValue('output_dir', user_arguments)
     debug = runner.getBoolArgumentValue('debug', user_arguments)
+    skip_validation = runner.getBoolArgumentValue('skip_validation', user_arguments)
 
     unless (Pathname.new hpxml_path).absolute?
       hpxml_path = File.expand_path(File.join(File.dirname(__FILE__), hpxml_path))
@@ -108,8 +115,12 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     end
 
     begin
-      stron_paths = [File.join(File.dirname(__FILE__), 'resources', 'HPXMLvalidator.xml'),
-                     File.join(File.dirname(__FILE__), 'resources', 'EPvalidator.xml')]
+      if skip_validation
+        stron_paths = []
+      else
+        stron_paths = [File.join(File.dirname(__FILE__), 'resources', 'HPXMLvalidator.xml'),
+                       File.join(File.dirname(__FILE__), 'resources', 'EPvalidator.xml')]
+      end
       hpxml = HPXML.new(hpxml_path: hpxml_path, schematron_validators: stron_paths)
       hpxml.errors.each do |error|
         runner.registerError(error)

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3dc75d52-73dd-43c1-b4e4-5bca221fde57</version_id>
-  <version_modified>20201216T051729Z</version_modified>
+  <version_id>83c9c9b9-2695-4aac-b106-291ce2ae71ee</version_id>
+  <version_modified>20201216T052503Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -535,7 +535,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>EE4EBEF8</checksum>
+      <checksum>10C4AB91</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6c749d72-1968-444d-a033-fa79a05bcd7a</version_id>
-  <version_modified>20201215T205425Z</version_modified>
+  <version_id>3dc75d52-73dd-43c1-b4e4-5bca221fde57</version_id>
+  <version_modified>20201216T051729Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -30,7 +30,26 @@
     <argument>
       <name>debug</name>
       <display_name>Debug Mode?</display_name>
-      <description>If enabled: 1) Writes in.osm file, 2) Writes in.xml HPXML file with defaults populated, 3) Generates additional log output, and 4) Creates all EnergyPlus output files. Any files written will be in the output path specified above.</description>
+      <description>If true: 1) Writes in.osm file, 2) Writes in.xml HPXML file with defaults populated, 3) Generates additional log output, and 4) Creates all EnergyPlus output files. Any files written will be in the output path specified above.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>skip_validation</name>
+      <display_name>Skip Validation?</display_name>
+      <description>If true, bypasses HPXML input validation for faster performance. WARNING: This should only be used if the supplied HPXML file has already been validated against the Schema &amp; Schematron documents.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -454,17 +473,6 @@
       <checksum>DF137AA1</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>AB6205D6</checksum>
-    </file>
-    <file>
       <filename>test_generator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -517,6 +525,17 @@
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
       <checksum>A8E978A1</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>EE4EBEF8</checksum>
     </file>
   </files>
 </measure>

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -9,109 +9,6 @@ The two OpenStudio measures used by the workflow are:
 #. ``HPXMLtoOpenStudio``: A measure that translates an HPXML file to an OpenStudio model.
 #. ``SimulationOutputReport``: A reporting measure that generates a variety of annual/timeseries outputs for a residential HPXML-based model.
 
-Modeling Capabilities
----------------------
-The OpenStudio-HPXML workflow can accommodate the following building features/technologies:
-
-- Enclosure
-
-  - Attics
-  
-    - Vented
-    - Unvented
-    - Conditioned
-    - Radiant Barriers
-    
-  - Foundations
-  
-    - Slab
-    - Unconditioned Basement
-    - Conditioned Basement
-    - Vented Crawlspace
-    - Unvented Crawlspace
-    - Ambient
-    
-  - Garages
-  - Windows & Overhangs
-  - Skylights
-  - Doors
-  
-- HVAC
-
-  - Heating Systems
-  
-    - Electric Resistance
-    - Central/Wall/Floor Furnaces
-    - Stoves, Portable/Fixed Heaters
-    - Boilers
-    - Fireplaces
-    
-  - Cooling Systems
-  
-    - Central/Room Air Conditioners
-    - Evaporative Coolers
-    - Mini Split Air Conditioners
-    - Chillers
-    - Cooling Towers
-    
-  - Heat Pumps
-  
-    - Air Source Heat Pumps
-    - Mini Split Heat Pumps
-    - Ground Source Heat Pumps
-    - Dual-Fuel Heat Pumps
-    - Water Loop Heat Pumps
-    
-  - Thermostat Setpoints
-  - Ducts
-  
-- Water Heating
-
-  - Water Heaters
-  
-    - Storage Tank
-    - Instantaneous Tankless
-    - Heat Pump Water Heater
-    - Indirect Water Heater (Combination Boiler)
-    - Tankless Coil (Combination Boiler)
-
-  - Solar Hot Water
-  - Desuperheaters
-  - Hot Water Distribution
-  
-    - Recirculation
-    
-  - Drain Water Heat Recovery
-  - Hot Water Fixtures
-  
-- Mechanical Ventilation
-
-  - Exhaust Only
-  - Supply Only
-  - Balanced
-  - Energy Recovery Ventilator
-  - Heat Recovery Ventilator
-  - Central Fan Integrated Supply
-  - Shared Systems w/ Recirculation and/or Preconditioning
-
-- Kitchen/Bath Fans
-- Whole House Fan
-- Photovoltaics
-- Generators
-- Appliances
-
-  - Clothes Washer
-  - Clothes Dryer
-  - Dishwasher
-  - Refrigerator
-  - Cooking Range/Oven
-
-- Dehumidifiers
-- Lighting
-- Ceiling Fans
-- Pool/Hot Tub
-- Plug/Fuel Loads
-
 Scope (Dwelling Units)
 ----------------------
 
@@ -146,9 +43,10 @@ End-to-end simulations typically run in 3-10 seconds, depending on complexity, c
 
 There are additional ways that software developers using this workflow can reduce runtime:
 
-- Run on Linux/Mac platform, which is significantly faster by taking advantage of the POSIX fork call.
-- Do not use the ``--hourly`` flag unless hourly output is required. If required, limit requests to hourly variables of interest.
+- Run on Linux/Mac platform, which is significantly faster than Windows.
 - Run on computing environments with 1) fast CPUs, 2) sufficient memory, and 3) enough processors to allow all simulations to run in parallel.
+- Limit requests for timeseries output (e.g., ``--hourly``, ``--daily``, ``--timestep`` arguments) and limit the number of output variables requested.
+- Use the ``--skip-validation`` argument if the HPXML input file has already been validated against the Schema & Schematron documents.
 
 License
 -------

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -155,10 +155,6 @@ unless Dir.exist?(options[:output_dir])
   FileUtils.mkdir_p(options[:output_dir])
 end
 
-if options[:skip_validation]
-  puts 'WARNING: Skipping HPXML input validation. This should only be used if the HPXML file has already been validated.'
-end
-
 # Create run dir
 rundir = File.join(options[:output_dir], 'run')
 

--- a/workflow/template.osw
+++ b/workflow/template.osw
@@ -8,7 +8,8 @@
       "arguments": {
         "hpxml_path": "../workflow/sample_files/base.xml",
         "output_dir": "../workflow/run",
-        "debug": false
+        "debug": false,
+        "skip_validation": false
       },
       "measure_dir_name": "HPXMLtoOpenStudio"
     },


### PR DESCRIPTION
## Pull Request Description

Adds a `--skip-validation` argument (for faster performance) for software that is already validating the HPXML file against Schema/Schematron upstream.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
