### PR TITLE
Add detail to "cannot convert" errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 __New Features__
 - **Breaking change**: Replaces `Site/extension/ShelterCoefficient` with `Site/ShieldingofHome`.
 - Moves additional error-checking from the ruby measure to the schematron validator.
+- Adds more detail to error messages regarding the wrong data type in the HPXML file.
 
 __Bugfixes__
 - Fixes possible "Electricity category end uses do not sum to total" error due to boiler pump energy.

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>bb2ad5cc-ea01-45e0-8643-404dfaf0dd6b</version_id>
-  <version_modified>20210311T212040Z</version_modified>
+  <version_id>becfb80a-06d1-4bcc-bc5a-076ebcb37907</version_id>
+  <version_modified>20210312T220906Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -373,12 +373,6 @@
       <checksum>E6A57DCD</checksum>
     </file>
     <file>
-      <filename>xmlhelper.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7DF95E45</checksum>
-    </file>
-    <file>
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -538,6 +532,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>A0A3EC7F</checksum>
+    </file>
+    <file>
+      <filename>xmlhelper.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>06740C1D</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/xmlhelper.rb
+++ b/HPXMLtoOpenStudio/resources/xmlhelper.rb
@@ -8,11 +8,11 @@ class XMLHelper
     parent.children << added
     if not value.nil?
       if datatype == :integer
-        value = to_integer(value)
+        value = to_integer(value, parent, element_name)
       elsif datatype == :float
-        value = to_float(value)
+        value = to_float(value, parent, element_name)
       elsif datatype == :boolean
-        value = to_boolean(value)
+        value = to_boolean(value, parent, element_name)
       elsif datatype != :string
         # If value provided, datatype required
         fail 'Unexpected datatype.'
@@ -65,11 +65,11 @@ class XMLHelper
     value = element.text
 
     if datatype == :integer
-      value = to_integer_or_nil(value)
+      value = to_integer_or_nil(value, parent, element_name)
     elsif datatype == :float
-      value = to_float_or_nil(value)
+      value = to_float_or_nil(value, parent, element_name)
     elsif datatype == :boolean
-      value = to_boolean_or_nil(value)
+      value = to_boolean_or_nil(value, parent, element_name)
     elsif datatype != :string
       fail 'Unexpected datatype.'
     end
@@ -84,11 +84,11 @@ class XMLHelper
       value = value.text
 
       if datatype == :integer
-        value = to_integer_or_nil(value)
+        value = to_integer_or_nil(value, parent, element_name)
       elsif datatype == :float
-        value = to_float_or_nil(value)
+        value = to_float_or_nil(value, parent, element_name)
       elsif datatype == :boolean
-        value = to_boolean_or_nil(value)
+        value = to_boolean_or_nil(value, parent, element_name)
       elsif datatype != :string
         fail 'Unexpected datatype.'
       end
@@ -215,28 +215,28 @@ class XMLHelper
   end
 end
 
-def to_float(value)
+def to_float(value, parent, element_name)
   begin
     return Float(value)
   rescue
-    fail "Cannot convert '#{value}' to float."
+    fail "Cannot convert '#{value}' to float for #{parent.name}/#{element_name}."
   end
 end
 
-def to_integer(value)
+def to_integer(value, parent, element_name)
   begin
     value = Float(value)
   rescue
-    fail "Cannot convert '#{value}' to integer."
+    fail "Cannot convert '#{value}' to integer for #{parent.name}/#{element_name}."
   end
   if value % 1 == 0
     return Integer(value)
   else
-    fail "Cannot convert '#{value}' to integer."
+    fail "Cannot convert '#{value}' to integer for #{parent.name}/#{element_name}."
   end
 end
 
-def to_boolean(value)
+def to_boolean(value, parent, element_name)
   if value.is_a? TrueClass
     return true
   elsif value.is_a? FalseClass
@@ -247,23 +247,23 @@ def to_boolean(value)
     return false
   end
 
-  fail "Cannot convert '#{value}' to boolean."
+  fail "Cannot convert '#{value}' to boolean for #{parent.name}/#{element_name}."
 end
 
-def to_float_or_nil(value)
+def to_float_or_nil(value, parent, element_name)
   return if value.nil?
 
-  return to_float(value)
+  return to_float(value, parent, element_name)
 end
 
-def to_integer_or_nil(value)
+def to_integer_or_nil(value, parent, element_name)
   return if value.nil?
 
-  return to_integer(value)
+  return to_integer(value, parent, element_name)
 end
 
-def to_boolean_or_nil(value)
+def to_boolean_or_nil(value, parent, element_name)
   return if value.nil?
 
-  return to_boolean(value)
+  return to_boolean(value, parent, element_name)
 end

--- a/tasks.rb
+++ b/tasks.rb
@@ -2322,9 +2322,6 @@ def set_hpxml_slabs(hpxml_file, hpxml)
       slab.carpet_fraction = nil
       slab.carpet_fraction = nil
     end
-  elsif ['invalid_files/mismatched-slab-and-foundation-wall.xml'].include? hpxml_file
-    hpxml.slabs[0].interior_adjacent_to = HPXML::LocationBasementUnconditioned
-    hpxml.slabs[0].depth_below_grade = 7.0
   elsif ['invalid_files/slab-zero-exposed-perimeter.xml'].include? hpxml_file
     hpxml.slabs[0].exposed_perimeter = 0
   elsif ['invalid_files/enclosure-living-missing-floor-slab.xml',
@@ -3903,13 +3900,6 @@ def set_hpxml_hvac_distributions(hpxml_file, hpxml)
         duct.duct_surface_area = nil
         duct.duct_location = nil
       end
-    end
-  elsif ['invalid_files/missing-duct-location-and-surface-area.xml'].include? hpxml_file
-    hpxml.hvac_distributions.each do |hvac_distribution|
-      next unless hvac_distribution.distribution_system_type == HPXML::HVACDistributionTypeAir
-
-      hvac_distribution.ducts[1].duct_surface_area = nil
-      hvac_distribution.ducts[1].duct_location = nil
     end
   elsif ['invalid_files/missing-duct-location.xml'].include? hpxml_file
     hpxml.hvac_distributions.each do |hvac_distribution|

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -188,12 +188,9 @@ class HPXMLTest < MiniTest::Test
                             'hvac-distribution-return-duct-leakage-missing.xml' => ['Expected 1 element(s) for xpath: DuctLeakageMeasurement[DuctType="return"]/DuctLeakage[(Units="CFM25" or Units="Percent") and TotalOrToOutside="to outside"] [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACDistribution/DistributionSystemType/AirDistribution]'],
                             'hvac-inconsistent-fan-powers.xml' => ["Fan powers for heating system 'HeatingSystem' and cooling system 'CoolingSystem' are attached to a single distribution system and therefore must be the same."],
                             'invalid-assembly-effective-rvalue.xml' => ['Expected Insulation/AssemblyEffectiveRValue to be greater than 0 [context: /HPXML/Building/BuildingDetails/Enclosure/Walls/Wall]'],
-                            'invalid-datatype-boolean.xml' => ["Cannot convert 'FOOBAR' to boolean."],
-                            'invalid-datatype-boolean2.xml' => ["Cannot convert '' to boolean."],
-                            'invalid-datatype-integer.xml' => ["Cannot convert '2.5' to integer."],
-                            'invalid-datatype-integer2.xml' => ["Cannot convert '' to integer."],
-                            'invalid-datatype-float.xml' => ["Cannot convert 'FOOBAR' to float."],
-                            'invalid-datatype-float2.xml' => ["Cannot convert '' to float."],
+                            'invalid-datatype-boolean.xml' => ["Cannot convert 'FOOBAR' to boolean for Roof/RadiantBarrier."],
+                            'invalid-datatype-integer.xml' => ["Cannot convert '2.5' to integer for BuildingConstruction/NumberofBedrooms."],
+                            'invalid-datatype-float.xml' => ["Cannot convert 'FOOBAR' to float for Slab/extension/CarpetFraction."],
                             'invalid-daylight-saving.xml' => ['Daylight Saving End Day of Month (31) must be one of: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30.'],
                             'invalid-distribution-cfa-served.xml' => ['The total conditioned floor area served by the HVAC distribution system(s) for heating is larger than the conditioned floor area of the building.',
                                                                       'The total conditioned floor area served by the HVAC distribution system(s) for cooling is larger than the conditioned floor area of the building.'],
@@ -230,11 +227,9 @@ class HPXMLTest < MiniTest::Test
                             'invalid-runperiod.xml' => ['Run Period End Day of Month (31) must be one of: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30.'],
                             'invalid-window-height.xml' => ['Expected DistanceToBottomOfWindow to be greater than DistanceToTopOfWindow [context: /HPXML/Building/BuildingDetails/Enclosure/Windows/Window/Overhangs]'],
                             'lighting-fractions.xml' => ['Sum of fractions of interior lighting (1.15) is greater than 1.'],
-                            'mismatched-slab-and-foundation-wall.xml' => ["Foundation wall 'FoundationWall' is adjacent to 'basement - conditioned' but no corresponding slab was found adjacent to"],
                             'missing-elements.xml' => ['Expected 1 element(s) for xpath: NumberofConditionedFloors [context: /HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction]',
                                                        'Expected 1 element(s) for xpath: ConditionedFloorArea [context: /HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction]'],
                             'missing-duct-location.xml' => ['Expected 0 or 2 element(s) for xpath: DuctSurfaceArea | DuctLocation [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACDistribution/DistributionSystemType/*/Ducts]'],
-                            'missing-duct-location-and-surface-area.xml' => ['Error: The location and surface area of all ducts must be provided or blank.'],
                             'multifamily-reference-appliance.xml' => ["The building is of type 'single-family detached' but"],
                             'multifamily-reference-duct.xml' => ["The building is of type 'single-family detached' but"],
                             'multifamily-reference-surface.xml' => ["The building is of type 'single-family detached' but"],
@@ -248,6 +243,8 @@ class HPXMLTest < MiniTest::Test
                             'num-bedrooms-exceeds-limit.xml' => ['Expected NumberofBedrooms to be less than or equal to (ConditionedFloorArea-120)/70 [context: /HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction]'],
                             'orphaned-hvac-distribution.xml' => ["Distribution system 'HVACDistribution' found but no HVAC system attached to it."],
                             'refrigerator-location.xml' => ['A location is specified as "garage" but no surfaces were found adjacent to this space type.'],
+                            'refrigerators-multiple-primary.xml' => ['More than one refrigerator designated as the primary.'],
+                            'refrigerators-no-primary.xml' => ['Could not find a primary refrigerator.'],
                             'repeated-relatedhvac-dhw-indirect.xml' => ["RelatedHVACSystem 'HeatingSystem' is attached to multiple water heating systems."],
                             'repeated-relatedhvac-desuperheater.xml' => ["RelatedHVACSystem 'CoolingSystem' is attached to multiple water heating systems."],
                             'slab-zero-exposed-perimeter.xml' => ['Expected ExposedPerimeter to be greater than 0 [context: /HPXML/Building/BuildingDetails/Enclosure/Slabs/Slab]'],
@@ -263,9 +260,7 @@ class HPXMLTest < MiniTest::Test
                             'unattached-shared-dishwasher-water-heater.xml' => ["Attached water heating system 'foobar' not found for dishwasher"],
                             'unattached-window.xml' => ["Attached wall 'foobar' not found for window 'WindowNorth'."],
                             'water-heater-location.xml' => ['A location is specified as "crawlspace - vented" but no surfaces were found adjacent to this space type.'],
-                            'water-heater-location-other.xml' => ["Expected Location to be 'living space' or 'basement - unconditioned' or 'basement - conditioned' or 'attic - unvented' or 'attic - vented' or 'garage' or 'crawlspace - unvented' or 'crawlspace - vented' or 'other exterior' or 'other housing unit' or 'other heated space' or 'other multifamily buffer space' or 'other non-freezing space' [context: /HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem]"],
-                            'refrigerators-multiple-primary.xml' => ['More than one refrigerator designated as the primary.'],
-                            'refrigerators-no-primary.xml' => ['Could not find a primary refrigerator.'] }
+                            'water-heater-location-other.xml' => ["Expected Location to be 'living space' or 'basement - unconditioned' or 'basement - conditioned' or 'attic - unvented' or 'attic - vented' or 'garage' or 'crawlspace - unvented' or 'crawlspace - vented' or 'other exterior' or 'other housing unit' or 'other heated space' or 'other multifamily buffer space' or 'other non-freezing space' [context: /HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem]"] }
 
     # Test simulations
     xmls = Dir["#{sample_files_dir}/invalid_files/*.xml"].sort


### PR DESCRIPTION
## Pull Request Description

If the wrong datatype was provided in the HPXML, we previously reported an error message like so:
`"Cannot convert '2.5' to integer."`
Now we report the error as:
`"Cannot convert '2.5' to integer for BuildingConstruction/NumberofBedrooms."`

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
