### PR TITLE
Fixes possible error w/ infiltration flue

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,7 @@ __Bugfixes__
 - HVAC sizing improvements for floors above crawlspaces/basements and walls.
 - Now recognizes Type="none" to prevent modeling of pools and hot tubs (pumps and heaters).
 - Fixes error for overhangs with zero depth.
+- Fixes possible error where the normalized flue height for the AIM-2 infiltration model is negative.
 - Slight adjustment of default water heater recovery efficiency equation to prevent errors from values being too high.
 - Fixes schematron file not being valid per ISO Schematron standard.
 

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -2390,7 +2390,7 @@ class OSModel
     @infil_volume = air_infils.select { |i| !i.infiltration_volume.nil? }[0].infiltration_volume
     infil_height = @hpxml.inferred_infiltration_height(@infil_volume)
     Airflow.apply(model, runner, weather, spaces, air_infils, @hpxml.ventilation_fans, @hpxml.clothes_dryers, @nbeds,
-                  duct_systems, @infil_volume, infil_height, open_window_area,
+                  @ncfl_ag, duct_systems, @infil_volume, infil_height, open_window_area,
                   @clg_ssn_sensor, @min_neighbor_distance, vented_attic, vented_crawl,
                   site_type, shelter_coef, @hpxml.building_construction.has_flue_or_chimney, @hvac_map, @eri_version,
                   @apply_ashrae140_assumptions)

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>bf91a9cf-95df-4feb-92d8-6c949ebfb65b</version_id>
-  <version_modified>20210201T215834Z</version_modified>
+  <version_id>b5e106a8-17a2-45a6-800e-6461a6b1b30f</version_id>
+  <version_modified>20210202T204151Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -281,12 +281,6 @@
       <checksum>00BB7C11</checksum>
     </file>
     <file>
-      <filename>airflow.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1A6416EF</checksum>
-    </file>
-    <file>
       <filename>hotwater_appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -515,10 +509,16 @@
       <checksum>A5A4BBB7</checksum>
     </file>
     <file>
+      <filename>airflow.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>246ED51D</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>065AACD0</checksum>
+      <checksum>19951FF5</checksum>
     </file>
     <file>
       <version>
@@ -529,7 +529,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>BDA7E7C1</checksum>
+      <checksum>14DFF9B1</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b5e106a8-17a2-45a6-800e-6461a6b1b30f</version_id>
-  <version_modified>20210202T204151Z</version_modified>
+  <version_id>ed52c4b7-7e4c-48b0-8391-922537df4858</version_id>
+  <version_modified>20210202T220437Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -473,12 +473,6 @@
       <checksum>6618BA4A</checksum>
     </file>
     <file>
-      <filename>test_airflow.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F9509B93</checksum>
-    </file>
-    <file>
       <filename>test_pv.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -530,6 +524,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>14DFF9B1</checksum>
+    </file>
+    <file>
+      <filename>test_airflow.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>E6A57DCD</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/airflow.rb
+++ b/HPXMLtoOpenStudio/resources/airflow.rb
@@ -2,7 +2,7 @@
 
 class Airflow
   def self.apply(model, runner, weather, spaces, air_infils, vent_fans, clothes_dryers, nbeds,
-                 duct_systems, infil_volume, infil_height, open_window_area,
+                 ncfl_ag, duct_systems, infil_volume, infil_height, open_window_area,
                  nv_clg_ssn_sensor, min_neighbor_distance, vented_attic, vented_crawl,
                  site_type, shelter_coef, has_flue_chimney, hvac_map, eri_version,
                  apply_ashrae140_assumptions)
@@ -11,12 +11,12 @@ class Airflow
 
     @runner = runner
     @spaces = spaces
-    @building_height = Geometry.get_max_z_of_spaces(model.getSpaces)
     @infil_volume = infil_volume
     @infil_height = infil_height
     @living_space = spaces[HPXML::LocationLivingSpace]
     @living_zone = @living_space.thermalZone.get
     @nbeds = nbeds
+    @ncfl_ag = ncfl_ag
     @eri_version = eri_version
     @apply_ashrae140_assumptions = apply_ashrae140_assumptions
     @cfa = UnitConversions.convert(@living_space.floorArea, 'm^2', 'ft^2')
@@ -1770,11 +1770,9 @@ class Airflow
 
       if has_flue_chimney
         y_i = 0.2 # Fraction of leakage through the flue; 0.2 is a "typical" value according to THE ALBERTA AIR INFIL1RATION MODEL, Walker and Wilson, 1990
-        flue_height = @building_height + 2.0 # ft
         s_wflue = 1.0 # Flue Shelter Coefficient
       else
         y_i = 0.0 # Fraction of leakage through the flu
-        flue_height = 0.0 # ft
         s_wflue = 0.0 # Flue Shelter Coefficient
       end
 
@@ -1795,7 +1793,6 @@ class Airflow
       x_i = (leakage_ceiling - leakage_floor)
       r_i *= (1 - y_i)
       x_i *= (1 - y_i)
-      z_f = flue_height / (@infil_height + Geometry.get_z_origin_for_zone(@living_zone))
 
       # Calculate Stack Coefficient
       m_o = (x_i + (2.0 * n_i + 1.0) * y_i)**2.0 / (2 - r_i)
@@ -1805,6 +1802,11 @@ class Airflow
         m_i = 1.0 # eq. 11
       end
       if has_flue_chimney
+        if @ncfl_ag <= 0
+          z_f = 1.0
+        else
+          z_f = (@ncfl_ag + 0.5) / @ncfl_ag # Typical value is 1.5 according to THE ALBERTA AIR INFIL1RATION MODEL, Walker and Wilson, 1990, presumably for a single story home
+        end
         x_c = r_i + (2.0 * (1.0 - r_i - y_i)) / (n_i + 1.0) - 2.0 * y_i * (z_f - 1.0)**n_i # Eq. 13
         f_i = n_i * y_i * (z_f - 1.0)**((3.0 * n_i - 1.0) / 3.0) * (1.0 - (3.0 * (x_c - x_i)**2.0 * r_i**(1 - n_i)) / (2.0 * (z_f + 1.0))) # Additive flue function, Eq. 12
       else

--- a/HPXMLtoOpenStudio/resources/geometry.rb
+++ b/HPXMLtoOpenStudio/resources/geometry.rb
@@ -60,15 +60,6 @@ class Geometry
     return maxzs.max - minzs.min
   end
 
-  def self.get_max_z_of_spaces(spaces)
-    maxzs = []
-    spaces.each do |space|
-      zvalues = getSurfaceZValues(space.surfaces)
-      maxzs << zvalues.max + UnitConversions.convert(space.zOrigin, 'm', 'ft')
-    end
-    return maxzs.max
-  end
-
   # Return an array of z values for surfaces passed in. The values will be relative to the parent origin. This was intended for spaces.
   def self.getSurfaceZValues(surfaceArray)
     zValueArray = []

--- a/HPXMLtoOpenStudio/tests/test_airflow.rb
+++ b/HPXMLtoOpenStudio/tests/test_airflow.rb
@@ -92,7 +92,7 @@ class HPXMLtoOpenStudioAirflowTest < MiniTest::Test
     # Check infiltration/ventilation program
     program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
     assert_in_epsilon(0.0436, program_values['c'].sum, 0.01)
-    assert_in_epsilon(0.0818, program_values['Cs'].sum, 0.01)
+    assert_in_epsilon(0.0661, program_values['Cs'].sum, 0.01)
     assert_in_epsilon(0.1323, program_values['Cw'].sum, 0.01)
   end
 


### PR DESCRIPTION
## Pull Request Description

Fixes possible error where the normalized flue height for the AIM-2 infiltration model is negative.

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
