### PR TITLE
Optional argument for site IECC zone

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -113,6 +113,17 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     arg.setDescription('Zip code - used for informational purposes only')
     args << arg
 
+    site_iecc_zone_choices = OpenStudio::StringVector.new
+    ['1A', '1B', '1C', '2A', '2B', '2C', '3A', '3B', '3C',
+     '4A', '4B', '4C', '5A', '5B', '5C', '6A', '6B', '6C', '7', '8'].each do |iz|
+      site_iecc_zone_choices << iz
+    end
+
+    arg = OpenStudio::Measure::OSArgument.makeChoiceArgument('site_iecc_zone', site_iecc_zone_choices, false)
+    arg.setDisplayName('Site: IECC Zone')
+    arg.setDescription('IECC zone of the home address. If not provided, uses the IECC zone corresponding to the EPW weather file.')
+    args << arg
+
     site_state_code_choices = OpenStudio::StringVector.new
     ['AK', 'AL', 'AR', 'AZ', 'CA', 'CO', 'CT', 'DC', 'DE', 'FL', 'GA',
      'HI', 'IA', 'ID', 'IL', 'IN', 'KS', 'KY', 'LA', 'MA', 'MD', 'ME',
@@ -3469,7 +3480,12 @@ class HPXMLFile
 
   def self.set_climate_and_risk_zones(hpxml, runner, args, epw_file)
     hpxml.climate_and_risk_zones.weather_station_id = 'WeatherStation'
-    iecc_zone = Location.get_climate_zone_iecc(epw_file.wmoNumber)
+
+    if args[:site_iecc_zone].is_initialized
+      iecc_zone = args[:site_iecc_zone].get
+    else
+      iecc_zone = Location.get_climate_zone_iecc(epw_file.wmoNumber)
+    end
 
     unless iecc_zone.nil?
       hpxml.climate_and_risk_zones.iecc_year = 2006

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>2e88007d-6470-46d0-9bc4-ee0a4b2d2047</version_id>
-  <version_modified>20211026T222502Z</version_modified>
+  <version_id>020ade2f-316c-49dc-8b5e-9ae957e2f5cd</version_id>
+  <version_modified>20211102T193137Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder (Beta)</display_name>
@@ -143,6 +143,96 @@
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>site_iecc_zone</name>
+      <display_name>Site: IECC Zone</display_name>
+      <description>IECC zone of the home address. If not provided, uses the IECC zone corresponding to the EPW weather file.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>1A</value>
+          <display_name>1A</display_name>
+        </choice>
+        <choice>
+          <value>1B</value>
+          <display_name>1B</display_name>
+        </choice>
+        <choice>
+          <value>1C</value>
+          <display_name>1C</display_name>
+        </choice>
+        <choice>
+          <value>2A</value>
+          <display_name>2A</display_name>
+        </choice>
+        <choice>
+          <value>2B</value>
+          <display_name>2B</display_name>
+        </choice>
+        <choice>
+          <value>2C</value>
+          <display_name>2C</display_name>
+        </choice>
+        <choice>
+          <value>3A</value>
+          <display_name>3A</display_name>
+        </choice>
+        <choice>
+          <value>3B</value>
+          <display_name>3B</display_name>
+        </choice>
+        <choice>
+          <value>3C</value>
+          <display_name>3C</display_name>
+        </choice>
+        <choice>
+          <value>4A</value>
+          <display_name>4A</display_name>
+        </choice>
+        <choice>
+          <value>4B</value>
+          <display_name>4B</display_name>
+        </choice>
+        <choice>
+          <value>4C</value>
+          <display_name>4C</display_name>
+        </choice>
+        <choice>
+          <value>5A</value>
+          <display_name>5A</display_name>
+        </choice>
+        <choice>
+          <value>5B</value>
+          <display_name>5B</display_name>
+        </choice>
+        <choice>
+          <value>5C</value>
+          <display_name>5C</display_name>
+        </choice>
+        <choice>
+          <value>6A</value>
+          <display_name>6A</display_name>
+        </choice>
+        <choice>
+          <value>6B</value>
+          <display_name>6B</display_name>
+        </choice>
+        <choice>
+          <value>6C</value>
+          <display_name>6C</display_name>
+        </choice>
+        <choice>
+          <value>7</value>
+          <display_name>7</display_name>
+        </choice>
+        <choice>
+          <value>8</value>
+          <display_name>8</display_name>
+        </choice>
+      </choices>
     </argument>
     <argument>
       <name>site_state_code</name>
@@ -5754,7 +5844,7 @@
       <filename>build_residential_hpxml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>C2AB19BE</checksum>
+      <checksum>4E4F01AF</checksum>
     </file>
     <file>
       <version>
@@ -5765,7 +5855,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>7F2F9277</checksum>
+      <checksum>BB7B7806</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
+++ b/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
@@ -40,7 +40,7 @@ class BuildResidentialHPXMLTest < MiniTest::Test
       'extra-gas-pool-heater-with-zero-kwh.xml' => 'base-sfd.xml',
       'extra-gas-hot-tub-heater-with-zero-kwh.xml' => 'base-sfd.xml',
       'extra-no-rim-joists.xml' => 'base-sfd.xml',
-      'extra-site-iecc-zone-different-than-epw.xml' => 'base-sfd.xml',
+      'extra-iecc-zone-different-than-epw.xml' => 'base-sfd.xml',
       'extra-state-code-different-than-epw.xml' => 'base-sfd.xml',
 
       'extra-sfa-atticroof-conditioned-eaves-gable.xml' => 'extra-sfa-slab.xml',
@@ -761,7 +761,7 @@ class BuildResidentialHPXMLTest < MiniTest::Test
     elsif ['extra-no-rim-joists.xml'].include? hpxml_file
       args.delete('geometry_rim_joist_height')
       args.delete('rim_joist_assembly_r')
-    elsif ['extra-site-iecc-zone-different-than-epw.xml'].include? hpxml_file
+    elsif ['extra-iecc-zone-different-than-epw.xml'].include? hpxml_file
       args['site_iecc_zone'] = '6B'
     elsif ['extra-state-code-different-than-epw.xml'].include? hpxml_file
       args['site_state_code'] = 'WY'

--- a/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
+++ b/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
@@ -40,6 +40,7 @@ class BuildResidentialHPXMLTest < MiniTest::Test
       'extra-gas-pool-heater-with-zero-kwh.xml' => 'base-sfd.xml',
       'extra-gas-hot-tub-heater-with-zero-kwh.xml' => 'base-sfd.xml',
       'extra-no-rim-joists.xml' => 'base-sfd.xml',
+      'extra-site-iecc-zone-different-than-epw.xml' => 'base-sfd.xml',
       'extra-state-code-different-than-epw.xml' => 'base-sfd.xml',
 
       'extra-sfa-atticroof-conditioned-eaves-gable.xml' => 'extra-sfa-slab.xml',
@@ -760,6 +761,8 @@ class BuildResidentialHPXMLTest < MiniTest::Test
     elsif ['extra-no-rim-joists.xml'].include? hpxml_file
       args.delete('geometry_rim_joist_height')
       args.delete('rim_joist_assembly_r')
+    elsif ['extra-site-iecc-zone-different-than-epw.xml'].include? hpxml_file
+      args['site_iecc_zone'] = '6B'
     elsif ['extra-state-code-different-than-epw.xml'].include? hpxml_file
       args['site_state_code'] = 'WY'
     elsif ['extra-sfa-atticroof-conditioned-eaves-gable.xml'].include? hpxml_file

--- a/Changelog.md
+++ b/Changelog.md
@@ -50,6 +50,7 @@ __New Features__
 - Eliminates EnergyPlus warnings related to unused objects or invalid output meters/variables.
 - Allows modeling PTAC and PTHP HVAC systems. 
 - Allows user inputs for partition wall mass and furniture mass.
+- Adds an optional argument for site IECC zone; if provided, overrides IECC zone corresponding to EPW location.
 
 __Bugfixes__
 - Improves ground reflectance when there is shading of windows/skylights.

--- a/Changelog.md
+++ b/Changelog.md
@@ -50,7 +50,6 @@ __New Features__
 - Eliminates EnergyPlus warnings related to unused objects or invalid output meters/variables.
 - Allows modeling PTAC and PTHP HVAC systems. 
 - Allows user inputs for partition wall mass and furniture mass.
-- Adds an optional argument for site IECC zone; if provided, overrides IECC zone corresponding to EPW location.
 
 __Bugfixes__
 - Improves ground reflectance when there is shading of windows/skylights.

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>593921ab-a54d-4778-bfbc-62bb07512e18</version_id>
-  <version_modified>20211102T193142Z</version_modified>
+  <version_id>4609ae06-f0ac-42a6-8f92-4984feef6eb4</version_id>
+  <version_modified>20211102T210509Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -499,16 +499,16 @@
       <checksum>52135818</checksum>
     </file>
     <file>
-      <filename>location.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6017D619</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>B00519DA</checksum>
+    </file>
+    <file>
+      <filename>location.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1CCF0162</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>a750c498-fc65-452c-b847-4d3f46019024</version_id>
-  <version_modified>20211101T202457Z</version_modified>
+  <version_id>593921ab-a54d-4778-bfbc-62bb07512e18</version_id>
+  <version_modified>20211102T193142Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -156,12 +156,6 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>5E866DCA</checksum>
-    </file>
-    <file>
-      <filename>location.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>CB27A3C5</checksum>
     </file>
     <file>
       <filename>test_hvac_sizing.rb</filename>
@@ -452,12 +446,6 @@
       <checksum>6E1D2DDC</checksum>
     </file>
     <file>
-      <filename>hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>63E2BB14</checksum>
-    </file>
-    <file>
       <filename>materials.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -509,6 +497,18 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>52135818</checksum>
+    </file>
+    <file>
+      <filename>location.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6017D619</checksum>
+    </file>
+    <file>
+      <filename>hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>B00519DA</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/location.rb
+++ b/HPXMLtoOpenStudio/resources/location.rb
@@ -4,7 +4,7 @@ class Location
   def self.apply(model, runner, weather, epw_file, hpxml)
     apply_year(model, hpxml)
     apply_site(model, epw_file)
-    apply_climate_zones(model, epw_file)
+    # apply_climate_zones(model, epw_file)
     apply_dst(model, hpxml)
     apply_ground_temps(model, weather)
   end
@@ -41,13 +41,13 @@ class Location
     site.setElevation(epw_file.elevation)
   end
 
-  def self.apply_climate_zones(model, epw_file)
-    ba_zone = get_climate_zone_ba(epw_file.wmoNumber)
-    return if ba_zone.nil?
+  # def self.apply_climate_zones(model, epw_file)
+  # ba_zone = get_climate_zone_ba(epw_file.wmoNumber)
+  # return if ba_zone.nil?
 
-    climateZones = model.getClimateZones
-    climateZones.setClimateZone(Constants.BuildingAmericaClimateZone, ba_zone)
-  end
+  # climateZones = model.getClimateZones
+  # climateZones.setClimateZone(Constants.BuildingAmericaClimateZone, ba_zone)
+  # end
 
   def self.apply_year(model, hpxml)
     year_description = model.getYearDescription
@@ -98,14 +98,14 @@ class Location
     return
   end
 
-  def self.get_climate_zone_ba(wmo)
-    zones_csv = get_climate_zones
+  # def self.get_climate_zone_ba(wmo)
+  # zones_csv = get_climate_zones
 
-    require 'csv'
-    CSV.foreach(zones_csv) do |row|
-      return row[5].to_s if row[0].to_s == wmo.to_s
-    end
+  # require 'csv'
+  # CSV.foreach(zones_csv) do |row|
+  # return row[5].to_s if row[0].to_s == wmo.to_s
+  # end
 
-    return
-  end
+  # return
+  # end
 end

--- a/HPXMLtoOpenStudio/resources/location.rb
+++ b/HPXMLtoOpenStudio/resources/location.rb
@@ -4,7 +4,6 @@ class Location
   def self.apply(model, runner, weather, epw_file, hpxml)
     apply_year(model, hpxml)
     apply_site(model, epw_file)
-    # apply_climate_zones(model, epw_file)
     apply_dst(model, hpxml)
     apply_ground_temps(model, weather)
   end
@@ -40,14 +39,6 @@ class Location
     site.setTimeZone(epw_file.timeZone)
     site.setElevation(epw_file.elevation)
   end
-
-  # def self.apply_climate_zones(model, epw_file)
-  # ba_zone = get_climate_zone_ba(epw_file.wmoNumber)
-  # return if ba_zone.nil?
-
-  # climateZones = model.getClimateZones
-  # climateZones.setClimateZone(Constants.BuildingAmericaClimateZone, ba_zone)
-  # end
 
   def self.apply_year(model, hpxml)
     year_description = model.getYearDescription
@@ -97,15 +88,4 @@ class Location
 
     return
   end
-
-  # def self.get_climate_zone_ba(wmo)
-  # zones_csv = get_climate_zones
-
-  # require 'csv'
-  # CSV.foreach(zones_csv) do |row|
-  # return row[5].to_s if row[0].to_s == wmo.to_s
-  # end
-
-  # return
-  # end
 end


### PR DESCRIPTION
## Pull Request Description

Similar to `site_state_code`: `site_iecc_zone` can be different from the EPW.

For ResStock-HPXML this is important because there is a `ASHRAE IECC Climate Zone 2004.tsv` file that gets sampled (i.e., used to determine water heater location).

## Checklist

Not all may apply:

- ~[ ] EPvalidator.xml has been updated~
- [x] Tests (and test files) have been updated
- [ ] ~Documentation has been updated~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
