### PR TITLE
Reporting measure: register net electricity use

### DIFF
--- a/SimulationOutputReport/measure.rb
+++ b/SimulationOutputReport/measure.rb
@@ -1014,8 +1014,19 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     all_outputs.each do |outputs|
       outputs.each do |key, obj|
         output_name = get_runner_output_name(obj)
-        runner.registerValue(output_name, obj.annual_output.round(2))
-        runner.registerInfo("Registering #{obj.annual_output.round(2)} for #{output_name}.")
+        output_val = obj.annual_output.round(2)
+        runner.registerValue(output_name, output_val)
+        runner.registerInfo("Registering #{output_val} for #{output_name}.")
+        next unless key == FT::Elec && obj.is_a?(Fuel)
+
+        # Also add Net Electricity
+        elec_total = @fuels[FT::Elec]
+        elec_pv_produced = @end_uses[[FT::Elec, EUT::PV]]
+        elec_generator_produced = @end_uses[[FT::Elec, EUT::Generator]]
+        output_name = 'Fuel Use: Electricity: Net (MBtu)'
+        output_val = (elec_total.annual_output + elec_pv_produced.annual_output + elec_generator_produced.annual_output).round(2)
+        runner.registerValue(output_name, output_val)
+        runner.registerInfo("Registering #{output_val} for #{output_name}.")
       end
     end
   end

--- a/SimulationOutputReport/measure.xml
+++ b/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>26437b7e-1501-4ee2-ab51-2fb41ce86df7</version_id>
-  <version_modified>20210527T215001Z</version_modified>
+  <version_id>0fe902bf-dca5-4ed0-806d-0d70b287bbaa</version_id>
+  <version_modified>20210622T222645Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1293,7 +1293,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>B210E49B</checksum>
+      <checksum>F0DD60CA</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Follow up to #767. Now includes net electricity in the registered values by the SimulationOutputReport reporting measure.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
