### PR TITLE
HVAC sizing negative TD bugfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## OpenStudio-HPXML v1.4.0
+__New Features__
+- ...
+
+__Bugfixes__
+- Fixes possible HVAC sizing error if design temperature difference (TD) is negative.
+
 ## OpenStudio-HPXML v1.3.0
 
 __New Features__

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>0e0e6aad-fba2-40a6-a75c-6015b209c47b</version_id>
-  <version_modified>20211129T193942Z</version_modified>
+  <version_id>b132aedb-834b-4204-adef-a26cebbfa11e</version_id>
+  <version_modified>20211129T202807Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -368,12 +368,6 @@
       <checksum>80061D4B</checksum>
     </file>
     <file>
-      <filename>hvac_sizing.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B4B76267</checksum>
-    </file>
-    <file>
       <filename>energyplus.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -479,6 +473,12 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>17A9015A</checksum>
+    </file>
+    <file>
+      <filename>hvac_sizing.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6E99E1DE</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -102,11 +102,11 @@ class HVACSizing
 
     @cool_design_grains = UnitConversions.convert(weather.design.CoolingHumidityRatio, 'lbm/lbm', 'grains')
 
-    # # Calculate the design temperature differences
-    @ctd = weather.design.CoolingDrybulb - @cool_setpoint
-    @htd = @heat_setpoint - weather.design.HeatingDrybulb
+    # Calculate the design temperature differences
+    @ctd = [weather.design.CoolingDrybulb - @cool_setpoint, 0.0].max
+    @htd = [@heat_setpoint - weather.design.HeatingDrybulb, 0.0].max
 
-    # # Calculate the average Daily Temperature Range (DTR) to determine the class (low, medium, high)
+    # Calculate the average Daily Temperature Range (DTR) to determine the class (low, medium, high)
     dtr = weather.design.DailyTemperatureRange
 
     if dtr < 16.0


### PR DESCRIPTION
## Pull Request Description

Fixes possible HVAC sizing error if the design temperature difference (TD) is negative for a given location. For example, Whidbey Island has a 99% cooling design temperature of 69.8F, which is less than the 75F indoor cooling setpoint.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
