### PR TITLE
Peak electricity output bugfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -54,6 +54,7 @@ __Bugfixes__
 - Fixes duct design load calculations for HPXML files with multiple ducted HVAC systems.
 - Relaxes `Overhangs` DistanceToBottomOfWindow vs DistanceToBottomOfWindow validation when Depth is zero.
 - Fixes possibility of double-counting HVAC distribution losses if an `HVACDistribution` element has both AirDistribution properties and DSE values
+- Fixes possibility of "Peak Electricity: Winter Total (W)" and "Peak Electricity: Summer Total (W)" outputs incorrectly having the same value.
 
 ## OpenStudio-HPXML v1.2.0
 

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -2051,12 +2051,14 @@ class OSModel
   end
 
   def self.add_total_loads_output(runner, model, living_zone)
+    # Energy transferred in the conditioned space, used for determining heating (winter) vs cooling (summer)
     liv_load_sensors = {}
     liv_load_sensors[:htg] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, "Heating:EnergyTransfer:Zone:#{living_zone.name.to_s.upcase}")
     liv_load_sensors[:htg].setName('htg_load_liv')
     liv_load_sensors[:clg] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, "Cooling:EnergyTransfer:Zone:#{living_zone.name.to_s.upcase}")
     liv_load_sensors[:clg].setName('clg_load_liv')
 
+    # Total energy transferred (above plus ducts)
     tot_load_sensors = {}
     tot_load_sensors[:htg] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Heating:EnergyTransfer')
     tot_load_sensors[:htg].setName('htg_load_tot')

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>8be4e790-d055-4a28-aef6-0f6b28a273e2</version_id>
-  <version_modified>20211018T222335Z</version_modified>
+  <version_id>34a06d28-4423-46d5-bf4e-5d6474a31b33</version_id>
+  <version_modified>20211020T153423Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -428,17 +428,6 @@
       <checksum>1B32161F</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>3.2.0</identifier>
-        <min_compatible>3.2.0</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>498EE8F6</checksum>
-    </file>
-    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -461,6 +450,17 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>6220E424</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.2.0</identifier>
+        <min_compatible>3.2.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>A35112A0</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -492,7 +492,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
         next # Don't report unmet hours if there is no heating/cooling system
       end
 
-      unmet_hour.annual_output = get_tabular_data_value('SystemSummary', 'Entire Facility', 'Time Setpoint Not Met', ['LIVING SPACE'], unmet_hour.col_name, unmet_hour.annual_units)
+      unmet_hour.annual_output = get_tabular_data_value('SystemSummary', 'Entire Facility', 'Time Setpoint Not Met', [HPXML::LocationLivingSpace.upcase], unmet_hour.col_name, unmet_hour.annual_units)
     end
 
     # Ideal system loads (expected fraction of loads that are not met by partial HVAC (e.g., room AC that meets 30% of load))
@@ -1586,9 +1586,10 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     end
 
     # Peak Fuels
+    # Using meters for energy transferred in conditioned space only (i.e., excluding ducts) to determine winter vs summer.
     @peak_fuels = {}
-    @peak_fuels[[FT::Elec, PFT::Winter]] = PeakFuel.new(meters: ['Heating:EnergyTransfer'], report: 'Peak Electricity Winter Total')
-    @peak_fuels[[FT::Elec, PFT::Summer]] = PeakFuel.new(meters: ['Cooling:EnergyTransfer'], report: 'Peak Electricity Summer Total')
+    @peak_fuels[[FT::Elec, PFT::Winter]] = PeakFuel.new(meters: ["Heating:EnergyTransfer:Zone:#{HPXML::LocationLivingSpace.upcase}"], report: 'Peak Electricity Winter Total')
+    @peak_fuels[[FT::Elec, PFT::Summer]] = PeakFuel.new(meters: ["Cooling:EnergyTransfer:Zone:#{HPXML::LocationLivingSpace.upcase}"], report: 'Peak Electricity Summer Total')
 
     @peak_fuels.each do |key, peak_fuel|
       fuel_type, peak_fuel_type = key
@@ -1680,6 +1681,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     end
 
     # Peak Loads
+    # Using meters for total energy transferred (i.e. including ducts)
     @peak_loads = {}
     @peak_loads[PLT::Heating] = PeakLoad.new(meters: ['Heating:EnergyTransfer'])
     @peak_loads[PLT::Cooling] = PeakLoad.new(meters: ['Cooling:EnergyTransfer'])

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>b606a6a9-5624-4b3f-a305-2d82039b390c</version_id>
-  <version_modified>20211018T173613Z</version_modified>
+  <version_id>e2264624-2c8f-46c3-ae16-a3f76aca8d9c</version_id>
+  <version_modified>20211020T153604Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1594,7 +1594,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>A1DD3F19</checksum>
+      <checksum>9F9F1CA6</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
Fixes possibility of "Peak Electricity: Winter Total (W)" and "Peak Electricity: Summer Total (W)" outputs incorrectly having the same value, due to the presence of duct losses messing up the algorithm of determining summer vs winter.

## Pull Request Description

[description here]

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
