### PR TITLE
Makes BuildResidentialHPXML measure deterministic

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3137,9 +3137,8 @@ class HPXMLFile
 
     @surface_ids = {}
 
-    # Sorting of objects
+    # Sorting of objects to make the measure deterministic
     def self.surface_order(s)
-      # Sort by adjacent space(s), then azimuth
       order_map = { HPXML::LocationLivingSpace => 0,
                     HPXML::LocationAtticUnvented => 1,
                     HPXML::LocationAtticVented => 1,
@@ -3159,7 +3158,11 @@ class HPXMLFile
 
       order = order * 10 + s.azimuth / 1000.0
       if s.outsideBoundaryCondition.downcase == 'adiabatic'
-        order += 0.5
+        if s.surfaceType != 'RoofCeiling' # Ensure adiabatic ceiling before adiabatic floor
+          order += 0.5
+        else
+          order += 0.4
+        end
       elsif (not location2.nil?) && location == HPXML::LocationLivingSpace
         order -= 0.5
       end

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>1acb0be3-82b8-466f-a065-2f19facace70</version_id>
-  <version_modified>20211018T205041Z</version_modified>
+  <version_id>43fb5c6b-99b5-415b-94e8-688cddc71d4f</version_id>
+  <version_modified>20211020T223616Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder (Beta)</display_name>
@@ -5728,7 +5728,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>A9E4801B</checksum>
+      <checksum>ACAE1E24</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Ensures a deterministic ordering of HPXML surfaces for MF units with both adiabatic floors and ceilings, to eliminate HPXML diffs and tiny simulation diffs. (This was originally implemented in https://github.com/NREL/OpenStudio-HPXML/pull/865, but it turns out that this one case wasn't being handled.)

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
