### PR TITLE
Small fix for mechanical ventilation compartmentalization area calculation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,7 @@ __New Features__
 __Bugfixes__
 - Improves ground reflectance when there is shading of windows/skylights.
 - Improves HVAC fan power for central forced air systems.
+- Fixes mechanical ventilation compartmentalization area calculation for SFA/MF homes with surfaces with InteriorAdjacentTo==ExteriorAdjacentTo.
 - Negative `DistanceToTopOfInsulation` values are now disallowed.
 - Fixes workflow errors if a `VentilationFan` has zero airflow rate or zero hours of operation.
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7434d544-1fa4-4dbe-80d3-03053f2679ea</version_id>
-  <version_modified>20210817T173123Z</version_modified>
+  <version_id>1dff98e3-8280-494e-8d54-ab7f6df51ae8</version_id>
+  <version_modified>20210818T152033Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -332,12 +332,6 @@
       <checksum>311D562C</checksum>
     </file>
     <file>
-      <filename>test_enclosure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>24CB55D0</checksum>
-    </file>
-    <file>
       <filename>materials.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -421,12 +415,6 @@
       <checksum>A96126CA</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>3316BE67</checksum>
-    </file>
-    <file>
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -461,6 +449,18 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>2D5FE96B</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>F4B6F8B7</checksum>
+    </file>
+    <file>
+      <filename>test_enclosure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>519E3162</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/tests/test_enclosure.rb
+++ b/HPXMLtoOpenStudio/tests/test_enclosure.rb
@@ -530,6 +530,41 @@ class HPXMLtoOpenStudioEnclosureTest < MiniTest::Test
     end
   end
 
+  def test_compartmentaliztion_area
+    # Test single-family detached
+    hpxml = _create_hpxml('base.xml')
+    total_area, exterior_area = hpxml.compartmentalization_boundary_areas()
+    a_ext_ratio = exterior_area / total_area
+    assert_equal(1.0, a_ext_ratio)
+
+    hpxml = _create_hpxml('base-foundation-unconditioned-basement.xml')
+    total_area, exterior_area = hpxml.compartmentalization_boundary_areas()
+    a_ext_ratio = exterior_area / total_area
+    assert_equal(1.0, a_ext_ratio)
+
+    hpxml = _create_hpxml('base-atticroof-cathedral.xml')
+    total_area, exterior_area = hpxml.compartmentalization_boundary_areas()
+    a_ext_ratio = exterior_area / total_area
+    assert_equal(1.0, a_ext_ratio)
+
+    # Test single-family attached
+    hpxml = _create_hpxml('base-bldgtype-single-family-attached.xml')
+    total_area, exterior_area = hpxml.compartmentalization_boundary_areas()
+    a_ext_ratio = exterior_area / total_area
+    assert_in_delta(0.840, a_ext_ratio, 0.001)
+
+    hpxml.attics[0].within_infiltration_volume = true
+    total_area, exterior_area = hpxml.compartmentalization_boundary_areas()
+    a_ext_ratio = exterior_area / total_area
+    assert_in_delta(0.817, a_ext_ratio, 0.001)
+
+    # Test multifamily
+    hpxml = _create_hpxml('base-bldgtype-multifamily.xml')
+    total_area, exterior_area = hpxml.compartmentalization_boundary_areas()
+    a_ext_ratio = exterior_area / total_area
+    assert_in_delta(0.247, a_ext_ratio, 0.001)
+  end
+
   def _check_surface(hpxml_surface, os_surface, expected_layer_names)
     os_construction = os_surface.construction.get.to_LayeredConstruction.get
 


### PR DESCRIPTION
## Pull Request Description

Fixes mechanical ventilation compartmentalization area calculation for SFA/MF homes with surfaces with `InteriorAdjacentTo`==`ExteriorAdjacentTo`. Adds unit tests.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
