### PR TITLE
Fix use of relative file paths for schedules

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -214,6 +214,11 @@ class OSModel
     @apply_ashrae140_assumptions = @hpxml.header.apply_ashrae140_assumptions # Hidden feature
     @apply_ashrae140_assumptions = false if @apply_ashrae140_assumptions.nil?
 
+    # Check paths
+    @hpxml.header.schedules_filepath = FilePath.check_path(@hpxml.header.schedules_filepath,
+                                                           File.dirname(hpxml_path),
+                                                           'Schedules')
+
     # Init
 
     @schedules_file = nil

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f9fa7cf4-8bcb-45dc-80c1-73977286bde4</version_id>
-  <version_modified>20211215T200600Z</version_modified>
+  <version_id>2a8fad0d-48c9-43c3-9270-044b24c96466</version_id>
+  <version_modified>20211217T004602Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -168,12 +168,6 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>FC0A4F2E</checksum>
-    </file>
-    <file>
-      <filename>util.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7DAA5F02</checksum>
     </file>
     <file>
       <filename>validator.rb</filename>
@@ -410,12 +404,6 @@
       <checksum>89CFDEB4</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7A3772E6</checksum>
-    </file>
-    <file>
       <filename>misc_loads.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -464,6 +452,24 @@
       <checksum>D4E7F340</checksum>
     </file>
     <file>
+      <filename>schedules.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3A9CB803</checksum>
+    </file>
+    <file>
+      <filename>util.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>AE6C2F42</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6958422B</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.2.0</identifier>
@@ -472,13 +478,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E78AB968</checksum>
-    </file>
-    <file>
-      <filename>schedules.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>3A9CB803</checksum>
+      <checksum>AD47319F</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -889,12 +889,6 @@ class HPXML < Object
 
       errors += HPXML::check_dates('Daylight Saving', @dst_begin_month, @dst_begin_day, @dst_end_month, @dst_end_day)
 
-      if not @schedules_filepath.nil?
-        unless File.exist? @schedules_filepath
-          errors << "Schedules file path '#{@schedules_filepath}' does not exist."
-        end
-      end
-
       return errors
     end
 

--- a/HPXMLtoOpenStudio/resources/util.rb
+++ b/HPXMLtoOpenStudio/resources/util.rb
@@ -321,3 +321,17 @@ class UrlResolver
     raise 'Too many http redirects' if attempts == max_attempts
   end
 end
+
+class FilePath
+  def self.check_path(path, relative_dir, name)
+    return if path.nil?
+    return path if File.exist? path
+
+    filepath = File.expand_path(File.join(relative_dir, path))
+    if not File.exist? filepath
+      fail "#{name} file path '#{path}' does not exist."
+    end
+
+    return filepath
+  end
+end

--- a/tasks.rb
+++ b/tasks.rb
@@ -2505,11 +2505,11 @@ def apply_hpxml_modification(hpxml_file, hpxml)
   if ['base-hvac-undersized-allow-increased-fixed-capacities.xml'].include? hpxml_file
     hpxml.header.allow_increased_fixed_capacities = true
   elsif ['base-schedules-detailed-stochastic.xml'].include? hpxml_file
-    hpxml.header.schedules_filepath = 'HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv'
+    hpxml.header.schedules_filepath = '../../HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv'
   elsif ['base-schedules-detailed-stochastic-vacancy.xml'].include? hpxml_file
-    hpxml.header.schedules_filepath = 'HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv'
+    hpxml.header.schedules_filepath = '../../HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv'
   elsif ['base-schedules-detailed-smooth.xml'].include? hpxml_file
-    hpxml.header.schedules_filepath = 'HPXMLtoOpenStudio/resources/schedule_files/smooth.csv'
+    hpxml.header.schedules_filepath = '../../HPXMLtoOpenStudio/resources/schedule_files/smooth.csv'
   elsif ['base-location-capetown-zaf.xml'].include? hpxml_file
     hpxml.header.state_code = nil
   end

--- a/workflow/sample_files/base-schedules-detailed-smooth.xml
+++ b/workflow/sample_files/base-schedules-detailed-smooth.xml
@@ -11,7 +11,7 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
-      <SchedulesFilePath>HPXMLtoOpenStudio/resources/schedule_files/smooth.csv</SchedulesFilePath>
+      <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/smooth.csv</SchedulesFilePath>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-detailed-stochastic-vacancy.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic-vacancy.xml
@@ -11,7 +11,7 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
-      <SchedulesFilePath>HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv</SchedulesFilePath>
+      <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv</SchedulesFilePath>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-detailed-stochastic.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic.xml
@@ -11,7 +11,7 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
-      <SchedulesFilePath>HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv</SchedulesFilePath>
+      <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv</SchedulesFilePath>
     </extension>
   </SoftwareInfo>
   <Building>


### PR DESCRIPTION
## Pull Request Description

Fix use of relative file paths for schedules to be relative to the HPXML file instead of the working directory. The previous behavior meant you could get errors simply because of where you ran the file from.

Before:
![image](https://user-images.githubusercontent.com/5861765/146470467-9c4c92f2-804f-40c4-9038-55634ca0bf2d.png)

After:
![image](https://user-images.githubusercontent.com/5861765/146470543-e894bd8e-2263-48d9-b37d-551ac8136068.png)

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
