### PR TITLE
Shared systems & defaulting

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>25013330-f522-4948-a763-a1e9758a5ae5</version_id>
-  <version_modified>20210426T215206Z</version_modified>
+  <version_id>4967295d-fdd1-4863-9f1a-b3029b792538</version_id>
+  <version_modified>20210427T191229Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -550,13 +550,13 @@
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D8454443</checksum>
+      <checksum>71B744B0</checksum>
     </file>
     <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>792D80FB</checksum>
+      <checksum>7F19D52B</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>4967295d-fdd1-4863-9f1a-b3029b792538</version_id>
-  <version_modified>20210427T191229Z</version_modified>
+  <version_id>61204500-43fc-4207-85bd-4629f126c84f</version_id>
+  <version_modified>20210427T234155Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -541,22 +541,22 @@
       <checksum>FEC94D37</checksum>
     </file>
     <file>
-      <filename>hvac_sizing.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6B040960</checksum>
-    </file>
-    <file>
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>71B744B0</checksum>
     </file>
     <file>
+      <filename>hvac_sizing.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>D99580D0</checksum>
+    </file>
+    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>7F19D52B</checksum>
+      <checksum>2AD627A4</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -6,7 +6,7 @@ class HPXMLDefaults
   # being written to the HPXML file. This is useful to associate additional values
   # with the HPXML objects that will ultimately get passed around.
 
-  def self.apply(hpxml, eri_version, weather, epw_file: nil)
+  def self.apply(hpxml, eri_version, weather, epw_file: nil, convert_shared_systems: true)
     cfa = hpxml.building_construction.conditioned_floor_area
     nbeds = hpxml.building_construction.number_of_bedrooms
     ncfl = hpxml.building_construction.number_of_conditioned_floors
@@ -27,7 +27,7 @@ class HPXMLDefaults
     apply_slabs(hpxml)
     apply_windows(hpxml)
     apply_skylights(hpxml)
-    apply_hvac(hpxml, weather)
+    apply_hvac(hpxml, weather, convert_shared_systems)
     apply_hvac_control(hpxml)
     apply_hvac_distribution(hpxml, ncfl, ncfl_ag)
     apply_ventilation_fans(hpxml)
@@ -423,8 +423,10 @@ class HPXMLDefaults
     end
   end
 
-  def self.apply_hvac(hpxml, weather)
-    HVAC.apply_shared_systems(hpxml)
+  def self.apply_hvac(hpxml, weather, convert_shared_systems)
+    if convert_shared_systems
+      HVAC.apply_shared_systems(hpxml)
+    end
 
     # Default AC/HP compressor type
     hpxml.cooling_systems.each do |cooling_system|

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -4177,8 +4177,6 @@ class HVAC
     hvac_systems = []
 
     hpxml.cooling_systems.each do |cooling_system|
-      next if cooling_system.is_shared_system
-
       heating_system = nil
       if is_central_air_conditioner_and_furnace(hpxml, cooling_system.attached_heating_system, cooling_system)
         heating_system = cooling_system.attached_heating_system
@@ -4188,8 +4186,6 @@ class HVAC
     end
 
     hpxml.heating_systems.each do |heating_system|
-      next if heating_system.is_shared_system
-
       if is_central_air_conditioner_and_furnace(hpxml, heating_system, heating_system.attached_cooling_system)
         next # Already processed combined AC+furnace
       end
@@ -4198,9 +4194,6 @@ class HVAC
     end
 
     hpxml.heat_pumps.each do |heat_pump|
-      next if heat_pump.is_shared_system
-      next if heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpWaterLoopToAir
-
       hvac_systems << { cooling: heat_pump,
                         heating: heat_pump }
     end

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -3965,7 +3965,7 @@ class HVAC
     return 30.0 # W/ton, per ANSI/RESNET/ICC 301-2019 Section 4.4.5 (closed loop)
   end
 
-  def self.apply_shared_systems(hpxml = true)
+  def self.apply_shared_systems(hpxml)
     applied_clg = apply_shared_cooling_systems(hpxml)
     applied_htg = apply_shared_heating_systems(hpxml)
     return unless (applied_clg || applied_htg)
@@ -4177,6 +4177,8 @@ class HVAC
     hvac_systems = []
 
     hpxml.cooling_systems.each do |cooling_system|
+      next if cooling_system.is_shared_system
+
       heating_system = nil
       if is_central_air_conditioner_and_furnace(hpxml, cooling_system.attached_heating_system, cooling_system)
         heating_system = cooling_system.attached_heating_system
@@ -4186,6 +4188,8 @@ class HVAC
     end
 
     hpxml.heating_systems.each do |heating_system|
+      next if heating_system.is_shared_system
+
       if is_central_air_conditioner_and_furnace(hpxml, heating_system, heating_system.attached_cooling_system)
         next # Already processed combined AC+furnace
       end
@@ -4194,6 +4198,9 @@ class HVAC
     end
 
     hpxml.heat_pumps.each do |heat_pump|
+      next if heat_pump.is_shared_system
+      next if heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpWaterLoopToAir
+
       hvac_systems << { cooling: heat_pump,
                         heating: heat_pump }
     end

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -30,6 +30,13 @@ class HVACSizing
     hvac_systems.each do |hvac_system|
       hvac = get_hvac_information(hvac_system)
 
+      # These shared systems should be converted to other equivalent
+      # systems before being autosized
+      next if [HPXML::HVACTypeChiller,
+               HPXML::HVACTypeCoolingTower].include?(hvac.CoolType)
+      next if [HPXML::HVACTypeHeatPumpWaterLoopToAir].include?(hvac.HeatType) &&
+              hvac.HeatingLoadFraction.nil?
+
       # Add duct losses
       apply_hvac_temperatures(hvac, bldg_design_loads)
       apply_load_ducts_heating(bldg_design_loads, weather, hvac)


### PR DESCRIPTION
## Pull Request Description

Allow excluding the conversion of shared systems (e.g., chiller -> central AC w/ SEEReq) when HPXML defaulting. Needed for OS-ERI. No diffs expected.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
