### PR TITLE
Fixes #1060

### DIFF
--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -227,7 +227,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
       include_timeseries_zone_temperatures = include_timeseries_zone_temperatures.is_initialized ? include_timeseries_zone_temperatures.get : false
       include_timeseries_airflows = include_timeseries_airflows.is_initialized ? include_timeseries_airflows.get : false
       include_timeseries_weather = include_timeseries_weather.is_initialized ? include_timeseries_weather.get : false
-      user_output_variables = user_output_variables.is_initialized ? user_output_variables.get : false
+      user_output_variables = user_output_variables.is_initialized ? user_output_variables.get : nil
     end
 
     setup_outputs(user_output_variables)
@@ -427,7 +427,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
       include_timeseries_zone_temperatures = include_timeseries_zone_temperatures.is_initialized ? include_timeseries_zone_temperatures.get : false
       include_timeseries_airflows = include_timeseries_airflows.is_initialized ? include_timeseries_airflows.get : false
       include_timeseries_weather = include_timeseries_weather.is_initialized ? include_timeseries_weather.get : false
-      user_output_variables = user_output_variables.is_initialized ? user_output_variables.get : false
+      user_output_variables = user_output_variables.is_initialized ? user_output_variables.get : nil
     end
     annual_output_file_name = runner.getOptionalStringArgumentValue('annual_output_file_name', user_arguments)
     timeseries_output_file_name = runner.getOptionalStringArgumentValue('timeseries_output_file_name', user_arguments)

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>da439151-791f-40ac-b797-ffd0403593cc</version_id>
-  <version_modified>20220504T164700Z</version_modified>
+  <version_id>b7313231-b06a-4db5-925c-4d953b8bac6a</version_id>
+  <version_modified>20220504T165546Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1588,7 +1588,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4C7626FD</checksum>
+      <checksum>93F56EC9</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>52622efe-b867-45ea-98b9-17dff531d153</version_id>
-  <version_modified>20220430T164936Z</version_modified>
+  <version_id>da439151-791f-40ac-b797-ffd0403593cc</version_id>
+  <version_modified>20220504T164700Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1588,7 +1588,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>45E9B986</checksum>
+      <checksum>4C7626FD</checksum>
     </file>
   </files>
 </measure>

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -197,10 +197,10 @@ class HPXMLTest < MiniTest::Test
         assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
       end
 
-      # Check TimeDST and TimeUTC exist
-      timeseries_rows = CSV.read(File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
-      assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
       if not invalid_variable_only
+        # Check timeseries columns exist
+        timeseries_rows = CSV.read(File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
+        assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
         assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeDST' }.size)
         assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeUTC' }.size)
         assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Occupant Count: Living Space' }.size)

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -174,26 +174,44 @@ class HPXMLTest < MiniTest::Test
   end
 
   def test_run_simulation_timeseries_outputs
-    # Check that the simulation produces timeseries with requested outputs
-    rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
-    xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
-    command = "#{OpenStudio.getOpenStudioCLI} #{rb_path} -x #{xml} --hourly ALL --add-timeseries-time-column DST --add-timeseries-time-column UTC"
-    command += " --add-timeseries-output-variable 'Zone People Occupant Count' --add-timeseries-output-variable 'Zone People Total Heating Energy'"
-    system(command, err: File::NULL)
+    [true, false].each do |invalid_variable_only|
+      # Check that the simulation produces timeseries with requested outputs
+      rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
+      xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
+      command = "#{OpenStudio.getOpenStudioCLI} #{rb_path} -x #{xml}"
+      if not invalid_variable_only
+        command += ' --hourly ALL'
+        command += ' --add-timeseries-time-column DST'
+        command += ' --add-timeseries-time-column UTC'
+        command += " --add-timeseries-output-variable 'Zone People Occupant Count'"
+        command += " --add-timeseries-output-variable 'Zone People Total Heating Energy'"
+      end
+      command += " --add-timeseries-output-variable 'Foobar Variable'" # Test invalid output variable request
+      system(command, err: File::NULL)
 
-    # Check for output files
-    assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
-    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
-    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_hpxml.csv'))
-    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
+      # Check for output files
+      assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+      assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+      assert(File.exist? File.join(File.dirname(xml), 'run', 'results_hpxml.csv'))
+      if not invalid_variable_only
+        assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
+      end
 
-    # Check TimeDST and TimeUTC exist
-    timeseries_rows = CSV.read(File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeDST' }.size)
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeUTC' }.size)
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Occupant Count: Living Space' }.size)
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Total Heating Energy: Living Space' }.size)
+      # Check TimeDST and TimeUTC exist
+      timeseries_rows = CSV.read(File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
+      assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
+      if not invalid_variable_only
+        assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeDST' }.size)
+        assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeUTC' }.size)
+        assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Occupant Count: Living Space' }.size)
+        assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Total Heating Energy: Living Space' }.size)
+      end
+
+      # Check run.log has warning about missing Foobar Variable
+      assert(File.exist? File.join(File.dirname(xml), 'run', 'run.log'))
+      log_lines = File.readlines(File.join(File.dirname(xml), 'run', 'run.log')).map(&:strip)
+      assert(log_lines.include? "Warning: Request for output variable 'Foobar Variable' returned no key values.")
+    end
   end
 
   def test_template_osw

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -195,9 +195,6 @@ class HPXMLTest < MiniTest::Test
       assert(File.exist? File.join(File.dirname(xml), 'run', 'results_hpxml.csv'))
       if not invalid_variable_only
         assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
-      end
-
-      if not invalid_variable_only
         # Check timeseries columns exist
         timeseries_rows = CSV.read(File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
         assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
@@ -205,6 +202,8 @@ class HPXMLTest < MiniTest::Test
         assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeUTC' }.size)
         assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Occupant Count: Living Space' }.size)
         assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Total Heating Energy: Living Space' }.size)
+      else
+        refute(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
       end
 
       # Check run.log has warning about missing Foobar Variable


### PR DESCRIPTION
## Pull Request Description

Fixes #1060. Fixes ReportSimulationOutput error if a user requests a non-existent output variable and no other timeseries outputs. (If they requested other valid timeseries outputs, the error did not occur.) Updates workflow test to check for success.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [x] ~Documentation has been updated~
- [x] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] ~Checked the code coverage report on CI~
- [x] No unexpected changes to simulation results of sample files
