### PR TITLE
Ruby verbose flag

### DIFF
--- a/HPXMLtoOpenStudio/resources/minitest_helper.rb
+++ b/HPXMLtoOpenStudio/resources/minitest_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-$VERBOSE = nil # Prevents ruby warnings, see https://github.com/NREL/OpenStudio/issues/4301
-
 called_from_cli = true
 begin
   OpenStudio.getOpenStudioCLI

--- a/tasks.rb
+++ b/tasks.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-$VERBOSE = nil # Prevents ruby warnings, see https://github.com/NREL/OpenStudio/issues/4301
-
 def create_hpxmls
   require 'oga'
   require_relative 'HPXMLtoOpenStudio/resources/constants'

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-$VERBOSE = nil # Prevents ruby warnings, see https://github.com/NREL/OpenStudio/issues/4301
-
 start_time = Time.now
 
 require 'fileutils'


### PR DESCRIPTION
## Pull Request Description

Removes use of ruby verbose flag now that https://github.com/NREL/OpenStudio/pull/4302 is merged.

Need to update to OS 3.2.1 before this is merged.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
