### PR TITLE
ReportSimulationOutput setup_outputs fix

### DIFF
--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -1650,6 +1650,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
 
   def create_all_object_variables_by_key
     @object_variables_by_key = {}
+    return if @model.nil?
 
     @model.getModelObjects.each do |object|
       next if object.to_AdditionalProperties.is_initialized

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>b68eb941-9058-4768-9f09-74a757df9e2d</version_id>
-  <version_modified>20220204T224846Z</version_modified>
+  <version_id>c882aea0-3d9a-44cf-a325-d6d9380b466b</version_id>
+  <version_modified>20220214T173317Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1594,7 +1594,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0378C9E5</checksum>
+      <checksum>D8B35255</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

The measure's `outputs` method gets run when clicking "Check for Updates" in PAT. However, `model` is not yet retrieved from `runner`. We don't need `model` for the `outputs` method, so just return before trying to use it.

## Checklist

Not all may apply:

- [ ] EPvalidator.xml has been updated
- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
