### PR TITLE
Add `AdditionalProperties/ParentHPXMLFile` to every sample file.

### DIFF
--- a/ReportUtilityBills/measure.xml
+++ b/ReportUtilityBills/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_utility_bills</name>
   <uid>ca88a425-e59a-4bc4-af51-c7e7d1e960fe</uid>
-  <version_id>39ab5818-aefe-49a9-bb68-16103616230a</version_id>
-  <version_modified>20220426T211941Z</version_modified>
+  <version_id>0127ab35-a318-429c-93e1-42f71ceb11b0</version_id>
+  <version_modified>20220427T233836Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>ReportUtilityBills</class_name>
   <display_name>Utility Bills Report</display_name>
@@ -291,12 +291,6 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>5DBFE7B9</checksum>
-    </file>
-    <file>
-      <filename>results_bills.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>test</usage_type>
-      <checksum>8C632692</checksum>
     </file>
     <file>
       <filename>utility_bills_test.rb</filename>

--- a/tasks.rb
+++ b/tasks.rb
@@ -384,11 +384,12 @@ def create_hpxmls
   puts "Generating #{hpxmls_files.size} HPXML files..."
 
   hpxml_docs = {}
-  hpxmls_files.each_with_index do |(hpxml_file, parent), i|
+  hpxmls_files.each_with_index do |(hpxml_file, orig_parent), i|
     puts "[#{i + 1}/#{hpxmls_files.size}] Generating #{hpxml_file}..."
 
     begin
       all_hpxml_files = [hpxml_file]
+      parent = orig_parent
       unless parent.nil?
         all_hpxml_files.unshift(parent)
       end
@@ -404,7 +405,7 @@ def create_hpxmls
       args = {}
       sch_args = {}
       all_hpxml_files.each do |f|
-        set_measure_argument_values(f, args, sch_args)
+        set_measure_argument_values(f, args, sch_args, orig_parent)
       end
 
       measures = {}
@@ -494,7 +495,7 @@ def create_hpxmls
   return hpxml_docs
 end
 
-def set_measure_argument_values(hpxml_file, args, sch_args)
+def set_measure_argument_values(hpxml_file, args, sch_args, orig_parent)
   if hpxml_file.include? 'ASHRAE_Standard_140'
     args['hpxml_path'] = "../workflow/tests/#{hpxml_file}"
   else
@@ -2202,8 +2203,11 @@ def set_measure_argument_values(hpxml_file, args, sch_args)
   end
 
   # Misc
+  if not orig_parent.nil?
+    args['additional_properties'] = "ParentHPXMLFile=#{File.basename(orig_parent)}"
+  end
   if ['base-misc-additional-properties.xml'].include? hpxml_file
-    args['additional_properties'] = 'LowIncome=false|Remodeled|Description=2-story home in Denver|comma=,|special=<|special2=>|special3=/|special4=\\'
+    args['additional_properties'] += '|LowIncome=false|Remodeled|Description=2-story home in Denver|comma=,|special=<|special2=>|special3=/|special4=\\'
   elsif ['base-misc-defaults.xml'].include? hpxml_file
     args.delete('simulation_control_timestep')
     args.delete('site_type')

--- a/workflow/sample_files/base-appliances-coal.xml
+++ b/workflow/sample_files/base-appliances-coal.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-dehumidifier-ief-portable.xml
+++ b/workflow/sample_files/base-appliances-dehumidifier-ief-portable.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-appliances-dehumidifier.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-dehumidifier-ief-whole-home.xml
+++ b/workflow/sample_files/base-appliances-dehumidifier-ief-whole-home.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-appliances-dehumidifier-ief-portable.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-dehumidifier-multiple.xml
+++ b/workflow/sample_files/base-appliances-dehumidifier-multiple.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-appliances-dehumidifier.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-dehumidifier.xml
+++ b/workflow/sample_files/base-appliances-dehumidifier.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-location-dallas-tx.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-gas.xml
+++ b/workflow/sample_files/base-appliances-gas.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-modified.xml
+++ b/workflow/sample_files/base-appliances-modified.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-none.xml
+++ b/workflow/sample_files/base-appliances-none.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-oil-location-miami-fl.xml
+++ b/workflow/sample_files/base-appliances-oil-location-miami-fl.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-appliances-oil.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-oil.xml
+++ b/workflow/sample_files/base-appliances-oil.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-propane-location-portland-or.xml
+++ b/workflow/sample_files/base-appliances-propane-location-portland-or.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-appliances-propane.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-propane.xml
+++ b/workflow/sample_files/base-appliances-propane.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-appliances-wood.xml
+++ b/workflow/sample_files/base-appliances-wood.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-atticroof-cathedral.xml
+++ b/workflow/sample_files/base-atticroof-cathedral.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-atticroof-conditioned.xml
+++ b/workflow/sample_files/base-atticroof-conditioned.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-atticroof-flat.xml
+++ b/workflow/sample_files/base-atticroof-flat.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-atticroof-radiant-barrier.xml
+++ b/workflow/sample_files/base-atticroof-radiant-barrier.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-location-dallas-tx.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-atticroof-unvented-insulated-roof.xml
+++ b/workflow/sample_files/base-atticroof-unvented-insulated-roof.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-atticroof-vented.xml
+++ b/workflow/sample_files/base-atticroof-vented.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-battery.xml
+++ b/workflow/sample_files/base-battery.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-multifamily-buffer-space.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-multifamily-buffer-space.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-multiple.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-multiple.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-non-freezing-space.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-non-freezing-space.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-other-heated-space.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-other-heated-space.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-other-housing-unit.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-adjacent-to-other-housing-unit.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-baseboard.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-baseboard.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-fan-coil-ducted.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-fan-coil-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-boiler-chiller-fan-coil.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-fan-coil.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-fan-coil.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-boiler-chiller-baseboard.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-chiller-water-loop-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-boiler-chiller-baseboard.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-cooling-tower-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-cooling-tower-water-loop-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-boiler-chiller-water-loop-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-baseboard.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-baseboard.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-fan-coil-ducted.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-fan-coil-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-boiler-only-fan-coil.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-fan-coil-eae.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-fan-coil-eae.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-boiler-only-fan-coil.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-fan-coil.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-fan-coil.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-boiler-only-baseboard.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-boiler-only-water-loop-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-boiler-only-baseboard.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-baseboard.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-baseboard.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-fan-coil-ducted.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-fan-coil-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-chiller-only-fan-coil.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-fan-coil.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-fan-coil.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-chiller-only-baseboard.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-chiller-only-water-loop-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-chiller-only-baseboard.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-cooling-tower-only-water-loop-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-cooling-tower-only-water-loop-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-chiller-only-water-loop-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-generator.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-generator.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-ground-loop-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-ground-loop-ground-to-air-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-laundry-room.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-laundry-room.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent-multiple.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent-multiple.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent-preconditioning.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent-preconditioning.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-mechvent.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-mechvent.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-pv.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-pv.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-water-heater-recirc.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-water-heater-recirc.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily-shared-water-heater.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-water-heater.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-water-heater.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-multifamily.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-multifamily.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-single-family-attached-2stories.xml
+++ b/workflow/sample_files/base-bldgtype-single-family-attached-2stories.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-single-family-attached.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-single-family-attached-atticroof-cathedral.xml
+++ b/workflow/sample_files/base-bldgtype-single-family-attached-atticroof-cathedral.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-bldgtype-single-family-attached-2stories.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-bldgtype-single-family-attached.xml
+++ b/workflow/sample_files/base-bldgtype-single-family-attached.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-combi-tankless-outside.xml
+++ b/workflow/sample_files/base-dhw-combi-tankless-outside.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-combi-tankless.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-combi-tankless.xml
+++ b/workflow/sample_files/base-dhw-combi-tankless.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-indirect.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-desuperheater-2-speed.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-only-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-desuperheater-gshp.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-gshp.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-desuperheater-hpwh.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-hpwh.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-desuperheater-tankless.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-tankless.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-only-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-desuperheater-var-speed.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-only-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-desuperheater.xml
+++ b/workflow/sample_files/base-dhw-desuperheater.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-only-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-dwhr.xml
+++ b/workflow/sample_files/base-dhw-dwhr.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-indirect-dse.xml
+++ b/workflow/sample_files/base-dhw-indirect-dse.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-indirect.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-indirect-outside.xml
+++ b/workflow/sample_files/base-dhw-indirect-outside.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-indirect.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-indirect-standbyloss.xml
+++ b/workflow/sample_files/base-dhw-indirect-standbyloss.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-indirect.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-indirect-with-solar-fraction.xml
+++ b/workflow/sample_files/base-dhw-indirect-with-solar-fraction.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-indirect.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-indirect.xml
+++ b/workflow/sample_files/base-dhw-indirect.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-jacket-electric.xml
+++ b/workflow/sample_files/base-dhw-jacket-electric.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-jacket-gas.xml
+++ b/workflow/sample_files/base-dhw-jacket-gas.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-jacket-hpwh.xml
+++ b/workflow/sample_files/base-dhw-jacket-hpwh.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-jacket-indirect.xml
+++ b/workflow/sample_files/base-dhw-jacket-indirect.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-indirect.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-low-flow-fixtures.xml
+++ b/workflow/sample_files/base-dhw-low-flow-fixtures.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-multiple.xml
+++ b/workflow/sample_files/base-dhw-multiple.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-none.xml
+++ b/workflow/sample_files/base-dhw-none.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-recirc-demand.xml
+++ b/workflow/sample_files/base-dhw-recirc-demand.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-recirc-manual.xml
+++ b/workflow/sample_files/base-dhw-recirc-manual.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-recirc-nocontrol.xml
+++ b/workflow/sample_files/base-dhw-recirc-nocontrol.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-recirc-temperature.xml
+++ b/workflow/sample_files/base-dhw-recirc-temperature.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-recirc-timer.xml
+++ b/workflow/sample_files/base-dhw-recirc-timer.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-solar-direct-evacuated-tube.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-evacuated-tube.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-solar-direct-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-flat-plate.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-solar-indirect-flat-plate.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-solar-direct-ics.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-ics.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-solar-indirect-flat-plate.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-solar-fraction.xml
+++ b/workflow/sample_files/base-dhw-solar-fraction.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-solar-indirect-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-indirect-flat-plate.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-solar-thermosyphon-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-thermosyphon-flat-plate.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-solar-indirect-flat-plate.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-coal.xml
+++ b/workflow/sample_files/base-dhw-tank-coal.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-elec-uef.xml
+++ b/workflow/sample_files/base-dhw-tank-elec-uef.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-gas-outside.xml
+++ b/workflow/sample_files/base-dhw-tank-gas-outside.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-gas-uef-fhr.xml
+++ b/workflow/sample_files/base-dhw-tank-gas-uef-fhr.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-gas-uef.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-gas-uef.xml
+++ b/workflow/sample_files/base-dhw-tank-gas-uef.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-gas.xml
+++ b/workflow/sample_files/base-dhw-tank-gas.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-heat-pump-outside.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump-outside.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-heat-pump-uef.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump-uef.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-heat-pump-with-solar-fraction.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump-with-solar-fraction.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-heat-pump-with-solar.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump-with-solar.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-heat-pump.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-oil.xml
+++ b/workflow/sample_files/base-dhw-tank-oil.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tank-wood.xml
+++ b/workflow/sample_files/base-dhw-tank-wood.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tank-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tankless-electric-outside.xml
+++ b/workflow/sample_files/base-dhw-tankless-electric-outside.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tankless-electric.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tankless-electric-uef.xml
+++ b/workflow/sample_files/base-dhw-tankless-electric-uef.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tankless-electric.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tankless-electric.xml
+++ b/workflow/sample_files/base-dhw-tankless-electric.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tankless-gas-uef.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas-uef.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tankless-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tankless-gas-with-solar-fraction.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas-with-solar-fraction.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tankless-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tankless-gas-with-solar.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas-with-solar.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tankless-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tankless-gas.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-dhw-tankless-propane.xml
+++ b/workflow/sample_files/base-dhw-tankless-propane.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-dhw-tankless-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-2stories-garage.xml
+++ b/workflow/sample_files/base-enclosure-2stories-garage.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-2stories.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-2stories.xml
+++ b/workflow/sample_files/base-enclosure-2stories.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-beds-1.xml
+++ b/workflow/sample_files/base-enclosure-beds-1.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-beds-2.xml
+++ b/workflow/sample_files/base-enclosure-beds-2.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-beds-4.xml
+++ b/workflow/sample_files/base-enclosure-beds-4.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-beds-5.xml
+++ b/workflow/sample_files/base-enclosure-beds-5.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-garage.xml
+++ b/workflow/sample_files/base-enclosure-garage.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-infil-ach-house-pressure.xml
+++ b/workflow/sample_files/base-enclosure-infil-ach-house-pressure.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-infil-cfm-house-pressure.xml
+++ b/workflow/sample_files/base-enclosure-infil-cfm-house-pressure.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-infil-cfm50.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-infil-cfm50.xml
+++ b/workflow/sample_files/base-enclosure-infil-cfm50.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-infil-flue.xml
+++ b/workflow/sample_files/base-enclosure-infil-flue.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-infil-natural-ach.xml
+++ b/workflow/sample_files/base-enclosure-infil-natural-ach.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-orientations.xml
+++ b/workflow/sample_files/base-enclosure-orientations.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-overhangs.xml
+++ b/workflow/sample_files/base-enclosure-overhangs.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-rooftypes.xml
+++ b/workflow/sample_files/base-enclosure-rooftypes.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-skylights-physical-properties.xml
+++ b/workflow/sample_files/base-enclosure-skylights-physical-properties.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-skylights.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-skylights-shading.xml
+++ b/workflow/sample_files/base-enclosure-skylights-shading.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-skylights.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-skylights-storms.xml
+++ b/workflow/sample_files/base-enclosure-skylights-storms.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-skylights.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-skylights.xml
+++ b/workflow/sample_files/base-enclosure-skylights.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-split-level.xml
+++ b/workflow/sample_files/base-enclosure-split-level.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-slab.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-split-surfaces.xml
+++ b/workflow/sample_files/base-enclosure-split-surfaces.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-skylights.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-split-surfaces2.xml
+++ b/workflow/sample_files/base-enclosure-split-surfaces2.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-skylights.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-thermal-mass.xml
+++ b/workflow/sample_files/base-enclosure-thermal-mass.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-walltypes.xml
+++ b/workflow/sample_files/base-enclosure-walltypes.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-windows-none.xml
+++ b/workflow/sample_files/base-enclosure-windows-none.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-windows-physical-properties.xml
+++ b/workflow/sample_files/base-enclosure-windows-physical-properties.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-windows-shading.xml
+++ b/workflow/sample_files/base-enclosure-windows-shading.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-enclosure-windows-storms.xml
+++ b/workflow/sample_files/base-enclosure-windows-storms.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-ambient.xml
+++ b/workflow/sample_files/base-foundation-ambient.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-basement-garage.xml
+++ b/workflow/sample_files/base-foundation-basement-garage.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-complex.xml
+++ b/workflow/sample_files/base-foundation-complex.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-conditioned-basement-slab-insulation.xml
+++ b/workflow/sample_files/base-foundation-conditioned-basement-slab-insulation.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-conditioned-basement-wall-interior-insulation.xml
+++ b/workflow/sample_files/base-foundation-conditioned-basement-wall-interior-insulation.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-conditioned-crawlspace.xml
+++ b/workflow/sample_files/base-foundation-conditioned-crawlspace.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-multiple.xml
+++ b/workflow/sample_files/base-foundation-multiple.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-unconditioned-basement.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-slab.xml
+++ b/workflow/sample_files/base-foundation-slab.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-above-grade.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-above-grade.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-unconditioned-basement.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-assembly-r.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-assembly-r.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-unconditioned-basement.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-wall-insulation.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-wall-insulation.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-unconditioned-basement.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-unconditioned-basement.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-unvented-crawlspace.xml
+++ b/workflow/sample_files/base-foundation-unvented-crawlspace.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-vented-crawlspace.xml
+++ b/workflow/sample_files/base-foundation-vented-crawlspace.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-foundation-walkout-basement.xml
+++ b/workflow/sample_files/base-foundation-walkout-basement.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed-cooling-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed-heating-only.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed-heating-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-2-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-boiler-switchover-temperature.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-boiler-switchover-temperature.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed-backup-boiler.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-boiler.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-boiler.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-furnace.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed-backup-furnace.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed-backup-boiler.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-cooling-only.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed-cooling-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-heating-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-heating-only.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed-heating-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-sizing-methodology-acca.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-sizing-methodology-acca.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>ACCA</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-sizing-methodology-hers.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-sizing-methodology-hers.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-sizing-methodology-maxload.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-1-speed-sizing-methodology-maxload.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>MaxLoad</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed-sizing-methodology-acca.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed-sizing-methodology-acca.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>ACCA</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed-sizing-methodology-hers.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed-sizing-methodology-hers.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed-sizing-methodology-maxload.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-2-speed-sizing-methodology-maxload.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>MaxLoad</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-backup-boiler.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-backup-boiler.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed-backup-boiler.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-backup-furnace.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-backup-furnace.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed-backup-furnace.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-sizing-methodology-acca.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-sizing-methodology-acca.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>ACCA</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-sizing-methodology-hers.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-sizing-methodology-hers.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-sizing-methodology-maxload.xml
+++ b/workflow/sample_files/base-hvac-autosize-air-to-air-heat-pump-var-speed-sizing-methodology-maxload.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>MaxLoad</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-boiler-elec-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-boiler-elec-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-elec-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-boiler-gas-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-boiler-gas-central-ac-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-gas-central-ac-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-boiler-gas-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-boiler-gas-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-central-ac-only-1-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-central-ac-only-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-only-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-central-ac-only-2-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-central-ac-only-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-only-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-central-ac-only-var-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-central-ac-only-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-only-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-central-ac-plus-air-to-air-heat-pump-heating.xml
+++ b/workflow/sample_files/base-hvac-autosize-central-ac-plus-air-to-air-heat-pump-heating.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-dual-fuel-air-to-air-heat-pump-1-speed-sizing-methodology-acca.xml
+++ b/workflow/sample_files/base-hvac-autosize-dual-fuel-air-to-air-heat-pump-1-speed-sizing-methodology-acca.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>ACCA</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-dual-fuel-air-to-air-heat-pump-1-speed-sizing-methodology-hers.xml
+++ b/workflow/sample_files/base-hvac-autosize-dual-fuel-air-to-air-heat-pump-1-speed-sizing-methodology-hers.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-dual-fuel-air-to-air-heat-pump-1-speed-sizing-methodology-maxload.xml
+++ b/workflow/sample_files/base-hvac-autosize-dual-fuel-air-to-air-heat-pump-1-speed-sizing-methodology-maxload.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>MaxLoad</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-dual-fuel-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-autosize-dual-fuel-mini-split-heat-pump-ducted.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-elec-resistance-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-elec-resistance-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-elec-resistance-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-evap-cooler-furnace-gas.xml
+++ b/workflow/sample_files/base-hvac-autosize-evap-cooler-furnace-gas.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-evap-cooler-furnace-gas.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-floor-furnace-propane-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-floor-furnace-propane-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-floor-furnace-propane-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-furnace-elec-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-elec-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-elec-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-furnace-gas-central-ac-2-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-gas-central-ac-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-central-ac-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-furnace-gas-central-ac-var-speed.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-gas-central-ac-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-central-ac-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-furnace-gas-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-gas-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-furnace-gas-room-ac.xml
+++ b/workflow/sample_files/base-hvac-autosize-furnace-gas-room-ac.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-room-ac.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-cooling-only.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump-cooling-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-heating-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-heating-only.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump-heating-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-sizing-methodology-acca.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-sizing-methodology-acca.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>ACCA</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-sizing-methodology-hers.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-sizing-methodology-hers.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-sizing-methodology-maxload.xml
+++ b/workflow/sample_files/base-hvac-autosize-ground-to-air-heat-pump-sizing-methodology-maxload.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>MaxLoad</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-air-conditioner-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-air-conditioner-only-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-air-conditioner-only-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-cooling-only.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted-cooling-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-heating-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-heating-only.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted-heating-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-sizing-methodology-acca.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-sizing-methodology-acca.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>ACCA</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-sizing-methodology-hers.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-sizing-methodology-hers.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-sizing-methodology-maxload.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ducted-sizing-methodology-maxload.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>MaxLoad</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ductless-backup-stove.xml
+++ b/workflow/sample_files/base-hvac-autosize-mini-split-heat-pump-ductless-backup-stove.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ductless-backup-stove.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-ptac-with-heating.xml
+++ b/workflow/sample_files/base-hvac-autosize-ptac-with-heating.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ptac-with-heating.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-ptac.xml
+++ b/workflow/sample_files/base-hvac-autosize-ptac.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ptac.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-pthp-sizing-methodology-acca.xml
+++ b/workflow/sample_files/base-hvac-autosize-pthp-sizing-methodology-acca.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>ACCA</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-pthp.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-pthp-sizing-methodology-hers.xml
+++ b/workflow/sample_files/base-hvac-autosize-pthp-sizing-methodology-hers.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>HERS</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-pthp.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-pthp-sizing-methodology-maxload.xml
+++ b/workflow/sample_files/base-hvac-autosize-pthp-sizing-methodology-maxload.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <HeatPumpSizingMethodology>MaxLoad</HeatPumpSizingMethodology>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-pthp.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-room-ac-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-room-ac-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-room-ac-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-stove-oil-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-stove-oil-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-stove-oil-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize-wall-furnace-elec-only.xml
+++ b/workflow/sample_files/base-hvac-autosize-wall-furnace-elec-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-wall-furnace-elec-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-autosize.xml
+++ b/workflow/sample_files/base-hvac-autosize.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-boiler-coal-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-coal-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-boiler-elec-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-elec-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-boiler-gas-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-boiler-gas-central-ac-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-boiler-gas-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-gas-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-boiler-oil-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-oil-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-boiler-propane-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-propane-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-boiler-wood-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-wood-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-boiler-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-central-ac-only-1-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-central-ac-only-2-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-central-ac-only-var-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
+++ b/workflow/sample_files/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-central-ac-only-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-dse.xml
+++ b/workflow/sample_files/base-hvac-dse.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-ducts-area-fractions.xml
+++ b/workflow/sample_files/base-hvac-ducts-area-fractions.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-2stories.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-ducts-leakage-cfm50.xml
+++ b/workflow/sample_files/base-hvac-ducts-leakage-cfm50.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-ducts-leakage-percent.xml
+++ b/workflow/sample_files/base-hvac-ducts-leakage-percent.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-elec-resistance-only.xml
+++ b/workflow/sample_files/base-hvac-elec-resistance-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-evap-cooler-furnace-gas.xml
+++ b/workflow/sample_files/base-hvac-evap-cooler-furnace-gas.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-evap-cooler-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-evap-cooler-only-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-evap-cooler-only.xml
+++ b/workflow/sample_files/base-hvac-evap-cooler-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-fireplace-wood-only.xml
+++ b/workflow/sample_files/base-hvac-fireplace-wood-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-stove-oil-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-fixed-heater-gas-only.xml
+++ b/workflow/sample_files/base-hvac-fixed-heater-gas-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-floor-furnace-propane-only.xml
+++ b/workflow/sample_files/base-hvac-floor-furnace-propane-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-stove-oil-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-coal-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-coal-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-elec-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-elec-central-ac-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-elec-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-elec-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-gas-central-ac-2-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-central-ac-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-gas-central-ac-var-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-central-ac-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-gas-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-gas-room-ac.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-room-ac.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-oil-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-oil-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-propane-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-propane-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-wood-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-wood-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-furnace-x3-dse.xml
+++ b/workflow/sample_files/base-hvac-furnace-x3-dse.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump-cooling-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump-heating-only.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump-heating-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-1-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-2-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-var-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-air-to-air-heat-pump-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-air-to-air-heat-pump-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-1-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-2-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-2-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-central-ac-2-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-var-speed.xml
+++ b/workflow/sample_files/base-hvac-install-quality-furnace-gas-central-ac-var-speed.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-central-ac-var-speed.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-furnace-gas-only.xml
+++ b/workflow/sample_files/base-hvac-install-quality-furnace-gas-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-furnace-gas-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-hvac-install-quality-ground-to-air-heat-pump.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-mini-split-air-conditioner-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-install-quality-mini-split-air-conditioner-only-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-air-conditioner-only-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-install-quality-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-install-quality-mini-split-heat-pump-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-mini-split-air-conditioner-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-mini-split-air-conditioner-only-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-mini-split-air-conditioner-only-ductless.xml
+++ b/workflow/sample_files/base-hvac-mini-split-air-conditioner-only-ductless.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-air-conditioner-only-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-cooling-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-heating-only.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-heating-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless-backup-stove.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless-backup-stove.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ductless.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-mini-split-heat-pump-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-multiple.xml
+++ b/workflow/sample_files/base-hvac-multiple.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-none.xml
+++ b/workflow/sample_files/base-hvac-none.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-portable-heater-gas-only.xml
+++ b/workflow/sample_files/base-hvac-portable-heater-gas-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-ptac-with-heating.xml
+++ b/workflow/sample_files/base-hvac-ptac-with-heating.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ptac.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-ptac.xml
+++ b/workflow/sample_files/base-hvac-ptac.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-pthp.xml
+++ b/workflow/sample_files/base-hvac-pthp.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-ground-to-air-heat-pump.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-room-ac-only-33percent.xml
+++ b/workflow/sample_files/base-hvac-room-ac-only-33percent.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-room-ac-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-room-ac-only-ceer.xml
+++ b/workflow/sample_files/base-hvac-room-ac-only-ceer.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-room-ac-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-room-ac-only.xml
+++ b/workflow/sample_files/base-hvac-room-ac-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-seasons.xml
+++ b/workflow/sample_files/base-hvac-seasons.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-setpoints-daily-schedules.xml
+++ b/workflow/sample_files/base-hvac-setpoints-daily-schedules.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-setpoints-daily-setbacks.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-setpoints-daily-setbacks.xml
+++ b/workflow/sample_files/base-hvac-setpoints-daily-setbacks.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-setpoints.xml
+++ b/workflow/sample_files/base-hvac-setpoints.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-stove-oil-only.xml
+++ b/workflow/sample_files/base-hvac-stove-oil-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-stove-wood-pellets-only.xml
+++ b/workflow/sample_files/base-hvac-stove-wood-pellets-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-stove-oil-only.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-undersized-allow-increased-fixed-capacities.xml
+++ b/workflow/sample_files/base-hvac-undersized-allow-increased-fixed-capacities.xml
@@ -14,6 +14,9 @@
       <HVACSizingControl>
         <AllowIncreasedFixedCapacities>true</AllowIncreasedFixedCapacities>
       </HVACSizingControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-undersized.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-undersized.xml
+++ b/workflow/sample_files/base-hvac-undersized.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-hvac-wall-furnace-elec-only.xml
+++ b/workflow/sample_files/base-hvac-wall-furnace-elec-only.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-lighting-ceiling-fans.xml
+++ b/workflow/sample_files/base-lighting-ceiling-fans.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-lighting-holiday.xml
+++ b/workflow/sample_files/base-lighting-holiday.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-lighting-none.xml
+++ b/workflow/sample_files/base-lighting-none.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-AMY-2012.xml
+++ b/workflow/sample_files/base-location-AMY-2012.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-baltimore-md.xml
+++ b/workflow/sample_files/base-location-baltimore-md.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-unvented-crawlspace.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-capetown-zaf.xml
+++ b/workflow/sample_files/base-location-capetown-zaf.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-vented-crawlspace.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-dallas-tx.xml
+++ b/workflow/sample_files/base-location-dallas-tx.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-slab.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-duluth-mn.xml
+++ b/workflow/sample_files/base-location-duluth-mn.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-unconditioned-basement.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-helena-mt.xml
+++ b/workflow/sample_files/base-location-helena-mt.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-honolulu-hi.xml
+++ b/workflow/sample_files/base-location-honolulu-hi.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-slab.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-miami-fl.xml
+++ b/workflow/sample_files/base-location-miami-fl.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-slab.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-phoenix-az.xml
+++ b/workflow/sample_files/base-location-phoenix-az.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-slab.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-location-portland-or.xml
+++ b/workflow/sample_files/base-location-portland-or.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-foundation-vented-crawlspace.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-balanced.xml
+++ b/workflow/sample_files/base-mechvent-balanced.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-bath-kitchen-fans.xml
+++ b/workflow/sample_files/base-mechvent-bath-kitchen-fans.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-cfis-airflow-fraction-zero.xml
+++ b/workflow/sample_files/base-mechvent-cfis-airflow-fraction-zero.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-mechvent-cfis.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-cfis-dse.xml
+++ b/workflow/sample_files/base-mechvent-cfis-dse.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-dse.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-cfis-evap-cooler-only-ducted.xml
+++ b/workflow/sample_files/base-mechvent-cfis-evap-cooler-only-ducted.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-hvac-evap-cooler-only-ducted.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-cfis.xml
+++ b/workflow/sample_files/base-mechvent-cfis.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-erv-atre-asre.xml
+++ b/workflow/sample_files/base-mechvent-erv-atre-asre.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-erv.xml
+++ b/workflow/sample_files/base-mechvent-erv.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-exhaust-rated-flow-rate.xml
+++ b/workflow/sample_files/base-mechvent-exhaust-rated-flow-rate.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-exhaust.xml
+++ b/workflow/sample_files/base-mechvent-exhaust.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-hrv-asre.xml
+++ b/workflow/sample_files/base-mechvent-hrv-asre.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-hrv.xml
+++ b/workflow/sample_files/base-mechvent-hrv.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-multiple.xml
+++ b/workflow/sample_files/base-mechvent-multiple.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-mechvent-bath-kitchen-fans.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-supply.xml
+++ b/workflow/sample_files/base-mechvent-supply.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-mechvent-whole-house-fan.xml
+++ b/workflow/sample_files/base-mechvent-whole-house-fan.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-misc-additional-properties.xml
+++ b/workflow/sample_files/base-misc-additional-properties.xml
@@ -12,6 +12,7 @@
         <Timestep>60</Timestep>
       </SimulationControl>
       <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
         <LowIncome>false</LowIncome>
         <Remodeled/>
         <Description>2-story home in Denver</Description>

--- a/workflow/sample_files/base-misc-defaults.xml
+++ b/workflow/sample_files/base-misc-defaults.xml
@@ -6,7 +6,13 @@
     <CreatedDateAndTime>2000-01-01T00:00:00-07:00</CreatedDateAndTime>
     <Transaction>create</Transaction>
   </XMLTransactionHeaderInformation>
-  <SoftwareInfo/>
+  <SoftwareInfo>
+    <extension>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
+    </extension>
+  </SoftwareInfo>
   <Building>
     <BuildingID id='MyBuilding'/>
     <ProjectStatus>

--- a/workflow/sample_files/base-misc-emissions.xml
+++ b/workflow/sample_files/base-misc-emissions.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-pv-battery.xml</ParentHPXMLFile>
+      </AdditionalProperties>
       <EmissionsScenarios>
         <EmissionsScenario>
           <Name>Cambium Hourly MidCase LRMER RMPA</Name>

--- a/workflow/sample_files/base-misc-generators.xml
+++ b/workflow/sample_files/base-misc-generators.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-misc-loads-large-uncommon.xml
+++ b/workflow/sample_files/base-misc-loads-large-uncommon.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-schedules-simple.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-misc-loads-large-uncommon2.xml
+++ b/workflow/sample_files/base-misc-loads-large-uncommon2.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-misc-loads-large-uncommon.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-misc-loads-none.xml
+++ b/workflow/sample_files/base-misc-loads-none.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-misc-neighbor-shading.xml
+++ b/workflow/sample_files/base-misc-neighbor-shading.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-misc-shielding-of-home.xml
+++ b/workflow/sample_files/base-misc-shielding-of-home.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-misc-usage-multiplier.xml
+++ b/workflow/sample_files/base-misc-usage-multiplier.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-multiple-buildings.xml
+++ b/workflow/sample_files/base-multiple-buildings.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-pv-battery-ah.xml
+++ b/workflow/sample_files/base-pv-battery-ah.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-pv-battery.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-pv-battery-garage.xml
+++ b/workflow/sample_files/base-pv-battery-garage.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-enclosure-garage.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-pv-battery-lifetime-model.xml
+++ b/workflow/sample_files/base-pv-battery-lifetime-model.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-pv-battery.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-pv-battery.xml
+++ b/workflow/sample_files/base-pv-battery.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-battery.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-pv.xml
+++ b/workflow/sample_files/base-pv.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-detailed-smooth.xml
+++ b/workflow/sample_files/base-schedules-detailed-smooth.xml
@@ -12,6 +12,9 @@
         <Timestep>60</Timestep>
       </SimulationControl>
       <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/smooth.csv</SchedulesFilePath>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-detailed-stochastic-10-mins.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic-10-mins.xml
@@ -12,6 +12,9 @@
         <Timestep>10</Timestep>
       </SimulationControl>
       <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic-10-mins.csv</SchedulesFilePath>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base-simcontrol-timestep-10-mins.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-detailed-stochastic-vacancy.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic-vacancy.xml
@@ -12,6 +12,9 @@
         <Timestep>60</Timestep>
       </SimulationControl>
       <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic-vacancy.csv</SchedulesFilePath>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-detailed-stochastic.xml
+++ b/workflow/sample_files/base-schedules-detailed-stochastic.xml
@@ -12,6 +12,9 @@
         <Timestep>60</Timestep>
       </SimulationControl>
       <SchedulesFilePath>../../HPXMLtoOpenStudio/resources/schedule_files/stochastic.csv</SchedulesFilePath>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-schedules-simple.xml
+++ b/workflow/sample_files/base-schedules-simple.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>60</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-simcontrol-calendar-year-custom.xml
+++ b/workflow/sample_files/base-simcontrol-calendar-year-custom.xml
@@ -12,6 +12,9 @@
         <Timestep>60</Timestep>
         <CalendarYear>2010</CalendarYear>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-simcontrol-daylight-saving-custom.xml
+++ b/workflow/sample_files/base-simcontrol-daylight-saving-custom.xml
@@ -18,6 +18,9 @@
           <EndDayOfMonth>6</EndDayOfMonth>
         </DaylightSaving>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-simcontrol-daylight-saving-disabled.xml
+++ b/workflow/sample_files/base-simcontrol-daylight-saving-disabled.xml
@@ -14,6 +14,9 @@
           <Enabled>false</Enabled>
         </DaylightSaving>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-simcontrol-runperiod-1-month.xml
+++ b/workflow/sample_files/base-simcontrol-runperiod-1-month.xml
@@ -15,6 +15,9 @@
         <EndMonth>1</EndMonth>
         <EndDayOfMonth>31</EndDayOfMonth>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/sample_files/base-simcontrol-timestep-10-mins.xml
+++ b/workflow/sample_files/base-simcontrol-timestep-10-mins.xml
@@ -11,6 +11,9 @@
       <SimulationControl>
         <Timestep>10</Timestep>
       </SimulationControl>
+      <AdditionalProperties>
+        <ParentHPXMLFile>base.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L100AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L100AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L110AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L110AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L110AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L110AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L120AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L120AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L120AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L120AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L130AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L130AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L130AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L130AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L140AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L140AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L140AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L140AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L150AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L150AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L150AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L150AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L155AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L155AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L150AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L155AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L155AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L150AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L160AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L160AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L160AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L160AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L170AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L170AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L170AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L170AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L200AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L200AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L200AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L200AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L202AC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L202AC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L200AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L202AL.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L202AL.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L200AL.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L302XC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L302XC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L304XC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L304XC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L302XC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L322XC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L322XC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L100AC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>

--- a/workflow/tests/ASHRAE_Standard_140/L324XC.xml
+++ b/workflow/tests/ASHRAE_Standard_140/L324XC.xml
@@ -9,6 +9,9 @@
   <SoftwareInfo>
     <extension>
       <ApplyASHRAE140Assumptions>true</ApplyASHRAE140Assumptions>
+      <AdditionalProperties>
+        <ParentHPXMLFile>L322XC.xml</ParentHPXMLFile>
+      </AdditionalProperties>
     </extension>
   </SoftwareInfo>
   <Building>


### PR DESCRIPTION
## Pull Request Description

Makes it easier to open up a sample HPXML file and see which parent file it was based on. Takes advantage of @joseph-robertson's [additional properties PR](https://github.com/NREL/OpenStudio-HPXML/pull/1012). Maybe some day we can add even more information to the sample files, like a brief description...

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] Checked the code coverage report on CI
- [ ] No unexpected changes to simulation results of sample files
