### PR TITLE
Fixes possible timeseries sum error

### DIFF
--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -1234,7 +1234,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     if (key_values.size == 1) && (key_values[0] == 'EMS') && (@timestamps.size > 0)
       if (timeseries_frequency.downcase == 'timestep' || (timeseries_frequency.downcase == 'hourly' && @model.getTimestep.numberOfTimestepsPerHour == 1))
         # Shift all values by 1 timestep due to EMS reporting lag
-        return values[1..-1] + [values[-1]]
+        return values[1..-1] + [values[0]]
       end
     end
 

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>5f0a305f-430b-4513-b95b-aff64a7979e2</version_id>
-  <version_modified>20211007T223048Z</version_modified>
+  <version_id>b606a6a9-5624-4b3f-a305-2d82039b390c</version_id>
+  <version_modified>20211018T173613Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1594,7 +1594,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F3E4ACB8</checksum>
+      <checksum>A1DD3F19</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Fixes possibility of, e.g., "Timeseries outputs (1109.5514059244974) do not sum to annual output (1109.3561760073724) for Load: Heating: Delivered."

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
