### PR TITLE
Relaxes CFA served input requirement

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -1410,9 +1410,9 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue(Constants.Auto)
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument::makeStringArgument('ducts_number_of_return_registers', true)
+    arg = OpenStudio::Measure::OSArgument::makeStringArgument('ducts_number_of_return_registers', false)
     arg.setDisplayName('Ducts: Number of Return Registers')
-    arg.setDescription("The number of return registers of the ducts. Ignored for ducted #{HPXML::HVACTypeEvaporativeCooler}.")
+    arg.setDescription("The number of return registers of the ducts. Only used if duct surface areas are set to #{Constants.Auto}.")
     arg.setUnits('#')
     arg.setDefaultValue(Constants.Auto)
     args << arg
@@ -4376,8 +4376,10 @@ class HPXMLFile
 
     return if air_distribution_systems.size == 0 && fan_coil_distribution_systems.size == 0
 
-    if args[:ducts_number_of_return_registers] != Constants.Auto
-      number_of_return_registers = Integer(args[:ducts_number_of_return_registers])
+    if args[:ducts_number_of_return_registers].is_initialized
+      if args[:ducts_number_of_return_registers].get != Constants.Auto
+        number_of_return_registers = Integer(args[:ducts_number_of_return_registers].get)
+      end
     end
 
     if [HPXML::HVACTypeEvaporativeCooler].include?(args[:cooling_system_type]) && hpxml.heating_systems.size == 0 && hpxml.heat_pumps.size == 0
@@ -4390,7 +4392,6 @@ class HPXMLFile
     if air_distribution_systems.size > 0
       hpxml.hvac_distributions.add(id: "HVACDistribution#{hpxml.hvac_distributions.size + 1}",
                                    distribution_system_type: HPXML::HVACDistributionTypeAir,
-                                   conditioned_floor_area_served: args[:geometry_unit_cfa],
                                    air_type: HPXML::AirTypeRegularVelocity,
                                    number_of_return_registers: number_of_return_registers)
       air_distribution_systems.each do |hvac_system|
@@ -4449,6 +4450,11 @@ class HPXMLFile
                                   duct_insulation_r_value: args[:ducts_return_insulation_r],
                                   duct_location: ducts_return_location,
                                   duct_surface_area: ducts_return_surface_area)
+    end
+
+    # If duct surface areas are defaulted, set CFA served
+    if hvac_distribution.ducts.select { |d| d.duct_surface_area.nil? }.size > 0
+      hvac_distribution.conditioned_floor_area_served = args[:geometry_unit_cfa]
     end
   end
 

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>8f79225c-3129-418a-abf8-82f4c127e4ec</version_id>
-  <version_modified>20220104T183957Z</version_modified>
+  <version_id>d3626024-281e-4086-a6b8-51dd984531d4</version_id>
+  <version_modified>20220113T015155Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder (Beta)</display_name>
@@ -2814,10 +2814,10 @@
     <argument>
       <name>ducts_number_of_return_registers</name>
       <display_name>Ducts: Number of Return Registers</display_name>
-      <description>The number of return registers of the ducts. Ignored for ducted evaporative cooler.</description>
+      <description>The number of return registers of the ducts. Only used if duct surface areas are set to auto.</description>
       <type>String</type>
       <units>#</units>
-      <required>true</required>
+      <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>auto</default_value>
     </argument>
@@ -5907,501 +5907,10 @@
       <checksum>D3409E06</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.9.0</identifier>
-        <min_compatible>2.9.0</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>32A26FB1</checksum>
-    </file>
-    <file>
-      <filename>extra_files/base-mf.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/base-sfa.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>A6F31A0C</checksum>
-    </file>
-    <file>
-      <filename>extra_files/base-sfd.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>E26C353B</checksum>
-    </file>
-    <file>
       <filename>extra_files/extra-auto.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
       <checksum>CE8B80B7</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-dhw-solar-latitude.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>954423B2</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-enclosure-atticroof-conditioned-eaves-gable.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>35E525D0</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-enclosure-atticroof-conditioned-eaves-hip.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>0F8344C6</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-enclosure-garage-atticroof-conditioned.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>B8A32D83</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-enclosure-garage-partially-protruded.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>A6A8FF24</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-enclosure-windows-shading.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>A2555193</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-gas-hot-tub-heater-with-zero-kwh.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>CCB3E3FC</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-gas-pool-heater-with-zero-kwh.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>80EE40C6</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-iecc-zone-different-than-epw.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>2D585701</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-eaves.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>CEC7F465</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-exterior-corridor.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-left-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>63D05DF3</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-left-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>9BC60182</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-left-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F4239B63</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-left-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-left-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F4239B63</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-left-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-middle-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>BC635E2F</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-middle-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>471A2148</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-middle-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-middle-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-middle-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-middle-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>63D05DF3</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-right-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>BC635E2F</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-right-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>471A2148</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-right-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-right-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-right-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab-right-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-slab.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>9BC60182</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-left-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>0E33D6AB</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-left-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>6B7E14D4</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-left-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F4239B63</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-left-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-left-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F4239B63</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-left-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-middle-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>1FE0CE03</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-middle-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>6A3DABC2</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-middle-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-middle-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-middle-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-middle-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>0E33D6AB</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-right-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>1FE0CE03</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-right-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>6A3DABC2</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-right-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-right-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-right-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace-right-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-unvented-crawlspace.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>6B7E14D4</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-left-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>05B16E50</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-left-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>876E9B67</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-left-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F4239B63</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-left-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-left-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F4239B63</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-left-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ED7A5266</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-middle-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>4F08C973</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-middle-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>7AC61E6E</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-middle-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-middle-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-middle-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-middle-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>05B16E50</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-right-bottom-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>4F08C973</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-right-bottom.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>7AC61E6E</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-right-middle-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-right-middle.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-right-top-rear-units.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>79A8DC70</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace-right-top.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C1F97A9D</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-mf-vented-crawlspace.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>876E9B67</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-no-rim-joists.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>D6F8CE89</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-pv-roofpitch.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>9AB2E60C</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-second-heating-system-boiler-to-heat-pump.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>5EA74004</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-second-heating-system-boiler-to-heating-system.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>ABB90EC4</checksum>
-    </file>
-    <file>
-      <filename>extra_files/extra-second-heating-system-fireplace-to-heat-pump.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C8824163</checksum>
     </file>
     <file>
       <filename>extra_files/extra-second-heating-system-fireplace-to-heating-system.xml</filename>
@@ -6410,268 +5919,759 @@
       <checksum>5D5101CC</checksum>
     </file>
     <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.9.0</identifier>
+        <min_compatible>2.9.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>37503189</checksum>
+    </file>
+    <file>
+      <filename>extra_files/base-mf.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/base-sfa.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A77C384B</checksum>
+    </file>
+    <file>
+      <filename>extra_files/base-sfd.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>415957AF</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-dhw-solar-latitude.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>72383EF2</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-enclosure-atticroof-conditioned-eaves-gable.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>B2A1C486</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-enclosure-atticroof-conditioned-eaves-hip.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>928AC799</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-enclosure-garage-atticroof-conditioned.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2FCD642B</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-enclosure-garage-partially-protruded.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>50E1F03A</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-enclosure-windows-shading.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>1D2560A6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-gas-hot-tub-heater-with-zero-kwh.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>12364E7F</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-gas-pool-heater-with-zero-kwh.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3CE771CD</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-iecc-zone-different-than-epw.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A2D22E8A</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-eaves.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A202CF44</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-exterior-corridor.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-left-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>6CEE0843</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-left-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>00FF645C</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-left-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2A985B1D</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-left-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-left-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2A985B1D</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-left-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-middle-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>4C32F545</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-middle-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3D069763</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-middle-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-middle-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-middle-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-middle-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>6CEE0843</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-right-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>4C32F545</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-right-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3D069763</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-right-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-right-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-right-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab-right-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-slab.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>00FF645C</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-left-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A1EA5BC7</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-left-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>454A93AC</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-left-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2A985B1D</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-left-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-left-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2A985B1D</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-left-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-middle-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DF784FEA</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-middle-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>EE8D1A0D</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-middle-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-middle-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-middle-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-middle-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A1EA5BC7</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-right-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DF784FEA</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-right-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>EE8D1A0D</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-right-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-right-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-right-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace-right-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-unvented-crawlspace.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>454A93AC</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-left-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>25704BA5</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-left-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>19666A0E</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-left-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2A985B1D</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-left-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-left-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2A985B1D</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-left-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CE559523</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-middle-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>30D68EF7</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-middle-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F196AA8E</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-middle-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-middle-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-middle-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-middle-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>25704BA5</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-right-bottom-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>30D68EF7</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-right-bottom.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F196AA8E</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-right-middle-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-right-middle.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-right-top-rear-units.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9B00B6E6</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace-right-top.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DBD9C9CE</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-mf-vented-crawlspace.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>19666A0E</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-no-rim-joists.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>57F4EE9C</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-pv-roofpitch.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>488ECB01</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-second-heating-system-boiler-to-heat-pump.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>B2288CD1</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-second-heating-system-boiler-to-heating-system.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F8F44C3B</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-second-heating-system-fireplace-to-heat-pump.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>ED1BECD7</checksum>
+    </file>
+    <file>
       <filename>extra_files/extra-second-heating-system-portable-heater-to-heat-pump.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>CD96362D</checksum>
+      <checksum>8BB1BE99</checksum>
     </file>
     <file>
       <filename>extra_files/extra-second-heating-system-portable-heater-to-heating-system.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>E9F4EE2E</checksum>
+      <checksum>8A83E0B1</checksum>
     </file>
     <file>
       <filename>extra_files/extra-second-refrigerator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>01EFB9C8</checksum>
+      <checksum>18B82C45</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-atticroof-conditioned-eaves-gable.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>75957265</checksum>
+      <checksum>9C882440</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-atticroof-conditioned-eaves-hip.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>2EFD3F74</checksum>
+      <checksum>5293940B</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-atticroof-flat.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>42E12690</checksum>
+      <checksum>F4402A1B</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-conditioned-crawlspace.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>A195B235</checksum>
+      <checksum>D04099F4</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-exterior-corridor.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>A6F31A0C</checksum>
+      <checksum>A77C384B</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-rear-units.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>A6F31A0C</checksum>
+      <checksum>A77C384B</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-slab-middle.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>CA83360B</checksum>
+      <checksum>17A9EC6B</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-slab-right.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>CA83360B</checksum>
+      <checksum>17A9EC6B</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-slab.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>DF290A1B</checksum>
+      <checksum>004B1AC1</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-unconditioned-basement-middle.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>D668FB68</checksum>
+      <checksum>C8A6003A</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-unconditioned-basement-right.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>D668FB68</checksum>
+      <checksum>C8A6003A</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-unconditioned-basement.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>9B2494A5</checksum>
+      <checksum>22D018C4</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-unvented-crawlspace-middle.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>C0578BCF</checksum>
+      <checksum>18197322</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-unvented-crawlspace-right.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>C0578BCF</checksum>
+      <checksum>18197322</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-unvented-crawlspace.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>53A18CB3</checksum>
+      <checksum>5ACB0D51</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-vented-crawlspace-middle.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B2EB955</checksum>
+      <checksum>668F8FD7</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-vented-crawlspace-right.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B2EB955</checksum>
+      <checksum>668F8FD7</checksum>
     </file>
     <file>
       <filename>extra_files/extra-sfa-vented-crawlspace.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>13AF7843</checksum>
+      <checksum>024064E2</checksum>
     </file>
     <file>
       <filename>extra_files/extra-state-code-different-than-epw.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>5B2CE00E</checksum>
+      <checksum>7D75A9B0</checksum>
     </file>
     <file>
       <filename>extra_files/extra-zero-clothes-washer-kwh.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>531758D3</checksum>
+      <checksum>F0402A30</checksum>
     </file>
     <file>
       <filename>extra_files/extra-zero-dishwasher-kwh.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>2859B6E8</checksum>
+      <checksum>E1EBF131</checksum>
     </file>
     <file>
       <filename>extra_files/extra-zero-extra-refrigerator-kwh.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>E26C353B</checksum>
+      <checksum>415957AF</checksum>
     </file>
     <file>
       <filename>extra_files/extra-zero-freezer-kwh.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>E26C353B</checksum>
+      <checksum>415957AF</checksum>
     </file>
     <file>
       <filename>extra_files/extra-zero-refrigerator-kwh.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>848A79B5</checksum>
+      <checksum>42AEBCC0</checksum>
     </file>
     <file>
       <filename>extra_files/warning-conditioned-attic-with-floor-insulation.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>EE3AA343</checksum>
+      <checksum>7DCE1EC5</checksum>
     </file>
     <file>
       <filename>extra_files/warning-conditioned-basement-with-ceiling-insulation.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>E26C353B</checksum>
+      <checksum>415957AF</checksum>
     </file>
     <file>
       <filename>extra_files/warning-mf-bottom-slab-non-zero-foundation-height.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>9BC60182</checksum>
+      <checksum>00FF645C</checksum>
     </file>
     <file>
       <filename>extra_files/warning-multipliers-without-fuel-loads.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>E26C353B</checksum>
+      <checksum>415957AF</checksum>
     </file>
     <file>
       <filename>extra_files/warning-multipliers-without-other-plug-loads.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>30DD6506</checksum>
+      <checksum>F0B6D83D</checksum>
     </file>
     <file>
       <filename>extra_files/warning-multipliers-without-tv-plug-loads.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>68AAFA47</checksum>
+      <checksum>D96178DE</checksum>
     </file>
     <file>
       <filename>extra_files/warning-multipliers-without-vehicle-plug-loads.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>E26C353B</checksum>
+      <checksum>415957AF</checksum>
     </file>
     <file>
       <filename>extra_files/warning-multipliers-without-well-pump-plug-loads.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>E26C353B</checksum>
+      <checksum>415957AF</checksum>
     </file>
     <file>
       <filename>extra_files/warning-non-electric-heat-pump-water-heater.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>FD1318B9</checksum>
+      <checksum>2ADF2171</checksum>
     </file>
     <file>
       <filename>extra_files/warning-second-heating-system-serves-majority-heat.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>8FAB1DDA</checksum>
+      <checksum>0212A41B</checksum>
     </file>
     <file>
       <filename>extra_files/warning-sfd-slab-non-zero-foundation-height.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>2D4E3C7D</checksum>
+      <checksum>A14AF5F1</checksum>
     </file>
     <file>
       <filename>extra_files/warning-slab-non-zero-foundation-height-above-grade.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>2D4E3C7D</checksum>
+      <checksum>A14AF5F1</checksum>
     </file>
     <file>
       <filename>extra_files/warning-unconditioned-basement-with-wall-and-ceiling-insulation.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>C3CFF950</checksum>
+      <checksum>0CC75E39</checksum>
     </file>
     <file>
       <filename>extra_files/warning-unvented-attic-with-floor-and-roof-insulation.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>484CD47C</checksum>
+      <checksum>397BAA2C</checksum>
     </file>
     <file>
       <filename>extra_files/warning-unvented-crawlspace-with-wall-and-ceiling-insulation.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>3272A22B</checksum>
+      <checksum>C93C16EA</checksum>
     </file>
     <file>
       <filename>extra_files/warning-vented-attic-with-floor-and-roof-insulation.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>CD6E07BC</checksum>
+      <checksum>11BAA9F6</checksum>
     </file>
     <file>
       <filename>extra_files/warning-vented-crawlspace-with-wall-and-ceiling-insulation.xml</filename>
       <filetype>xml</filetype>
       <usage_type>test</usage_type>
-      <checksum>627C06E9</checksum>
+      <checksum>A887B353</checksum>
     </file>
   </files>
 </measure>

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ __New Features__
 - BuildResidentialHPXML measure: Adds an optional argument to allow the HPXML file to be written with default values applied.
 - ReportSimulationOutput measure: Allows user-specified annual/timeseries output file names.
 - The `WaterFixturesUsageMultiplier` input now also applies to general water use internal gains and recirculation pump energy (for some control types).
+- Relaxes requirement for `ConditionedFloorAreaServed` for air distribution systems; now only needed if duct surface areas not provided.
 
 __Bugfixes__
 - Fixes possible HVAC sizing error if design temperature difference (TD) is negative.

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>67926ab0-6a1f-4f97-9d85-dd6bdc06507f</version_id>
-  <version_modified>20220111T004818Z</version_modified>
+  <version_id>090f89da-5952-4a25-9791-5880284ef4a8</version_id>
+  <version_modified>20220113T015158Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -16,22 +16,31 @@
       <display_name>HPXML File Path</display_name>
       <description>Absolute/relative path of the HPXML file.</description>
       <type>String</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
+      <default_value></default_value>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>output_dir</name>
       <display_name>Directory for Output Files</display_name>
       <description>Absolute/relative path for the output files directory.</description>
       <type>String</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
+      <default_value></default_value>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>debug</name>
       <display_name>Debug Mode?</display_name>
       <description>If true: 1) Writes in.osm file, 2) Generates additional log output, and 3) Creates all EnergyPlus output files.</description>
       <type>Boolean</type>
+      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -45,12 +54,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>add_component_loads</name>
       <display_name>Add component loads?</display_name>
       <description>If true, adds the calculation of heating/cooling component loads (not enabled by default for faster performance).</description>
       <type>Boolean</type>
+      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -64,12 +76,15 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>skip_validation</name>
       <display_name>Skip Validation?</display_name>
       <description>If true, bypasses HPXML input validation for faster performance. WARNING: This should only be used if the supplied HPXML file has already been validated against the Schema &amp; Schematron documents.</description>
       <type>Boolean</type>
+      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -83,14 +98,20 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>building_id</name>
       <display_name>BuildingID</display_name>
       <description>The ID of the HPXML Building. Only required if there are multiple Building elements in the HPXML file.</description>
       <type>String</type>
+      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
+      <default_value></default_value>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
   </arguments>
   <outputs />
@@ -404,12 +425,6 @@
       <checksum>424F1127</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>66B067B5</checksum>
-    </file>
-    <file>
       <filename>test_schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -440,18 +455,6 @@
       <checksum>6958422B</checksum>
     </file>
     <file>
-      <filename>test_validation.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>B2CC41EA</checksum>
-    </file>
-    <file>
-      <filename>hpxml_schematron/EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>33DE274B</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.2.0</identifier>
@@ -461,12 +464,6 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>474AAC07</checksum>
-    </file>
-    <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>07CE2A02</checksum>
     </file>
     <file>
       <filename>hotwater_appliances.rb</filename>
@@ -479,6 +476,30 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>15303EA4</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>EA3B16FF</checksum>
+    </file>
+    <file>
+      <filename>test_validation.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>69AA12F3</checksum>
+    </file>
+    <file>
+      <filename>hpxml_schematron/EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C95FD690</checksum>
+    </file>
+    <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>35FE48AC</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>090f89da-5952-4a25-9791-5880284ef4a8</version_id>
-  <version_modified>20220113T015158Z</version_modified>
+  <version_id>09215967-d6a2-46fd-9a5e-33681afd9dde</version_id>
+  <version_modified>20220113T195206Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -16,31 +16,22 @@
       <display_name>HPXML File Path</display_name>
       <description>Absolute/relative path of the HPXML file.</description>
       <type>String</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value></default_value>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>output_dir</name>
       <display_name>Directory for Output Files</display_name>
       <description>Absolute/relative path for the output files directory.</description>
       <type>String</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value></default_value>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>debug</name>
       <display_name>Debug Mode?</display_name>
       <description>If true: 1) Writes in.osm file, 2) Generates additional log output, and 3) Creates all EnergyPlus output files.</description>
       <type>Boolean</type>
-      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -54,15 +45,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>add_component_loads</name>
       <display_name>Add component loads?</display_name>
       <description>If true, adds the calculation of heating/cooling component loads (not enabled by default for faster performance).</description>
       <type>Boolean</type>
-      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -76,15 +64,12 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>skip_validation</name>
       <display_name>Skip Validation?</display_name>
       <description>If true, bypasses HPXML input validation for faster performance. WARNING: This should only be used if the supplied HPXML file has already been validated against the Schema &amp; Schematron documents.</description>
       <type>Boolean</type>
-      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -98,20 +83,14 @@
           <display_name>false</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>building_id</name>
       <display_name>BuildingID</display_name>
       <description>The ID of the HPXML Building. Only required if there are multiple Building elements in the HPXML file.</description>
       <type>String</type>
-      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
-      <default_value></default_value>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
   </arguments>
   <outputs />
@@ -466,12 +445,6 @@
       <checksum>474AAC07</checksum>
     </file>
     <file>
-      <filename>hotwater_appliances.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>A20BE4CA</checksum>
-    </file>
-    <file>
       <filename>test_hotwater_appliance.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -500,6 +473,12 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>35FE48AC</checksum>
+    </file>
+    <file>
+      <filename>hotwater_appliances.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>BE6FF1FB</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
+++ b/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
@@ -924,7 +924,7 @@ class HotWaterAndAppliances
     return f_eff * ref_f_gpd * fixtures_usage_multiplier
   end
 
-  def self.get_water_gains_sens_lat(nbeds, fixtures_usage_multiplier)
+  def self.get_water_gains_sens_lat(nbeds, fixtures_usage_multiplier = 1.0)
     # Table 4.2.2(3). Internal Gains for Reference Homes
     sens_gains = (-1227.0 - 409.0 * nbeds) * fixtures_usage_multiplier # Btu/day
     lat_gains = (1245.0 + 415.0 * nbeds) * fixtures_usage_multiplier # Btu/day

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -1219,21 +1219,21 @@ class HPXMLDefaults
   def self.apply_hvac_distribution(hpxml, ncfl, ncfl_ag)
     hpxml.hvac_distributions.each do |hvac_distribution|
       next unless [HPXML::HVACDistributionTypeAir].include? hvac_distribution.distribution_system_type
-
-      # Default return registers
-      if hvac_distribution.number_of_return_registers.nil?
-        hvac_distribution.number_of_return_registers = ncfl.ceil # Add 1 return register per conditioned floor if not provided
-        hvac_distribution.number_of_return_registers_isdefaulted = true
-      end
-
       next if hvac_distribution.ducts.empty?
 
       # Default ducts
 
-      cfa_served = hvac_distribution.conditioned_floor_area_served
-      n_returns = hvac_distribution.number_of_return_registers
       supply_ducts = hvac_distribution.ducts.select { |duct| duct.duct_type == HPXML::DuctTypeSupply }
       return_ducts = hvac_distribution.ducts.select { |duct| duct.duct_type == HPXML::DuctTypeReturn }
+
+      # Default return registers
+      if hvac_distribution.number_of_return_registers.nil? && (return_ducts.size > 0)
+        hvac_distribution.number_of_return_registers = ncfl.ceil # Add 1 return register per conditioned floor if not provided
+        hvac_distribution.number_of_return_registers_isdefaulted = true
+      end
+
+      cfa_served = hvac_distribution.conditioned_floor_area_served
+      n_returns = hvac_distribution.number_of_return_registers
 
       if hvac_distribution.ducts[0].duct_location.nil?
         # Default both duct location(s) and duct surface area(s)

--- a/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml
@@ -1174,22 +1174,28 @@
       <sch:assert role='ERROR' test='count(h:DuctInsulationRValue) = 1'>Expected 1 element(s) for xpath: DuctInsulationRValue</sch:assert>
       <sch:assert role='ERROR' test='count(h:DuctLocation) &lt;= 1'>Expected 0 or 1 element(s) for xpath: DuctLocation</sch:assert> <!-- See [HVACDuct=WithLocation] or [HVACDuct=WithoutLocation] -->
       <sch:assert role='ERROR' test='h:DuctLocation[text()="living space" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="crawlspace - conditioned" or text()="attic - vented" or text()="attic - unvented" or text()="garage" or text()="exterior wall" or text()="under slab" or text()="roof deck" or text()="outside" or text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"] or not(h:DuctLocation)'>Expected DuctLocation to be 'living space' or 'basement - conditioned' or 'basement - unconditioned' or 'crawlspace - vented' or 'crawlspace - unvented' or 'crawlspace - conditioned' or 'attic - vented' or 'attic - unvented' or 'garage' or 'exterior wall' or 'under slab' or 'roof deck' or 'outside' or 'other housing unit' or 'other heated space' or 'other multifamily buffer space' or 'other non-freezing space'</sch:assert>
-      <sch:assert role='ERROR' test='count(../h:NumberofReturnRegisters) &lt;= 1'>Expected 0 or 1 element(s) for xpath: ../NumberofReturnRegisters</sch:assert>
-      <sch:assert role='ERROR' test='count(../../../h:ConditionedFloorAreaServed) = 1'>Expected 1 element(s) for xpath: ../../../ConditionedFloorAreaServed</sch:assert>
     </sch:rule>
   </sch:pattern>
 
   <sch:pattern>
     <sch:title>[HVACDuct=WithLocation]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:HVAC/h:HVACDistribution/h:DistributionSystemType/h:AirDistribution/h:Ducts[h:DuctLocation]'>
-      <sch:assert role='ERROR' test='count(h:FractionDuctArea) + count(h:DuctSurfaceArea) &gt;= 1'>Expected 1 or more element(s) for xpath: FractionDuctArea | DuctSurfaceArea</sch:assert>
+      <sch:assert role='ERROR' test='count(h:FractionDuctArea) + count(h:DuctSurfaceArea) &gt;= 1'>Expected 1 or more element(s) for xpath: FractionDuctArea | DuctSurfaceArea</sch:assert> <!-- See [HVACDuct=SurfaceAreaDefaulted] -->
     </sch:rule>
   </sch:pattern>
 
   <sch:pattern>
     <sch:title>[HVACDuct=WithoutLocation]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:HVAC/h:HVACDistribution/h:DistributionSystemType/h:AirDistribution/h:Ducts[not(h:DuctLocation)]'>
-      <sch:assert role='ERROR' test='count(h:FractionDuctArea) + count(h:DuctSurfaceArea) = 0'>Expected 0 element(s) for xpath: FractionDuctArea | DuctSurfaceArea</sch:assert>
+      <sch:assert role='ERROR' test='count(h:FractionDuctArea) + count(h:DuctSurfaceArea) = 0'>Expected 0 element(s) for xpath: FractionDuctArea | DuctSurfaceArea</sch:assert> <!-- See [HVACDuct=SurfaceAreaDefaulted] -->
+    </sch:rule>
+  </sch:pattern>
+
+  <sch:pattern>
+    <sch:title>[HVACDuct=SurfaceAreaDefaulted]</sch:title>
+    <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:HVAC/h:HVACDistribution/h:DistributionSystemType/h:AirDistribution/h:Ducts[not(h:DuctSurfaceArea)]'>
+      <sch:assert role='ERROR' test='count(../h:NumberofReturnRegisters) &lt;= 1'>Expected 0 or 1 element(s) for xpath: ../NumberofReturnRegisters</sch:assert>
+      <sch:assert role='ERROR' test='count(../../../h:ConditionedFloorAreaServed) = 1'>Expected 1 element(s) for xpath: ../../../ConditionedFloorAreaServed</sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -1244,6 +1244,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
   def test_hvac_distribution
     # Test inputs not overridden by defaults
     hpxml = _create_hpxml('base.xml')
+    hpxml.hvac_distributions[0].conditioned_floor_area_served = 2700.0
+    hpxml.hvac_distributions[0].number_of_return_registers = 2
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     expected_supply_locations = ['attic - unvented']
@@ -1258,11 +1260,9 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
     # Test defaults w/ conditioned basement
     hpxml.hvac_distributions[0].number_of_return_registers = nil
-    hpxml.hvac_distributions.each do |hvac_distribution|
-      hvac_distribution.ducts.each do |duct|
-        duct.duct_location = nil
-        duct.duct_surface_area = nil
-      end
+    hpxml.hvac_distributions[0].ducts.each do |duct|
+      duct.duct_location = nil
+      duct.duct_surface_area = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
@@ -1278,11 +1278,11 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
     # Test defaults w/ multiple foundations
     hpxml = _create_hpxml('base-foundation-multiple.xml')
-    hpxml.hvac_distributions.each do |hvac_distribution|
-      hvac_distribution.ducts.each do |duct|
-        duct.duct_location = nil
-        duct.duct_surface_area = nil
-      end
+    hpxml.hvac_distributions[0].conditioned_floor_area_served = 1350.0
+    hpxml.hvac_distributions[0].number_of_return_registers = 1
+    hpxml.hvac_distributions[0].ducts.each do |duct|
+      duct.duct_location = nil
+      duct.duct_surface_area = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
@@ -1298,11 +1298,11 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
     # Test defaults w/ foundation exposed to ambient
     hpxml = _create_hpxml('base-foundation-ambient.xml')
-    hpxml.hvac_distributions.each do |hvac_distribution|
-      hvac_distribution.ducts.each do |duct|
-        duct.duct_location = nil
-        duct.duct_surface_area = nil
-      end
+    hpxml.hvac_distributions[0].conditioned_floor_area_served = 1350.0
+    hpxml.hvac_distributions[0].number_of_return_registers = 1
+    hpxml.hvac_distributions[0].ducts.each do |duct|
+      duct.duct_location = nil
+      duct.duct_surface_area = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
@@ -1318,11 +1318,11 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
     # Test defaults w/ building/unit adjacent to other housing unit
     hpxml = _create_hpxml('base-bldgtype-multifamily-adjacent-to-other-housing-unit.xml')
-    hpxml.hvac_distributions.each do |hvac_distribution|
-      hvac_distribution.ducts.each do |duct|
-        duct.duct_location = nil
-        duct.duct_surface_area = nil
-      end
+    hpxml.hvac_distributions[0].conditioned_floor_area_served = 900.0
+    hpxml.hvac_distributions[0].number_of_return_registers = 1
+    hpxml.hvac_distributions[0].ducts.each do |duct|
+      duct.duct_location = nil
+      duct.duct_surface_area = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
@@ -1338,11 +1338,11 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
     # Test defaults w/ 2-story building
     hpxml = _create_hpxml('base-enclosure-2stories.xml')
-    hpxml.hvac_distributions.each do |hvac_distribution|
-      hvac_distribution.ducts.each do |duct|
-        duct.duct_location = nil
-        duct.duct_surface_area = nil
-      end
+    hpxml.hvac_distributions[0].conditioned_floor_area_served = 4050.0
+    hpxml.hvac_distributions[0].number_of_return_registers = 3
+    hpxml.hvac_distributions[0].ducts.each do |duct|
+      duct.duct_location = nil
+      duct.duct_surface_area = nil
     end
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
@@ -1359,6 +1359,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     # Test defaults w/ 1-story building & multiple HVAC systems
     hpxml = _create_hpxml('base-hvac-multiple.xml')
     hpxml.hvac_distributions.each do |hvac_distribution|
+      next unless hvac_distribution.distribution_system_type == HPXML::HVACDistributionTypeAir
+
+      hvac_distribution.conditioned_floor_area_served = 270.0
+      hvac_distribution.number_of_return_registers = 2
       hvac_distribution.ducts.each do |duct|
         duct.duct_location = nil
         duct.duct_surface_area = nil
@@ -1380,6 +1384,10 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml = _create_hpxml('base-hvac-multiple.xml')
     hpxml.building_construction.number_of_conditioned_floors_above_grade = 2
     hpxml.hvac_distributions.each do |hvac_distribution|
+      next unless hvac_distribution.distribution_system_type == HPXML::HVACDistributionTypeAir
+
+      hvac_distribution.conditioned_floor_area_served = 270.0
+      hvac_distribution.number_of_return_registers = 2
       hvac_distribution.ducts.each do |duct|
         duct.duct_location = nil
         duct.duct_surface_area = nil
@@ -1403,6 +1411,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.hvac_distributions.each do |hvac_distribution|
       next unless hvac_distribution.distribution_system_type == HPXML::HVACDistributionTypeAir
 
+      hvac_distribution.conditioned_floor_area_served = 270.0
+      hvac_distribution.number_of_return_registers = 2
       hvac_distribution.ducts[0].duct_fraction_area = 0.75
       hvac_distribution.ducts[1].duct_fraction_area = 0.25
       hvac_distribution.ducts[2].duct_fraction_area = 0.5

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -1530,7 +1530,7 @@ Each separate HVAC distribution system is entered as a ``/HPXML/Building/Buildin
   ==============================  =======  =======  ===========  ========  =========  =============================
 
   .. [#] DistributionSystemType child element choices are ``AirDistribution``, ``HydronicDistribution``, or ``Other=DSE``.
-  .. [#] ConditionedFloorAreaServed required only when DistributionSystemType is AirDistribution and ``AirDistribution/Ducts`` are present.
+  .. [#] ConditionedFloorAreaServed required only when DistributionSystemType is AirDistribution and duct surface area is defaulted (i.e., ``AirDistribution/Ducts`` are present without ``DuctSurfaceArea`` child elements).
 
 .. note::
   
@@ -1559,7 +1559,7 @@ To define an air distribution system, additional information is entered in ``HVA
   .. [#] Supply duct leakage required if AirDistributionType is "regular velocity" or "gravity" and optional if AirDistributionType is "fan coil".
   .. [#] Return duct leakage required if AirDistributionType is "regular velocity" or "gravity" and optional if AirDistributionType is "fan coil".
   .. [#] Provide a Ducts element for each supply duct and each return duct.
-  .. [#] If NumberofReturnRegisters not provided and ``AirDistribution/Ducts`` are present, defaults to one return register per conditioned floor per `ASHRAE Standard 152 <https://www.energy.gov/eere/buildings/downloads/ashrae-standard-152-spreadsheet>`_, rounded up to the nearest integer if needed.
+  .. [#] If NumberofReturnRegisters not provided and return ducts are present, defaults to one return register per conditioned floor per `ASHRAE Standard 152 <https://www.energy.gov/eere/buildings/downloads/ashrae-standard-152-spreadsheet>`_, rounded up to the nearest integer if needed.
 
 Additional information is entered in each ``DuctLeakageMeasurement``.
 
@@ -1592,16 +1592,16 @@ Additional information is entered in each ``Ducts``.
   .. [#] If DuctLocation not provided, defaults to the first present space type: "basement - conditioned", "basement - unconditioned", "crawlspace - conditioned", "crawlspace - vented", "crawlspace - unvented", "attic - vented", "attic - unvented", "garage", or "living space".
          If NumberofConditionedFloorsAboveGrade > 1, secondary ducts will be located in "living space".
   .. [#] The sum of all ``[DuctType="supply"]/FractionDuctArea`` and ``[DuctType="return"]/FractionDuctArea`` must each equal to 1.
-  .. [#] Either FractionDuctArea or DuctSurfaceArea (or both) are required if DuctLocation is provided.
-  .. [#] If DuctSurfaceArea not provided, duct surface areas will be calculated based on FractionDuctArea if provided.
-         If FractionDuctArea also not provided, duct surface areas will be calculated based on `ASHRAE Standard 152 <https://www.energy.gov/eere/buildings/downloads/ashrae-standard-152-spreadsheet>`_:
+  .. [#] FractionDuctArea and/or DuctSurfaceArea are required if DuctLocation is provided.
+  .. [#] If neither DuctSurfaceArea nor FractionDuctArea provided, duct surface areas will be calculated based on `ASHRAE Standard 152 <https://www.energy.gov/eere/buildings/downloads/ashrae-standard-152-spreadsheet>`_:
 
-         - **Primary supply ducts**: 0.27 * F_out * ConditionedFloorAreaServed
-         - **Secondary supply ducts**: 0.27 * (1 - F_out) * ConditionedFloorAreaServed
-         - **Primary return ducts**: b_r * F_out * ConditionedFloorAreaServed
-         - **Secondary return ducts**: b_r * (1 - F_out) * ConditionedFloorAreaServed
+         - **Primary supply duct area**: 0.27 * F_out * ConditionedFloorAreaServed
+         - **Secondary supply duct area**: 0.27 * (1 - F_out) * ConditionedFloorAreaServed
+         - **Primary return duct area**: b_r * F_out * ConditionedFloorAreaServed
+         - **Secondary return duct area**: b_r * (1 - F_out) * ConditionedFloorAreaServed
 
          where F_out is 1.0 when NumberofConditionedFloorsAboveGrade <= 1 and 0.75 when NumberofConditionedFloorsAboveGrade > 1, and b_r is 0.05 * NumberofReturnRegisters with a maximum value of 0.25.
+         If FractionDuctArea is provided, each duct surface area will be FractionDuctArea times total duct area, which is calculated using the sum of primary and secondary duct areas from the equations above.
 
 Hydronic Distribution
 ~~~~~~~~~~~~~~~~~~~~~

--- a/tasks.rb
+++ b/tasks.rb
@@ -633,7 +633,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['ducts_return_location'] = HPXML::LocationAtticUnvented
     args['ducts_supply_surface_area'] = 150.0
     args['ducts_return_surface_area'] = 50.0
-    args['ducts_number_of_return_registers'] = 2
     args['heating_system_2_type'] = 'none'
     args['heating_system_2_fuel'] = HPXML::FuelTypeElectricity
     args['heating_system_2_heating_efficiency'] = 1.0
@@ -957,7 +956,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['ducts_return_location'] = HPXML::LocationLivingSpace
     args['ducts_supply_surface_area'] = 0
     args['ducts_return_surface_area'] = 0
-    args['ducts_number_of_return_registers'] = 0
     args['heating_system_2_type'] = 'none'
     args['heating_system_2_fuel'] = HPXML::FuelTypeElectricity
     args['heating_system_2_heating_efficiency'] = 0
@@ -1291,7 +1289,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['ducts_return_location'] = HPXML::LocationLivingSpace
     args['ducts_supply_leakage_to_outside_value'] = 50
     args['ducts_return_leakage_to_outside_value'] = 100
-    args['ducts_number_of_return_registers'] = 3
     args['water_heater_location'] = HPXML::LocationBasementConditioned
     args['clothes_washer_location'] = HPXML::LocationBasementConditioned
     args['clothes_dryer_location'] = HPXML::LocationBasementConditioned
@@ -1338,7 +1335,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['cooling_system_cooling_capacity'] = 36000.0
     args['ducts_supply_surface_area'] = 112.5
     args['ducts_return_surface_area'] = 37.5
-    args['ducts_number_of_return_registers'] = 3
     args['misc_plug_loads_other_annual_kwh'] = 2457.0
   end
 
@@ -1365,7 +1361,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['ducts_supply_location'] = HPXML::LocationLivingSpace
     args['ducts_return_location'] = HPXML::LocationLivingSpace
     args['ducts_supply_insulation_r'] = 0.0
-    args['ducts_number_of_return_registers'] = 1
     args['door_area'] = 20.0
     args['misc_plug_loads_other_annual_kwh'] = 819.0
   elsif ['base-bldgtype-multifamily-shared-boiler-only-baseboard.xml',
@@ -1563,7 +1558,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['cooling_system_cooling_capacity'] = 36000.0
     args['ducts_supply_surface_area'] = 112.5
     args['ducts_return_surface_area'] = 37.5
-    args['ducts_number_of_return_registers'] = 3
     args['misc_plug_loads_other_annual_kwh'] = 3685.5
   elsif ['base-enclosure-2stories-garage.xml'].include? hpxml_file
     args['geometry_unit_cfa'] = 3250.0
@@ -1631,8 +1625,6 @@ def set_measure_argument_values(hpxml_file, args)
   elsif ['base-enclosure-skylights.xml'].include? hpxml_file
     args['skylight_area_front'] = 15
     args['skylight_area_back'] = 15
-  elsif ['base-enclosure-split-level.xml'].include? hpxml_file
-    args['ducts_number_of_return_registers'] = 2
   end
 
   # Foundation
@@ -1642,7 +1634,6 @@ def set_measure_argument_values(hpxml_file, args)
     args.delete('geometry_rim_joist_height')
     args['floor_over_foundation_assembly_r'] = 18.7
     args.delete('rim_joist_assembly_r')
-    args['ducts_number_of_return_registers'] = 1
     args['misc_plug_loads_other_annual_kwh'] = 1228.5
   elsif ['base-foundation-conditioned-basement-slab-insulation.xml'].include? hpxml_file
     args['slab_under_insulation_r'] = 10
@@ -1663,7 +1654,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['slab_carpet_r'] = 2.5
     args['ducts_supply_location'] = HPXML::LocationUnderSlab
     args['ducts_return_location'] = HPXML::LocationUnderSlab
-    args['ducts_number_of_return_registers'] = 1
     args['misc_plug_loads_other_annual_kwh'] = 1228.5
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     args['geometry_unit_cfa'] = 1350.0
@@ -1674,7 +1664,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['rim_joist_assembly_r'] = 4.0
     args['ducts_supply_location'] = HPXML::LocationBasementUnconditioned
     args['ducts_return_location'] = HPXML::LocationBasementUnconditioned
-    args['ducts_number_of_return_registers'] = 1
     args['water_heater_location'] = HPXML::LocationBasementUnconditioned
     args['clothes_washer_location'] = HPXML::LocationBasementUnconditioned
     args['clothes_dryer_location'] = HPXML::LocationBasementUnconditioned
@@ -1702,7 +1691,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['foundation_wall_insulation_distance_to_bottom'] = 4.0
     args['ducts_supply_location'] = HPXML::LocationCrawlspaceUnvented
     args['ducts_return_location'] = HPXML::LocationCrawlspaceUnvented
-    args['ducts_number_of_return_registers'] = 1
     args['water_heater_location'] = HPXML::LocationCrawlspaceUnvented
     args['misc_plug_loads_other_annual_kwh'] = 1228.5
   elsif ['base-foundation-vented-crawlspace.xml'].include? hpxml_file
@@ -1714,7 +1702,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['foundation_wall_insulation_distance_to_bottom'] = 4.0
     args['ducts_supply_location'] = HPXML::LocationCrawlspaceVented
     args['ducts_return_location'] = HPXML::LocationCrawlspaceVented
-    args['ducts_number_of_return_registers'] = 1
     args['water_heater_location'] = HPXML::LocationCrawlspaceVented
     args['misc_plug_loads_other_annual_kwh'] = 1228.5
   elsif ['base-foundation-conditioned-crawlspace.xml'].include? hpxml_file
@@ -1727,7 +1714,6 @@ def set_measure_argument_values(hpxml_file, args)
     args['ducts_return_location'] = HPXML::LocationCrawlspaceConditioned
     args['ducts_supply_leakage_to_outside_value'] = 0.0
     args['ducts_return_leakage_to_outside_value'] = 0.0
-    args['ducts_number_of_return_registers'] = 1
     args['water_heater_location'] = HPXML::LocationCrawlspaceConditioned
     args['misc_plug_loads_other_annual_kwh'] = 1228.5
   elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
@@ -2185,6 +2171,7 @@ def set_measure_argument_values(hpxml_file, args)
     args['ducts_return_location'] = Constants.Auto
     args['ducts_supply_surface_area'] = Constants.Auto
     args['ducts_return_surface_area'] = Constants.Auto
+    args['ducts_number_of_return_registers'] = 2
     args['kitchen_fans_quantity'] = Constants.Auto
     args['bathroom_fans_quantity'] = Constants.Auto
     args['water_heater_location'] = Constants.Auto
@@ -2558,7 +2545,6 @@ def apply_hpxml_modification(hpxml_file, hpxml)
     hpxml.building_construction.conditioned_floor_area -= 400 * 2
     hpxml.building_construction.conditioned_building_volume -= 400 * 2 * 8
     hpxml.air_infiltration_measurements[0].infiltration_volume = hpxml.building_construction.conditioned_building_volume
-    hpxml.hvac_distributions[0].conditioned_floor_area_served = hpxml.building_construction.conditioned_floor_area
   end
 
   # --------------- #
@@ -3661,8 +3647,6 @@ def apply_hpxml_modification(hpxml_file, hpxml)
                                              duct_insulation_r_value: 0,
                                              duct_location: HPXML::LocationOtherMultifamilyBufferSpace,
                                              duct_surface_area: 20)
-      hpxml.hvac_distributions[-1].number_of_return_registers = 1
-      hpxml.hvac_distributions[-1].conditioned_floor_area_served = 900
     end
   end
   if hpxml_file.include? 'shared-ground-loop'
@@ -3726,8 +3710,6 @@ def apply_hpxml_modification(hpxml_file, hpxml)
     hpxml.hvac_controls[0].cooling_setup_temp = 80
     hpxml.hvac_controls[0].cooling_setup_hours_per_week = 6 * 7
     hpxml.hvac_controls[0].cooling_setup_start_hour = 9 # 9am
-  elsif ['base-atticroof-cathedral.xml'].include? hpxml_file
-    hpxml.hvac_distributions[0].conditioned_floor_area_served = 2700
   elsif ['base-hvac-dse.xml',
          'base-dhw-indirect-dse.xml',
          'base-mechvent-cfis-dse.xml'].include? hpxml_file
@@ -3787,6 +3769,8 @@ def apply_hpxml_modification(hpxml_file, hpxml)
       hpxml.hvac_distributions[0].ducts[1].duct_fraction_area = 0.75
       hpxml.hvac_distributions[0].ducts[2].duct_fraction_area = 0.25
       hpxml.hvac_distributions[0].ducts[3].duct_fraction_area = 0.25
+      hpxml.hvac_distributions[0].conditioned_floor_area_served = 4050.0
+      hpxml.hvac_distributions[0].number_of_return_registers = 3
     end
   elsif ['base-hvac-multiple.xml'].include? hpxml_file
     hpxml.hvac_distributions.reverse_each do |hvac_distribution|
@@ -3794,9 +3778,7 @@ def apply_hpxml_modification(hpxml_file, hpxml)
     end
     hpxml.hvac_distributions.add(id: "HVACDistribution#{hpxml.hvac_distributions.size + 1}",
                                  distribution_system_type: HPXML::HVACDistributionTypeAir,
-                                 air_type: HPXML::AirTypeRegularVelocity,
-                                 number_of_return_registers: 2,
-                                 conditioned_floor_area_served: 270)
+                                 air_type: HPXML::AirTypeRegularVelocity)
     hpxml.hvac_distributions[-1].duct_leakage_measurements.add(duct_type: HPXML::DuctTypeSupply,
                                                                duct_leakage_units: HPXML::UnitsCFM25,
                                                                duct_leakage_value: 75,
@@ -3955,7 +3937,6 @@ def apply_hpxml_modification(hpxml_file, hpxml)
                          primary_heating_system: true)
   elsif ['base-mechvent-multiple.xml',
          'base-bldgtype-multifamily-shared-mechvent-multiple.xml'].include? hpxml_file
-    hpxml.hvac_distributions[0].conditioned_floor_area_served /= 2.0
     hpxml.hvac_distributions << hpxml.hvac_distributions[0].dup
     hpxml.hvac_distributions[1].id = "HVACDistribution#{hpxml.hvac_distributions.size}"
     hpxml.heating_systems[0].heating_capacity /= 2.0

--- a/workflow/sample_files/base-appliances-coal.xml
+++ b/workflow/sample_files/base-appliances-coal.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-dehumidifier-ief-portable.xml
+++ b/workflow/sample_files/base-appliances-dehumidifier-ief-portable.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-dehumidifier-ief-whole-home.xml
+++ b/workflow/sample_files/base-appliances-dehumidifier-ief-whole-home.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-dehumidifier-multiple.xml
+++ b/workflow/sample_files/base-appliances-dehumidifier-multiple.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-dehumidifier.xml
+++ b/workflow/sample_files/base-appliances-dehumidifier.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-gas.xml
+++ b/workflow/sample_files/base-appliances-gas.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-modified.xml
+++ b/workflow/sample_files/base-appliances-modified.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-none.xml
+++ b/workflow/sample_files/base-appliances-none.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-oil.xml
+++ b/workflow/sample_files/base-appliances-oil.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-propane.xml
+++ b/workflow/sample_files/base-appliances-propane.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-appliances-wood.xml
+++ b/workflow/sample_files/base-appliances-wood.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-atticroof-cathedral.xml
+++ b/workflow/sample_files/base-atticroof-cathedral.xml
@@ -347,10 +347,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-atticroof-conditioned.xml
+++ b/workflow/sample_files/base-atticroof-conditioned.xml
@@ -460,10 +460,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>3</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>3600.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-atticroof-flat.xml
+++ b/workflow/sample_files/base-atticroof-flat.xml
@@ -347,10 +347,8 @@
                   <DuctLocation>basement - conditioned</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-atticroof-radiant-barrier.xml
+++ b/workflow/sample_files/base-atticroof-radiant-barrier.xml
@@ -338,10 +338,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-atticroof-unvented-insulated-roof.xml
+++ b/workflow/sample_files/base-atticroof-unvented-insulated-roof.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-atticroof-vented.xml
+++ b/workflow/sample_files/base-atticroof-vented.xml
@@ -385,10 +385,8 @@
                   <DuctLocation>attic - vented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-battery-outside.xml
+++ b/workflow/sample_files/base-battery-outside.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-multifamily-buffer-space.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-multifamily-buffer-space.xml
@@ -296,10 +296,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-multiple.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-multiple.xml
@@ -404,10 +404,8 @@
                   <DuctLocation>roof deck</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-non-freezing-space.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-non-freezing-space.xml
@@ -296,10 +296,8 @@
                   <DuctLocation>other non-freezing space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-other-heated-space.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-other-heated-space.xml
@@ -296,10 +296,8 @@
                   <DuctLocation>other heated space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-other-housing-unit.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-other-housing-unit.xml
@@ -296,10 +296,8 @@
                   <DuctLocation>other housing unit</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-fan-coil-ducted.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-fan-coil-ducted.xml
@@ -298,10 +298,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>20.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-water-loop-heat-pump.xml
@@ -320,10 +320,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>20.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-cooling-tower-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-cooling-tower-water-loop-heat-pump.xml
@@ -315,10 +315,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>20.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-fan-coil-ducted.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-fan-coil-ducted.xml
@@ -278,10 +278,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>20.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-water-loop-heat-pump.xml
@@ -296,10 +296,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>20.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-fan-coil-ducted.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-fan-coil-ducted.xml
@@ -278,10 +278,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>20.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-water-loop-heat-pump.xml
@@ -296,10 +296,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>20.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-cooling-tower-only-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-cooling-tower-only-water-loop-heat-pump.xml
@@ -291,10 +291,8 @@
                   <DuctLocation>other multifamily buffer space</DuctLocation>
                   <DuctSurfaceArea>20.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-generator.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-generator.xml
@@ -289,10 +289,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-ground-loop-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-ground-loop-ground-to-air-heat-pump.xml
@@ -293,10 +293,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-laundry-room.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-laundry-room.xml
@@ -289,10 +289,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent-multiple.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent-multiple.xml
@@ -317,10 +317,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>450.0</ConditionedFloorAreaServed>
           </HVACDistribution>
           <HVACDistribution>
             <SystemIdentifier id='HVACDistribution2'/>
@@ -355,10 +353,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>450.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent-preconditioning.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent-preconditioning.xml
@@ -289,10 +289,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent.xml
@@ -289,10 +289,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-pv.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-pv.xml
@@ -289,10 +289,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-water-heater-recirc.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-water-heater-recirc.xml
@@ -289,10 +289,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-water-heater.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-water-heater.xml
@@ -289,10 +289,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-multifamily.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily.xml
@@ -289,10 +289,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-single-family-attached-2stories.xml
+++ b/workflow/sample_files/base-bldgtype-single-family-attached-2stories.xml
@@ -439,10 +439,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>37.5</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>3</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-bldgtype-single-family-attached.xml
+++ b/workflow/sample_files/base-bldgtype-single-family-attached.xml
@@ -439,10 +439,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1800.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-desuperheater-2-speed.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-2-speed.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-desuperheater-gshp.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-gshp.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-desuperheater-hpwh.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-hpwh.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-desuperheater-tankless.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-tankless.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-desuperheater-var-speed.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-var-speed.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-desuperheater.xml
+++ b/workflow/sample_files/base-dhw-desuperheater.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-dwhr.xml
+++ b/workflow/sample_files/base-dhw-dwhr.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-jacket-electric.xml
+++ b/workflow/sample_files/base-dhw-jacket-electric.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-jacket-gas.xml
+++ b/workflow/sample_files/base-dhw-jacket-gas.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-jacket-hpwh.xml
+++ b/workflow/sample_files/base-dhw-jacket-hpwh.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-low-flow-fixtures.xml
+++ b/workflow/sample_files/base-dhw-low-flow-fixtures.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-none.xml
+++ b/workflow/sample_files/base-dhw-none.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
       </Systems>

--- a/workflow/sample_files/base-dhw-recirc-demand.xml
+++ b/workflow/sample_files/base-dhw-recirc-demand.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-recirc-manual.xml
+++ b/workflow/sample_files/base-dhw-recirc-manual.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-recirc-nocontrol.xml
+++ b/workflow/sample_files/base-dhw-recirc-nocontrol.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-recirc-temperature.xml
+++ b/workflow/sample_files/base-dhw-recirc-temperature.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-recirc-timer.xml
+++ b/workflow/sample_files/base-dhw-recirc-timer.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-solar-direct-evacuated-tube.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-evacuated-tube.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-solar-direct-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-flat-plate.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-solar-direct-ics.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-ics.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-solar-fraction.xml
+++ b/workflow/sample_files/base-dhw-solar-fraction.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-solar-indirect-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-indirect-flat-plate.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-solar-thermosyphon-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-thermosyphon-flat-plate.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-coal.xml
+++ b/workflow/sample_files/base-dhw-tank-coal.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-elec-uef.xml
+++ b/workflow/sample_files/base-dhw-tank-elec-uef.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-gas-outside.xml
+++ b/workflow/sample_files/base-dhw-tank-gas-outside.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-gas-uef-fhr.xml
+++ b/workflow/sample_files/base-dhw-tank-gas-uef-fhr.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-gas-uef.xml
+++ b/workflow/sample_files/base-dhw-tank-gas-uef.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-gas.xml
+++ b/workflow/sample_files/base-dhw-tank-gas.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-heat-pump-outside.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump-outside.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-heat-pump-uef.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump-uef.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-heat-pump-with-solar-fraction.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump-with-solar-fraction.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-heat-pump-with-solar.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump-with-solar.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-heat-pump.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-oil.xml
+++ b/workflow/sample_files/base-dhw-tank-oil.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tank-wood.xml
+++ b/workflow/sample_files/base-dhw-tank-wood.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tankless-electric-outside.xml
+++ b/workflow/sample_files/base-dhw-tankless-electric-outside.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tankless-electric-uef.xml
+++ b/workflow/sample_files/base-dhw-tankless-electric-uef.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tankless-electric.xml
+++ b/workflow/sample_files/base-dhw-tankless-electric.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tankless-gas-uef.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas-uef.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tankless-gas-with-solar-fraction.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas-with-solar-fraction.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tankless-gas-with-solar.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas-with-solar.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tankless-gas.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-dhw-tankless-propane.xml
+++ b/workflow/sample_files/base-dhw-tankless-propane.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-2stories-garage.xml
+++ b/workflow/sample_files/base-enclosure-2stories-garage.xml
@@ -484,10 +484,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>12.5</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>3</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>3250.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-2stories.xml
+++ b/workflow/sample_files/base-enclosure-2stories.xml
@@ -407,10 +407,8 @@
                   <DuctLocation>living space</DuctLocation>
                   <DuctSurfaceArea>12.5</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>3</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>4050.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-beds-1.xml
+++ b/workflow/sample_files/base-enclosure-beds-1.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-beds-2.xml
+++ b/workflow/sample_files/base-enclosure-beds-2.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-beds-4.xml
+++ b/workflow/sample_files/base-enclosure-beds-4.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-beds-5.xml
+++ b/workflow/sample_files/base-enclosure-beds-5.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-garage.xml
+++ b/workflow/sample_files/base-enclosure-garage.xml
@@ -460,10 +460,8 @@
                   <DuctLocation>garage</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-infil-ach-house-pressure.xml
+++ b/workflow/sample_files/base-enclosure-infil-ach-house-pressure.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-infil-cfm-house-pressure.xml
+++ b/workflow/sample_files/base-enclosure-infil-cfm-house-pressure.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-infil-cfm50.xml
+++ b/workflow/sample_files/base-enclosure-infil-cfm50.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-infil-flue.xml
+++ b/workflow/sample_files/base-enclosure-infil-flue.xml
@@ -385,10 +385,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-infil-natural-ach.xml
+++ b/workflow/sample_files/base-enclosure-infil-natural-ach.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-orientations.xml
+++ b/workflow/sample_files/base-enclosure-orientations.xml
@@ -389,10 +389,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-overhangs.xml
+++ b/workflow/sample_files/base-enclosure-overhangs.xml
@@ -402,10 +402,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-rooftypes.xml
+++ b/workflow/sample_files/base-enclosure-rooftypes.xml
@@ -519,10 +519,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-skylights-physical-properties.xml
+++ b/workflow/sample_files/base-enclosure-skylights-physical-properties.xml
@@ -419,10 +419,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-skylights-shading.xml
+++ b/workflow/sample_files/base-enclosure-skylights-shading.xml
@@ -420,10 +420,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-skylights.xml
+++ b/workflow/sample_files/base-enclosure-skylights.xml
@@ -410,10 +410,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-split-level.xml
+++ b/workflow/sample_files/base-enclosure-split-level.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-split-surfaces.xml
+++ b/workflow/sample_files/base-enclosure-split-surfaces.xml
@@ -2271,10 +2271,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-split-surfaces2.xml
+++ b/workflow/sample_files/base-enclosure-split-surfaces2.xml
@@ -2271,10 +2271,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-thermal-mass.xml
+++ b/workflow/sample_files/base-enclosure-thermal-mass.xml
@@ -395,10 +395,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-walltypes.xml
+++ b/workflow/sample_files/base-enclosure-walltypes.xml
@@ -695,10 +695,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-windows-none.xml
+++ b/workflow/sample_files/base-enclosure-windows-none.xml
@@ -324,10 +324,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-windows-physical-properties.xml
+++ b/workflow/sample_files/base-enclosure-windows-physical-properties.xml
@@ -394,10 +394,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-enclosure-windows-shading.xml
+++ b/workflow/sample_files/base-enclosure-windows-shading.xml
@@ -397,10 +397,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-ambient.xml
+++ b/workflow/sample_files/base-foundation-ambient.xml
@@ -319,10 +319,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-basement-garage.xml
+++ b/workflow/sample_files/base-foundation-basement-garage.xml
@@ -467,10 +467,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1900.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-complex.xml
+++ b/workflow/sample_files/base-foundation-complex.xml
@@ -482,10 +482,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-conditioned-basement-slab-insulation.xml
+++ b/workflow/sample_files/base-foundation-conditioned-basement-slab-insulation.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-conditioned-basement-wall-interior-insulation.xml
+++ b/workflow/sample_files/base-foundation-conditioned-basement-wall-interior-insulation.xml
@@ -385,10 +385,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-conditioned-crawlspace.xml
+++ b/workflow/sample_files/base-foundation-conditioned-crawlspace.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>crawlspace - conditioned</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-multiple.xml
+++ b/workflow/sample_files/base-foundation-multiple.xml
@@ -487,10 +487,8 @@
                   <DuctLocation>basement - unconditioned</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-slab.xml
+++ b/workflow/sample_files/base-foundation-slab.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-above-grade.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-above-grade.xml
@@ -427,10 +427,8 @@
                   <DuctLocation>basement - unconditioned</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-assembly-r.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-assembly-r.xml
@@ -186,7 +186,7 @@
             </InteriorFinish>
             <Insulation>
               <SystemIdentifier id='FoundationWall1Insulation'/>
-              <AssemblyEffectiveRValue>10.6899995803833</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>10.69</AssemblyEffectiveRValue>
             </Insulation>
           </FoundationWall>
         </FoundationWalls>
@@ -384,10 +384,8 @@
                   <DuctLocation>basement - unconditioned</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-wall-insulation.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-wall-insulation.xml
@@ -393,10 +393,8 @@
                   <DuctLocation>basement - unconditioned</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-unconditioned-basement.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement.xml
@@ -392,10 +392,8 @@
                   <DuctLocation>basement - unconditioned</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-unvented-crawlspace.xml
+++ b/workflow/sample_files/base-foundation-unvented-crawlspace.xml
@@ -394,10 +394,8 @@
                   <DuctLocation>crawlspace - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-vented-crawlspace.xml
+++ b/workflow/sample_files/base-foundation-vented-crawlspace.xml
@@ -397,10 +397,8 @@
                   <DuctLocation>crawlspace - vented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-foundation-walkout-basement.xml
+++ b/workflow/sample_files/base-foundation-walkout-basement.xml
@@ -443,10 +443,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed-cooling-only.xml
@@ -373,10 +373,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed-heating-only.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed-heating-only.xml
@@ -380,10 +380,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-2-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-2-speed.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-boiler-switchover-temperature.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-boiler-switchover-temperature.xml
@@ -400,10 +400,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-boiler.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-boiler.xml
@@ -399,10 +399,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-cooling-only.xml
@@ -373,10 +373,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-heating-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-heating-only.xml
@@ -379,10 +379,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-manual-s-oversize-allowances.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-manual-s-oversize-allowances.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed-manual-s-oversize-allowances.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed-manual-s-oversize-allowances.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-backup-boiler.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-backup-boiler.xml
@@ -398,10 +398,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-manual-s-oversize-allowances.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-manual-s-oversize-allowances.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-boiler-gas-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-boiler-gas-central-ac-1-speed.xml
@@ -389,10 +389,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-central-ac-only-1-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-central-ac-only-1-speed.xml
@@ -365,10 +365,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-central-ac-only-2-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-central-ac-only-2-speed.xml
@@ -365,10 +365,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-central-ac-only-var-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-central-ac-only-var-speed.xml
@@ -365,10 +365,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-central-ac-plus-air-to-air-heat-pump-heating.xml
+++ b/workflow/sample_files/base-hvac-autosize-central-ac-plus-air-to-air-heat-pump-heating.xml
@@ -394,10 +394,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-dual-fuel-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-dual-fuel-air-to-air-heat-pump-1-speed.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-dual-fuel-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-autosize-dual-fuel-mini-split-heat-pump-ducted.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-evap-cooler-furnace-gas.xml
+++ b/workflow/sample_files/base-hvac-autosize-evap-cooler-furnace-gas.xml
@@ -373,10 +373,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-furnace-elec-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-elec-only.xml
@@ -365,10 +365,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-furnace-gas-central-ac-2-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-gas-central-ac-2-speed.xml
@@ -380,10 +380,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-furnace-gas-central-ac-var-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-gas-central-ac-var-speed.xml
@@ -380,10 +380,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-furnace-gas-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-gas-only.xml
@@ -365,10 +365,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-furnace-gas-room-ac.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-gas-room-ac.xml
@@ -378,10 +378,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-cooling-only.xml
@@ -375,10 +375,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-heating-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-heating-only.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-manual-s-oversize-allowances.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-manual-s-oversize-allowances.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-air-conditioner-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-air-conditioner-only-ducted.xml
@@ -364,10 +364,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-cooling-only.xml
@@ -372,10 +372,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-heating-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-heating-only.xml
@@ -378,10 +378,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-manual-s-oversize-allowances.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-manual-s-oversize-allowances.xml
@@ -380,10 +380,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted.xml
@@ -380,10 +380,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-autosize.xml
+++ b/workflow/sample_files/base-hvac-autosize.xml
@@ -380,10 +380,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-boiler-gas-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-boiler-gas-central-ac-1-speed.xml
@@ -391,10 +391,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-central-ac-only-1-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-1-speed.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-central-ac-only-2-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-2-speed.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-central-ac-only-var-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-var-speed.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
+++ b/workflow/sample_files/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
@@ -396,10 +396,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-ducts-leakage-cfm50.xml
+++ b/workflow/sample_files/base-hvac-ducts-leakage-cfm50.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-ducts-leakage-percent.xml
+++ b/workflow/sample_files/base-hvac-ducts-leakage-percent.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-evap-cooler-furnace-gas.xml
+++ b/workflow/sample_files/base-hvac-evap-cooler-furnace-gas.xml
@@ -375,10 +375,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-evap-cooler-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-evap-cooler-only-ducted.xml
@@ -357,7 +357,6 @@
                 <NumberofReturnRegisters>0</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-coal-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-coal-only.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-elec-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-elec-central-ac-1-speed.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-elec-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-elec-only.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-gas-central-ac-2-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-central-ac-2-speed.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-gas-central-ac-var-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-central-ac-var-speed.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-gas-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-only.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-gas-room-ac.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-room-ac.xml
@@ -380,10 +380,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-oil-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-oil-only.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-propane-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-propane-only.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-furnace-wood-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-wood-only.xml
@@ -366,10 +366,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump-cooling-only.xml
@@ -374,10 +374,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump-heating-only.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump-heating-only.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-1-speed.xml
@@ -387,10 +387,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-2-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-2-speed.xml
@@ -387,10 +387,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-var-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-var-speed.xml
@@ -387,10 +387,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-1-speed.xml
@@ -391,10 +391,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-2-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-2-speed.xml
@@ -391,10 +391,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-var-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-var-speed.xml
@@ -391,10 +391,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-furnace-gas-only.xml
+++ b/workflow/sample_files/base-hvac-install-quality-furnace-gas-only.xml
@@ -370,10 +370,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-hvac-install-quality-ground-to-air-heat-pump.xml
@@ -386,10 +386,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-mini-split-air-conditioner-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-install-quality-mini-split-air-conditioner-only-ducted.xml
@@ -370,10 +370,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-install-quality-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-install-quality-mini-split-heat-pump-ducted.xml
@@ -386,10 +386,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-mini-split-air-conditioner-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-mini-split-air-conditioner-only-ducted.xml
@@ -365,10 +365,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-cooling-only.xml
@@ -372,10 +372,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-heating-only.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-heating-only.xml
@@ -379,10 +379,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted.xml
@@ -381,10 +381,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>10.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-multiple.xml
+++ b/workflow/sample_files/base-hvac-multiple.xml
@@ -589,10 +589,8 @@
                   <DuctLocation>outside</DuctLocation>
                   <DuctSurfaceArea>25.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>270.0</ConditionedFloorAreaServed>
           </HVACDistribution>
           <HVACDistribution>
             <SystemIdentifier id='HVACDistribution2'/>
@@ -639,10 +637,8 @@
                   <DuctLocation>outside</DuctLocation>
                   <DuctSurfaceArea>25.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>270.0</ConditionedFloorAreaServed>
           </HVACDistribution>
           <HVACDistribution>
             <SystemIdentifier id='HVACDistribution3'/>
@@ -705,10 +701,8 @@
                   <DuctLocation>outside</DuctLocation>
                   <DuctSurfaceArea>25.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>270.0</ConditionedFloorAreaServed>
           </HVACDistribution>
           <HVACDistribution>
             <SystemIdentifier id='HVACDistribution6'/>
@@ -755,10 +749,8 @@
                   <DuctLocation>outside</DuctLocation>
                   <DuctSurfaceArea>25.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>270.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-seasons.xml
+++ b/workflow/sample_files/base-hvac-seasons.xml
@@ -394,10 +394,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-setpoints-daily-schedules.xml
+++ b/workflow/sample_files/base-hvac-setpoints-daily-schedules.xml
@@ -386,10 +386,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-setpoints-daily-setbacks.xml
+++ b/workflow/sample_files/base-hvac-setpoints-daily-setbacks.xml
@@ -390,10 +390,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-setpoints.xml
+++ b/workflow/sample_files/base-hvac-setpoints.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-undersized-allow-increased-fixed-capacities.xml
+++ b/workflow/sample_files/base-hvac-undersized-allow-increased-fixed-capacities.xml
@@ -385,10 +385,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-hvac-undersized.xml
+++ b/workflow/sample_files/base-hvac-undersized.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-lighting-ceiling-fans.xml
+++ b/workflow/sample_files/base-lighting-ceiling-fans.xml
@@ -385,10 +385,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-lighting-holiday.xml
+++ b/workflow/sample_files/base-lighting-holiday.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-lighting-none.xml
+++ b/workflow/sample_files/base-lighting-none.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-AMY-2012.xml
+++ b/workflow/sample_files/base-location-AMY-2012.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-baltimore-md.xml
+++ b/workflow/sample_files/base-location-baltimore-md.xml
@@ -394,10 +394,8 @@
                   <DuctLocation>crawlspace - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-capetown-zaf.xml
+++ b/workflow/sample_files/base-location-capetown-zaf.xml
@@ -391,10 +391,8 @@
                   <DuctLocation>crawlspace - vented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-dallas-tx.xml
+++ b/workflow/sample_files/base-location-dallas-tx.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-duluth-mn.xml
+++ b/workflow/sample_files/base-location-duluth-mn.xml
@@ -391,10 +391,8 @@
                   <DuctLocation>basement - unconditioned</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-helena-mt.xml
+++ b/workflow/sample_files/base-location-helena-mt.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-honolulu-hi.xml
+++ b/workflow/sample_files/base-location-honolulu-hi.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-miami-fl.xml
+++ b/workflow/sample_files/base-location-miami-fl.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-phoenix-az.xml
+++ b/workflow/sample_files/base-location-phoenix-az.xml
@@ -337,10 +337,8 @@
                   <DuctLocation>under slab</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-location-portland-or.xml
+++ b/workflow/sample_files/base-location-portland-or.xml
@@ -397,10 +397,8 @@
                   <DuctLocation>crawlspace - vented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>1</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-mechvent-balanced.xml
+++ b/workflow/sample_files/base-mechvent-balanced.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-bath-kitchen-fans.xml
+++ b/workflow/sample_files/base-mechvent-bath-kitchen-fans.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-cfis-evap-cooler-only-ducted.xml
+++ b/workflow/sample_files/base-mechvent-cfis-evap-cooler-only-ducted.xml
@@ -357,7 +357,6 @@
                 <NumberofReturnRegisters>0</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-cfis.xml
+++ b/workflow/sample_files/base-mechvent-cfis.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-erv-atre-asre.xml
+++ b/workflow/sample_files/base-mechvent-erv-atre-asre.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-erv.xml
+++ b/workflow/sample_files/base-mechvent-erv.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-exhaust-rated-flow-rate.xml
+++ b/workflow/sample_files/base-mechvent-exhaust-rated-flow-rate.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-exhaust.xml
+++ b/workflow/sample_files/base-mechvent-exhaust.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-hrv-asre.xml
+++ b/workflow/sample_files/base-mechvent-hrv-asre.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-hrv.xml
+++ b/workflow/sample_files/base-mechvent-hrv.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-multiple.xml
+++ b/workflow/sample_files/base-mechvent-multiple.xml
@@ -410,10 +410,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
           <HVACDistribution>
             <SystemIdentifier id='HVACDistribution2'/>
@@ -448,10 +446,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>1350.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-supply.xml
+++ b/workflow/sample_files/base-mechvent-supply.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-mechvent-whole-house-fan.xml
+++ b/workflow/sample_files/base-mechvent-whole-house-fan.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <MechanicalVentilation>

--- a/workflow/sample_files/base-misc-generators.xml
+++ b/workflow/sample_files/base-misc-generators.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-misc-loads-large-uncommon.xml
+++ b/workflow/sample_files/base-misc-loads-large-uncommon.xml
@@ -387,10 +387,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-misc-loads-large-uncommon2.xml
+++ b/workflow/sample_files/base-misc-loads-large-uncommon2.xml
@@ -387,10 +387,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-misc-loads-none.xml
+++ b/workflow/sample_files/base-misc-loads-none.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-misc-neighbor-shading.xml
+++ b/workflow/sample_files/base-misc-neighbor-shading.xml
@@ -395,10 +395,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-misc-shielding-of-home.xml
+++ b/workflow/sample_files/base-misc-shielding-of-home.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-misc-usage-multiplier.xml
+++ b/workflow/sample_files/base-misc-usage-multiplier.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-multiple-buildings.xml
+++ b/workflow/sample_files/base-multiple-buildings.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>
@@ -937,10 +935,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>
@@ -1492,10 +1488,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-pv-battery-ah.xml
+++ b/workflow/sample_files/base-pv-battery-ah.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-pv-battery-garage.xml
+++ b/workflow/sample_files/base-pv-battery-garage.xml
@@ -453,10 +453,8 @@
                   <DuctLocation>garage</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-pv-battery-outside-degrades.xml
+++ b/workflow/sample_files/base-pv-battery-outside-degrades.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-pv-battery-outside.xml
+++ b/workflow/sample_files/base-pv-battery-outside.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-pv.xml
+++ b/workflow/sample_files/base-pv.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-schedules-detailed-smooth.xml
+++ b/workflow/sample_files/base-schedules-detailed-smooth.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-schedules-detailed-stochastic-vacancy.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic-vacancy.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-schedules-detailed-stochastic.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-schedules-simple.xml
+++ b/workflow/sample_files/base-schedules-simple.xml
@@ -387,10 +387,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-simcontrol-calendar-year-custom.xml
+++ b/workflow/sample_files/base-simcontrol-calendar-year-custom.xml
@@ -383,10 +383,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-simcontrol-daylight-saving-custom.xml
+++ b/workflow/sample_files/base-simcontrol-daylight-saving-custom.xml
@@ -389,10 +389,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-simcontrol-daylight-saving-disabled.xml
+++ b/workflow/sample_files/base-simcontrol-daylight-saving-disabled.xml
@@ -385,10 +385,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-simcontrol-runperiod-1-month.xml
+++ b/workflow/sample_files/base-simcontrol-runperiod-1-month.xml
@@ -386,10 +386,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base-simcontrol-timestep-10-mins.xml
+++ b/workflow/sample_files/base-simcontrol-timestep-10-mins.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>

--- a/workflow/sample_files/base.xml
+++ b/workflow/sample_files/base.xml
@@ -382,10 +382,8 @@
                   <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
-                <NumberofReturnRegisters>2</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
-            <ConditionedFloorAreaServed>2700.0</ConditionedFloorAreaServed>
           </HVACDistribution>
         </HVAC>
         <WaterHeating>


### PR DESCRIPTION
## Pull Request Description

Relaxes requirement for `ConditionedFloorAreaServed` for air distribution systems; now only needed if duct surface areas not provided, as the input is used via ASHRAE 152 equations to calculate default duct area. Updated HPXML sample files.

## Checklist

Not all may apply:

- [x] EPvalidator.xml has been updated
- [x] Tests (and test files) have been updated
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
