### PR TITLE
Return from ReportSimOutput `energyPlusOutputRequests` if runner is halted

### DIFF
--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -137,6 +137,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     super(runner, user_arguments)
 
     result = OpenStudio::IdfObjectVector.new
+    return result if runner.halted
 
     model = runner.lastOpenStudioModel
     if model.empty?

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>82fbc69f-20ec-4aff-8eb4-c35bb68bc873</version_id>
-  <version_modified>20211107T033242Z</version_modified>
+  <version_id>dea2f975-2214-40e5-b60b-2954b392df2b</version_id>
+  <version_modified>20211115T160037Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1594,7 +1594,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>B5E425AC</checksum>
+      <checksum>E2308650</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

ResStock can halt workflow from both `BuildExistingModel` and `ApplyUpgrade`.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
