### PR TITLE
Tiny fix to GSHP sample file

### DIFF
--- a/tasks.rb
+++ b/tasks.rb
@@ -3331,7 +3331,9 @@ def set_hpxml_heat_pumps(hpxml_file, hpxml)
          'base-hvac-ground-to-air-heat-pump-cooling-only.xml',
          'base-hvac-mini-split-heat-pump-ducted-cooling-only.xml'].include? hpxml_file
     hpxml.heat_pumps[0].heating_capacity = 0
-    hpxml.heat_pumps[0].heating_capacity_17F = 0
+    if not ['base-hvac-ground-to-air-heat-pump-cooling-only.xml'].include? hpxml_file
+      hpxml.heat_pumps[0].heating_capacity_17F = 0
+    end
     hpxml.heat_pumps[0].fraction_heat_load_served = 0
     hpxml.heat_pumps[0].backup_heating_fuel = nil
     hpxml.heat_pumps[0].backup_heating_capacity = nil

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump-cooling-only.xml
@@ -310,7 +310,6 @@
               <HeatPumpType>ground-to-air</HeatPumpType>
               <HeatPumpFuel>electricity</HeatPumpFuel>
               <HeatingCapacity>0.0</HeatingCapacity>
-              <HeatingCapacity17F>0.0</HeatingCapacity17F>
               <CoolingCapacity>48000.0</CoolingCapacity>
               <CoolingSensibleHeatFraction>0.73</CoolingSensibleHeatFraction>
               <FractionHeatLoadServed>0.0</FractionHeatLoadServed>


### PR DESCRIPTION
## Pull Request Description

Removes accidental `HeatingCapacity17F` element in GSHP sample file. No diffs expected.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
