### PR TITLE
Populate FractionDuctArea when duct area defaulting

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -4,8 +4,8 @@
   <error>Unable to extract OpenStudio::Measure::OSMeasure object from /mnt/c/git/openstudio-hpxml/HPXMLtoOpenStudio/measure.rb. The script should contain a class that derives from OpenStudio::Measure::OSMeasure and should close with a line stating the class name followed by .new.registerWithApplication.</error>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>eaec420d-b044-444e-a37e-a9529e6e0b6f</version_id>
-  <version_modified>20210510T230919Z</version_modified>
+  <version_id>7f3add7c-3791-479f-8637-cc6f545bfa51</version_id>
+  <version_modified>20210511T220343Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -414,12 +414,6 @@
       <checksum>C18610A9</checksum>
     </file>
     <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>3065BE57</checksum>
-    </file>
-    <file>
       <filename>test_water_heater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -539,12 +533,6 @@
       <checksum>C3F9378E</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7E2C2773</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -563,12 +551,6 @@
       <checksum>25E2DA28</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>018B0831</checksum>
-    </file>
-    <file>
       <filename>EPvalidator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
@@ -585,6 +567,24 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>F3E1BE58</checksum>
+    </file>
+    <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>0858010C</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3F802C5B</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>D167F388</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -3553,7 +3553,7 @@ class HPXML < Object
       end
       XMLHelper.add_element(ducts_el, 'DuctInsulationRValue', @duct_insulation_r_value, :float) unless @duct_insulation_r_value.nil?
       XMLHelper.add_element(ducts_el, 'DuctLocation', @duct_location, :string, @duct_location_isdefaulted) unless @duct_location.nil?
-      XMLHelper.add_element(ducts_el, 'FractionDuctArea', @duct_fraction_area, :float) unless @duct_fraction_area.nil?
+      XMLHelper.add_element(ducts_el, 'FractionDuctArea', @duct_fraction_area, :float, @duct_fraction_area_isdefaulted) unless @duct_fraction_area.nil?
       XMLHelper.add_element(ducts_el, 'DuctSurfaceArea', @duct_surface_area, :float, @duct_surface_area_isdefaulted) unless @duct_surface_area.nil?
     end
 

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -812,6 +812,21 @@ class HPXMLDefaults
           duct.duct_location_isdefaulted = true
         end
       end
+
+      # Also update FractionDuctArea for informational purposes
+      supply_ducts = hvac_distribution.ducts.select { |duct| duct.duct_type == HPXML::DuctTypeSupply }
+      return_ducts = hvac_distribution.ducts.select { |duct| duct.duct_type == HPXML::DuctTypeReturn }
+      total_supply_area = supply_ducts.map { |d| d.duct_surface_area }.sum
+      total_return_area = return_ducts.map { |d| d.duct_surface_area }.sum
+      (supply_ducts + return_ducts).each do |duct|
+        if duct.duct_type == HPXML::DuctTypeSupply
+          duct.duct_fraction_area = (duct.duct_surface_area / total_supply_area).round(3)
+          duct.duct_fraction_area_isdefaulted = true
+        elsif duct.duct_type == HPXML::DuctTypeReturn
+          duct.duct_fraction_area = (duct.duct_surface_area / total_return_area).round(3)
+          duct.duct_fraction_area_isdefaulted = true
+        end
+      end
     end
   end
 

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -770,8 +770,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_return_locations = ['attic - unvented']
     expected_supply_areas = [150.0]
     expected_return_areas = [50.0]
+    expected_area_fracs = [1.0]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas,
+                              expected_area_fracs, expected_n_return_registers)
 
     # Test defaults w/ conditioned basement
     hpxml.hvac_distributions[0].number_of_return_registers = nil
@@ -787,8 +789,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_return_locations = ['basement - conditioned']
     expected_supply_areas = [729.0]
     expected_return_areas = [270.0]
+    expected_area_fracs = [1.0]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas,
+                              expected_area_fracs, expected_n_return_registers)
 
     # Test defaults w/ multiple foundations
     hpxml = _create_hpxml('base-foundation-multiple.xml')
@@ -804,8 +808,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_return_locations = ['basement - unconditioned']
     expected_supply_areas = [364.5]
     expected_return_areas = [67.5]
+    expected_area_fracs = [1.0]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas,
+                              expected_area_fracs, expected_n_return_registers)
 
     # Test defaults w/ foundation exposed to ambient
     hpxml = _create_hpxml('base-foundation-ambient.xml')
@@ -821,8 +827,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_return_locations = ['attic - unvented']
     expected_supply_areas = [364.5]
     expected_return_areas = [67.5]
+    expected_area_fracs = [1.0]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas,
+                              expected_area_fracs, expected_n_return_registers)
 
     # Test defaults w/ building/unit adjacent to other housing unit
     hpxml = _create_hpxml('base-bldgtype-multifamily-adjacent-to-other-housing-unit.xml')
@@ -838,8 +846,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_return_locations = ['living space']
     expected_supply_areas = [243.0]
     expected_return_areas = [45.0]
+    expected_area_fracs = [1.0]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas,
+                              expected_area_fracs, expected_n_return_registers)
 
     # Test defaults w/ 2-story building
     hpxml = _create_hpxml('base-enclosure-2stories.xml')
@@ -855,8 +865,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_return_locations = ['basement - conditioned', 'living space']
     expected_supply_areas = [820.13, 273.38]
     expected_return_areas = [455.63, 151.88]
+    expected_area_fracs = [0.75, 0.25]
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas,
+                              expected_area_fracs, expected_n_return_registers)
 
     # Test defaults w/ 1-story building & multiple HVAC systems
     hpxml = _create_hpxml('base-hvac-multiple.xml')
@@ -872,8 +884,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_return_locations = ['basement - conditioned', 'basement - conditioned'] * hpxml_default.hvac_distributions.size
     expected_supply_areas = [36.45, 36.45] * hpxml_default.hvac_distributions.size
     expected_return_areas = [13.5, 13.5] * hpxml_default.hvac_distributions.size
+    expected_area_fracs = [0.5, 0.5] * hpxml_default.hvac_distributions.size
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas,
+                              expected_area_fracs, expected_n_return_registers)
 
     # Test defaults w/ 2-story building & multiple HVAC systems
     hpxml = _create_hpxml('base-hvac-multiple.xml')
@@ -890,8 +904,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     expected_return_locations = ['basement - conditioned', 'basement - conditioned', 'living space', 'living space'] * hpxml_default.hvac_distributions.size
     expected_supply_areas = [27.34, 27.34, 9.11, 9.11] * hpxml_default.hvac_distributions.size
     expected_return_areas = [10.13, 10.13, 3.38, 3.38] * hpxml_default.hvac_distributions.size
+    expected_area_fracs = [0.375, 0.375, 0.125, 0.125] * hpxml_default.hvac_distributions.size
     expected_n_return_registers = hpxml_default.building_construction.number_of_conditioned_floors
-    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas, expected_n_return_registers)
+    _test_default_duct_values(hpxml_default, expected_supply_locations, expected_return_locations, expected_supply_areas, expected_return_areas,
+                              expected_area_fracs, expected_n_return_registers)
   end
 
   def test_mech_ventilation_fans
@@ -2258,7 +2274,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_equal(clg_setup_start_hr, hvac_control.cooling_setup_start_hour)
   end
 
-  def _test_default_duct_values(hpxml, supply_locations, return_locations, supply_areas, return_areas, n_return_registers)
+  def _test_default_duct_values(hpxml, supply_locations, return_locations, supply_areas, return_areas,
+                                area_fracs, n_return_registers)
     supply_duct_idx = 0
     return_duct_idx = 0
     hpxml.hvac_distributions.each do |hvac_distribution|
@@ -2269,10 +2286,12 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
         if duct.duct_type == HPXML::DuctTypeSupply
           assert_equal(supply_locations[supply_duct_idx], duct.duct_location)
           assert_in_epsilon(supply_areas[supply_duct_idx], duct.duct_surface_area, 0.01)
+          assert_in_epsilon(area_fracs[supply_duct_idx], duct.duct_fraction_area, 0.01)
           supply_duct_idx += 1
         elsif duct.duct_type == HPXML::DuctTypeReturn
           assert_equal(return_locations[return_duct_idx], duct.duct_location)
           assert_in_epsilon(return_areas[return_duct_idx], duct.duct_surface_area, 0.01)
+          assert_in_epsilon(area_fracs[return_duct_idx], duct.duct_fraction_area, 0.01)
           return_duct_idx += 1
         end
       end


### PR DESCRIPTION
## Pull Request Description

When duct surface areas are defaulted, also populate the HPXML `FractionDuctArea` elements for informational purposes. Not needed/used as part of the simulation.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
