### PR TITLE
Fix ruby error for SystemIdentifier element w/o id attribute

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ __New Features__
 - Moves additional error-checking from the ruby measure to the schematron validator.
 
 __Bugfixes__
+- Fixes ruby error if `SystemIdentifier` element exists without an 'id' attribute.
 - Fixes possible "Electricity category end uses do not sum to total" error due to boiler pump energy.
 - Fixes possible "Construction R-value ... does not match Assembly R-value" error for highly insulated enclosure elements.
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>bb2ad5cc-ea01-45e0-8643-404dfaf0dd6b</version_id>
-  <version_modified>20210311T212040Z</version_modified>
+  <version_id>815b6dd3-e3e6-42c8-9e21-68fac1b12253</version_id>
+  <version_modified>20210312T210732Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -516,12 +516,6 @@
       <checksum>05C704E0</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>5EE68DF9</checksum>
-    </file>
-    <file>
       <filename>EPvalidator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
@@ -538,6 +532,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>A0A3EC7F</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>9F008790</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -5437,7 +5437,7 @@ class HPXML < Object
         sys_ids[obj.id] = 0 if sys_ids[obj.id].nil?
         sys_ids[obj.id] += 1
 
-        errors << "Empty SystemIdentifier ID ('#{obj.id}') detected for #{attribute}." if obj.id.size == 0
+        errors << "Empty SystemIdentifier ID ('#{obj.id}') detected for #{attribute}." if !obj.id || obj.id.size == 0
       end
     end
     sys_ids.each do |sys_id, cnt|


### PR DESCRIPTION
## Pull Request Description

Backport from https://github.com/NREL/OpenStudio-ERI/pull/499

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
