### PR TITLE
Opt-in component loads calc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,9 @@
 ## OpenStudio-HPXML v1.2.0 (Pending)
 
 __New Features__
-- Adds a `--skip-component-loads` argument for faster performance.
-- Allow `Slab/ExposedPerimeter` to be zero.
+- **Breaking change**: Heating/cooling component loads no longer calculated by default for faster performance; use `--add-component-loads` argument if desired.
 - **Breaking change**: Replaces `Site/extension/ShelterCoefficient` with `Site/ShieldingofHome`.
+- Allows `Slab/ExposedPerimeter` to be zero.
 - Removes `ClothesDryer/ControlType` from being a required input, it is not used.
 - Moves additional error-checking from the ruby measure to the schematron validator.
 - Adds more detail to error messages regarding the wrong data type in the HPXML file.

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -70,9 +70,9 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue(false)
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument.makeBoolArgument('skip_component_loads', false)
-    arg.setDisplayName('Skip component loads?')
-    arg.setDescription('If true, skips the calculation of heating/cooling component loads for faster performance.')
+    arg = OpenStudio::Measure::OSArgument.makeBoolArgument('add_component_loads', false)
+    arg.setDisplayName('Add component loads?')
+    arg.setDescription('If true, adds the calculation of heating/cooling component loads (not enabled by default for faster performance).')
     arg.setDefaultValue(false)
     args << arg
 
@@ -106,7 +106,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     # assign the user inputs to variables
     hpxml_path = runner.getStringArgumentValue('hpxml_path', user_arguments)
     output_dir = runner.getStringArgumentValue('output_dir', user_arguments)
-    skip_component_loads = runner.getBoolArgumentValue('skip_component_loads', user_arguments)
+    add_component_loads = runner.getBoolArgumentValue('add_component_loads', user_arguments)
     debug = runner.getBoolArgumentValue('debug', user_arguments)
     skip_validation = runner.getBoolArgumentValue('skip_validation', user_arguments)
     building_id = runner.getOptionalStringArgumentValue('building_id', user_arguments)
@@ -152,7 +152,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
       end
 
       OSModel.create(hpxml, runner, model, hpxml_path, epw_path, cache_path, output_dir,
-                     skip_component_loads, building_id, debug)
+                     add_component_loads, building_id, debug)
     rescue Exception => e
       runner.registerError("#{e.message}\n#{e.backtrace.join("\n")}")
       return false
@@ -198,7 +198,7 @@ end
 
 class OSModel
   def self.create(hpxml, runner, model, hpxml_path, epw_path, cache_path, output_dir,
-                  skip_component_loads, building_id, debug)
+                  add_component_loads, building_id, debug)
     @hpxml = hpxml
     @debug = debug
 
@@ -272,7 +272,7 @@ class OSModel
 
     # Output
 
-    add_loads_output(runner, model, spaces, skip_component_loads)
+    add_loads_output(runner, model, spaces, add_component_loads)
     add_output_control_files(runner, model)
     # Uncomment to debug EMS
     # add_ems_debug_output(runner, model)
@@ -2451,11 +2451,11 @@ class OSModel
     return map_str.to_s
   end
 
-  def self.add_loads_output(runner, model, spaces, skip_component_loads)
+  def self.add_loads_output(runner, model, spaces, add_component_loads)
     living_zone = spaces[HPXML::LocationLivingSpace].thermalZone.get
 
     liv_load_sensors, intgain_dehumidifier = add_total_loads_output(runner, model, living_zone)
-    return if skip_component_loads
+    return unless add_component_loads
 
     add_component_loads_output(runner, model, living_zone, liv_load_sensors, intgain_dehumidifier)
   end

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>31748d88-9324-41ec-9eeb-4113b38affd2</version_id>
-  <version_modified>20210330T150843Z</version_modified>
+  <version_id>59939bcd-5de3-4091-9b7f-80b12ffda704</version_id>
+  <version_modified>20210331T140029Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -47,9 +47,9 @@
       </choices>
     </argument>
     <argument>
-      <name>skip_component_loads</name>
-      <display_name>Skip component loads?</display_name>
-      <description>If true, skips the calculation of heating/cooling component loads for faster performance.</description>
+      <name>add_component_loads</name>
+      <display_name>Add component loads?</display_name>
+      <description>If true, adds the calculation of heating/cooling component loads (not enabled by default for faster performance).</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -556,7 +556,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F49E8B85</checksum>
+      <checksum>A0728E31</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -958,9 +958,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     @peak_loads.each do |load_type, peak_load|
       results_out << ["#{peak_load.name} (#{peak_load.annual_units})", peak_load.annual_output.round(2)]
     end
-    results_out << [line_break]
-    @component_loads.each do |load_type, load|
-      results_out << ["#{load.name} (#{load.annual_units})", load.annual_output.round(2)]
+    if @component_loads.values.map { |load| load.annual_output }.sum > 0 # Skip if component loads not calculated
+      results_out << [line_break]
+      @component_loads.each do |load_type, load|
+        results_out << ["#{load.name} (#{load.annual_units})", load.annual_output.round(2)]
+      end
     end
     results_out << [line_break]
     @hot_water_uses.each do |hot_water_type, hot_water|

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>96e26b91-6565-43ff-aaec-c785557d4f85</version_id>
-  <version_modified>20210331T140029Z</version_modified>
+  <version_id>3c542c9b-d3f4-4c05-b75d-3b0644045717</version_id>
+  <version_modified>20210331T153452Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -16,6 +16,7 @@
       <display_name>Output Format</display_name>
       <description>The file format of the annual (and timeseries, if requested) outputs.</description>
       <type>Choice</type>
+      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>csv</default_value>
@@ -29,12 +30,15 @@
           <display_name>json</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>timeseries_frequency</name>
       <display_name>Timeseries Reporting Frequency</display_name>
       <description>The frequency at which to report timeseries output data. Using 'none' will disable timeseries outputs.</description>
       <type>Choice</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>none</default_value>
@@ -60,12 +64,15 @@
           <display_name>monthly</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_fuel_consumptions</name>
       <display_name>Generate Timeseries Output: Fuel Consumptions</display_name>
       <description>Generates timeseries energy consumptions for each fuel type.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -79,12 +86,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_end_use_consumptions</name>
       <display_name>Generate Timeseries Output: End Use Consumptions</display_name>
       <description>Generates timeseries energy consumptions for each end use.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -98,12 +108,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_hot_water_uses</name>
       <display_name>Generate Timeseries Output: Hot Water Uses</display_name>
       <description>Generates timeseries hot water usages for each end use.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -117,12 +130,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_total_loads</name>
       <display_name>Generate Timeseries Output: Total Loads</display_name>
       <description>Generates timeseries total heating, cooling, and hot water loads.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -136,12 +152,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_component_loads</name>
       <display_name>Generate Timeseries Output: Component Loads</display_name>
       <description>Generates timeseries heating and cooling loads disaggregated by component type.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -155,12 +174,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_unmet_loads</name>
       <display_name>Generate Timeseries Output: Unmet Loads</display_name>
       <description>Generates timeseries unmet heating and cooling loads.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -174,12 +196,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_zone_temperatures</name>
       <display_name>Generate Timeseries Output: Zone Temperatures</display_name>
       <description>Generates timeseries temperatures for each thermal zone.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -193,12 +218,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_airflows</name>
       <display_name>Generate Timeseries Output: Airflows</display_name>
       <description>Generates timeseries airflows.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -212,12 +240,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>include_timeseries_weather</name>
       <display_name>Generate Timeseries Output: Weather</display_name>
       <description>Generates timeseries weather data.</description>
       <type>Boolean</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -231,6 +262,8 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
   </arguments>
   <outputs>
@@ -238,637 +271,819 @@
       <name>Fuel Use: Electricity: Total MBtu</name>
       <display_name>Fuel Use: Electricity: Total MBtu</display_name>
       <short_name>Fuel Use: Electricity: Total MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Use: Natural Gas: Total MBtu</name>
       <display_name>Fuel Use: Natural Gas: Total MBtu</display_name>
       <short_name>Fuel Use: Natural Gas: Total MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Use: Fuel Oil: Total MBtu</name>
       <display_name>Fuel Use: Fuel Oil: Total MBtu</display_name>
       <short_name>Fuel Use: Fuel Oil: Total MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Use: Propane: Total MBtu</name>
       <display_name>Fuel Use: Propane: Total MBtu</display_name>
       <short_name>Fuel Use: Propane: Total MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Use: Wood Cord: Total MBtu</name>
       <display_name>Fuel Use: Wood Cord: Total MBtu</display_name>
       <short_name>Fuel Use: Wood Cord: Total MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Use: Wood Pellets: Total MBtu</name>
       <display_name>Fuel Use: Wood Pellets: Total MBtu</display_name>
       <short_name>Fuel Use: Wood Pellets: Total MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>Fuel Use: Coal: Total MBtu</name>
       <display_name>Fuel Use: Coal: Total MBtu</display_name>
       <short_name>Fuel Use: Coal: Total MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Heating MBtu</name>
       <display_name>End Use: Electricity: Heating MBtu</display_name>
       <short_name>End Use: Electricity: Heating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Heating Fans/Pumps MBtu</name>
       <display_name>End Use: Electricity: Heating Fans/Pumps MBtu</display_name>
       <short_name>End Use: Electricity: Heating Fans/Pumps MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Cooling MBtu</name>
       <display_name>End Use: Electricity: Cooling MBtu</display_name>
       <short_name>End Use: Electricity: Cooling MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Cooling Fans/Pumps MBtu</name>
       <display_name>End Use: Electricity: Cooling Fans/Pumps MBtu</display_name>
       <short_name>End Use: Electricity: Cooling Fans/Pumps MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Hot Water MBtu</name>
       <display_name>End Use: Electricity: Hot Water MBtu</display_name>
       <short_name>End Use: Electricity: Hot Water MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Hot Water Recirc Pump MBtu</name>
       <display_name>End Use: Electricity: Hot Water Recirc Pump MBtu</display_name>
       <short_name>End Use: Electricity: Hot Water Recirc Pump MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Hot Water Solar Thermal Pump MBtu</name>
       <display_name>End Use: Electricity: Hot Water Solar Thermal Pump MBtu</display_name>
       <short_name>End Use: Electricity: Hot Water Solar Thermal Pump MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Lighting Interior MBtu</name>
       <display_name>End Use: Electricity: Lighting Interior MBtu</display_name>
       <short_name>End Use: Electricity: Lighting Interior MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Lighting Garage MBtu</name>
       <display_name>End Use: Electricity: Lighting Garage MBtu</display_name>
       <short_name>End Use: Electricity: Lighting Garage MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Lighting Exterior MBtu</name>
       <display_name>End Use: Electricity: Lighting Exterior MBtu</display_name>
       <short_name>End Use: Electricity: Lighting Exterior MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Mech Vent MBtu</name>
       <display_name>End Use: Electricity: Mech Vent MBtu</display_name>
       <short_name>End Use: Electricity: Mech Vent MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Mech Vent Preheating MBtu</name>
       <display_name>End Use: Electricity: Mech Vent Preheating MBtu</display_name>
       <short_name>End Use: Electricity: Mech Vent Preheating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Mech Vent Precooling MBtu</name>
       <display_name>End Use: Electricity: Mech Vent Precooling MBtu</display_name>
       <short_name>End Use: Electricity: Mech Vent Precooling MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Whole House Fan MBtu</name>
       <display_name>End Use: Electricity: Whole House Fan MBtu</display_name>
       <short_name>End Use: Electricity: Whole House Fan MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Refrigerator MBtu</name>
       <display_name>End Use: Electricity: Refrigerator MBtu</display_name>
       <short_name>End Use: Electricity: Refrigerator MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Freezer MBtu</name>
       <display_name>End Use: Electricity: Freezer MBtu</display_name>
       <short_name>End Use: Electricity: Freezer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Dehumidifier MBtu</name>
       <display_name>End Use: Electricity: Dehumidifier MBtu</display_name>
       <short_name>End Use: Electricity: Dehumidifier MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Dishwasher MBtu</name>
       <display_name>End Use: Electricity: Dishwasher MBtu</display_name>
       <short_name>End Use: Electricity: Dishwasher MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Clothes Washer MBtu</name>
       <display_name>End Use: Electricity: Clothes Washer MBtu</display_name>
       <short_name>End Use: Electricity: Clothes Washer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Clothes Dryer MBtu</name>
       <display_name>End Use: Electricity: Clothes Dryer MBtu</display_name>
       <short_name>End Use: Electricity: Clothes Dryer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Range/Oven MBtu</name>
       <display_name>End Use: Electricity: Range/Oven MBtu</display_name>
       <short_name>End Use: Electricity: Range/Oven MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Ceiling Fan MBtu</name>
       <display_name>End Use: Electricity: Ceiling Fan MBtu</display_name>
       <short_name>End Use: Electricity: Ceiling Fan MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Television MBtu</name>
       <display_name>End Use: Electricity: Television MBtu</display_name>
       <short_name>End Use: Electricity: Television MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Plug Loads MBtu</name>
       <display_name>End Use: Electricity: Plug Loads MBtu</display_name>
       <short_name>End Use: Electricity: Plug Loads MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Electric Vehicle Charging MBtu</name>
       <display_name>End Use: Electricity: Electric Vehicle Charging MBtu</display_name>
       <short_name>End Use: Electricity: Electric Vehicle Charging MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Well Pump MBtu</name>
       <display_name>End Use: Electricity: Well Pump MBtu</display_name>
       <short_name>End Use: Electricity: Well Pump MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Pool Heater MBtu</name>
       <display_name>End Use: Electricity: Pool Heater MBtu</display_name>
       <short_name>End Use: Electricity: Pool Heater MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Pool Pump MBtu</name>
       <display_name>End Use: Electricity: Pool Pump MBtu</display_name>
       <short_name>End Use: Electricity: Pool Pump MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Hot Tub Heater MBtu</name>
       <display_name>End Use: Electricity: Hot Tub Heater MBtu</display_name>
       <short_name>End Use: Electricity: Hot Tub Heater MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Hot Tub Pump MBtu</name>
       <display_name>End Use: Electricity: Hot Tub Pump MBtu</display_name>
       <short_name>End Use: Electricity: Hot Tub Pump MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: PV MBtu</name>
       <display_name>End Use: Electricity: PV MBtu</display_name>
       <short_name>End Use: Electricity: PV MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Electricity: Generator MBtu</name>
       <display_name>End Use: Electricity: Generator MBtu</display_name>
       <short_name>End Use: Electricity: Generator MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Heating MBtu</name>
       <display_name>End Use: Natural Gas: Heating MBtu</display_name>
       <short_name>End Use: Natural Gas: Heating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Hot Water MBtu</name>
       <display_name>End Use: Natural Gas: Hot Water MBtu</display_name>
       <short_name>End Use: Natural Gas: Hot Water MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Clothes Dryer MBtu</name>
       <display_name>End Use: Natural Gas: Clothes Dryer MBtu</display_name>
       <short_name>End Use: Natural Gas: Clothes Dryer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Range/Oven MBtu</name>
       <display_name>End Use: Natural Gas: Range/Oven MBtu</display_name>
       <short_name>End Use: Natural Gas: Range/Oven MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Mech Vent Preheating MBtu</name>
       <display_name>End Use: Natural Gas: Mech Vent Preheating MBtu</display_name>
       <short_name>End Use: Natural Gas: Mech Vent Preheating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Pool Heater MBtu</name>
       <display_name>End Use: Natural Gas: Pool Heater MBtu</display_name>
       <short_name>End Use: Natural Gas: Pool Heater MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Hot Tub Heater MBtu</name>
       <display_name>End Use: Natural Gas: Hot Tub Heater MBtu</display_name>
       <short_name>End Use: Natural Gas: Hot Tub Heater MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Grill MBtu</name>
       <display_name>End Use: Natural Gas: Grill MBtu</display_name>
       <short_name>End Use: Natural Gas: Grill MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Lighting MBtu</name>
       <display_name>End Use: Natural Gas: Lighting MBtu</display_name>
       <short_name>End Use: Natural Gas: Lighting MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Fireplace MBtu</name>
       <display_name>End Use: Natural Gas: Fireplace MBtu</display_name>
       <short_name>End Use: Natural Gas: Fireplace MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Natural Gas: Generator MBtu</name>
       <display_name>End Use: Natural Gas: Generator MBtu</display_name>
       <short_name>End Use: Natural Gas: Generator MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Fuel Oil: Heating MBtu</name>
       <display_name>End Use: Fuel Oil: Heating MBtu</display_name>
       <short_name>End Use: Fuel Oil: Heating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Fuel Oil: Hot Water MBtu</name>
       <display_name>End Use: Fuel Oil: Hot Water MBtu</display_name>
       <short_name>End Use: Fuel Oil: Hot Water MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Fuel Oil: Clothes Dryer MBtu</name>
       <display_name>End Use: Fuel Oil: Clothes Dryer MBtu</display_name>
       <short_name>End Use: Fuel Oil: Clothes Dryer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Fuel Oil: Range/Oven MBtu</name>
       <display_name>End Use: Fuel Oil: Range/Oven MBtu</display_name>
       <short_name>End Use: Fuel Oil: Range/Oven MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Fuel Oil: Mech Vent Preheating MBtu</name>
       <display_name>End Use: Fuel Oil: Mech Vent Preheating MBtu</display_name>
       <short_name>End Use: Fuel Oil: Mech Vent Preheating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Fuel Oil: Grill MBtu</name>
       <display_name>End Use: Fuel Oil: Grill MBtu</display_name>
       <short_name>End Use: Fuel Oil: Grill MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Fuel Oil: Lighting MBtu</name>
       <display_name>End Use: Fuel Oil: Lighting MBtu</display_name>
       <short_name>End Use: Fuel Oil: Lighting MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Fuel Oil: Fireplace MBtu</name>
       <display_name>End Use: Fuel Oil: Fireplace MBtu</display_name>
       <short_name>End Use: Fuel Oil: Fireplace MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Heating MBtu</name>
       <display_name>End Use: Propane: Heating MBtu</display_name>
       <short_name>End Use: Propane: Heating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Hot Water MBtu</name>
       <display_name>End Use: Propane: Hot Water MBtu</display_name>
       <short_name>End Use: Propane: Hot Water MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Clothes Dryer MBtu</name>
       <display_name>End Use: Propane: Clothes Dryer MBtu</display_name>
       <short_name>End Use: Propane: Clothes Dryer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Range/Oven MBtu</name>
       <display_name>End Use: Propane: Range/Oven MBtu</display_name>
       <short_name>End Use: Propane: Range/Oven MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Mech Vent Preheating MBtu</name>
       <display_name>End Use: Propane: Mech Vent Preheating MBtu</display_name>
       <short_name>End Use: Propane: Mech Vent Preheating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Grill MBtu</name>
       <display_name>End Use: Propane: Grill MBtu</display_name>
       <short_name>End Use: Propane: Grill MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Lighting MBtu</name>
       <display_name>End Use: Propane: Lighting MBtu</display_name>
       <short_name>End Use: Propane: Lighting MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Fireplace MBtu</name>
       <display_name>End Use: Propane: Fireplace MBtu</display_name>
       <short_name>End Use: Propane: Fireplace MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Propane: Generator MBtu</name>
       <display_name>End Use: Propane: Generator MBtu</display_name>
       <short_name>End Use: Propane: Generator MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Cord: Heating MBtu</name>
       <display_name>End Use: Wood Cord: Heating MBtu</display_name>
       <short_name>End Use: Wood Cord: Heating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Cord: Hot Water MBtu</name>
       <display_name>End Use: Wood Cord: Hot Water MBtu</display_name>
       <short_name>End Use: Wood Cord: Hot Water MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Cord: Clothes Dryer MBtu</name>
       <display_name>End Use: Wood Cord: Clothes Dryer MBtu</display_name>
       <short_name>End Use: Wood Cord: Clothes Dryer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Cord: Range/Oven MBtu</name>
       <display_name>End Use: Wood Cord: Range/Oven MBtu</display_name>
       <short_name>End Use: Wood Cord: Range/Oven MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Cord: Mech Vent Preheating MBtu</name>
       <display_name>End Use: Wood Cord: Mech Vent Preheating MBtu</display_name>
       <short_name>End Use: Wood Cord: Mech Vent Preheating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Cord: Grill MBtu</name>
       <display_name>End Use: Wood Cord: Grill MBtu</display_name>
       <short_name>End Use: Wood Cord: Grill MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Cord: Lighting MBtu</name>
       <display_name>End Use: Wood Cord: Lighting MBtu</display_name>
       <short_name>End Use: Wood Cord: Lighting MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Cord: Fireplace MBtu</name>
       <display_name>End Use: Wood Cord: Fireplace MBtu</display_name>
       <short_name>End Use: Wood Cord: Fireplace MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Pellets: Heating MBtu</name>
       <display_name>End Use: Wood Pellets: Heating MBtu</display_name>
       <short_name>End Use: Wood Pellets: Heating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Pellets: Hot Water MBtu</name>
       <display_name>End Use: Wood Pellets: Hot Water MBtu</display_name>
       <short_name>End Use: Wood Pellets: Hot Water MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Pellets: Clothes Dryer MBtu</name>
       <display_name>End Use: Wood Pellets: Clothes Dryer MBtu</display_name>
       <short_name>End Use: Wood Pellets: Clothes Dryer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Pellets: Range/Oven MBtu</name>
       <display_name>End Use: Wood Pellets: Range/Oven MBtu</display_name>
       <short_name>End Use: Wood Pellets: Range/Oven MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Pellets: Mech Vent Preheating MBtu</name>
       <display_name>End Use: Wood Pellets: Mech Vent Preheating MBtu</display_name>
       <short_name>End Use: Wood Pellets: Mech Vent Preheating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Pellets: Grill MBtu</name>
       <display_name>End Use: Wood Pellets: Grill MBtu</display_name>
       <short_name>End Use: Wood Pellets: Grill MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Pellets: Lighting MBtu</name>
       <display_name>End Use: Wood Pellets: Lighting MBtu</display_name>
       <short_name>End Use: Wood Pellets: Lighting MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Wood Pellets: Fireplace MBtu</name>
       <display_name>End Use: Wood Pellets: Fireplace MBtu</display_name>
       <short_name>End Use: Wood Pellets: Fireplace MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Coal: Heating MBtu</name>
       <display_name>End Use: Coal: Heating MBtu</display_name>
       <short_name>End Use: Coal: Heating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Coal: Hot Water MBtu</name>
       <display_name>End Use: Coal: Hot Water MBtu</display_name>
       <short_name>End Use: Coal: Hot Water MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Coal: Clothes Dryer MBtu</name>
       <display_name>End Use: Coal: Clothes Dryer MBtu</display_name>
       <short_name>End Use: Coal: Clothes Dryer MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Coal: Range/Oven MBtu</name>
       <display_name>End Use: Coal: Range/Oven MBtu</display_name>
       <short_name>End Use: Coal: Range/Oven MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Coal: Mech Vent Preheating MBtu</name>
       <display_name>End Use: Coal: Mech Vent Preheating MBtu</display_name>
       <short_name>End Use: Coal: Mech Vent Preheating MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Coal: Grill MBtu</name>
       <display_name>End Use: Coal: Grill MBtu</display_name>
       <short_name>End Use: Coal: Grill MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Coal: Lighting MBtu</name>
       <display_name>End Use: Coal: Lighting MBtu</display_name>
       <short_name>End Use: Coal: Lighting MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
     <output>
       <name>End Use: Coal: Fireplace MBtu</name>
       <display_name>End Use: Coal: Fireplace MBtu</display_name>
       <short_name>End Use: Coal: Fireplace MBtu</short_name>
+      <description></description>
       <type>Double</type>
+      <units></units>
       <model_dependent>false</model_dependent>
     </output>
   </outputs>
@@ -901,12 +1116,6 @@
       <checksum>4E3EAA6F</checksum>
     </file>
     <file>
-      <filename>output_report_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>4CF3D80C</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.9.1</identifier>
@@ -917,5 +1126,12 @@
       <usage_type>script</usage_type>
       <checksum>A8CD702E</checksum>
     </file>
+    <file>
+      <filename>output_report_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>61F4ADAC</checksum>
+    </file>
   </files>
 </measure>
+<error>uninitialized constant SimulationOutputReport::EPlus</error>

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>fe011dfb-d01a-41f7-be5e-f4a1a8e5e416</version_id>
-  <version_modified>20210330T150844Z</version_modified>
+  <version_id>96e26b91-6565-43ff-aaec-c785557d4f85</version_id>
+  <version_modified>20210331T140029Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -915,7 +915,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>38DDD4F1</checksum>
+      <checksum>A8CD702E</checksum>
     </file>
   </files>
 </measure>

--- a/SimulationOutputReport/tests/output_report_test.rb
+++ b/SimulationOutputReport/tests/output_report_test.rb
@@ -426,6 +426,7 @@ class SimulationOutputReportTest < MiniTest::Test
 
   def test_annual_only
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
+                  'add_component_loads' => true,
                   'timeseries_frequency' => 'hourly',
                   'include_timeseries_fuel_consumptions' => false,
                   'include_timeseries_end_use_consumptions' => false,
@@ -446,6 +447,7 @@ class SimulationOutputReportTest < MiniTest::Test
 
   def test_annual_only2
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
+                  'add_component_loads' => true,
                   'timeseries_frequency' => 'none',
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
@@ -554,6 +556,7 @@ class SimulationOutputReportTest < MiniTest::Test
 
   def test_timeseries_hourly_component_loads
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
+                  'add_component_loads' => true,
                   'timeseries_frequency' => 'hourly',
                   'include_timeseries_fuel_consumptions' => false,
                   'include_timeseries_end_use_consumptions' => false,
@@ -1032,7 +1035,7 @@ class SimulationOutputReportTest < MiniTest::Test
     workflow.setWorkflowSteps(steps)
     osw_path = File.join(File.dirname(template_osw), 'test.osw')
     workflow.saveAs(osw_path)
-    assert_equal(11, found_args.size)
+    assert_equal(args_hash.size, found_args.size)
 
     # Run OSW
     success = system("#{OpenStudio.getOpenStudioCLI} run -w #{osw_path}")

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -46,7 +46,7 @@ There are additional ways that software developers using this workflow can reduc
 - Run on Linux/Mac platform, which is significantly faster than Windows.
 - Run on computing environments with 1) fast CPUs, 2) sufficient memory, and 3) enough processors to allow all simulations to run in parallel.
 - Limit requests for timeseries output (e.g., ``--hourly``, ``--daily``, ``--timestep`` arguments) and limit the number of output variables requested.
-- Use the ``--skip-component-loads`` argument if heating/cooling component loads are not of interest.
+- Avoid using the ``--add-component-loads`` argument if heating/cooling component loads are not of interest.
 - Use the ``--skip-validation`` argument if the HPXML input file has already been validated against the Schema & Schematron documents.
 
 License

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -208,10 +208,11 @@ Current peak building loads are listed below.
 Annual Component Building Loads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Note**: This section is only available if the ``--add-component-loads`` argument is used.
+The argument is not used by default for faster performance.
+
 Component loads represent the estimated contribution of different building components to the annual heating/cooling building loads.
 The sum of component loads for heating (or cooling) will roughly equal the annual heating (or cooling) building load reported above.
-
-**Note**: These values will be zero if the ``--skip-component-loads`` argument is used.
 
 Current component loads disaggregated by Heating/Cooling are listed below.
    

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -10,7 +10,7 @@ require_relative '../HPXMLtoOpenStudio/resources/version'
 
 basedir = File.expand_path(File.dirname(__FILE__))
 
-def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseries_outputs, skip_validation, skip_comp_loads,
+def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseries_outputs, skip_validation, add_comp_loads,
                  output_format, building_id)
   measures_dir = File.join(basedir, '..')
 
@@ -21,8 +21,8 @@ def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseri
   args = {}
   args['hpxml_path'] = hpxml
   args['output_dir'] = rundir
-  args['skip_component_loads'] = skip_comp_loads
   args['debug'] = debug
+  args['add_component_loads'] = (add_comp_loads || timeseries_outputs.include?('componentloads'))
   args['skip_validation'] = skip_validation
   args['building_id'] = building_id
   update_args_hash(measures, measure_subdir, args)
@@ -91,9 +91,9 @@ OptionParser.new do |opts|
     options[:skip_validation] = true
   end
 
-  options[:skip_comp_loads] = false
-  opts.on('--skip-component-loads', 'Skip heating/cooling component loads calculation for faster performance') do |t|
-    options[:skip_comp_loads] = true
+  options[:add_comp_loads] = false
+  opts.on('--add-component-loads', 'Add heating/cooling component loads calculation') do |t|
+    options[:add_comp_loads] = true
   end
 
   opts.on('-b', '--building-id <ID>', 'ID of Building to simulate (required when multiple HPXML Building elements)') do |t|
@@ -179,7 +179,7 @@ rundir = File.join(options[:output_dir], 'run')
 # Run design
 puts "HPXML: #{options[:hpxml]}"
 success = run_workflow(basedir, rundir, options[:hpxml], options[:debug], timeseries_output_freq, timeseries_outputs,
-                       options[:skip_validation], options[:skip_comp_loads], options[:output_format], options[:building_id])
+                       options[:skip_validation], options[:add_comp_loads], options[:output_format], options[:building_id])
 
 if not success
   exit! 1

--- a/workflow/template.osw
+++ b/workflow/template.osw
@@ -9,7 +9,7 @@
         "hpxml_path": "../workflow/sample_files/base.xml",
         "output_dir": "../workflow/run",
         "debug": false,
-        "skip_component_loads": false,
+        "add_component_loads": false,
         "skip_validation": false
       },
       "measure_dir_name": "HPXMLtoOpenStudio"


### PR DESCRIPTION
## Pull Request Description

Follow-up to #684. 

**Breaking change**: Changes component load calculation to opt-in w/ `--add-component-loads` arguments. (Previously opt-out w/ `--skip-component-loads` argument.)

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
