### PR TITLE
Timeseries Unmet Loads

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,14 +8,15 @@ __New Features__
 - Allows detailed heating/cooling setpoints to be specified: 24-hour weekday & weekend values.
 - Allows JSON annual/timeseries output files to be generated instead of CSV. **Breaking change**: For CSV outputs, the first two sections in the results_annual.csv file are now prefixed with "Fuel Use:" and "End Use:", respectively.
 - Allows more defaulting (optional inputs) for a variety of HPXML elements.
-- Includes hot water loads (in addition to heating/cooling loads) when timeseries total loads are requested.
+- Allows requesting timeseries unmet heating/cooling loads.
 - Allows skipping schema/schematron validation (for speed); should only be used if the HPXML was already validated upstream.
+- Includes hot water loads (in addition to heating/cooling loads) when timeseries total loads are requested.
 - Overhauls documentation to be more comprehensive and standardized.
 - `run_simulation.rb` now returns exit code 1 if not successful (i.e., either invalid inputs or simulation fails).
 
 __Bugfixes__
 - Adds error-checking on the HPXML schemaVersion.
-- Adds various error-checking the schematron validator.
+- Adds various error-checking to the schematron validator.
 - Adds error-checking for empty IDs in the HPXML file.
 - Fixes heat pump water heater fan energy not included in SimulationOutputReport outputs.
 - Fixes possibility of incorrect "A neighbor building has an azimuth (XXX) not equal to the azimuth of any wall" error.

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>faa47bb2-7362-429d-be2b-701cf2245888</version_id>
-  <version_modified>20201223T175332Z</version_modified>
+  <version_id>498cd352-421c-448e-b872-6617e186b6b3</version_id>
+  <version_modified>20210109T003213Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1097,7 +1097,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>F24CC2AB</checksum>
+      <checksum>4CF3D80C</checksum>
     </file>
     <file>
       <version>
@@ -1108,7 +1108,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>379F4359</checksum>
+      <checksum>65ACC79B</checksum>
     </file>
   </files>
 </measure>

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -249,6 +249,7 @@ Depending on the outputs requested, the file may include:
    Hot Water Uses                      Water use for each end use type (in gallons).
    Total Loads                         Heating, cooling, and hot water loads (in kBtu) for the building.
    Component Loads                     Heating and cooling loads (in kBtu) disaggregated by component (e.g., Walls, Windows, Infiltration, Ducts, etc.).
+   Unmet Loads                         Unmet heating and cooling loads (in kBtu) for the building.
    Zone Temperatures                   Average temperatures (in deg-F) for each space modeled (e.g., living space, attic, garage, basement, crawlspace, etc.).
    Airflows                            Airflow rates (in cfm) for infiltration, mechanical ventilation (including clothes dryer exhaust), natural ventilation, whole house fans.
    Weather                             Weather file data including outdoor temperatures, relative humidity, wind speed, and solar.

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -34,6 +34,7 @@ def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseri
   args['include_timeseries_hot_water_uses'] = timeseries_outputs.include? 'hotwater'
   args['include_timeseries_total_loads'] = timeseries_outputs.include? 'loads'
   args['include_timeseries_component_loads'] = timeseries_outputs.include? 'componentloads'
+  args['include_timeseries_unmet_loads'] = timeseries_outputs.include? 'unmetloads'
   args['include_timeseries_zone_temperatures'] = timeseries_outputs.include? 'temperatures'
   args['include_timeseries_airflows'] = timeseries_outputs.include? 'airflows'
   args['include_timeseries_weather'] = timeseries_outputs.include? 'weather'
@@ -44,7 +45,7 @@ def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseri
   return results[:success]
 end
 
-timeseries_types = ['ALL', 'fuels', 'enduses', 'hotwater', 'loads', 'componentloads', 'temperatures', 'airflows', 'weather']
+timeseries_types = ['ALL', 'fuels', 'enduses', 'hotwater', 'loads', 'componentloads', 'unmetloads', 'temperatures', 'airflows', 'weather']
 
 options = {}
 OptionParser.new do |opts|

--- a/workflow/template.osw
+++ b/workflow/template.osw
@@ -22,6 +22,7 @@
         "include_timeseries_hot_water_uses": false,
         "include_timeseries_total_loads": false,
         "include_timeseries_component_loads": false,
+        "include_timeseries_unmet_loads": false,
         "include_timeseries_zone_temperatures": false,
         "include_timeseries_airflows": false,
         "include_timeseries_weather": false


### PR DESCRIPTION
## Pull Request Description

Allows requesting timeseries unmet loads.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
