### PR TITLE
Bugfixes for basement adjacent surfaces

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -578,10 +578,9 @@ class OSModel
     new_cond_bsmnt_surfaces = @cond_bsmnt_surfaces.dup
     @cond_bsmnt_surfaces.each do |cond_bsmnt_surface|
       next if cond_bsmnt_surface.is_a? OpenStudio::Model::InternalMassDefinition
-      if not cond_bsmnt_surface.subSurfaces.empty?
-        cond_bsmnt_surface.subSurfaces.each do |ss|
-          new_cond_bsmnt_surfaces << ss
-        end
+      next unless not cond_bsmnt_surface.subSurfaces.empty?
+      cond_bsmnt_surface.subSurfaces.each do |ss|
+        new_cond_bsmnt_surfaces << ss
       end
     end
     @cond_bsmnt_surfaces = new_cond_bsmnt_surfaces.dup
@@ -593,7 +592,7 @@ class OSModel
   def self.update_solar_absorptances(runner, model)
     # modify conditioned basement surface properties
     # zero out interior solar absorptance in conditioned basement
-    
+
     @cond_bsmnt_surfaces.each do |cond_bsmnt_surface|
       adj_surface = nil
       if not cond_bsmnt_surface.is_a? OpenStudio::Model::InternalMassDefinition
@@ -632,13 +631,12 @@ class OSModel
       innermost_material = layered_const.layers[layered_const.numLayers() - 1].to_StandardOpaqueMaterial.get
       innermost_material.setSolarAbsorptance(0.0)
       innermost_material.setVisibleAbsorptance(0.0)
-      if not adj_surface.nil?
-        # Create new construction in case of shared construciton.
-        layered_const_adj = OpenStudio::Model::Construction.new(model)
-        layered_const_adj.setName(cond_bsmnt_surface.construction.get.name.get + ' Reversed Bsmnt')
-        adj_surface.setConstruction(layered_const_adj)
-        layered_const_adj.setLayers(cond_bsmnt_surface.construction.get.to_LayeredConstruction.get.layers.reverse())
-      end
+      next unless not adj_surface.nil?
+      # Create new construction in case of shared construciton.
+      layered_const_adj = OpenStudio::Model::Construction.new(model)
+      layered_const_adj.setName(cond_bsmnt_surface.construction.get.name.get + ' Reversed Bsmnt')
+      adj_surface.setConstruction(layered_const_adj)
+      layered_const_adj.setLayers(cond_bsmnt_surface.construction.get.to_LayeredConstruction.get.layers.reverse())
     end
   end
 

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -594,6 +594,8 @@ class OSModel
     # zero out interior solar absorptance in conditioned basement
 
     @cond_bsmnt_surfaces.each do |cond_bsmnt_surface|
+      # skip windows because windows don't have such property to change.
+      next if cond_bsmnt_surface.is_a?(OpenStudio::Model::SubSurface) && (cond_bsmnt_surface.subSurfaceType.downcase == 'fixedwindow')
       adj_surface = nil
       if not cond_bsmnt_surface.is_a? OpenStudio::Model::InternalMassDefinition
         if not cond_bsmnt_surface.is_a? OpenStudio::Model::SubSurface

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -578,7 +578,7 @@ class OSModel
     new_cond_bsmnt_surfaces = @cond_bsmnt_surfaces.dup
     @cond_bsmnt_surfaces.each do |cond_bsmnt_surface|
       next if cond_bsmnt_surface.is_a? OpenStudio::Model::InternalMassDefinition
-      next unless not cond_bsmnt_surface.subSurfaces.empty?
+      next if cond_bsmnt_surface.subSurfaces.empty?
       cond_bsmnt_surface.subSurfaces.each do |ss|
         new_cond_bsmnt_surfaces << ss
       end
@@ -633,7 +633,7 @@ class OSModel
       innermost_material = layered_const.layers[layered_const.numLayers() - 1].to_StandardOpaqueMaterial.get
       innermost_material.setSolarAbsorptance(0.0)
       innermost_material.setVisibleAbsorptance(0.0)
-      next unless not adj_surface.nil?
+      next if adj_surface.nil?
       # Create new construction in case of shared construciton.
       layered_const_adj = OpenStudio::Model::Construction.new(model)
       layered_const_adj.setName(cond_bsmnt_surface.construction.get.name.get + ' Reversed Bsmnt')

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -672,6 +672,7 @@ class HPXMLTest < MiniTest::Test
       num_expected_kiva_instances = { 'base-foundation-ambient.xml' => 0,                # no foundation in contact w/ ground
                                       'base-foundation-multiple.xml' => 2,               # additional instance for 2nd foundation type
                                       'base-enclosure-2stories-garage.xml' => 2,         # additional instance for garage
+                                      'base-foundation-basement-garage.xml' => 2,        # additional instance for garage
                                       'base-enclosure-garage.xml' => 2,                  # additional instance for garage
                                       'base-foundation-walkout-basement.xml' => 4,       # 3 foundation walls plus a no-wall exposed perimeter
                                       'base-foundation-complex.xml' => 10 }              # lots of foundations for testing


### PR DESCRIPTION
## Pull Request Description

There're some bugs in eliminating basement interior surface solar absorptance:
1. Subsurfaces in conditioned basement (window modeled as door as current workaround) are not modified
2. Those basement surfaces with adjacent surfaces are not handled perfectly. The properties of adjacent surfaces are not modified correspondingly, while OpenStudio expects these two adjacent surfaces are of symmetric construction.
3. For those surfaces exterior adjacent to conditioned basement, their adjacent surfaces are supposed to be put into conditioned basement surface list instead of the surfaces themselves.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
