### PR TITLE
Recognize Type="none" for Pools and Hot Tubs

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -2353,11 +2353,15 @@ class OSModel
 
   def self.add_pools_and_hot_tubs(runner, model, spaces)
     @hpxml.pools.each do |pool|
+      next if pool.type == HPXML::TypeNone
+
       MiscLoads.apply_pool_or_hot_tub_heater(model, pool, Constants.ObjectNameMiscPoolHeater, spaces[HPXML::LocationLivingSpace])
       MiscLoads.apply_pool_or_hot_tub_pump(model, pool, Constants.ObjectNameMiscPoolPump, spaces[HPXML::LocationLivingSpace])
     end
 
     @hpxml.hot_tubs.each do |hot_tub|
+      next if hot_tub.type == HPXML::TypeNone
+
       MiscLoads.apply_pool_or_hot_tub_heater(model, hot_tub, Constants.ObjectNameMiscHotTubHeater, spaces[HPXML::LocationLivingSpace])
       MiscLoads.apply_pool_or_hot_tub_pump(model, hot_tub, Constants.ObjectNameMiscHotTubPump, spaces[HPXML::LocationLivingSpace])
     end

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>2d8214ae-53d7-44d4-b5fa-b0f7064ebfde</version_id>
-  <version_modified>20201224T234647Z</version_modified>
+  <version_id>769ce570-ace5-43c3-9525-a731c0ba2164</version_id>
+  <version_modified>20201230T174951Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -413,12 +413,6 @@
       <checksum>1932CF82</checksum>
     </file>
     <file>
-      <filename>misc_loads.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>EF9CAB5E</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -479,12 +473,6 @@
       <checksum>0033A8C0</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D6372E4F</checksum>
-    </file>
-    <file>
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -497,28 +485,28 @@
       <checksum>206E1C74</checksum>
     </file>
     <file>
-      <filename>HPXMLvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>A8E978A1</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>769DAEDF</checksum>
-    </file>
-    <file>
-      <filename>EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7D05FD81</checksum>
-    </file>
-    <file>
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>C46E5E61</checksum>
+    </file>
+    <file>
+      <filename>hvac_sizing.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>780D9C17</checksum>
+    </file>
+    <file>
+      <filename>misc_loads.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>32F08043</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>85291D94</checksum>
     </file>
     <file>
       <version>
@@ -529,13 +517,25 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>B9E87055</checksum>
+      <checksum>2A8811F6</checksum>
     </file>
     <file>
-      <filename>hvac_sizing.rb</filename>
+      <filename>HPXMLvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>2D8BA500</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>780D9C17</checksum>
+      <checksum>3732F8F4</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>12D1BD69</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.xml
@@ -1414,7 +1414,8 @@
     <sch:title>[Pool]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Pools/h:Pool'>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: SystemIdentifier</sch:assert>
-      <sch:assert role='ERROR' test='count(h:PoolPumps/h:PoolPump) = 1'>Expected 1 element(s) for xpath: PoolPumps/PoolPump</sch:assert> <!-- See [PoolPump] -->
+      <sch:assert role='ERROR' test='count(h:Type) = 1'>Expected 1 element(s) for xpath: Type</sch:assert>
+      <sch:assert role='ERROR' test='count(h:PoolPumps/h:PoolPump) &lt;= 1'>Expected 0 or 1 element(s) for xpath: PoolPumps/PoolPump</sch:assert> <!-- See [PoolPump] -->
       <sch:assert role='ERROR' test='count(h:Heater) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Heater</sch:assert> <!-- See [PoolHeater] -->
     </sch:rule>
   </sch:pattern>
@@ -1423,6 +1424,7 @@
     <sch:title>[PoolPump]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Pools/h:Pool/h:PoolPumps/h:PoolPump'>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: SystemIdentifier</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Type) = 1'>Expected 1 element(s) for xpath: Type</sch:assert>
       <sch:assert role='ERROR' test='count(h:Load[h:Units="kWh/year"]/h:Value) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Load[Units="kWh/year"]/Value</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:UsageMultiplier) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/UsageMultiplier</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:WeekdayScheduleFractions) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/WeekdayScheduleFractions</sch:assert>
@@ -1436,7 +1438,7 @@
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Pools/h:Pool/h:Heater'>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Type) = 1'>Expected 1 element(s) for xpath: Type</sch:assert>
-      <sch:assert role='ERROR' test='h:Type[text()="gas fired" or text()="electric resistance" or text()="heat pump"] or not(h:Type)'>Expected Type to be 'gas fired' or 'electric resistance' or 'heat pump'</sch:assert>
+      <sch:assert role='ERROR' test='h:Type[text()="none" or text()="gas fired" or text()="electric resistance" or text()="heat pump"] or not(h:Type)'>Expected Type to be 'gas fired' or 'electric resistance' or 'heat pump'</sch:assert>
       <sch:assert role='ERROR' test='count(h:Load[h:Units="kWh/year" or h:Units="therm/year"]/h:Value) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Load[Units="kWh/year" or Units="therm/year"]/Value</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:UsageMultiplier) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/UsageMultiplier</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:WeekdayScheduleFractions) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/WeekdayScheduleFractions</sch:assert>
@@ -1449,7 +1451,8 @@
     <sch:title>[HotTub]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:HotTubs/h:HotTub'>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: SystemIdentifier</sch:assert>
-      <sch:assert role='ERROR' test='count(h:HotTubPumps/h:HotTubPump) = 1'>Expected 1 element(s) for xpath: HotTubPumps/HotTubPump</sch:assert> <!-- See [HotTubPump] -->
+      <sch:assert role='ERROR' test='count(h:Type) = 1'>Expected 1 element(s) for xpath: Type</sch:assert>
+      <sch:assert role='ERROR' test='count(h:HotTubPumps/h:HotTubPump) &lt;= 1'>Expected 0 or 1 element(s) for xpath: HotTubPumps/HotTubPump</sch:assert> <!-- See [HotTubPump] -->
       <sch:assert role='ERROR' test='count(h:Heater) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Heater</sch:assert> <!-- See [HotTubHeater] -->
     </sch:rule>
   </sch:pattern>
@@ -1458,6 +1461,7 @@
     <sch:title>[HotTubPump]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:HotTubs/h:HotTub/h:HotTubPumps/h:HotTubPump'>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: SystemIdentifier</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Type) = 1'>Expected 1 element(s) for xpath: Type</sch:assert>
       <sch:assert role='ERROR' test='count(h:Load[h:Units="kWh/year"]/h:Value) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Load[Units="kWh/year"]/Value</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:UsageMultiplier) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/UsageMultiplier</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:WeekdayScheduleFractions) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/WeekdayScheduleFractions</sch:assert>
@@ -1471,7 +1475,7 @@
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:HotTubs/h:HotTub/h:Heater'>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Type) = 1'>Expected 1 element(s) for xpath: Type</sch:assert>
-      <sch:assert role='ERROR' test='h:Type[text()="gas fired" or text()="electric resistance" or text()="heat pump"] or not(h:Type)'>Expected Type to be 'gas fired' or 'electric resistance' or 'heat pump'</sch:assert>
+      <sch:assert role='ERROR' test='h:Type[text()="none" or text()="gas fired" or text()="electric resistance" or text()="heat pump"] or not(h:Type)'>Expected Type to be 'gas fired' or 'electric resistance' or 'heat pump'</sch:assert>
       <sch:assert role='ERROR' test='count(h:Load[h:Units="kWh/year" or h:Units="therm/year"]/h:Value) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Load[Units="kWh/year" or Units="therm/year"]/Value</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:UsageMultiplier) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/UsageMultiplier</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:WeekdayScheduleFractions) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/WeekdayScheduleFractions</sch:assert>

--- a/HPXMLtoOpenStudio/resources/HPXMLvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/HPXMLvalidator.xml
@@ -403,6 +403,12 @@
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Lighting/h:CeilingFan'>
       <sch:assert role='ERROR' test='number(h:Quantity) &gt; 0 or not(h:Quantity)'>Expected Quantity to be greater than 0</sch:assert>
     </sch:rule>
+    <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Pools/h:Pool'>
+      <sch:assert role='ERROR' test='h:Type[text()="in ground" or text()="on ground" or text()="above ground" or text()="other" or text()="unknown" or text()="none"] or not(h:Type)'>Expected Type to be 'in ground' or 'on ground' or 'above ground' or 'other' or 'unknown' or 'none'</sch:assert>
+    </sch:rule>
+    <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Pools/h:Pool/h:PoolPumps/h:PoolPump'>
+      <sch:assert role='ERROR' test='h:Type[text()="single speed" or text()="multi speed" or text()="variable speed" or text()="variable flow" or text()="other" or text()="unknown" or text()="none"] or not(h:Type)'>Expected Type to be 'single speed' or 'multi speed' or 'variable speed' or 'variable flow' or 'other' or 'unknown' or 'none'</sch:assert>
+    </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Pools/h:Pool/h:PoolPumps/h:PoolPump/h:Load'>
       <sch:assert role='ERROR' test='h:Units[text()="kWh/year" or text()="W"] or not(h:Units)'>Expected Units to be 'kWh/year' or 'W'</sch:assert>
     </sch:rule>
@@ -411,6 +417,12 @@
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Pools/h:Pool/h:Heater/h:Load'>
       <sch:assert role='ERROR' test='h:Units[text()="kWh/year" or text()="therm/year" or text()="W" or text()="Btuh"] or not(h:Units)'>Expected Units to be 'kWh/year' or 'therm/year' or 'W' or 'Btuh'</sch:assert>
+    </sch:rule>
+    <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:HotTubs/h:HotTub'>
+      <sch:assert role='ERROR' test='h:Type[text()="in ground" or text()="on ground" or text()="above ground" or text()="other" or text()="unknown" or text()="none"] or not(h:Type)'>Expected Type to be 'in ground' or 'on ground' or 'above ground' or 'other' or 'unknown' or 'none'</sch:assert>
+    </sch:rule>
+    <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:HotTubs/h:HotTub/h:HotTubPumps/h:HotTubPump'>
+      <sch:assert role='ERROR' test='h:Type[text()="single speed" or text()="multi speed" or text()="variable speed" or text()="variable flow" or text()="other" or text()="unknown" or text()="none"] or not(h:Type)'>Expected Type to be 'single speed' or 'multi speed' or 'variable speed' or 'variable flow' or 'other' or 'unknown' or 'none'</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:HotTubs/h:HotTub/h:HotTubPumps/h:HotTubPump/h:Load'>
       <sch:assert role='ERROR' test='h:Units[text()="kWh/year" or text()="W"] or not(h:Units)'>Expected Units to be 'kWh/year' or 'W'</sch:assert>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -233,6 +233,8 @@ class HPXML < Object
   SolarThermalTypeEvacuatedTube = 'evacuated tube'
   SolarThermalTypeICS = 'integrated collector storage'
   SolarThermalTypeSingleGlazing = 'single glazing black'
+  TypeNone = 'none'
+  TypeUnknown = 'unknown'
   UnitsACH = 'ACH'
   UnitsACHNatural = 'ACHnatural'
   UnitsAFUE = 'AFUE'
@@ -4707,8 +4709,8 @@ class HPXML < Object
   end
 
   class Pool < BaseElement
-    ATTRS = [:id, :heater_id, :heater_type, :heater_load_units, :heater_load_value, :heater_usage_multiplier,
-             :pump_id, :pump_kwh_per_year, :pump_usage_multiplier,
+    ATTRS = [:id, :type, :heater_id, :heater_type, :heater_load_units, :heater_load_value, :heater_usage_multiplier,
+             :pump_id, :pump_type, :pump_kwh_per_year, :pump_usage_multiplier,
              :heater_weekday_fractions, :heater_weekend_fractions, :heater_monthly_multipliers,
              :pump_weekday_fractions, :pump_weekend_fractions, :pump_monthly_multipliers]
     attr_accessor(*ATTRS)
@@ -4729,24 +4731,28 @@ class HPXML < Object
       pool = XMLHelper.add_element(pools, 'Pool')
       sys_id = XMLHelper.add_element(pool, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      pumps = XMLHelper.add_element(pool, 'PoolPumps')
-      pool_pump = XMLHelper.add_element(pumps, 'PoolPump')
-      sys_id = XMLHelper.add_element(pool_pump, 'SystemIdentifier')
-      if not @pump_id.nil?
-        XMLHelper.add_attribute(sys_id, 'id', @pump_id)
-      else
-        XMLHelper.add_attribute(sys_id, 'id', @id + 'Pump')
-      end
-      if not @pump_kwh_per_year.nil?
-        load = XMLHelper.add_element(pool_pump, 'Load')
-        XMLHelper.add_element(load, 'Units', UnitsKwhPerYear, :string)
-        XMLHelper.add_element(load, 'Value', @pump_kwh_per_year, :float, @pump_kwh_per_year_isdefaulted)
-        XMLHelper.add_extension(pool_pump, 'UsageMultiplier', @pump_usage_multiplier, :float, @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
-        XMLHelper.add_extension(pool_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, :string, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
-        XMLHelper.add_extension(pool_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, :string, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
-        XMLHelper.add_extension(pool_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, :string, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
-      end
-      if not @heater_type.nil?
+      XMLHelper.add_element(pool, 'Type', @type, :string) unless @type.nil?
+      if @type != HPXML::TypeNone
+        pumps = XMLHelper.add_element(pool, 'PoolPumps')
+        pool_pump = XMLHelper.add_element(pumps, 'PoolPump')
+        sys_id = XMLHelper.add_element(pool_pump, 'SystemIdentifier')
+        if not @pump_id.nil?
+          XMLHelper.add_attribute(sys_id, 'id', @pump_id)
+        else
+          XMLHelper.add_attribute(sys_id, 'id', @id + 'Pump')
+        end
+        XMLHelper.add_element(pool_pump, 'Type', @pump_type, :string)
+        if @pump_type != HPXML::TypeNone
+          if not @pump_kwh_per_year.nil?
+            load = XMLHelper.add_element(pool_pump, 'Load')
+            XMLHelper.add_element(load, 'Units', UnitsKwhPerYear, :string)
+            XMLHelper.add_element(load, 'Value', @pump_kwh_per_year, :float, @pump_kwh_per_year_isdefaulted)
+          end
+          XMLHelper.add_extension(pool_pump, 'UsageMultiplier', @pump_usage_multiplier, :float, @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
+          XMLHelper.add_extension(pool_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, :string, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
+          XMLHelper.add_extension(pool_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, :string, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
+          XMLHelper.add_extension(pool_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, :string, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
+        end
         heater = XMLHelper.add_element(pool, 'Heater')
         sys_id = XMLHelper.add_element(heater, 'SystemIdentifier')
         if not @heater_id.nil?
@@ -4755,27 +4761,33 @@ class HPXML < Object
           XMLHelper.add_attribute(sys_id, 'id', @id + 'Heater')
         end
         XMLHelper.add_element(heater, 'Type', @heater_type, :string)
-        if (not @heater_load_units.nil?) && (not @heater_load_value.nil?)
-          load = XMLHelper.add_element(heater, 'Load')
-          XMLHelper.add_element(load, 'Units', @heater_load_units, :string)
-          XMLHelper.add_element(load, 'Value', @heater_load_value, :float, @heater_load_value_isdefaulted)
+        if @heater_type != HPXML::TypeNone
+          if (not @heater_load_units.nil?) && (not @heater_load_value.nil?)
+            load = XMLHelper.add_element(heater, 'Load')
+            XMLHelper.add_element(load, 'Units', @heater_load_units, :string)
+            XMLHelper.add_element(load, 'Value', @heater_load_value, :float, @heater_load_value_isdefaulted)
+          end
+          XMLHelper.add_extension(heater, 'UsageMultiplier', @heater_usage_multiplier, :float, @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
+          XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, :string, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
+          XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, :string, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
+          XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, :string, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
         end
-        XMLHelper.add_extension(heater, 'UsageMultiplier', @heater_usage_multiplier, :float, @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
-        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, :string, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
-        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, :string, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
-        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, :string, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
       end
     end
 
     def from_oga(pool)
       @id = HPXML::get_id(pool)
+      @type = XMLHelper.get_value(pool, 'Type', :string)
       pool_pump = XMLHelper.get_element(pool, 'PoolPumps/PoolPump')
-      @pump_id = HPXML::get_id(pool_pump)
-      @pump_kwh_per_year, @pump_kwh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
-      @pump_usage_multiplier, @pump_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/UsageMultiplier', :float)
-      @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekdayScheduleFractions', :string)
-      @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekendScheduleFractions', :string)
-      @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/MonthlyScheduleMultipliers', :string)
+      if not pool_pump.nil?
+        @pump_id = HPXML::get_id(pool_pump)
+        @pump_type = XMLHelper.get_value(pool_pump, 'Type', :string)
+        @pump_kwh_per_year, @pump_kwh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
+        @pump_usage_multiplier, @pump_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/UsageMultiplier', :float)
+        @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekdayScheduleFractions', :string)
+        @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/WeekendScheduleFractions', :string)
+        @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(pool_pump, 'extension/MonthlyScheduleMultipliers', :string)
+      end
       heater = XMLHelper.get_element(pool, 'Heater')
       if not heater.nil?
         @heater_id = HPXML::get_id(heater)
@@ -4805,8 +4817,8 @@ class HPXML < Object
   end
 
   class HotTub < BaseElement
-    ATTRS = [:id, :heater_id, :heater_type, :heater_load_units, :heater_load_value, :heater_usage_multiplier,
-             :pump_id, :pump_kwh_per_year, :pump_usage_multiplier,
+    ATTRS = [:id, :type, :heater_id, :heater_type, :heater_load_units, :heater_load_value, :heater_usage_multiplier,
+             :pump_id, :pump_type, :pump_kwh_per_year, :pump_usage_multiplier,
              :heater_weekday_fractions, :heater_weekend_fractions, :heater_monthly_multipliers,
              :pump_weekday_fractions, :pump_weekend_fractions, :pump_monthly_multipliers]
     attr_accessor(*ATTRS)
@@ -4827,24 +4839,28 @@ class HPXML < Object
       hot_tub = XMLHelper.add_element(hot_tubs, 'HotTub')
       sys_id = XMLHelper.add_element(hot_tub, 'SystemIdentifier')
       XMLHelper.add_attribute(sys_id, 'id', @id)
-      pumps = XMLHelper.add_element(hot_tub, 'HotTubPumps')
-      hot_tub_pump = XMLHelper.add_element(pumps, 'HotTubPump')
-      sys_id = XMLHelper.add_element(hot_tub_pump, 'SystemIdentifier')
-      if not @pump_id.nil?
-        XMLHelper.add_attribute(sys_id, 'id', @pump_id)
-      else
-        XMLHelper.add_attribute(sys_id, 'id', @id + 'Pump')
-      end
-      if not @pump_kwh_per_year.nil?
-        load = XMLHelper.add_element(hot_tub_pump, 'Load')
-        XMLHelper.add_element(load, 'Units', UnitsKwhPerYear, :string)
-        XMLHelper.add_element(load, 'Value', @pump_kwh_per_year, :float, @pump_kwh_per_year_isdefaulted)
-        XMLHelper.add_extension(hot_tub_pump, 'UsageMultiplier', @pump_usage_multiplier, :float, @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, :string, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, :string, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
-        XMLHelper.add_extension(hot_tub_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, :string, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
-      end
-      if not @heater_type.nil?
+      XMLHelper.add_element(hot_tub, 'Type', @type, :string) unless @type.nil?
+      if @type != HPXML::TypeNone
+        pumps = XMLHelper.add_element(hot_tub, 'HotTubPumps')
+        hot_tub_pump = XMLHelper.add_element(pumps, 'HotTubPump')
+        sys_id = XMLHelper.add_element(hot_tub_pump, 'SystemIdentifier')
+        if not @pump_id.nil?
+          XMLHelper.add_attribute(sys_id, 'id', @pump_id)
+        else
+          XMLHelper.add_attribute(sys_id, 'id', @id + 'Pump')
+        end
+        XMLHelper.add_element(hot_tub_pump, 'Type', @pump_type, :string)
+        if @pump_type != HPXML::TypeNone
+          if not @pump_kwh_per_year.nil?
+            load = XMLHelper.add_element(hot_tub_pump, 'Load')
+            XMLHelper.add_element(load, 'Units', UnitsKwhPerYear, :string)
+            XMLHelper.add_element(load, 'Value', @pump_kwh_per_year, :float, @pump_kwh_per_year_isdefaulted)
+          end
+          XMLHelper.add_extension(hot_tub_pump, 'UsageMultiplier', @pump_usage_multiplier, :float, @pump_usage_multiplier_isdefaulted) unless @pump_usage_multiplier.nil?
+          XMLHelper.add_extension(hot_tub_pump, 'WeekdayScheduleFractions', @pump_weekday_fractions, :string, @pump_weekday_fractions_isdefaulted) unless @pump_weekday_fractions.nil?
+          XMLHelper.add_extension(hot_tub_pump, 'WeekendScheduleFractions', @pump_weekend_fractions, :string, @pump_weekend_fractions_isdefaulted) unless @pump_weekend_fractions.nil?
+          XMLHelper.add_extension(hot_tub_pump, 'MonthlyScheduleMultipliers', @pump_monthly_multipliers, :string, @pump_monthly_multipliers_isdefaulted) unless @pump_monthly_multipliers.nil?
+        end
         heater = XMLHelper.add_element(hot_tub, 'Heater')
         sys_id = XMLHelper.add_element(heater, 'SystemIdentifier')
         if not @heater_id.nil?
@@ -4853,27 +4869,33 @@ class HPXML < Object
           XMLHelper.add_attribute(sys_id, 'id', @id + 'Heater')
         end
         XMLHelper.add_element(heater, 'Type', @heater_type, :string)
-        if (not @heater_load_units.nil?) && (not @heater_load_value.nil?)
-          load = XMLHelper.add_element(heater, 'Load')
-          XMLHelper.add_element(load, 'Units', @heater_load_units, :string)
-          XMLHelper.add_element(load, 'Value', @heater_load_value, :float, @heater_load_value_isdefaulted)
+        if @heater_type != HPXML::TypeNone
+          if (not @heater_load_units.nil?) && (not @heater_load_value.nil?)
+            load = XMLHelper.add_element(heater, 'Load')
+            XMLHelper.add_element(load, 'Units', @heater_load_units, :string)
+            XMLHelper.add_element(load, 'Value', @heater_load_value, :float, @heater_load_value_isdefaulted)
+          end
+          XMLHelper.add_extension(heater, 'UsageMultiplier', @heater_usage_multiplier, :float, @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
+          XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, :string, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
+          XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, :string, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
+          XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, :string, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
         end
-        XMLHelper.add_extension(heater, 'UsageMultiplier', @heater_usage_multiplier, :float, @heater_usage_multiplier_isdefaulted) unless @heater_usage_multiplier.nil?
-        XMLHelper.add_extension(heater, 'WeekdayScheduleFractions', @heater_weekday_fractions, :string, @heater_weekday_fractions_isdefaulted) unless @heater_weekday_fractions.nil?
-        XMLHelper.add_extension(heater, 'WeekendScheduleFractions', @heater_weekend_fractions, :string, @heater_weekend_fractions_isdefaulted) unless @heater_weekend_fractions.nil?
-        XMLHelper.add_extension(heater, 'MonthlyScheduleMultipliers', @heater_monthly_multipliers, :string, @heater_monthly_multipliers_isdefaulted) unless @heater_monthly_multipliers.nil?
       end
     end
 
     def from_oga(hot_tub)
       @id = HPXML::get_id(hot_tub)
+      @type = XMLHelper.get_value(hot_tub, 'Type', :string)
       hot_tub_pump = XMLHelper.get_element(hot_tub, 'HotTubPumps/HotTubPump')
-      @pump_id = HPXML::get_id(hot_tub_pump)
-      @pump_kwh_per_year, @pump_kwh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
-      @pump_usage_multiplier, @pump_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/UsageMultiplier', :float)
-      @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekdayScheduleFractions', :string)
-      @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekendScheduleFractions', :string)
-      @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/MonthlyScheduleMultipliers', :string)
+      if not hot_tub_pump.nil?
+        @pump_id = HPXML::get_id(hot_tub_pump)
+        @pump_type = XMLHelper.get_value(hot_tub_pump, 'Type', :string)
+        @pump_kwh_per_year, @pump_kwh_per_year_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, "Load[Units='#{UnitsKwhPerYear}']/Value", :float)
+        @pump_usage_multiplier, @pump_usage_multiplier_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/UsageMultiplier', :float)
+        @pump_weekday_fractions, @pump_weekday_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekdayScheduleFractions', :string)
+        @pump_weekend_fractions, @pump_weekend_fractions_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/WeekendScheduleFractions', :string)
+        @pump_monthly_multipliers, @pump_monthly_multipliers_isdefaulted = XMLHelper.get_value_and_defaulted(hot_tub_pump, 'extension/MonthlyScheduleMultipliers', :string)
+      end
       heater = XMLHelper.get_element(hot_tub, 'Heater')
       if not heater.nil?
         @heater_id = HPXML::get_id(heater)

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -1154,10 +1154,34 @@ class HPXMLDefaults
 
   def self.apply_pools_and_hot_tubs(hpxml, cfa, nbeds)
     hpxml.pools.each do |pool|
-      if pool.pump_kwh_per_year.nil?
-        pool.pump_kwh_per_year = MiscLoads.get_pool_pump_default_values(cfa, nbeds)
-        pool.pump_kwh_per_year_isdefaulted = true
+      next if pool.type == HPXML::TypeNone
+
+      if pool.pump_type != HPXML::TypeNone
+        # Pump
+        if pool.pump_kwh_per_year.nil?
+          pool.pump_kwh_per_year = MiscLoads.get_pool_pump_default_values(cfa, nbeds)
+          pool.pump_kwh_per_year_isdefaulted = true
+        end
+        if pool.pump_usage_multiplier.nil?
+          pool.pump_usage_multiplier = 1.0
+          pool.pump_usage_multiplier_isdefaulted = true
+        end
+        if pool.pump_weekday_fractions.nil?
+          pool.pump_weekday_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
+          pool.pump_weekday_fractions_isdefaulted = true
+        end
+        if pool.pump_weekend_fractions.nil?
+          pool.pump_weekend_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
+          pool.pump_weekend_fractions_isdefaulted = true
+        end
+        if pool.pump_monthly_multipliers.nil?
+          pool.pump_monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
+          pool.pump_monthly_multipliers_isdefaulted = true
+        end
       end
+
+      next unless pool.heater_type != HPXML::TypeNone
+      # Heater
       if pool.heater_load_value.nil?
         default_heater_load_units, default_heater_load_value = MiscLoads.get_pool_heater_default_values(cfa, nbeds, pool.heater_type)
         pool.heater_load_units = default_heater_load_units
@@ -1167,22 +1191,6 @@ class HPXMLDefaults
       if pool.heater_usage_multiplier.nil?
         pool.heater_usage_multiplier = 1.0
         pool.heater_usage_multiplier_isdefaulted = true
-      end
-      if pool.pump_usage_multiplier.nil?
-        pool.pump_usage_multiplier = 1.0
-        pool.pump_usage_multiplier_isdefaulted = true
-      end
-      if pool.pump_weekday_fractions.nil?
-        pool.pump_weekday_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
-        pool.pump_weekday_fractions_isdefaulted = true
-      end
-      if pool.pump_weekend_fractions.nil?
-        pool.pump_weekend_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
-        pool.pump_weekend_fractions_isdefaulted = true
-      end
-      if pool.pump_monthly_multipliers.nil?
-        pool.pump_monthly_multipliers = '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154'
-        pool.pump_monthly_multipliers_isdefaulted = true
       end
       if pool.heater_weekday_fractions.nil?
         pool.heater_weekday_fractions = '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003'
@@ -1199,10 +1207,34 @@ class HPXMLDefaults
     end
 
     hpxml.hot_tubs.each do |hot_tub|
-      if hot_tub.pump_kwh_per_year.nil?
-        hot_tub.pump_kwh_per_year = MiscLoads.get_hot_tub_pump_default_values(cfa, nbeds)
-        hot_tub.pump_kwh_per_year_isdefaulted = true
+      next if hot_tub.type == HPXML::TypeNone
+
+      if hot_tub.pump_type != HPXML::TypeNone
+        # Pump
+        if hot_tub.pump_kwh_per_year.nil?
+          hot_tub.pump_kwh_per_year = MiscLoads.get_hot_tub_pump_default_values(cfa, nbeds)
+          hot_tub.pump_kwh_per_year_isdefaulted = true
+        end
+        if hot_tub.pump_usage_multiplier.nil?
+          hot_tub.pump_usage_multiplier = 1.0
+          hot_tub.pump_usage_multiplier_isdefaulted = true
+        end
+        if hot_tub.pump_weekday_fractions.nil?
+          hot_tub.pump_weekday_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
+          hot_tub.pump_weekday_fractions_isdefaulted = true
+        end
+        if hot_tub.pump_weekend_fractions.nil?
+          hot_tub.pump_weekend_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
+          hot_tub.pump_weekend_fractions_isdefaulted = true
+        end
+        if hot_tub.pump_monthly_multipliers.nil?
+          hot_tub.pump_monthly_multipliers = '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921'
+          hot_tub.pump_monthly_multipliers_isdefaulted = true
+        end
       end
+
+      next unless hot_tub.heater_type != HPXML::TypeNone
+      # Heater
       if hot_tub.heater_load_value.nil?
         default_heater_load_units, default_heater_load_value = MiscLoads.get_hot_tub_heater_default_values(cfa, nbeds, hot_tub.heater_type)
         hot_tub.heater_load_units = default_heater_load_units
@@ -1212,22 +1244,6 @@ class HPXMLDefaults
       if hot_tub.heater_usage_multiplier.nil?
         hot_tub.heater_usage_multiplier = 1.0
         hot_tub.heater_usage_multiplier_isdefaulted = true
-      end
-      if hot_tub.pump_usage_multiplier.nil?
-        hot_tub.pump_usage_multiplier = 1.0
-        hot_tub.pump_usage_multiplier_isdefaulted = true
-      end
-      if hot_tub.pump_weekday_fractions.nil?
-        hot_tub.pump_weekday_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
-        hot_tub.pump_weekday_fractions_isdefaulted = true
-      end
-      if hot_tub.pump_weekend_fractions.nil?
-        hot_tub.pump_weekend_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'
-        hot_tub.pump_weekend_fractions_isdefaulted = true
-      end
-      if hot_tub.pump_monthly_multipliers.nil?
-        hot_tub.pump_monthly_multipliers = '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921'
-        hot_tub.pump_monthly_multipliers_isdefaulted = true
       end
       if hot_tub.heater_weekday_fractions.nil?
         hot_tub.heater_weekday_fractions = '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024'

--- a/HPXMLtoOpenStudio/resources/misc_loads.rb
+++ b/HPXMLtoOpenStudio/resources/misc_loads.rb
@@ -88,13 +88,18 @@ class MiscLoads
   end
 
   def self.apply_pool_or_hot_tub_heater(model, pool_or_hot_tub, obj_name, living_space)
+    return if pool_or_hot_tub.heater_type == HPXML::TypeNone
+
     heater_kwh = 0
     heater_therm = 0
-    heater_sch = MonthWeekdayWeekendSchedule.new(model, obj_name + ' schedule', pool_or_hot_tub.heater_weekday_fractions, pool_or_hot_tub.heater_weekend_fractions, pool_or_hot_tub.heater_monthly_multipliers, Constants.ScheduleTypeLimitsFraction)
     if pool_or_hot_tub.heater_load_units == HPXML::UnitsKwhPerYear
       heater_kwh = pool_or_hot_tub.heater_load_value * pool_or_hot_tub.heater_usage_multiplier
     elsif pool_or_hot_tub.heater_load_units == HPXML::UnitsThermPerYear
       heater_therm = pool_or_hot_tub.heater_load_value * pool_or_hot_tub.heater_usage_multiplier
+    end
+
+    if (heater_kwh > 0) || (heater_therm > 0)
+      heater_sch = MonthWeekdayWeekendSchedule.new(model, obj_name + ' schedule', pool_or_hot_tub.heater_weekday_fractions, pool_or_hot_tub.heater_weekend_fractions, pool_or_hot_tub.heater_monthly_multipliers, Constants.ScheduleTypeLimitsFraction)
     end
 
     if heater_kwh > 0
@@ -131,13 +136,15 @@ class MiscLoads
   end
 
   def self.apply_pool_or_hot_tub_pump(model, pool_or_hot_tub, obj_name, living_space)
+    return if pool_or_hot_tub.pump_type == HPXML::TypeNone
+
     pump_kwh = 0
-    pump_sch = MonthWeekdayWeekendSchedule.new(model, obj_name + ' schedule', pool_or_hot_tub.pump_weekday_fractions, pool_or_hot_tub.pump_weekend_fractions, pool_or_hot_tub.pump_monthly_multipliers, Constants.ScheduleTypeLimitsFraction)
     if not pool_or_hot_tub.pump_kwh_per_year.nil?
       pump_kwh = pool_or_hot_tub.pump_kwh_per_year * pool_or_hot_tub.pump_usage_multiplier
     end
 
     if pump_kwh > 0
+      pump_sch = MonthWeekdayWeekendSchedule.new(model, obj_name + ' schedule', pool_or_hot_tub.pump_weekday_fractions, pool_or_hot_tub.pump_weekend_fractions, pool_or_hot_tub.pump_monthly_multipliers, Constants.ScheduleTypeLimitsFraction)
       space_design_level = pump_sch.calcDesignLevelFromDailykWh(pump_kwh / 365.0)
 
       mel_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -2096,17 +2096,23 @@ If not entered, the simulation will not include a pool.
   Element               Type     Units   Constraints  Required  Default       Notes
   ====================  =======  ======  ===========  ========  ============  =================
   ``SystemIdentifier``  id                            Yes                     Unique identifier
+  ``Type``              string           See [#]_     Yes                     Pool type
   ====================  =======  ======  ===========  ========  ============  =================
+
+  .. [#] Type choices are "in ground", "on ground", "above ground", "other", "unknown", or "none".
+         If "none" is entered, the simulation will not include a pool.
 
 Pool Pump
 ~~~~~~~~~
 
-If a pool is specified, a single pool pump must be entered as a ``Pool/PoolPumps/PoolPump``.
+If a pool is specified, a single pool pump can be entered as a ``Pool/PoolPumps/PoolPump``.
+If not entered, the simulation will not include a pool heater.
 
   ========================================  =======  ======  ===========  ========  ============  ======================================
   Element                                   Type     Units   Constraints  Required  Default       Notes
   ========================================  =======  ======  ===========  ========  ============  ======================================
   ``SystemIdentifier``                      id                            Yes                     Unique identifier
+  ``Type``                                  string           See [#]_     Yes                     Pool pump type
   ``Load[Units="kWh/year"]/Value``          double   kWh/yr  >= 0         No        See [#]_      Pool pump energy use
   ``extension/UsageMultiplier``             double           >= 0         No        1.0           Multiplier on pool pump energy use
   ``extension/WeekdayScheduleFractions``    array                         No        See [#]_      24 comma-separated weekday fractions
@@ -2114,6 +2120,8 @@ If a pool is specified, a single pool pump must be entered as a ``Pool/PoolPumps
   ``extension/MonthlyScheduleMultipliers``  array                         No        See [#]_      12 comma-separated monthly multipliers
   ========================================  =======  ======  ===========  ========  ============  ======================================
 
+  .. [#] Type choices are "single speed", "multi speed", "variable speed", "variable flow", "other", "unknown", or "none".
+         If "none" is entered, the simulation will not include a pool pump.
   .. [#] If Value not provided, defaults based on the `2010 BAHSP <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_: 158.5 / 0.070 * (0.5 + 0.25 * NumberofBedrooms / 3 + 0.35 * ConditionedFloorArea / 1920).
   .. [#] If WeekdayScheduleFractions or WeekendScheduleFractions not provided, default values from Figure 23 of the `2010 BAHSP <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_ are used: "0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003".
   .. [#] If MonthlyScheduleMultipliers not provided, default values from Figure 24 of the `2010 BAHSP <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_ are used: "1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154".
@@ -2122,6 +2130,7 @@ Pool Heater
 ~~~~~~~~~~~
 
 If a pool is specified, a pool heater can be entered as a ``Pool/Heater``.
+If not entered, the simulation will not include a pool heater.
 
   ======================================================  =======  ==================  ===========  ========  ========  ======================================
   Element                                                 Type     Units               Constraints  Required  Default   Notes
@@ -2135,7 +2144,8 @@ If a pool is specified, a pool heater can be entered as a ``Pool/Heater``.
   ``extension/MonthlyScheduleMultipliers``                array                                     No        See [#]_  12 comma-separated monthly multipliers
   ======================================================  =======  ==================  ===========  ========  ========  ======================================
 
-  .. [#] Type choices are "gas fired", "electric resistance", or "heat pump".
+  .. [#] Type choices are "none, "gas fired", "electric resistance", or "heat pump".
+         If "none" is entered, the simulation will not include a pool heater.
   .. [#] If Value not provided, defaults as follows:
          
          - **gas fired**: 3.0 / 0.014 * (0.5 + 0.25 * NumberofBedrooms / 3 + 0.35 * ConditionedFloorArea / 1920) (based on the `2010 BAHSP <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_)
@@ -2155,17 +2165,23 @@ If not entered, the simulation will not include a hot tub.
   Element               Type     Units   Constraints  Required  Default       Notes
   ====================  =======  ======  ===========  ========  ============  =================
   ``SystemIdentifier``  id                            Yes                     Unique identifier
+  ``Type``              string           See [#]_     Yes                     Hot tub type
   ====================  =======  ======  ===========  ========  ============  =================
+
+  .. [#] Type choices are "in ground", "on ground", "above ground", "other", "unknown", or "none".
+         If "none" is entered, the simulation will not include a hot tub.
 
 Hot Tub Pump
 ~~~~~~~~~~~~
 
-If a hot tub is specified, a single hot tub pump must be entered as a ``HotTub/HotTubPumps/HotTubPump``.
+If a hot tub is specified, a single hot tub pump can be entered as a ``HotTub/HotTubPumps/HotTubPump``.
+If not entered, the simulation will not include a hot tub pump.
 
   ========================================  =======  ======  ===========  ========  ============  ======================================
   Element                                   Type     Units   Constraints  Required  Default       Notes
   ========================================  =======  ======  ===========  ========  ============  ======================================
   ``SystemIdentifier``                      id                            Yes                     Unique identifier
+  ``Type``                                  string           See [#]_     Yes                     Hot tub pump type
   ``Load[Units="kWh/year"]/Value``          double   kWh/yr  >= 0         No        See [#]_      Hot tub pump energy use
   ``extension/UsageMultiplier``             double           >= 0         No        1.0           Multiplier on hot tub pump energy use
   ``extension/WeekdayScheduleFractions``    array                         No        See [#]_      24 comma-separated weekday fractions
@@ -2173,6 +2189,8 @@ If a hot tub is specified, a single hot tub pump must be entered as a ``HotTub/H
   ``extension/MonthlyScheduleMultipliers``  array                         No        See [#]_      12 comma-separated monthly multipliers
   ========================================  =======  ======  ===========  ========  ============  ======================================
 
+  .. [#] Type choices are "single speed", "multi speed", "variable speed", "variable flow", "other", "unknown", or "none".
+         If "none" is entered, the simulation will not include a hot tub pump.
   .. [#] If Value not provided, defaults based on the `2010 BAHSP <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_: 59.5 / 0.059 * (0.5 + 0.25 * NumberofBedrooms / 3 + 0.35 * ConditionedFloorArea / 1920).
   .. [#] If WeekdayScheduleFractions or WeekendScheduleFractions not provided, default values from Figure 23 of the `2010 BAHSP <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_ are used: "0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024".
   .. [#] If MonthlyScheduleMultipliers not provided, default values from Figure 24 of the `2010 BAHSP <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_ are used: "0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921".
@@ -2181,6 +2199,7 @@ Hot Tub Heater
 ~~~~~~~~~~~~~~
 
 If a hot tub is specified, a hot tub heater can be entered as a ``HotTub/Heater``.
+If not entered, the simulation will not include a hot tub heater.
 
   ======================================================  =======  ==================  ===========  ========  ========  =======================================
   Element                                                 Type     Units               Constraints  Required  Default   Notes
@@ -2194,7 +2213,8 @@ If a hot tub is specified, a hot tub heater can be entered as a ``HotTub/Heater`
   ``extension/MonthlyScheduleMultipliers``                array                                     No        See [#]_  12 comma-separated monthly multipliers
   ======================================================  =======  ==================  ===========  ========  ========  =======================================
 
-  .. [#] Type choices are "gas fired", "electric resistance", or "heat pump".
+  .. [#] Type choices are "none, "gas fired", "electric resistance", or "heat pump".
+         If "none" is entered, the simulation will not include a hot tub heater.
   .. [#] If Value not provided, defaults as follows:
          
          - **gas fired [therm/year]**: 0.87 / 0.011 * (0.5 + 0.25 * NumberofBedrooms / 3 + 0.35 * ConditionedFloorArea / 1920) (based on the `2010 BAHSP <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_)

--- a/tasks.rb
+++ b/tasks.rb
@@ -4927,16 +4927,18 @@ def set_hpxml_pools(hpxml_file, hpxml)
   if ['base-misc-loads-large-uncommon.xml',
       'base-misc-usage-multiplier.xml'].include? hpxml_file
     hpxml.pools.add(id: 'Pool',
+                    type: HPXML::TypeUnknown,
+                    pump_type: HPXML::TypeUnknown,
+                    pump_kwh_per_year: 2700,
+                    pump_weekday_fractions: '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003',
+                    pump_weekend_fractions: '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003',
+                    pump_monthly_multipliers: '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154',
                     heater_type: HPXML::HeaterTypeGas,
                     heater_load_units: HPXML::UnitsThermPerYear,
                     heater_load_value: 500,
-                    pump_kwh_per_year: 2700,
                     heater_weekday_fractions: '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003',
                     heater_weekend_fractions: '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003',
-                    heater_monthly_multipliers: '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154',
-                    pump_weekday_fractions: '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003',
-                    pump_weekend_fractions: '0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003',
-                    pump_monthly_multipliers: '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
+                    heater_monthly_multipliers: '1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154')
     if hpxml_file == 'base-misc-usage-multiplier.xml'
       hpxml.pools.each do |pool|
         pool.pump_usage_multiplier = 0.9
@@ -4944,11 +4946,7 @@ def set_hpxml_pools(hpxml_file, hpxml)
       end
     end
   elsif ['base-misc-loads-large-uncommon2.xml'].include? hpxml_file
-    hpxml.pools[0].heater_type = nil
-    hpxml.pools[0].heater_load_value = nil
-    hpxml.pools[0].heater_weekday_fractions = nil
-    hpxml.pools[0].heater_weekend_fractions = nil
-    hpxml.pools[0].heater_monthly_multipliers = nil
+    hpxml.pools[0].heater_type = HPXML::TypeNone
   end
 end
 
@@ -4956,16 +4954,18 @@ def set_hpxml_hot_tubs(hpxml_file, hpxml)
   if ['base-misc-loads-large-uncommon.xml',
       'base-misc-usage-multiplier.xml'].include? hpxml_file
     hpxml.hot_tubs.add(id: 'HotTub',
+                       type: HPXML::TypeUnknown,
+                       pump_type: HPXML::TypeUnknown,
+                       pump_kwh_per_year: 1000,
+                       pump_weekday_fractions: '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024',
+                       pump_weekend_fractions: '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024',
+                       pump_monthly_multipliers: '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837',
                        heater_type: HPXML::HeaterTypeElectricResistance,
                        heater_load_units: HPXML::UnitsKwhPerYear,
                        heater_load_value: 1300,
-                       pump_kwh_per_year: 1000,
                        heater_weekday_fractions: '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024',
                        heater_weekend_fractions: '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024',
-                       heater_monthly_multipliers: '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921',
-                       pump_weekday_fractions: '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024',
-                       pump_weekend_fractions: '0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024',
-                       pump_monthly_multipliers: '0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837')
+                       heater_monthly_multipliers: '0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921')
     if hpxml_file == 'base-misc-usage-multiplier.xml'
       hpxml.hot_tubs.each do |hot_tub|
         hot_tub.pump_usage_multiplier = 0.9

--- a/workflow/sample_files/base-misc-loads-large-uncommon.xml
+++ b/workflow/sample_files/base-misc-loads-large-uncommon.xml
@@ -588,9 +588,11 @@
       <Pools>
         <Pool>
           <SystemIdentifier id='Pool'/>
+          <Type>unknown</Type>
           <PoolPumps>
             <PoolPump>
               <SystemIdentifier id='PoolPump'/>
+              <Type>unknown</Type>
               <Load>
                 <Units>kWh/year</Units>
                 <Value>2700.0</Value>
@@ -620,9 +622,11 @@
       <HotTubs>
         <HotTub>
           <SystemIdentifier id='HotTub'/>
+          <Type>unknown</Type>
           <HotTubPumps>
             <HotTubPump>
               <SystemIdentifier id='HotTubPump'/>
+              <Type>unknown</Type>
               <Load>
                 <Units>kWh/year</Units>
                 <Value>1000.0</Value>

--- a/workflow/sample_files/base-misc-loads-large-uncommon2.xml
+++ b/workflow/sample_files/base-misc-loads-large-uncommon2.xml
@@ -588,9 +588,11 @@
       <Pools>
         <Pool>
           <SystemIdentifier id='Pool'/>
+          <Type>unknown</Type>
           <PoolPumps>
             <PoolPump>
               <SystemIdentifier id='PoolPump'/>
+              <Type>unknown</Type>
               <Load>
                 <Units>kWh/year</Units>
                 <Value>2700.0</Value>
@@ -602,14 +604,20 @@
               </extension>
             </PoolPump>
           </PoolPumps>
+          <Heater>
+            <SystemIdentifier id='PoolHeater'/>
+            <Type>none</Type>
+          </Heater>
         </Pool>
       </Pools>
       <HotTubs>
         <HotTub>
           <SystemIdentifier id='HotTub'/>
+          <Type>unknown</Type>
           <HotTubPumps>
             <HotTubPump>
               <SystemIdentifier id='HotTubPump'/>
+              <Type>unknown</Type>
               <Load>
                 <Units>kWh/year</Units>
                 <Value>1000.0</Value>

--- a/workflow/sample_files/base-misc-usage-multiplier.xml
+++ b/workflow/sample_files/base-misc-usage-multiplier.xml
@@ -581,9 +581,11 @@
       <Pools>
         <Pool>
           <SystemIdentifier id='Pool'/>
+          <Type>unknown</Type>
           <PoolPumps>
             <PoolPump>
               <SystemIdentifier id='PoolPump'/>
+              <Type>unknown</Type>
               <Load>
                 <Units>kWh/year</Units>
                 <Value>2700.0</Value>
@@ -615,9 +617,11 @@
       <HotTubs>
         <HotTub>
           <SystemIdentifier id='HotTub'/>
+          <Type>unknown</Type>
           <HotTubPumps>
             <HotTubPump>
               <SystemIdentifier id='HotTubPump'/>
+              <Type>unknown</Type>
               <Load>
                 <Units>kWh/year</Units>
                 <Value>1000.0</Value>


### PR DESCRIPTION
## Pull Request Description

Now recognizes Type="none" to prevent modeling of pools and hot tubs (pumps and heaters). 

**Breaking Change**: `Type` is now a required input for Pool, PoolPump, HotTub, and HotTubPump.

## Checklist

Not all may apply:

- [x] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
