### PR TITLE
Small refactor related to AssemblyEffectiveRvalue

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>ad960581-f03f-4ca9-86b1-47d446e8acf3</version_id>
-  <version_modified>20210501T001318Z</version_modified>
+  <version_id>5a602a0a-62c5-4ac1-b9af-f668b29d1554</version_id>
+  <version_modified>20210503T200131Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -350,24 +350,6 @@
       <checksum>E5A74D5B</checksum>
     </file>
     <file>
-      <filename>HPXMLvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>BCC4746A</checksum>
-    </file>
-    <file>
-      <filename>HPXMLDataTypes.xsd</filename>
-      <filetype>xsd</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>4F3B76D8</checksum>
-    </file>
-    <file>
-      <filename>BaseElements.xsd</filename>
-      <filetype>xsd</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7EA2CFE9</checksum>
-    </file>
-    <file>
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -505,12 +487,6 @@
       <checksum>2AD627A4</checksum>
     </file>
     <file>
-      <filename>EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>95FBB68A</checksum>
-    </file>
-    <file>
       <filename>test_water_heater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -557,6 +533,30 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>33E46C96</checksum>
+    </file>
+    <file>
+      <filename>HPXMLvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>25C5E8C4</checksum>
+    </file>
+    <file>
+      <filename>HPXMLDataTypes.xsd</filename>
+      <filetype>xsd</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3259B8DD</checksum>
+    </file>
+    <file>
+      <filename>BaseElements.xsd</filename>
+      <filetype>xsd</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>CAF4AA69</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>2CC230A6</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/BaseElements.xsd
+++ b/HPXMLtoOpenStudio/resources/BaseElements.xsd
@@ -189,7 +189,7 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" name="InsulationGrade" type="InsulationGrade"/>
 			<xs:element minOccurs="0" name="InsulationCondition" type="InsulationCondition"/>
-			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="RValue">
+			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="AssemblyRValue">
 				<xs:annotation>
 					<xs:documentation>This should indicate the effective R-value of the complete assembly including any air films or other treatments.</xs:documentation>
 				</xs:annotation>
@@ -264,6 +264,8 @@
 						</xs:annotation>
 					</xs:element>
 					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"> </xs:element>
+					<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
+					<xs:element minOccurs="0" name="VentedFlowRate" type="FlowRate"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -939,6 +941,11 @@
 									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean">
+										<xs:annotation>
+											<xs:documentation>Indicates whether the walls are vented or not. For example, the walls of a mobile home may be intentionally ventilated to remove accumulated moisture by having corrugated metal siding open at the bottom to provide space for air to flow between the exterior and interior wall materials.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
@@ -3458,6 +3465,11 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="HVACMaintenance" type="HVACMaintenance"/>
+			<xs:element minOccurs="0" name="IsPackagedSystem" type="HPXMLBoolean">
+				<xs:annotation>
+					<xs:documentation>Is the system a packaged system?</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
 				<xs:annotation>
 					<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
@@ -3496,6 +3508,7 @@
 								Consumer’s Directory of Certified Efficiency Ratings.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="AttachedToCoolingSystem" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -3589,6 +3602,14 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="FixedHeater">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+					<xs:attribute name="dataSource" type="DataSource"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="PackagedTerminalAirConditionerHeating">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>

--- a/HPXMLtoOpenStudio/resources/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/EPvalidator.xml
@@ -232,7 +232,6 @@
       <sch:assert role='ERROR' test='count(h:RadiantBarrier) &lt;= 1'>Expected 0 or 1 element(s) for xpath: RadiantBarrier</sch:assert> <!-- See [RadiantBarrier] -->
       <sch:assert role='ERROR' test='count(h:Insulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: Insulation/SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/AssemblyEffectiveRValue</sch:assert>
-      <sch:assert role='ERROR' test='number(h:Insulation/h:AssemblyEffectiveRValue) &gt; 0 or not(h:Insulation/h:AssemblyEffectiveRValue)'>Expected Insulation/AssemblyEffectiveRValue to be greater than 0</sch:assert>
     </sch:rule>
   </sch:pattern>
 
@@ -266,7 +265,6 @@
       <sch:assert role='ERROR' test='count(h:Emittance) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Emittance</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: Insulation/SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/AssemblyEffectiveRValue</sch:assert>
-      <sch:assert role='ERROR' test='number(h:Insulation/h:AssemblyEffectiveRValue) &gt; 0 or not(h:Insulation/h:AssemblyEffectiveRValue)'>Expected Insulation/AssemblyEffectiveRValue to be greater than 0</sch:assert>
     </sch:rule>
   </sch:pattern>
 
@@ -287,7 +285,6 @@
       <sch:assert role='ERROR' test='count(h:Emittance) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Emittance</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: Insulation/SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/AssemblyEffectiveRValue</sch:assert>
-      <sch:assert role='ERROR' test='number(h:Insulation/h:AssemblyEffectiveRValue) &gt; 0 or not(h:Insulation/h:AssemblyEffectiveRValue)'>Expected Insulation/AssemblyEffectiveRValue to be greater than 0</sch:assert>
     </sch:rule>
   </sch:pattern>
 
@@ -309,7 +306,6 @@
       <!-- Insulation: either specify interior and exterior layers OR assembly R-value: -->
       <sch:assert role='ERROR' test='count(h:Insulation/h:Layer[h:InstallationType[text()="continuous - interior"]]) + count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/Layer[InstallationType[text()="continuous - interior"]] | Insulation/AssemblyEffectiveRValue</sch:assert> <!-- See [FoundationWallInsulationLayer] -->
       <sch:assert role='ERROR' test='count(h:Insulation/h:Layer[h:InstallationType[text()="continuous - exterior"]]) + count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/Layer[InstallationType[text()="continuous - exterior"]] | Insulation/AssemblyEffectiveRValue</sch:assert> <!-- See [FoundationWallInsulationLayer] -->
-      <sch:assert role='ERROR' test='number(h:Insulation/h:AssemblyEffectiveRValue) &gt; 0 or not(h:Insulation/h:AssemblyEffectiveRValue)'>Expected Insulation/AssemblyEffectiveRValue to be greater than 0</sch:assert>
     </sch:rule>
   </sch:pattern>
 
@@ -342,7 +338,6 @@
       <sch:assert role='ERROR' test='count(h:Area) = 1'>Expected 1 element(s) for xpath: Area</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:SystemIdentifier) = 1'>Expected 1 element(s) for xpath: Insulation/SystemIdentifier</sch:assert>
       <sch:assert role='ERROR' test='count(h:Insulation/h:AssemblyEffectiveRValue) = 1'>Expected 1 element(s) for xpath: Insulation/AssemblyEffectiveRValue</sch:assert>
-      <sch:assert role='ERROR' test='number(h:Insulation/h:AssemblyEffectiveRValue) &gt; 0 or not(h:Insulation/h:AssemblyEffectiveRValue)'>Expected Insulation/AssemblyEffectiveRValue to be greater than 0</sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/HPXMLtoOpenStudio/resources/HPXMLDataTypes.xsd
+++ b/HPXMLtoOpenStudio/resources/HPXMLDataTypes.xsd
@@ -1262,6 +1262,18 @@
 		</xs:simpleContent>
 	</xs:complexType>
 	<!--Insulation Below-->
+	<xs:simpleType name="AssemblyRValue_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AssemblyRValue">
+		<xs:simpleContent>
+			<xs:extension base="AssemblyRValue_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="DoorThirdPartyCertifications_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
@@ -1765,6 +1777,7 @@
 			<xs:enumeration value="evaporative cooler"/>
 			<xs:enumeration value="chiller"/>
 			<xs:enumeration value="cooling tower"/>
+			<xs:enumeration value="packaged terminal air conditioner"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
@@ -1855,6 +1868,7 @@
 			<xs:enumeration value="mini-split"/>
 			<xs:enumeration value="ground-to-air"/>
 			<xs:enumeration value="ground-to-water"/>
+			<xs:enumeration value="packaged terminal heat pump"/>
 			<xs:enumeration value="water-loop-to-air"/>
 			<xs:enumeration value="variable refrigerant flow"/>
 		</xs:restriction>

--- a/HPXMLtoOpenStudio/resources/HPXMLvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/HPXMLvalidator.xml
@@ -65,7 +65,7 @@
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:Roofs/h:Roof/h:Insulation'>
-      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt;= 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than or equal to 0</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt; 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:RimJoists/h:RimJoist'>
@@ -83,7 +83,7 @@
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:RimJoists/h:RimJoist/h:Insulation'>
-      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt;= 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than or equal to 0</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt; 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:Walls/h:Wall'>
@@ -101,7 +101,7 @@
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:Walls/h:Wall/h:Insulation'>
-      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt;= 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than or equal to 0</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt; 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:FoundationWalls/h:FoundationWall'>
@@ -116,7 +116,7 @@
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:FoundationWalls/h:FoundationWall/h:Insulation'>
-      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt;= 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than or equal to 0</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt; 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:FoundationWalls/h:FoundationWall/h:Insulation/h:Layer'>
@@ -130,7 +130,7 @@
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:FrameFloors/h:FrameFloor/h:Insulation'>
-      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt;= 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than or equal to 0</sch:assert>
+      <sch:assert role='ERROR' test='number(h:AssemblyEffectiveRValue) &gt; 0 or not(h:AssemblyEffectiveRValue)'>Expected AssemblyEffectiveRValue to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:SystemIdentifier[@id]) = 1 or not (h:SystemIdentifier)'>Expected id attribute for SystemIdentifier</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Enclosure/h:Slabs/h:Slab'>
@@ -225,7 +225,7 @@
       <sch:assert role='ERROR' test='number(h:Value) &gt;= 0 or not(h:Value)'>Expected Value to be greater than or equal to 0</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:HVAC/h:HVACPlant/h:CoolingSystem'>
-      <sch:assert role='ERROR' test='h:CoolingSystemType[text()="central air conditioner" or text()="mini-split" or text()="room air conditioner" or text()="evaporative cooler" or text()="chiller" or text()="cooling tower" or text()="other"] or not(h:CoolingSystemType)'>Expected CoolingSystemType to be 'central air conditioner' or 'mini-split' or 'room air conditioner' or 'evaporative cooler' or 'chiller' or 'cooling tower' or 'other'</sch:assert>
+      <sch:assert role='ERROR' test='h:CoolingSystemType[text()="central air conditioner" or text()="mini-split" or text()="room air conditioner" or text()="evaporative cooler" or text()="chiller" or text()="cooling tower" or text()="packaged terminal air conditioner" or text()="other"] or not(h:CoolingSystemType)'>Expected CoolingSystemType to be 'central air conditioner' or 'mini-split' or 'room air conditioner' or 'evaporative cooler' or 'chiller' or 'cooling tower' or 'packaged terminal air conditioner' or 'other'</sch:assert>
       <sch:assert role='ERROR' test='h:CoolingSystemFuel[text()="electricity" or text()="renewable electricity" or text()="natural gas" or text()="renewable natural gas" or text()="fuel oil" or text()="fuel oil 1" or text()="fuel oil 2" or text()="fuel oil 4" or text()="fuel oil 5/6" or text()="district steam" or text()="district hot water" or text()="district chilled water" or text()="solar hot water" or text()="propane" or text()="kerosene" or text()="diesel" or text()="coal" or text()="anthracite coal" or text()="bituminous coal" or text()="coke" or text()="wood" or text()="wood pellets" or text()="combination" or text()="other"] or not(h:CoolingSystemFuel)'>Expected CoolingSystemFuel to be 'electricity' or 'renewable electricity' or 'natural gas' or 'renewable natural gas' or 'fuel oil' or 'fuel oil 1' or 'fuel oil 2' or 'fuel oil 4' or 'fuel oil 5/6' or 'district steam' or 'district hot water' or 'district chilled water' or 'solar hot water' or 'propane' or 'kerosene' or 'diesel' or 'coal' or 'anthracite coal' or 'bituminous coal' or 'coke' or 'wood' or 'wood pellets' or 'combination' or 'other'</sch:assert>
       <sch:assert role='ERROR' test='h:CompressorType[text()="single stage" or text()="two stage" or text()="variable speed"] or not(h:CompressorType)'>Expected CompressorType to be 'single stage' or 'two stage' or 'variable speed'</sch:assert>
       <sch:assert role='ERROR' test='number(h:FractionCoolLoadServed) &gt;= 0 or not(h:FractionCoolLoadServed)'>Expected FractionCoolLoadServed to be greater than or equal to 0</sch:assert>
@@ -240,7 +240,7 @@
       <sch:assert role='ERROR' test='number(h:Value) &gt;= 0 or not(h:Value)'>Expected Value to be greater than or equal to 0</sch:assert>
     </sch:rule>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:HVAC/h:HVACPlant/h:HeatPump'>
-      <sch:assert role='ERROR' test='h:HeatPumpType[text()="water-to-air" or text()="water-to-water" or text()="air-to-air" or text()="air-to-water" or text()="mini-split" or text()="ground-to-air" or text()="ground-to-water" or text()="water-loop-to-air" or text()="variable refrigerant flow"] or not(h:HeatPumpType)'>Expected HeatPumpType to be 'water-to-air' or 'water-to-water' or 'air-to-air' or 'air-to-water' or 'mini-split' or 'ground-to-air' or 'ground-to-water' or 'water-loop-to-air' or 'variable refrigerant flow'</sch:assert>
+      <sch:assert role='ERROR' test='h:HeatPumpType[text()="water-to-air" or text()="water-to-water" or text()="air-to-air" or text()="air-to-water" or text()="mini-split" or text()="ground-to-air" or text()="ground-to-water" or text()="packaged terminal heat pump" or text()="water-loop-to-air" or text()="variable refrigerant flow"] or not(h:HeatPumpType)'>Expected HeatPumpType to be 'water-to-air' or 'water-to-water' or 'air-to-air' or 'air-to-water' or 'mini-split' or 'ground-to-air' or 'ground-to-water' or 'packaged terminal heat pump' or 'water-loop-to-air' or 'variable refrigerant flow'</sch:assert>
       <sch:assert role='ERROR' test='h:HeatPumpFuel[text()="electricity" or text()="renewable electricity" or text()="natural gas" or text()="renewable natural gas" or text()="fuel oil" or text()="fuel oil 1" or text()="fuel oil 2" or text()="fuel oil 4" or text()="fuel oil 5/6" or text()="district steam" or text()="district hot water" or text()="district chilled water" or text()="solar hot water" or text()="propane" or text()="kerosene" or text()="diesel" or text()="coal" or text()="anthracite coal" or text()="bituminous coal" or text()="coke" or text()="wood" or text()="wood pellets" or text()="combination" or text()="other"] or not(h:HeatPumpFuel)'>Expected HeatPumpFuel to be 'electricity' or 'renewable electricity' or 'natural gas' or 'renewable natural gas' or 'fuel oil' or 'fuel oil 1' or 'fuel oil 2' or 'fuel oil 4' or 'fuel oil 5/6' or 'district steam' or 'district hot water' or 'district chilled water' or 'solar hot water' or 'propane' or 'kerosene' or 'diesel' or 'coal' or 'anthracite coal' or 'bituminous coal' or 'coke' or 'wood' or 'wood pellets' or 'combination' or 'other'</sch:assert>
       <sch:assert role='ERROR' test='h:CompressorType[text()="single stage" or text()="two stage" or text()="variable speed"] or not(h:CompressorType)'>Expected CompressorType to be 'single stage' or 'two stage' or 'variable speed'</sch:assert>
       <sch:assert role='ERROR' test='number(h:CoolingSensibleHeatFraction) &gt;= 0 or not(h:CoolingSensibleHeatFraction)'>Expected CoolingSensibleHeatFraction to be greater than or equal to 0</sch:assert>

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -211,7 +211,7 @@ class HPXMLTest < MiniTest::Test
                             'hvac-inconsistent-fan-powers.xml' => ["Fan powers for heating system 'HeatingSystem' and cooling system 'CoolingSystem' are attached to a single distribution system and therefore must be the same."],
                             'hvac-invalid-distribution-system-type.xml' => ["Incorrect HVAC distribution system type for HVAC type: 'Furnace'. Should be one of: ["],
                             'hvac-shared-negative-seer-eq.xml' => ["Negative SEER equivalent calculated for cooling system 'CoolingSystem', double check inputs."],
-                            'invalid-assembly-effective-rvalue.xml' => ['Expected Insulation/AssemblyEffectiveRValue to be greater than 0 [context: /HPXML/Building/BuildingDetails/Enclosure/Walls/Wall, id: "Wall"]'],
+                            'invalid-assembly-effective-rvalue.xml' => ['Expected AssemblyEffectiveRValue to be greater than 0 [context: /HPXML/Building/BuildingDetails/Enclosure/Walls/Wall/Insulation, id: "WallInsulation"]'],
                             'invalid-datatype-boolean.xml' => ["Cannot convert 'FOOBAR' to boolean for Roof/RadiantBarrier."],
                             'invalid-datatype-integer.xml' => ["Cannot convert '2.5' to integer for BuildingConstruction/NumberofBedrooms."],
                             'invalid-datatype-float.xml' => ["Cannot convert 'FOOBAR' to float for Slab/extension/CarpetFraction."],


### PR DESCRIPTION
## Pull Request Description

Addresses #747.

Now that HPXML 3.1 is proposing to [require AssemblyEffectiveRvalue > 0](https://github.com/hpxmlwg/hpxml/pull/257), we no longer need our own checks in our EPvalidator.xml Schematron file. The only effect from this PR is that error messages will change slightly if a value of zero is (incorrectly) provided.

## Checklist

Not all may apply:

- [x] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
