### PR TITLE
BuildResidentialHPXML measure: Change schedules.csv name

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3223,7 +3223,7 @@ class HPXMLFile
     return false if not success
 
     # export the schedule
-    args[:schedules_path] = "../#{File.basename(args[:hpxml_path], '.xml')}.csv"
+    args[:schedules_path] = "../#{File.basename(args[:hpxml_path], '.xml')}_schedules.csv"
     success = schedule_generator.export(schedules_path: File.expand_path(args[:schedules_path]))
     return false if not success
 

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3223,7 +3223,7 @@ class HPXMLFile
     return false if not success
 
     # export the schedule
-    args[:schedules_path] = '../schedules.csv'
+    args[:schedules_path] = "../#{File.basename(args[:hpxml_path], '.xml')}.csv"
     success = schedule_generator.export(schedules_path: File.expand_path(args[:schedules_path]))
     return false if not success
 

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>144504e9-68d1-44fc-8a1e-c2ac6b69350b</version_id>
-  <version_modified>20210310T182538Z</version_modified>
+  <version_id>71a74794-5f7b-4353-a671-beb34d5b8110</version_id>
+  <version_modified>20210311T145233Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -8041,17 +8041,6 @@
       <checksum>3B954F0A</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.9.0</identifier>
-        <min_compatible>2.9.0</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>740DA201</checksum>
-    </file>
-    <file>
       <filename>extra-bldgtype-single-family-attached-atticroof-conditioned-eaves-gable.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
@@ -8064,10 +8053,33 @@
       <checksum>19A343F0</checksum>
     </file>
     <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.9.0</identifier>
+        <min_compatible>2.9.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>EBC3520B</checksum>
+    </file>
+    <file>
       <filename>build_residential_hpxml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>575C9D3E</checksum>
+      <checksum>30D725F1</checksum>
+    </file>
+    <file>
+      <filename>test_measure.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>61A02181</checksum>
+    </file>
+    <file>
+      <filename>test_rakefile.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>18284CA6</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Change from `schedules.csv` to `#{hpxml_path}.csv`. For example, `base.csv` or `1.csv`. This will connect schedule file with xml more clearly, and will enable variation across units for a given building.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
