### PR TITLE
Use setPartofTotalFloorArea(false) for unconditioned spaces

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -238,6 +238,7 @@ class OSModel
     set_zone_volumes(runner, model, spaces)
     explode_surfaces(runner, model)
     add_num_occupants(model, runner, spaces)
+    set_part_of_total_floor_area(model, runner, spaces)
 
     # HVAC
 
@@ -951,6 +952,14 @@ class OSModel
       weekend_sch = weekday_sch
       monthly_sch = '1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0'
       Geometry.process_occupants(model, num_occ, occ_gain, sens_frac, lat_frac, weekday_sch, weekend_sch, monthly_sch, @cfa, @nbeds, spaces[HPXML::LocationLivingSpace])
+    end
+  end
+
+  def self.set_part_of_total_floor_area(model, runner, spaces)
+    spaces.keys.each do |space_type|
+      next if [HPXML::LocationBasementConditioned, HPXML::LocationLivingSpace].include? space_type
+
+      spaces[space_type].setPartofTotalFloorArea(false)
     end
   end
 


### PR DESCRIPTION
## Pull Request Description

Related to this URBANopt-residential card: https://trello.com/c/AjYdzIHL/76-exclude-unconditioned-zone-floor-areas-from-eui.

Basically, the question is whether unconditioned floor area should be included or excluded in EUI calculations.

Options are:
* (A) Include all floor area in EUI calculations
* (B) Exclude all (e.g., garage, unconditioned basement) unconditioned floor area from EUI calculations
* (C) Exclude only garage floor area from EUI calculations

For (A), we wouldn't need to do anything. All floor area (both conditioned and unconditioned) is included in EnergyPlus output "Total Building Area", and this output is currently used in URBANopt to calculate EUI.

For (B), we would need to either (i) use `setPartofTotalFloorArea(false)` for unconditioned spaces, or (ii) update the EUI calculation to use EnergyPlus output "Net Conditioned Building Area", or (iii) update default feature reports measure to exclude unconditioned floor area from residential EUI calculations. (i) has the downside of reporting the wrong "Unconditioned Building Area" because this output is reduced along with "Total Building Area" (see below).

For (C), we would need to use `setPartofTotalFloorArea(false)` for garage spaces. Again, this would have the downside of reporting the wrong "Unconditioned Building Area".

For base.xml, here is what happens when you `setPartofTotalFloorArea(false)` for all unconditioned spaces:

BEFORE:

  | Area [m2]
-- | --
Total Building Area | 376.26
Net Conditioned Building Area | 250.84
Unconditioned Building Area | 125.42

AFTER:

  | Area [m2]
-- | --
Total Building Area | 250.84
Net Conditioned Building Area | 250.84
Unconditioned Building Area | 0.00

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
