### PR TITLE
Avoid E+ warnings about unused objects

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -398,8 +398,9 @@ class OSModel
       # Create new construction in case of shared construction.
       layered_const_adj = OpenStudio::Model::Construction.new(model)
       layered_const_adj.setName(cond_bsmnt_surface.construction.get.name.get + ' Reversed Bsmnt')
-      adj_surface.setConstruction(layered_const_adj)
       layered_const_adj.setLayers(cond_bsmnt_surface.construction.get.to_LayeredConstruction.get.layers.reverse())
+      adj_surface.construction.get.remove
+      adj_surface.setConstruction(layered_const_adj)
     end
   end
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b2cda7c6-1940-4216-8499-f4b622026fc9</version_id>
-  <version_modified>20210823T231947Z</version_modified>
+  <version_id>9c7862db-007c-46fd-90e2-3fed619a292d</version_id>
+  <version_modified>20210824T002807Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -338,12 +338,6 @@
       <checksum>D990460D</checksum>
     </file>
     <file>
-      <filename>misc_loads.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>F085602D</checksum>
-    </file>
-    <file>
       <filename>test_lighting.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -461,6 +455,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>EDDA05E3</checksum>
+    </file>
+    <file>
+      <filename>misc_loads.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>81977FB8</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>8701f320-639e-401d-ab32-d71a649bd9f5</version_id>
-  <version_modified>20210820T155720Z</version_modified>
+  <version_id>b2cda7c6-1940-4216-8499-f4b622026fc9</version_id>
+  <version_modified>20210823T231947Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -296,12 +296,6 @@
       <checksum>B415B698</checksum>
     </file>
     <file>
-      <filename>meta_measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6B409E9A</checksum>
-    </file>
-    <file>
       <filename>minitest_helper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -386,17 +380,6 @@
       <checksum>844CFC8D</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>3.2.0</identifier>
-        <min_compatible>3.2.0</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>A38E8064</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -451,22 +434,33 @@
       <checksum>151356DC</checksum>
     </file>
     <file>
+      <filename>meta_measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>14ADBCF2</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.2.0</identifier>
+        <min_compatible>3.2.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>43BEAA52</checksum>
+    </file>
+    <file>
       <filename>airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>EE437A80</checksum>
+      <checksum>3391649D</checksum>
     </file>
     <file>
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>2A0C6409</checksum>
-    </file>
-    <file>
-      <filename>waterheater.rb.bak</filename>
-      <filetype>bak</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B42F461D</checksum>
+      <checksum>EDDA05E3</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/airflow.rb
+++ b/HPXMLtoOpenStudio/resources/airflow.rb
@@ -42,13 +42,7 @@ class Airflow
     @tout_sensor.setName("#{Constants.ObjectNameAirflow} tt s")
     @tout_sensor.setKeyName(@living_zone.name.to_s)
 
-    # Adiabatic construction for duct plenum
-
-    adiabatic_mat = OpenStudio::Model::MasslessOpaqueMaterial.new(model, 'Rough', 176.1)
-    adiabatic_mat.setName('Adiabatic')
-    @adiabatic_const = OpenStudio::Model::Construction.new(model)
-    @adiabatic_const.setName('AdiabaticConst')
-    @adiabatic_const.insertLayer(0, adiabatic_mat)
+    @adiabatic_const = nil
 
     # Ventilation fans
     vent_fans_mech = []
@@ -465,6 +459,15 @@ class Airflow
     ra_space.setThermalZone(ra_duct_zone)
 
     ra_space.surfaces.each do |surface|
+      if @adiabatic_const.nil?
+        adiabatic_mat = OpenStudio::Model::MasslessOpaqueMaterial.new(model, 'Rough', 176.1)
+        adiabatic_mat.setName('Adiabatic')
+
+        @adiabatic_const = OpenStudio::Model::Construction.new(model)
+        @adiabatic_const.setName('AdiabaticConst')
+        @adiabatic_const.insertLayer(0, adiabatic_mat)
+      end
+
       surface.setConstruction(@adiabatic_const)
       surface.setOutsideBoundaryCondition('Adiabatic')
       surface.setSunExposure('NoSun')

--- a/HPXMLtoOpenStudio/resources/misc_loads.rb
+++ b/HPXMLtoOpenStudio/resources/misc_loads.rb
@@ -3,29 +3,29 @@
 class MiscLoads
   def self.apply_plug(model, plug_load, obj_name, living_space, apply_ashrae140_assumptions, schedules_file)
     kwh = 0
-
     if not plug_load.nil?
       kwh = plug_load.kWh_per_year * plug_load.usage_multiplier
-      if not schedules_file.nil?
-        if plug_load.plug_load_type == HPXML::PlugLoadTypeOther
-          col_name = 'plug_loads_other'
-        elsif plug_load.plug_load_type == HPXML::PlugLoadTypeTelevision
-          col_name = 'plug_loads_tv'
-        elsif plug_load.plug_load_type == HPXML::PlugLoadTypeElectricVehicleCharging
-          col_name = 'plug_loads_vehicle'
-        elsif plug_load.plug_load_type == HPXML::PlugLoadTypeWellPump
-          col_name = 'plug_loads_well_pump'
-        end
-        space_design_level = schedules_file.calc_design_level_from_annual_kwh(col_name: col_name, annual_kwh: kwh)
-        sch = schedules_file.create_schedule_file(col_name: col_name)
-      else
-        sch = MonthWeekdayWeekendSchedule.new(model, obj_name + ' schedule', plug_load.weekday_fractions, plug_load.weekend_fractions, plug_load.monthly_multipliers, Constants.ScheduleTypeLimitsFraction)
-        space_design_level = sch.calcDesignLevelFromDailykWh(kwh / 365.0)
-        sch = sch.schedule
-      end
     end
 
     return if kwh <= 0
+
+    if not schedules_file.nil?
+      if plug_load.plug_load_type == HPXML::PlugLoadTypeOther
+        col_name = 'plug_loads_other'
+      elsif plug_load.plug_load_type == HPXML::PlugLoadTypeTelevision
+        col_name = 'plug_loads_tv'
+      elsif plug_load.plug_load_type == HPXML::PlugLoadTypeElectricVehicleCharging
+        col_name = 'plug_loads_vehicle'
+      elsif plug_load.plug_load_type == HPXML::PlugLoadTypeWellPump
+        col_name = 'plug_loads_well_pump'
+      end
+      space_design_level = schedules_file.calc_design_level_from_annual_kwh(col_name: col_name, annual_kwh: kwh)
+      sch = schedules_file.create_schedule_file(col_name: col_name)
+    else
+      sch = MonthWeekdayWeekendSchedule.new(model, obj_name + ' schedule', plug_load.weekday_fractions, plug_load.weekend_fractions, plug_load.monthly_multipliers, Constants.ScheduleTypeLimitsFraction)
+      space_design_level = sch.calcDesignLevelFromDailykWh(kwh / 365.0)
+      sch = sch.schedule
+    end
 
     sens_frac = plug_load.frac_sensible
     lat_frac = plug_load.frac_latent

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -819,10 +819,12 @@ class Waterheater
     tank.setTankHeight(h_tank)
     tank.setMaximumTemperatureLimit(90)
     tank.setHeaterPriorityControl('MasterSlave')
+    tank.heater1SetpointTemperatureSchedule.remove
     tank.setHeater1SetpointTemperatureSchedule(hpwh_top_element_sp) # Overwritten later by EMS
     tank.setHeater1Capacity(UnitConversions.convert(e_cap, 'kW', 'W'))
     tank.setHeater1Height(h_UE)
     tank.setHeater1DeadbandTemperatureDifference(18.5)
+    tank.heater2SetpointTemperatureSchedule.remove
     tank.setHeater2SetpointTemperatureSchedule(hpwh_bottom_element_sp)
     tank.setHeater2Capacity(UnitConversions.convert(e_cap, 'kW', 'W'))
     tank.setHeater2Height(h_LE)
@@ -834,6 +836,7 @@ class Waterheater
     tank.setOnCycleParasiticFuelConsumptionRate(parasitics)
     tank.setOnCycleParasiticFuelType(EPlus::FuelTypeElectricity)
     tank.setUniformSkinLossCoefficientperUnitAreatoAmbientTemperature(u_tank)
+    tank.ambientTemperatureSchedule.get.remove
     tank.setAmbientTemperatureSchedule(hpwh_tamb)
     tank.setNumberofNodes(6)
     tank.setAdditionalDestratificationConductivity(0)

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -724,6 +724,23 @@ class HPXMLTest < MiniTest::Test
       flunk "Unexpected warning found: #{err_line}"
     end
 
+    # Check for unused objects/schedules/constructions
+    num_unused_objects = 0
+    num_unused_schedules = 0
+    num_unused_constructions = 0
+    File.readlines(File.join(rundir, 'eplusout.err')).each do |err_line|
+      if err_line.include? 'unused objects in input'
+        num_unused_objects = Integer(err_line.split(' ')[3])
+      elsif err_line.include? 'unused schedules in input'
+        num_unused_schedules = Integer(err_line.split(' ')[3])
+      elsif err_line.include? 'unused constructions in input'
+        num_unused_constructions = Integer(err_line.split(' ')[6])
+      end
+    end
+    assert_equal(0, num_unused_objects)
+    assert_equal(0, num_unused_schedules)
+    assert_equal(0, num_unused_constructions)
+
     # Timestep
     timestep = hpxml.header.timestep
     if timestep.nil?


### PR DESCRIPTION
## Pull Request Description

Avoiding E+ warnings about unused objects/schedules/constructions. Added tests. Closes #831.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
