### PR TITLE
Allow applying defaults to the HXPML file produced by BuildResHPXML

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3263,11 +3263,7 @@ class HPXMLFile
 
     if apply_defaults
       eri_version = Constants.ERIVersions[-1]
-      epw_path = args[:weather_station_epw_filepath]
-      if not File.exist? epw_path
-        epw_path = File.join(File.expand_path(File.join(File.dirname(__FILE__), '..', 'weather')), epw_path) # a filename was entered for weather_station_epw_filepath
-      end
-      weather, epw_file = Location.apply_weather_file(model, runner, epw_path, '')
+      weather = WeatherProcess.new(model, runner)      
       HPXMLDefaults.apply(hpxml, eri_version, weather, epw_file: epw_file)
     end
 

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3263,7 +3263,7 @@ class HPXMLFile
 
     if apply_defaults
       eri_version = Constants.ERIVersions[-1]
-      weather = WeatherProcess.new(model, runner)      
+      weather = WeatherProcess.new(model, runner)
       HPXMLDefaults.apply(hpxml, eri_version, weather, epw_file: epw_file)
     end
 

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -2878,7 +2878,7 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
 
     arg = OpenStudio::Measure::OSArgument::makeBoolArgument('apply_defaults', false)
     arg.setDisplayName('Apply default values')
-    arg.setDescription('Sets default values to the HPXML object')
+    arg.setDescription('Sets OS-HPXML default values in the HPXML output file')
     arg.setDefaultValue(false)
     args << arg
 

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -2876,9 +2876,9 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue(1.0)
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument::makeBoolArgument('write_default_hpxml', false)
-    arg.setDisplayName('Write default hpxml')
-    arg.setDescription('Sets default values to the hpxml object and writes to in.xml')
+    arg = OpenStudio::Measure::OSArgument::makeBoolArgument('apply_defaults', false)
+    arg.setDisplayName('Apply default values')
+    arg.setDescription('Sets default values to the HPXML object')
     arg.setDefaultValue(false)
     args << arg
 
@@ -3255,9 +3255,13 @@ class HPXMLFile
       end
     end
 
-    hpxml_doc = hpxml.to_oga()
+    if args[:apply_defaults].is_initialized
+      apply_defaults = args[:apply_defaults].get
+    else
+      apply_defaults = false
+    end
 
-    if write_default_hpxml
+    if apply_defaults
       eri_version = Constants.ERIVersions[-1]
       epw_path = args[:weather_station_epw_filepath]
       if not File.exist? epw_path
@@ -3265,11 +3269,9 @@ class HPXMLFile
       end
       weather, epw_file = Location.apply_weather_file(model, runner, epw_path, '')
       HPXMLDefaults.apply(hpxml, eri_version, weather, epw_file: epw_file)
-
-      output_dir = File.expand_path('..')
-      hpxml_defaults_path = File.join(output_dir, 'in.xml')
-      XMLHelper.write_file(hpxml.to_oga, hpxml_defaults_path)
     end
+
+    hpxml_doc = hpxml.to_oga()
 
     return hpxml_doc
   end

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -8,21 +8,29 @@ require 'pathname'
 require 'csv'
 require 'oga'
 require_relative 'resources/geometry'
+require_relative '../HPXMLtoOpenStudio/resources/airflow'
 require_relative '../HPXMLtoOpenStudio/resources/battery'
 require_relative '../HPXMLtoOpenStudio/resources/constants'
 require_relative '../HPXMLtoOpenStudio/resources/constructions'
 require_relative '../HPXMLtoOpenStudio/resources/geometry'
+require_relative '../HPXMLtoOpenStudio/resources/hotwater_appliances'
+require_relative '../HPXMLtoOpenStudio/resources/hpxml_defaults'
 require_relative '../HPXMLtoOpenStudio/resources/hpxml'
 require_relative '../HPXMLtoOpenStudio/resources/hvac'
+require_relative '../HPXMLtoOpenStudio/resources/hvac_sizing'
 require_relative '../HPXMLtoOpenStudio/resources/lighting'
 require_relative '../HPXMLtoOpenStudio/resources/location'
 require_relative '../HPXMLtoOpenStudio/resources/materials'
+require_relative '../HPXMLtoOpenStudio/resources/misc_loads'
 require_relative '../HPXMLtoOpenStudio/resources/meta_measure'
 require_relative '../HPXMLtoOpenStudio/resources/psychrometrics'
+require_relative '../HPXMLtoOpenStudio/resources/pv'
 require_relative '../HPXMLtoOpenStudio/resources/schedules'
 require_relative '../HPXMLtoOpenStudio/resources/unit_conversions'
+require_relative '../HPXMLtoOpenStudio/resources/util'
 require_relative '../HPXMLtoOpenStudio/resources/validator'
 require_relative '../HPXMLtoOpenStudio/resources/version'
+require_relative '../HPXMLtoOpenStudio/resources/waterheater'
 require_relative '../HPXMLtoOpenStudio/resources/xmlhelper'
 
 # start the measure
@@ -2868,6 +2876,12 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue(1.0)
     args << arg
 
+    arg = OpenStudio::Measure::OSArgument::makeBoolArgument('write_default_hpxml', false)
+    arg.setDisplayName('Write default hpxml')
+    arg.setDescription('Sets default values to the hpxml object and writes to in.xml')
+    arg.setDefaultValue(false)
+    args << arg
+
     return args
   end
 
@@ -3242,6 +3256,20 @@ class HPXMLFile
     end
 
     hpxml_doc = hpxml.to_oga()
+
+    if write_default_hpxml
+      eri_version = Constants.ERIVersions[-1]
+      epw_path = args[:weather_station_epw_filepath]
+      if not File.exist? epw_path
+        epw_path = File.join(File.expand_path(File.join(File.dirname(__FILE__), '..', 'weather')), epw_path) # a filename was entered for weather_station_epw_filepath
+      end
+      weather, epw_file = Location.apply_weather_file(model, runner, epw_path, '')
+      HPXMLDefaults.apply(hpxml, eri_version, weather, epw_file: epw_file)
+
+      output_dir = File.expand_path('..')
+      hpxml_defaults_path = File.join(output_dir, 'in.xml')
+      XMLHelper.write_file(hpxml.to_oga, hpxml_defaults_path)
+    end
 
     return hpxml_doc
   end

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>fa50bb52-fbc8-4135-b2ef-bcf68f058930</version_id>
-  <version_modified>20211215T162249Z</version_modified>
+  <version_id>8c8d2530-394a-4108-8033-19afa1b64568</version_id>
+  <version_modified>20211215T180735Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder (Beta)</display_name>
@@ -5864,7 +5864,7 @@
     <argument>
       <name>apply_defaults</name>
       <display_name>Apply default values</display_name>
-      <description>Sets default values to the HPXML object</description>
+      <description>Sets OS-HPXML default values in the HPXML output file</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5915,7 +5915,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>FDD3BD6B</checksum>
+      <checksum>90D2A289</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>85f90aa8-2959-4c7f-8631-f18f41feb8b4</version_id>
-  <version_modified>20211215T152930Z</version_modified>
+  <version_id>fa50bb52-fbc8-4135-b2ef-bcf68f058930</version_id>
+  <version_modified>20211215T162249Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder (Beta)</display_name>
@@ -5862,9 +5862,9 @@
       <default_value>1</default_value>
     </argument>
     <argument>
-      <name>write_default_hpxml</name>
-      <display_name>Write default hpxml</display_name>
-      <description>Sets default values to the hpxml object and writes to in.xml</description>
+      <name>apply_defaults</name>
+      <display_name>Apply default values</display_name>
+      <description>Sets default values to the HPXML object</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5915,7 +5915,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>46D4218D</checksum>
+      <checksum>FDD3BD6B</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>fb5edbce-fb62-4066-9333-c2beef01cb17</version_id>
-  <version_modified>20211214T204238Z</version_modified>
+  <version_id>85f90aa8-2959-4c7f-8631-f18f41feb8b4</version_id>
+  <version_modified>20211215T152930Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder (Beta)</display_name>
@@ -5861,6 +5861,25 @@
       <model_dependent>false</model_dependent>
       <default_value>1</default_value>
     </argument>
+    <argument>
+      <name>write_default_hpxml</name>
+      <display_name>Write default hpxml</display_name>
+      <description>Sets default values to the hpxml object and writes to in.xml</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
   </arguments>
   <outputs />
   <provenances />
@@ -5896,7 +5915,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F64FDC49</checksum>
+      <checksum>46D4218D</checksum>
     </file>
   </files>
 </measure>

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 __New Features__
 - Allows optional `AirInfiltrationMeasurement/InfiltrationHeight` input.
 - Allows user-specified annual/timeseries output file names in the ReportSimulationOutput reporting measure.
+- Allows the HPXML file with defaults applied (`in.xml`) to be written from the BuildResidentialHPXML measure using the optional arguement `write_default_hpxml`.
 
 __Bugfixes__
 - Fixes possible HVAC sizing error if design temperature difference (TD) is negative.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 __New Features__
 - Allows optional `AirInfiltrationMeasurement/InfiltrationHeight` input.
 - Allows user-specified annual/timeseries output file names in the ReportSimulationOutput reporting measure.
-- Allows the HPXML file with defaults applied (`in.xml`) to be written from the BuildResidentialHPXML measure using the optional arguement `write_default_hpxml`.
+- Allows the HPXML file to be written with defaults applied in the BuildResidentialHPXML measure using the optional arguement `apply_defaults`.
 
 __Bugfixes__
 - Fixes possible HVAC sizing error if design temperature difference (TD) is negative.


### PR DESCRIPTION
## Pull Request Description

Adds a new argument `apply_defaults` in `BuildResidentialHPXML` to apply default values to the HPXML file. This allows a user to avoid running `HPXMLtoOpenstudio` if only the default HPXML file is needed.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
