### PR TITLE
Support multiple schedule file paths

### DIFF
--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>5f1fad1d-c43c-49be-b470-b4ec4aadcc1b</version_id>
-  <version_modified>20211215T200559Z</version_modified>
+  <version_id>5dd5389e-b0a8-4781-b99d-e341375f506c</version_id>
+  <version_modified>20220107T201007Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -58,7 +58,7 @@
     <argument>
       <name>output_csv_path</name>
       <display_name>Schedules: Output CSV Path</display_name>
-      <description>Absolute (or relative) path of the csv file containing user-specified occupancy schedules.</description>
+      <description>Absolute/relative path of the csv file containing user-specified occupancy schedules.</description>
       <type>String</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -872,6 +872,12 @@
       <checksum>5FC694CF</checksum>
     </file>
     <file>
+      <filename>schedules.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>507E49D4</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.2.0</identifier>
@@ -880,19 +886,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>7C5869C1</checksum>
+      <checksum>E3851F45</checksum>
     </file>
     <file>
       <filename>build_residential_schedule_file_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>1FB3B4B0</checksum>
-    </file>
-    <file>
-      <filename>schedules.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>507E49D4</checksum>
+      <checksum>FEEAB50D</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialScheduleFile/resources/schedules.rb
+++ b/BuildResidentialScheduleFile/resources/schedules.rb
@@ -44,9 +44,7 @@ class ScheduleGenerator
   def initialize_schedules
     @schedules = {}
 
-    SchedulesFile.ColumnNames.keys.each do |col_name|
-      next if col_name == SchedulesFile::ColumnVacancy
-
+    SchedulesFile.OccupancyColumnNames.each do |col_name|
       @schedules[col_name] = Array.new(@total_days_in_year * @steps_in_day, 0.0)
     end
 

--- a/BuildResidentialScheduleFile/tests/build_residential_schedule_file_test.rb
+++ b/BuildResidentialScheduleFile/tests/build_residential_schedule_file_test.rb
@@ -43,7 +43,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(!info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod') })
     assert(!warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2007)
 
     assert_in_epsilon(6020, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnOccupants, schedules: sf.tmp_schedules), 0.1)
@@ -73,7 +73,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(2994, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(4158, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(4204, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert(!sf.schedules.keys.include?('vacancy'))
+    assert(!sf.schedules.keys.include?(SchedulesFile::ColumnVacancy))
   end
 
   def test_smooth_vacancy
@@ -95,7 +95,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod=Dec 1 - Jan 31') })
     assert(!warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2007)
 
     vacancy_hrs = 31.0 * 2.0 * 24.0
@@ -128,7 +128,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(2994 * occupied_ratio, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(4158 * occupied_ratio, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(4204 * occupied_ratio, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert_in_epsilon(vacancy_hrs, sf.annual_equivalent_full_load_hrs(col_name: 'vacancy', schedules: sf.tmp_schedules), 0.1)
+    assert_in_epsilon(vacancy_hrs, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnVacancy, schedules: sf.tmp_schedules), 0.1)
   end
 
   def test_stochastic
@@ -150,7 +150,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(!info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod') })
     assert(!warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2007)
 
     assert_in_epsilon(6689, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnOccupants, schedules: sf.tmp_schedules), 0.1)
@@ -180,7 +180,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(298, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(325, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(887, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert(!sf.schedules.keys.include?('vacancy'))
+    assert(!sf.schedules.keys.include?(SchedulesFile::ColumnVacancy))
   end
 
   def test_stochastic_vacancy
@@ -203,7 +203,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod=Dec 1 - Jan 31') })
     assert(!warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2007)
 
     vacancy_hrs = 31.0 * 2.0 * 24.0
@@ -236,7 +236,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(298 * occupied_ratio, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(325 * occupied_ratio, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(887 * occupied_ratio, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert_in_epsilon(vacancy_hrs, sf.annual_equivalent_full_load_hrs(col_name: 'vacancy', schedules: sf.tmp_schedules), 0.1)
+    assert_in_epsilon(vacancy_hrs, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnVacancy, schedules: sf.tmp_schedules), 0.1)
   end
 
   def test_random_seed
@@ -259,7 +259,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(!info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod') })
     assert(!warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2007)
 
     assert_in_epsilon(6689, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnOccupants, schedules: sf.tmp_schedules), 0.1)
@@ -289,7 +289,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(298, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(325, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(898, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert(!sf.schedules.keys.include?('vacancy'))
+    assert(!sf.schedules.keys.include?(SchedulesFile::ColumnVacancy))
 
     @args_hash['schedules_random_seed'] = 2
     model, hpxml, result = _test_measure()
@@ -305,7 +305,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(!info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod') })
     assert(warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2007)
 
     assert_in_epsilon(6072, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnOccupants, schedules: sf.tmp_schedules), 0.1)
@@ -335,7 +335,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(226, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(244, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(1077, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert(!sf.schedules.keys.include?('vacancy'))
+    assert(!sf.schedules.keys.include?(SchedulesFile::ColumnVacancy))
   end
 
   def test_AMY_2012_vacancy
@@ -357,7 +357,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod=Jan 1 - Dec 31') })
     assert(!warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2012)
 
     vacancy_hrs = 366.0 * 24.0
@@ -389,7 +389,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(0, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(0, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(0, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert_in_epsilon(vacancy_hrs, sf.annual_equivalent_full_load_hrs(col_name: 'vacancy', schedules: sf.tmp_schedules), 0.1)
+    assert_in_epsilon(vacancy_hrs, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnVacancy, schedules: sf.tmp_schedules), 0.1)
   end
 
   def test_10_min_timestep_vacancy
@@ -410,7 +410,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(!info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod') })
     assert(!warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2007)
 
     assert_in_epsilon(6020, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnOccupants, schedules: sf.tmp_schedules), 0.1)
@@ -440,7 +440,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(2994, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(4158, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(4204, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert(!sf.schedules.keys.include?('vacancy'))
+    assert(!sf.schedules.keys.include?(SchedulesFile::ColumnVacancy))
   end
 
   def test_overwrite_schedules_filepath
@@ -461,7 +461,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(!info_msgs.any? { |info_msg| info_msg.include?('VacancyPeriod') })
     assert(warn_msgs.any? { |warn_msg| warn_msg.include?('Overwriting') })
 
-    sf = SchedulesFile.new(model: model, schedules_path: @args_hash['output_csv_path'])
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_files.collect { |s| s.path }, col_names: SchedulesFile.ColumnNames)
     sf.validate_schedules(year: 2007)
 
     assert_in_epsilon(6020, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnOccupants, schedules: sf.tmp_schedules), 0.1)
@@ -491,7 +491,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert_in_epsilon(2994, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterDishwasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(4158, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterClothesWasher, schedules: sf.tmp_schedules), 0.1)
     assert_in_epsilon(4204, sf.annual_equivalent_full_load_hrs(col_name: SchedulesFile::ColumnHotWaterFixtures, schedules: sf.tmp_schedules), 0.1)
-    assert(!sf.schedules.keys.include?('vacancy'))
+    assert(!sf.schedules.keys.include?(SchedulesFile::ColumnVacancy))
   end
 
   def _test_measure()

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b4eadfda-78c1-4b3f-ae79-dcd1803ac1b7</version_id>
-  <version_modified>20220103T183813Z</version_modified>
+  <version_id>f03a3ba6-4c53-4d66-a784-ca9ae20a74b0</version_id>
+  <version_modified>20220107T201013Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -434,34 +434,40 @@
       <checksum>D4E7F340</checksum>
     </file>
     <file>
-      <filename>schedules.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>3A9CB803</checksum>
-    </file>
-    <file>
       <filename>util.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>AE6C2F42</checksum>
     </file>
     <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>07CE2A02</checksum>
+    </file>
+    <file>
+      <filename>schedules.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>467C6A6F</checksum>
+    </file>
+    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>6958422B</checksum>
+      <checksum>5793FD44</checksum>
     </file>
     <file>
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>B2CC41EA</checksum>
+      <checksum>E3633C8E</checksum>
     </file>
     <file>
       <filename>hpxml_schematron/EPvalidator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
-      <checksum>33DE274B</checksum>
+      <checksum>307D6611</checksum>
     </file>
     <file>
       <version>
@@ -472,13 +478,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>474AAC07</checksum>
-    </file>
-    <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>07CE2A02</checksum>
+      <checksum>F9621ED4</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -854,14 +854,19 @@ class HPXML < Object
   end
 
   class Header < BaseElement
+    def initialize(hpxml_object, *args)
+      @schedules_files = SchedulesFiles.new(hpxml_object)
+      super(hpxml_object, *args)
+    end
     ATTRS = [:xml_type, :xml_generated_by, :created_date_and_time, :transaction,
              :software_program_used, :software_program_version, :eri_calculation_version,
              :eri_design, :timestep, :building_id, :event_type, :state_code, :zip_code,
              :sim_begin_month, :sim_begin_day, :sim_end_month, :sim_end_day, :sim_calendar_year,
              :dst_enabled, :dst_begin_month, :dst_begin_day, :dst_end_month, :dst_end_day,
              :use_max_load_for_heat_pumps, :allow_increased_fixed_capacities,
-             :apply_ashrae140_assumptions, :energystar_calculation_version, :schedules_filepath]
+             :apply_ashrae140_assumptions, :energystar_calculation_version]
     attr_accessor(*ATTRS)
+    attr_reader(:schedules_files)
 
     def check_for_errors
       errors = []
@@ -888,6 +893,8 @@ class HPXML < Object
       end
 
       errors += HPXML::check_dates('Daylight Saving', @dst_begin_month, @dst_begin_day, @dst_end_month, @dst_end_day)
+
+      errors += @schedules_files.check_for_errors
 
       return errors
     end
@@ -948,10 +955,7 @@ class HPXML < Object
         XMLHelper.add_element(hvac_sizing_control, 'UseMaxLoadForHeatPumps', @use_max_load_for_heat_pumps, :boolean, @use_max_load_for_heat_pumps_isdefaulted) unless @use_max_load_for_heat_pumps.nil?
         XMLHelper.add_element(hvac_sizing_control, 'AllowIncreasedFixedCapacities', @allow_increased_fixed_capacities, :boolean, @allow_increased_fixed_capacities_isdefaulted) unless @allow_increased_fixed_capacities.nil?
       end
-      if not @schedules_filepath.nil?
-        extension = XMLHelper.create_elements_as_needed(software_info, ['extension'])
-        XMLHelper.add_element(extension, 'SchedulesFilePath', @schedules_filepath, :string) unless @schedules_filepath.nil?
-      end
+      @schedules_files.to_oga(software_info)
 
       building = XMLHelper.add_element(hpxml, 'Building')
       building_building_id = XMLHelper.add_element(building, 'BuildingID')
@@ -994,11 +998,53 @@ class HPXML < Object
       @apply_ashrae140_assumptions = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/ApplyASHRAE140Assumptions', :boolean)
       @use_max_load_for_heat_pumps = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/HVACSizingControl/UseMaxLoadForHeatPumps', :boolean)
       @allow_increased_fixed_capacities = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/HVACSizingControl/AllowIncreasedFixedCapacities', :boolean)
-      @schedules_filepath = XMLHelper.get_value(hpxml, 'SoftwareInfo/extension/SchedulesFilePath', :string)
+      @schedules_files.from_oga(XMLHelper.get_element(hpxml, 'SoftwareInfo'))
       @building_id = HPXML::get_id(hpxml, 'Building/BuildingID')
       @event_type = XMLHelper.get_value(hpxml, 'Building/ProjectStatus/EventType', :string)
       @state_code = XMLHelper.get_value(hpxml, 'Building/Site/Address/StateCode', :string)
       @zip_code = XMLHelper.get_value(hpxml, 'Building/Site/Address/ZipCode', :string)
+    end
+  end
+
+  class SchedulesFiles < BaseArrayElement
+    def add(**kwargs)
+      self << SchedulesFile.new(@hpxml_object, **kwargs)
+    end
+
+    def from_oga(software_info)
+      return if software_info.nil?
+
+      XMLHelper.get_elements(software_info, 'extension/SchedulesFiles/SchedulesFile').each do |schedules_file|
+        self << SchedulesFile.new(@hpxml_object, schedules_file)
+      end
+    end
+  end
+
+  class SchedulesFile < BaseElement
+    ATTRS = [:name, :path]
+    attr_accessor(*ATTRS)
+
+    def delete
+      @hpxml_object.schedules_files.delete(self)
+    end
+
+    def check_for_errors
+      errors = []
+      return errors
+    end
+
+    def to_oga(software_info)
+      schedules_files = XMLHelper.create_elements_as_needed(software_info, ['extension', 'SchedulesFiles'])
+      schedules_file = XMLHelper.add_element(schedules_files, 'SchedulesFile')
+      XMLHelper.add_element(schedules_file, 'Name', @name, :string) unless @name.nil?
+      XMLHelper.add_element(schedules_file, 'Path', @path, :string) unless @path.nil?
+    end
+
+    def from_oga(schedules_file)
+      return if schedules_file.nil?
+
+      @name = XMLHelper.get_value(schedules_file, 'Name', :string)
+      @path = XMLHelper.get_value(schedules_file, 'Path', :string)
     end
   end
 

--- a/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml
@@ -9,7 +9,7 @@
       <sch:assert role='ERROR' test='count(h:XMLTransactionHeaderInformation) = 1'>Expected 1 element(s) for xpath: XMLTransactionHeaderInformation</sch:assert> <!-- See [XMLTransactionHeaderInformation] -->
       <sch:assert role='ERROR' test='count(h:SoftwareInfo/h:extension/h:SimulationControl) &lt;= 1'>Expected 0 or 1 element(s) for xpath: SoftwareInfo/extension/SimulationControl</sch:assert> <!-- See [SimulationControl] -->
       <sch:assert role='ERROR' test='count(h:SoftwareInfo/h:extension/h:HVACSizingControl) &lt;= 1'>Expected 0 or 1 element(s) for xpath: SoftwareInfo/extension/HVACSizingControl</sch:assert> <!-- See [HVACSizingControl] -->
-      <sch:assert role='ERROR' test='count(h:SoftwareInfo/h:extension/h:SchedulesFilePath) &lt;= 1'>Expected 0 or 1 element(s) for xpath: SoftwareInfo/extension/SchedulesFilePath</sch:assert>
+      <sch:assert role='ERROR' test='count(h:SoftwareInfo/h:extension/h:SchedulesFiles/h:SchedulesFile) &gt;= 0'>Expected 0 or more element(s) for xpath: SoftwareInfo/extension/SchedulesFiles/SchedulesFile</sch:assert> <!-- See [SchedulesFile] -->
       <sch:assert role='ERROR' test='count(h:Building) &gt;= 1'>Expected 1 or more element(s) for xpath: Building</sch:assert> <!-- See [Building] -->
     </sch:rule>
   </sch:pattern>
@@ -50,6 +50,14 @@
     <sch:rule context='/h:HPXML/h:SoftwareInfo/h:extension/h:HVACSizingControl'>
       <sch:assert role='ERROR' test='count(h:AllowIncreasedFixedCapacities) &lt;= 1'>Expected 0 or 1 element(s) for xpath: AllowIncreasedFixedCapacities</sch:assert> <!-- boolean -->
       <sch:assert role='ERROR' test='count(h:UseMaxLoadForHeatPumps) &lt;= 1'>Expected 0 or 1 element(s) for xpath: UseMaxLoadForHeatPumps</sch:assert> <!-- boolean -->
+    </sch:rule>
+  </sch:pattern>
+
+  <sch:pattern>
+    <sch:title>[SchedulesFile]</sch:title>
+    <sch:rule context='/h:HPXML/h:SoftwareInfo/h:extension/h:SchedulesFiles/h:SchedulesFile'>
+      <sch:assert role='ERROR' test='count(h:Name) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Name</sch:assert>
+      <sch:assert role='ERROR' test='count(h:Path) = 1'>Expected 1 element(s) for xpath: Path</sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1138,13 +1138,15 @@ class SchedulesFile
 
   def initialize(runner: nil,
                  model: nil,
-                 schedules_path:)
+                 schedules_paths:,
+                 col_names:)
+    return if schedules_paths.empty?
 
     @runner = runner
     @model = model
-    @schedules_path = schedules_path
+    @schedules_paths = schedules_paths
 
-    import(col_names: SchedulesFile.ColumnNames.keys)
+    import(col_names: col_names)
 
     @tmp_schedules = Marshal.load(Marshal.dump(@schedules))
     set_vacancy
@@ -1156,24 +1158,34 @@ class SchedulesFile
     get_external_file
   end
 
+  def nil?
+    if @schedules.nil?
+      return true
+    end
+
+    return false
+  end
+
   def import(col_names:)
     @schedules = {}
-    columns = CSV.read(@schedules_path).transpose
-    columns.each do |col|
-      col_name = col[0]
-      unless col_names.include? col_name
-        fail "Schedule column name '#{col_name}' is invalid. [context: #{@schedules_path}]"
+    @schedules_paths.each do |schedules_path|
+      columns = CSV.read(schedules_path).transpose
+      columns.each do |col|
+        col_name = col[0]
+        unless col_names.include? col_name
+          fail "Schedule column name '#{col_name}' is invalid. [context: #{schedules_path}]" unless [SchedulesFile::ColumnVacancy].include?(col_name)
+        end
+
+        values = col[1..-1].reject { |v| v.nil? }
+
+        begin
+          values = values.map { |v| Float(v) }
+        rescue ArgumentError
+          fail "Schedule value must be numeric for column '#{col_name}'. [context: #{schedules_path}]"
+        end
+
+        @schedules[col_name] = values
       end
-
-      values = col[1..-1].reject { |v| v.nil? }
-
-      begin
-        values = values.map { |v| Float(v) }
-      rescue ArgumentError
-        fail "Schedule value must be numeric for column '#{col_name}'. [context: #{@schedules_path}]"
-      end
-
-      @schedules[col_name] = values
     end
   end
 
@@ -1181,25 +1193,31 @@ class SchedulesFile
     @year = year
     num_hrs_in_year = Constants.NumHoursInYear(@year)
 
-    columns = CSV.read(@schedules_path).transpose
-    columns.each do |col|
-      col_name = col[0]
-      values = col[1..-1].reject { |v| v.nil? }
-      values = values.map { |v| Float(v) }
-      schedule_length = values.length
+    @schedules_paths.each do |schedules_path|
+      columns = CSV.read(schedules_path).transpose
+      columns.each do |col|
+        col_name = col[0]
+        values = col[1..-1].reject { |v| v.nil? }
+        values = values.map { |v| Float(v) }
+        schedule_length = values.length
 
-      if (1.0 - values.max).abs > 0.01
-        fail "Schedule max value for column '#{col_name}' must be 1. [context: #{@schedules_path}]"
-      end
+        if max_value_one[col_name]
+          if values.max > 1
+            fail "Schedule max value for column '#{col_name}' must be 1. [context: #{schedules_path}]"
+          end
+        end
 
-      if values.min < 0
-        fail "Schedule min value for column '#{col_name}' must be non-negative. [context: #{@schedules_path}]"
-      end
+        if min_value_zero[col_name]
+          if values.min < 0
+            fail "Schedule min value for column '#{col_name}' must be non-negative. [context: #{schedules_path}]"
+          end
+        end
 
-      valid_minutes_per_item = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60]
-      valid_num_rows = valid_minutes_per_item.map { |min_per_item| (60.0 * num_hrs_in_year / min_per_item).to_i }
-      unless valid_num_rows.include? schedule_length
-        fail "Schedule has invalid number of rows (#{schedule_length}) for column '#{col_name}'. Must be one of: #{valid_num_rows.reverse.join(', ')}. [context: #{@schedules_path}]"
+        valid_minutes_per_item = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60]
+        valid_num_rows = valid_minutes_per_item.map { |min_per_item| (60.0 * num_hrs_in_year / min_per_item).to_i }
+        unless valid_num_rows.include? schedule_length
+          fail "Schedule has invalid number of rows (#{schedule_length}) for column '#{col_name}'. Must be one of: #{valid_num_rows.reverse.join(', ')}. [context: #{@schedules_path}]"
+        end
       end
     end
   end
@@ -1231,7 +1249,12 @@ class SchedulesFile
   end
 
   def get_col_index(col_name:)
-    headers = CSV.open(@schedules_path, 'r') { |csv| csv.first }
+    headers = []
+    @schedules_paths.each do |schedules_path|
+      next if schedules_path.nil?
+
+      headers += CSV.open(schedules_path, 'r') { |csv| csv.first }
+    end
     col_num = headers.index(col_name)
     return col_num
   end
@@ -1266,6 +1289,10 @@ class SchedulesFile
   # the equivalent number of hours in the year, if the schedule was at full load (1.0)
   def annual_equivalent_full_load_hrs(col_name:,
                                       schedules: nil)
+    if @schedules[col_name].nil?
+      return
+    end
+
     if schedules.nil?
       schedules = @schedules # the schedules before vacancy is applied
     end
@@ -1283,6 +1310,9 @@ class SchedulesFile
   # is at 1.0, so that, for the given schedule values, the equipment will consume annual_kwh energy in a year.
   def calc_design_level_from_annual_kwh(col_name:,
                                         annual_kwh:)
+    if @schedules[col_name].nil?
+      return
+    end
 
     ann_equiv_full_load_hrs = annual_equivalent_full_load_hrs(col_name: col_name)
     design_level = annual_kwh * 1000.0 / ann_equiv_full_load_hrs # W
@@ -1293,6 +1323,9 @@ class SchedulesFile
   # Similar to ann_equiv_full_load_hrs, but for thermal energy
   def calc_design_level_from_annual_therm(col_name:,
                                           annual_therm:)
+    if @schedules[col_name].nil?
+      return
+    end
 
     annual_kwh = UnitConversions.convert(annual_therm, 'therm', 'kWh')
     design_level = calc_design_level_from_annual_kwh(col_name: col_name, annual_kwh: annual_kwh)
@@ -1304,6 +1337,10 @@ class SchedulesFile
   # level
   def calc_design_level_from_daily_kwh(col_name:,
                                        daily_kwh:)
+    if @schedules[col_name].nil?
+      return
+    end
+
     full_load_hrs = annual_equivalent_full_load_hrs(col_name: col_name)
     num_days_in_year = Constants.NumDaysInYear(@year)
     daily_full_load_hrs = full_load_hrs / num_days_in_year
@@ -1314,6 +1351,10 @@ class SchedulesFile
 
   # similar to calc_design_level_from_daily_kwh but for water usage
   def calc_peak_flow_from_daily_gpm(col_name:, daily_water:)
+    if @schedules[col_name].nil?
+      return
+    end
+
     ann_equiv_full_load_hrs = annual_equivalent_full_load_hrs(col_name: col_name)
     num_days_in_year = Constants.NumDaysInYear(@year)
     daily_full_load_hrs = ann_equiv_full_load_hrs / num_days_in_year
@@ -1333,52 +1374,89 @@ class SchedulesFile
   end
 
   def set_vacancy
-    return unless @tmp_schedules.keys.include? 'vacancy'
-    return if @tmp_schedules['vacancy'].all? { |i| i == 0 }
+    return unless @tmp_schedules.keys.include? ColumnVacancy
+    return if @tmp_schedules[ColumnVacancy].all? { |i| i == 0 }
 
     col_names = SchedulesFile.ColumnNames
 
-    @tmp_schedules[col_names.keys[0]].each_with_index do |ts, i|
-      col_names.keys.each do |col_name|
-        next if col_names[col_name].nil?
-        next unless col_names[col_name] # skip those unaffected by vacancy
+    @tmp_schedules[col_names[0]].each_with_index do |ts, i|
+      col_names.each do |col_name|
+        next unless affected_by_vacancy[col_name] # skip those unaffected by vacancy
 
-        @tmp_schedules[col_name][i] *= (1.0 - @tmp_schedules['vacancy'][i])
+        @tmp_schedules[col_name][i] *= (1.0 - @tmp_schedules[ColumnVacancy][i])
       end
     end
   end
 
   def self.ColumnNames
-    # col_name => affected_by_vacancy
-    return {
-      ColumnOccupants => true,
-      ColumnLightingInterior => true,
-      ColumnLightingExterior => true,
-      ColumnLightingGarage => true,
-      ColumnLightingExteriorHoliday => true,
-      ColumnCookingRange => true,
-      ColumnRefrigerator => false,
-      ColumnExtraRefrigerator => false,
-      ColumnFreezer => false,
-      ColumnDishwasher => true,
-      ColumnClothesWasher => true,
-      ColumnClothesDryer => true,
-      ColumnCeilingFan => true,
-      ColumnPlugLoadsOther => true,
-      ColumnPlugLoadsTV => true,
-      ColumnPlugLoadsVehicle => true,
-      ColumnPlugLoadsWellPump => true,
-      ColumnFuelLoadsGrill => true,
-      ColumnFuelLoadsLighting => true,
-      ColumnFuelLoadsFireplace => true,
-      ColumnPoolPump => false,
-      ColumnPoolHeater => false,
-      ColumnHotTubPump => false,
-      ColumnHotTubHeater => false,
-      ColumnHotWaterDishwasher => true,
-      ColumnHotWaterClothesWasher => true,
-      ColumnHotWaterFixtures => true,
-      ColumnVacancy => nil,
-    }
+    return SchedulesFile.OccupancyColumnNames
+  end
+
+  def self.OccupancyColumnNames
+    return [
+      ColumnOccupants,
+      ColumnLightingInterior,
+      ColumnLightingExterior,
+      ColumnLightingGarage,
+      ColumnLightingExteriorHoliday,
+      ColumnCookingRange,
+      ColumnRefrigerator,
+      ColumnExtraRefrigerator,
+      ColumnFreezer,
+      ColumnDishwasher,
+      ColumnClothesWasher,
+      ColumnClothesDryer,
+      ColumnCeilingFan,
+      ColumnPlugLoadsOther,
+      ColumnPlugLoadsTV,
+      ColumnPlugLoadsVehicle,
+      ColumnPlugLoadsWellPump,
+      ColumnFuelLoadsGrill,
+      ColumnFuelLoadsLighting,
+      ColumnFuelLoadsFireplace,
+      ColumnPoolPump,
+      ColumnPoolHeater,
+      ColumnHotTubPump,
+      ColumnHotTubHeater,
+      ColumnHotWaterDishwasher,
+      ColumnHotWaterClothesWasher,
+      ColumnHotWaterFixtures
+    ]
+  end
+
+  def affected_by_vacancy
+    affected_by_vacancy = {}
+    column_names = SchedulesFile.ColumnNames
+    column_names.each do |column_name|
+      affected_by_vacancy[column_name] = true
+      next unless [ColumnRefrigerator,
+                   ColumnExtraRefrigerator,
+                   ColumnFreezer,
+                   ColumnPoolPump,
+                   ColumnPoolHeater,
+                   ColumnHotTubPump,
+                   ColumnHotTubHeater].include? column_name
+
+      affected_by_vacancy[column_name] = false
+    end
+    return affected_by_vacancy
+  end
+
+  def max_value_one
+    max_value_one = {}
+    column_names = SchedulesFile.ColumnNames
+    column_names.each do |column_name|
+      max_value_one[column_name] = true
+    end
+    return max_value_one
+  end
+
+  def min_value_zero
+    min_value_zero = {}
+    column_names = SchedulesFile.ColumnNames
+    column_names.each do |column_name|
+      min_value_zero[column_name] = true
+    end
+    return min_value_zero
   end
 end

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -840,33 +840,33 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
         csv_data[1][1] = 1.1
         File.write(@tmp_csv_path, csv_data.map(&:to_csv).join)
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base.xml'))
-        hpxml.header.schedules_filepath = @tmp_csv_path
+        hpxml.header.schedules_files.add(path: @tmp_csv_path)
       elsif ['schedule-detailed-bad-values-negative'].include? error_case
         csv_data = CSV.read(File.join(File.dirname(__FILE__), '../resources/schedule_files/stochastic.csv'))
         csv_data[1][1] = -0.5
         File.write(@tmp_csv_path, csv_data.map(&:to_csv).join)
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base.xml'))
-        hpxml.header.schedules_filepath = @tmp_csv_path
+        hpxml.header.schedules_files.add(path: @tmp_csv_path)
       elsif ['schedule-detailed-bad-values-non-numeric'].include? error_case
         csv_data = CSV.read(File.join(File.dirname(__FILE__), '../resources/schedule_files/stochastic.csv'))
         csv_data[1][1] = 'NA'
         File.write(@tmp_csv_path, csv_data.map(&:to_csv).join)
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base.xml'))
-        hpxml.header.schedules_filepath = @tmp_csv_path
+        hpxml.header.schedules_files.add(path: @tmp_csv_path)
       elsif ['schedule-detailed-wrong-columns'].include? error_case
         csv_data = CSV.read(File.join(File.dirname(__FILE__), '../resources/schedule_files/stochastic.csv'))
         csv_data[0][1] = 'lighting'
         File.write(@tmp_csv_path, csv_data.map(&:to_csv).join)
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base.xml'))
-        hpxml.header.schedules_filepath = @tmp_csv_path
+        hpxml.header.schedules_files.add(path: @tmp_csv_path)
       elsif ['schedule-detailed-wrong-filename'].include? error_case
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base.xml'))
-        hpxml.header.schedules_filepath = 'HPXMLtoOpenStudio/resources/schedule_files/invalid-wrong-filename.csv'
+        hpxml.header.schedules_files.add(path: 'HPXMLtoOpenStudio/resources/schedule_files/invalid-wrong-filename.csv')
       elsif ['schedule-detailed-wrong-rows'].include? error_case
         csv_data = CSV.read(File.join(File.dirname(__FILE__), '../resources/schedule_files/stochastic.csv'))
         File.write(@tmp_csv_path, csv_data[0..-2].map(&:to_csv).join)
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base.xml'))
-        hpxml.header.schedules_filepath = @tmp_csv_path
+        hpxml.header.schedules_files.add(path: @tmp_csv_path)
       elsif ['solar-thermal-system-with-combi-tankless'].include? error_case
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base-dhw-combi-tankless.xml'))
         hpxml.solar_thermal_systems.add(id: "SolarThermalSystem#{hpxml.solar_thermal_systems.size + 1}",
@@ -995,7 +995,7 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
       # Create HPXML object
       if ['schedule-file-and-weekday-weekend-multipliers'].include? warning_case
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base-schedules-simple.xml'))
-        hpxml.header.schedules_filepath = 'HPXMLtoOpenStudio/resources/schedule_files/smooth.csv'
+        hpxml.header.schedules_files.add(path: 'HPXMLtoOpenStudio/resources/schedule_files/smooth.csv')
       else
         fail "Unhandled case: #{warning_case}."
       end

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -151,44 +151,52 @@ Detailed Schedule Inputs
 Detailed schedule inputs allow schedule values for every hour or timestep of the simulation.
 They can be smooth schedules, or they can reflect real-world or stochastic occupancy.
 
-Detailed schedule inputs are provided via a CSV file that should be referenced in the HPXML file at ``/HPXML/SoftwareInfo/extension/SchedulesFilePath``.
-Each column must be normalized to MAX=1; that is, the schedules only define *when* energy is used, not *how much* energy is used.
-The columns in the schedule CSV are:
+Detailed schedule inputs are provided via CSV file(s) that should be referenced in the HPXML file as a ``/HPXML/SoftwareInfo/extension/SchedulesFiles/SchedulesFile``.
 
-  =============================  ========================================================  ===================
-  Column Name                    Description                                               Affected by Vacancy
-  =============================  ========================================================  ===================
-  ``occupants``                  Occupant heat gain schedule.                              Yes
-  ``lighting_interior``          Interior lighting energy use schedule.                    Yes
-  ``lighting_exterior``          Exterior lighting energy use schedule.                    Yes
-  ``lighting_garage``            Garage lighting energy use schedule.                      Yes
-  ``lighting_exterior_holiday``  Exterior holiday lighting energy use schedule.            Yes
-  ``cooking_range``              Cooking range & oven energy use schedule.                 Yes
-  ``refrigerator``               Primary refrigerator energy use schedule.                 No
-  ``extra_refrigerator``         Non-primary refrigerator energy use schedule.             No
-  ``freezer``                    Freezer energy use schedule.                              No
-  ``dishwasher``                 Dishwasher energy use schedule.                           Yes
-  ``clothes_washer``             Clothes washer energy use schedule.                       Yes
-  ``clothes_dryer``              Clothes dryer energy use schedule.                        Yes
-  ``ceiling_fan``                Ceiling fan energy use schedule.                          Yes
-  ``plug_loads_other``           Other plug load energy use schedule.                      Yes
-  ``plug_loads_tv``              Television plug load energy use schedule.                 Yes
-  ``plug_loads_vehicle``         Electric vehicle plug load energy use schedule.           Yes
-  ``plug_loads_well_pump``       Well pump plug load energy use schedule.                  Yes
-  ``fuel_loads_grill``           Grill fuel load energy use schedule.                      Yes
-  ``fuel_loads_lighting``        Lighting fuel load energy use schedule.                   Yes
-  ``fuel_loads_fireplace``       Fireplace fuel load energy use schedule.                  Yes
-  ``pool_pump``                  Pool pump energy use schedule.                            No
-  ``pool_heater``                Pool heater energy use schedule.                          No
-  ``hot_tub_pump``               Hot tub pump energy use schedule.                         No
-  ``hot_tub_heater``             Hot tub heater energy use schedule.                       No
-  ``hot_water_dishwasher``       Dishwasher hot water use schedule.                        Yes
-  ``hot_water_clothes_washer``   Clothes washer hot water use schedule.                    Yes
-  ``hot_water_fixtures``         Fixtures (sinks, showers, baths) hot water use schedule.  Yes
-  ``vacancy``                    1=Home is vacant. Automatically overrides other columns.  N/A
-  =============================  ========================================================  ===================
+  =========================  =======  =======  ===========  ========  ========  ================================================================
+  Element                    Type     Units    Constraints  Required  Default   Notes
+  =========================  =======  =======  ===========  ========  ========  ================================================================
+  ``Name``                   string                         No                  Category of the schedules file.
+  ``Path``                   string                         Yes                 Path of the schedules file.
+  =========================  =======  =======  ===========  ========  ========  ================================================================
 
-A couple schedule CSV file examples are provided in the ``HPXMLtoOpenStudio/resources/schedule_files`` directory.
+Occupancy related schedule columns must be normalized to MAX=1; that is, these schedules only define *when* energy is used, not *how much* energy is used.
+The schedule columns in the schedule CSV are:
+
+  ==============================  ========================================================  ===================
+  Column Name                     Description                                               Affected by Vacancy
+  ==============================  ========================================================  ===================
+  ``occupants``                   Occupant heat gain schedule.                              Yes
+  ``lighting_interior``           Interior lighting energy use schedule.                    Yes
+  ``lighting_exterior``           Exterior lighting energy use schedule.                    Yes
+  ``lighting_garage``             Garage lighting energy use schedule.                      Yes
+  ``lighting_exterior_holiday``   Exterior holiday lighting energy use schedule.            Yes
+  ``cooking_range``               Cooking range & oven energy use schedule.                 Yes
+  ``refrigerator``                Primary refrigerator energy use schedule.                 No
+  ``extra_refrigerator``          Non-primary refrigerator energy use schedule.             No
+  ``freezer``                     Freezer energy use schedule.                              No
+  ``dishwasher``                  Dishwasher energy use schedule.                           Yes
+  ``clothes_washer``              Clothes washer energy use schedule.                       Yes
+  ``clothes_dryer``               Clothes dryer energy use schedule.                        Yes
+  ``ceiling_fan``                 Ceiling fan energy use schedule.                          Yes
+  ``plug_loads_other``            Other plug load energy use schedule.                      Yes
+  ``plug_loads_tv``               Television plug load energy use schedule.                 Yes
+  ``plug_loads_vehicle``          Electric vehicle plug load energy use schedule.           Yes
+  ``plug_loads_well_pump``        Well pump plug load energy use schedule.                  Yes
+  ``fuel_loads_grill``            Grill fuel load energy use schedule.                      Yes
+  ``fuel_loads_lighting``         Lighting fuel load energy use schedule.                   Yes
+  ``fuel_loads_fireplace``        Fireplace fuel load energy use schedule.                  Yes
+  ``pool_pump``                   Pool pump energy use schedule.                            No
+  ``pool_heater``                 Pool heater energy use schedule.                          No
+  ``hot_tub_pump``                Hot tub pump energy use schedule.                         No
+  ``hot_tub_heater``              Hot tub heater energy use schedule.                       No
+  ``hot_water_dishwasher``        Dishwasher hot water use schedule.                        Yes
+  ``hot_water_clothes_washer``    Clothes washer hot water use schedule.                    Yes
+  ``hot_water_fixtures``          Fixtures (sinks, showers, baths) hot water use schedule.  Yes
+  ``vacancy``                     1=Home is vacant. Automatically overrides other columns.  N/A
+  ==============================  ========================================================  ===================
+
+Example schedule CSV files are provided in the ``HPXMLtoOpenStudio/resources/schedule_files`` directory.
 
 A detailed stochastic or smooth schedule CSV file can also be automatically generated for you; see the :ref:`usage_instructions` for the commands.
 

--- a/tasks.rb
+++ b/tasks.rb
@@ -2505,11 +2505,11 @@ def apply_hpxml_modification(hpxml_file, hpxml)
   if ['base-hvac-undersized-allow-increased-fixed-capacities.xml'].include? hpxml_file
     hpxml.header.allow_increased_fixed_capacities = true
   elsif ['base-schedules-detailed-stochastic.xml'].include? hpxml_file
-    hpxml.header.schedules_filepath = '../../HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv'
+    hpxml.header.schedules_files.add(path: '../../HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv')
   elsif ['base-schedules-detailed-stochastic-vacancy.xml'].include? hpxml_file
-    hpxml.header.schedules_filepath = '../../HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv'
+    hpxml.header.schedules_files.add(path: '../../HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv')
   elsif ['base-schedules-detailed-smooth.xml'].include? hpxml_file
-    hpxml.header.schedules_filepath = '../../HPXMLtoOpenStudio/resources/schedule_files/smooth.csv'
+    hpxml.header.schedules_files.add(path: '../../HPXMLtoOpenStudio/resources/schedule_files/smooth.csv')
   elsif ['base-location-capetown-zaf.xml'].include? hpxml_file
     hpxml.header.state_code = nil
   end

--- a/workflow/sample_files/base-schedules-detailed-smooth.xml
+++ b/workflow/sample_files/base-schedules-detailed-smooth.xml
@@ -11,7 +11,11 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
-      <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/smooth.csv</SchedulesFilePath>
+      <SchedulesFiles>
+        <SchedulesFile>
+          <Path>../../HPXMLtoOpenStudio/resources/schedule_files/smooth.csv</Path>
+        </SchedulesFile>
+      </SchedulesFiles>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-detailed-stochastic-vacancy.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic-vacancy.xml
@@ -11,7 +11,11 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
-      <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv</SchedulesFilePath>
+      <SchedulesFiles>
+        <SchedulesFile>
+          <Path>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv</Path>
+        </SchedulesFile>
+      </SchedulesFiles>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-detailed-stochastic.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic.xml
@@ -11,7 +11,11 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
-      <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv</SchedulesFilePath>
+      <SchedulesFiles>
+        <SchedulesFile>
+          <Path>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv</Path>
+        </SchedulesFile>
+      </SchedulesFiles>
     </extension>
   </SoftwareInfo>
   <Building>


### PR DESCRIPTION
## Pull Request Description

Changes `SoftwareInfo/extension/SchedulesFilePath` to multiple `SoftwareInfo/extension/SchedulesFiles/SchedulesFile` elements with `Name` and `Path` child elements. See below. Likewise, the `SchedulesFile` class gets updated to import schedules from each file in `SchedulesFiles`.

```
  <SoftwareInfo>
    <extension>
      <SimulationControl>
        <Timestep>60</Timestep>
      </SimulationControl>
      <SchedulesFiles>
        <SchedulesFile>
          <Path>../../HPXMLtoOpenStudio/resources/schedule_files/smooth.csv</Path>
        </SchedulesFile>
        <SchedulesFile>
          <Path>../../HPXMLtoOpenStudio/resources/schedule_files/tank/hourly_setpoint_schedule.csv</Path>
        </SchedulesFile>
      </SchedulesFiles>
```

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
