### PR TITLE
Time.utc for Time column in results_timeseries.csv

### DIFF
--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -425,7 +425,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     timestamps = []
     values.get.each do |value|
       year, month, day, hour, minute = value.split(' ')
-      ts = Time.new(year, month, day, hour, minute)
+      ts = Time.utc(year, month, day, hour, minute)
       timestamps << ts.strftime('%Y/%m/%d %H:%M:00')
     end
 

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>dea2f975-2214-40e5-b60b-2954b392df2b</version_id>
-  <version_modified>20211115T160037Z</version_modified>
+  <version_id>5a8d5bcc-0c9f-4f6a-b478-248fc1d40dac</version_id>
+  <version_modified>20211203T172055Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1583,7 +1583,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>4740F41B</checksum>
+      <checksum>EC3031CD</checksum>
     </file>
     <file>
       <version>
@@ -1594,7 +1594,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E2308650</checksum>
+      <checksum>557E0863</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/tests/output_report_test.rb
+++ b/ReportSimulationOutput/tests/output_report_test.rb
@@ -398,7 +398,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsFuels
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, ['Fuel Use: Electricity: Total'])
   end
 
@@ -419,7 +422,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsEndUses
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, ['End Use: Electricity: Plug Loads'])
   end
 
@@ -440,7 +446,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsWaterUses
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsWaterUses)
   end
 
@@ -461,7 +470,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsTotalLoads
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsTotalLoads)
   end
 
@@ -483,7 +495,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsComponentLoads
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, ['Component Load: Heating: Internal Gains', 'Component Load: Cooling: Internal Gains'])
   end
 
@@ -504,7 +519,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsZoneTemps
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsZoneTemps)
   end
 
@@ -532,7 +550,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     cols_temps_other_side.each do |expected_col|
       assert(actual_timeseries_cols.include? expected_col)
     end
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, cols_temps_other_side)
   end
 
@@ -553,7 +574,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsAirflows.select { |t| t != 'Airflow: Whole House Fan' })
   end
 
@@ -576,7 +600,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows + add_cols - remove_cols
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, add_cols)
   end
 
@@ -597,7 +624,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, ['Airflow: Mechanical Ventilation'])
   end
 
@@ -618,7 +648,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, ['Airflow: Mechanical Ventilation'])
   end
 
@@ -639,7 +672,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, ['Airflow: Mechanical Ventilation'])
   end
 
@@ -660,7 +696,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsWeather
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_nonzero_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsWeather)
   end
 
@@ -681,7 +720,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + all_timeseries_cols
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_zero_baseload_timeseries_value(timeseries_csv, ['End Use: Electricity: Refrigerator'])
   end
 
@@ -702,7 +744,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + all_timeseries_cols
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(365, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(365, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
     _check_for_zero_baseload_timeseries_value(timeseries_csv, ['End Use: Electricity: Refrigerator'])
   end
 
@@ -723,7 +768,8 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_timeseries_cols = ['Time'] + all_timeseries_cols
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    assert_equal(12, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(12, timeseries_rows.size - 2)
     _check_for_zero_baseload_timeseries_value(timeseries_csv, ['End Use: Electricity: Refrigerator'])
   end
 
@@ -741,7 +787,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
   end
 
   def test_timeseries_timestep_10min
@@ -758,7 +807,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    assert_equal(52560, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(52560, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
   end
 
   def test_timeseries_hourly_runperiod_Jan
@@ -775,7 +827,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    assert_equal(31 * 24, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(31 * 24, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
   end
 
   def test_timeseries_daily_runperiod_Jan
@@ -792,7 +847,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    assert_equal(31, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(31, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
   end
 
   def test_timeseries_monthly_runperiod_Jan
@@ -809,7 +867,8 @@ class ReportSimulationOutputTest < MiniTest::Test
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    assert_equal(1, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(1, timeseries_rows.size - 2)
   end
 
   def test_timeseries_timestep_runperiod_Jan
@@ -826,7 +885,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    assert_equal(31 * 24, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(31 * 24, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
   end
 
   def test_timeseries_hourly_AMY_2012
@@ -843,7 +905,10 @@ class ReportSimulationOutputTest < MiniTest::Test
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    assert_equal(8784, File.readlines(timeseries_csv).size - 2)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8784, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
   end
 
   def test_eri_designs
@@ -933,6 +998,26 @@ class ReportSimulationOutputTest < MiniTest::Test
       eri_csv = nil
     end
     return annual_csv, timeseries_csv, eri_csv
+  end
+
+  def _parse_time(ts)
+    date, time = ts.split(' ')
+    year, month, day = date.split('/')
+    hour, minute, second = time.split(':')
+    return Time.new(year, month, day, hour, minute)
+  end
+
+  def _check_for_constant_timeseries_step(time_col)
+    steps = []
+    time_col.each_with_index do |ts, i|
+      next if i < 3
+
+      t0 = _parse_time(time_col[i - 1])
+      t1 = _parse_time(time_col[i])
+
+      steps << t1 - t0
+    end
+    assert_equal(1, steps.uniq.size)
   end
 
   def _check_for_nonzero_timeseries_value(timeseries_csv, timeseries_cols)


### PR DESCRIPTION
## Pull Request Description

Related to "short-term fix" in: https://github.com/NREL/OpenStudio-HPXML/issues/928

```
Pacific
ts = Time.new(2019,3,10,1,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 01:00:00"
ts = Time.new(2019,3,10,2,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 03:00:00"
ts = Time.new(2019,3,10,3,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 03:00:00"
ts = Time.new(2019,3,10,4,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 04:00:00"

ts = Time.utc(2019,3,10,1,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 01:00:00"
ts = Time.utc(2019,3,10,2,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 02:00:00"
ts = Time.utc(2019,3,10,3,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 03:00:00"
ts = Time.utc(2019,3,10,4,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 04:00:00"

Arizona
ts = Time.new(2019,3,10,1,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 01:00:00"
ts = Time.new(2019,3,10,2,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 02:00:00"
ts = Time.new(2019,3,10,3,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 03:00:00"
ts = Time.new(2019,3,10,4,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 04:00:00"

ts = Time.utc(2019,3,10,1,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 01:00:00"
ts = Time.utc(2019,3,10,2,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 02:00:00"
ts = Time.utc(2019,3,10,3,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 03:00:00"
ts = Time.utc(2019,3,10,4,0,0).strftime('%Y/%m/%d %H:%M:00')
=> "2019/03/10 04:00:00"
```

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
