### PR TITLE
"Fuel Use: Electricity: Net" timeseries column

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 ## OpenStudio-HPXML v1.4.0
 __New Features__
 - Allows optional `AirInfiltrationMeasurement/InfiltrationHeight` input.
-- Allows user-specified annual/timeseries output file names in the ReportSimulationOutput reporting measure.
-- Allows the HPXML file to be written with defaults applied in the BuildResidentialHPXML measure using the optional arguement `apply_defaults`.
+- Adds a "Fuel Use: Electricity: Net" timeseries output column for homes with electricity generation.
+- BuildResidentialHPXML measure: Adds an optional argument to allow the HPXML file to be written with default values applied.
+- ReportSimulationOutput measure: Allows user-specified annual/timeseries output file names.
 
 __Bugfixes__
 - Fixes possible HVAC sizing error if design temperature difference (TD) is negative.

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -186,6 +186,16 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
       include_timeseries_weather = runner.getBoolArgumentValue('include_timeseries_weather', user_arguments)
     end
 
+    has_electricity_production = false
+    if @end_uses.select { |key, end_use| end_use.is_negative && end_use.variables.size > 0 }.size > 0
+      has_electricity_production = true
+    end
+
+    if include_timeseries_fuel_consumptions
+      # If fuel uses are selected, we also need to select end uses because fuels may be adjusted by DSE.
+      include_timeseries_end_use_consumptions = true
+    end
+
     # Fuel outputs
     @fuels.each do |fuel_type, fuel|
       fuel.meters.each do |meter|
@@ -195,8 +205,11 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
         end
       end
     end
-    if @end_uses.select { |key, end_use| end_use.is_negative && end_use.variables.size > 0 }.size > 0
+    if has_electricity_production
       result << OpenStudio::IdfObject.load('Output:Meter,ElectricityProduced:Facility,runperiod;').get # Used for error checking
+      if include_timeseries_fuel_consumptions
+        result << OpenStudio::IdfObject.load("Output:Meter,ElectricityProduced:Facility,#{timeseries_frequency};").get
+      end
     end
     if include_timeseries_fuel_consumptions
       # If fuel uses are selected, we also need to select end uses because fuels may be adjusted by DSE.
@@ -403,7 +416,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     write_annual_output_results(runner, outputs, output_format, annual_output_path)
     report_sim_outputs(runner)
     write_eri_output_results(outputs, eri_output_path)
-    write_timeseries_output_results(runner, output_format,
+    write_timeseries_output_results(runner, outputs, output_format,
                                     timeseries_output_path,
                                     timeseries_frequency,
                                     include_timeseries_fuel_consumptions,
@@ -478,8 +491,10 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
       end
     end
 
-    # Electricity Produced (used for error checking)
+    # Electricity Produced
     outputs[:total_elec_produced] = get_report_meter_data_annual(['ElectricityProduced:Facility'])
+    outputs[:total_elec_produced_timeseries] = get_report_meter_data_timeseries(['ElectricityProduced:Facility'], UnitConversions.convert(1.0, 'J', get_timeseries_units_from_fuel_type(FT::Elec)), 0, timeseries_frequency)
+    outputs[:total_elec_net_timeseries] = @fuels[FT::Elec].timeseries_output.zip(outputs[:total_elec_produced_timeseries]).map { |x, y| x - y }
 
     # Peak Electricity Consumption
     @peak_fuels.each do |key, peak_fuel|
@@ -1099,7 +1114,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     CSV.open(csv_path, 'wb') { |csv| results_out.to_a.each { |elem| csv << elem } }
   end
 
-  def write_timeseries_output_results(runner, output_format,
+  def write_timeseries_output_results(runner, outputs, output_format,
                                       timeseries_output_path,
                                       timeseries_frequency,
                                       include_timeseries_fuel_consumptions,
@@ -1124,6 +1139,9 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
 
     if include_timeseries_fuel_consumptions
       fuel_data = @fuels.values.select { |x| x.timeseries_output.sum(0.0) != 0 }.map { |x| [x.name, x.timeseries_units] + x.timeseries_output.map { |v| v.round(2) } }
+      if outputs[:total_elec_produced_timeseries].sum(0.0) != 0
+        fuel_data.insert(1, ['Fuel Use: Electricity: Net', get_timeseries_units_from_fuel_type(FT::Elec)] + outputs[:total_elec_net_timeseries].map { |v| v.round(2) })
+      end
     else
       fuel_data = []
     end

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>5e9ff585-e180-467c-9267-b092175c6f18</version_id>
-  <version_modified>20211214T172618Z</version_modified>
+  <version_id>5ca86e51-cc29-46bb-b797-3f31d049245c</version_id>
+  <version_modified>20211216T011000Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1583,7 +1583,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>EC3031CD</checksum>
+      <checksum>F67CC508</checksum>
     </file>
     <file>
       <version>
@@ -1594,7 +1594,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3E15DE9B</checksum>
+      <checksum>7AC8ABFF</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/tests/output_report_test.rb
+++ b/ReportSimulationOutput/tests/output_report_test.rb
@@ -405,6 +405,31 @@ class ReportSimulationOutputTest < MiniTest::Test
     _check_for_nonzero_timeseries_value(timeseries_csv, ['Fuel Use: Electricity: Total'])
   end
 
+  def test_timeseries_hourly_fuels_pv
+    args_hash = { 'hpxml_path' => '../workflow/sample_files/base-pv.xml',
+                  'timeseries_frequency' => 'hourly',
+                  'include_timeseries_fuel_consumptions' => true,
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
+    annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
+    assert(File.exist?(annual_csv))
+    assert(File.exist?(timeseries_csv))
+    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsFuels + ['Fuel Use: Electricity: Net']
+    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
+    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
+    timeseries_rows = CSV.read(timeseries_csv)
+    assert_equal(8760, timeseries_rows.size - 2)
+    timeseries_cols = timeseries_rows.transpose
+    _check_for_constant_timeseries_step(timeseries_cols[0])
+    _check_for_nonzero_timeseries_value(timeseries_csv, ['Fuel Use: Electricity: Total',
+                                                         'Fuel Use: Electricity: Net'])
+  end
+
   def test_timeseries_hourly_enduses
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
                   'timeseries_frequency' => 'hourly',
@@ -1004,7 +1029,7 @@ class ReportSimulationOutputTest < MiniTest::Test
     date, time = ts.split(' ')
     year, month, day = date.split('/')
     hour, minute, second = time.split(':')
-    return Time.new(year, month, day, hour, minute)
+    return Time.utc(year, month, day, hour, minute)
   end
 
   def _check_for_constant_timeseries_step(time_col)


### PR DESCRIPTION
## Pull Request Description

Closes #936. When timeseries fuel use is requested, adds a "Fuel Use: Electricity: Net" timeseries output column for homes with electricity generation.

## Checklist

Not all may apply:

- [x] ~EPvalidator.xml has been updated~
- [x] Tests (and test files) have been updated
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
