### PR TITLE
Tweak schematron warnings

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>a614a63f-fe66-4846-8ae5-9be2c5b080bb</version_id>
-  <version_modified>20220506T205521Z</version_modified>
+  <version_id>4f162acc-7ebc-43bf-b5b1-cfef32be4f0a</version_id>
+  <version_modified>20220509T165955Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -529,12 +529,6 @@
       <checksum>D5CCBB60</checksum>
     </file>
     <file>
-      <filename>hpxml_schematron/EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6FB532B0</checksum>
-    </file>
-    <file>
       <filename>hotwater_appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -547,12 +541,6 @@
       <checksum>622CDA49</checksum>
     </file>
     <file>
-      <filename>test_validation.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>37EF0573</checksum>
-    </file>
-    <file>
       <filename>test_hotwater_appliance.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -563,6 +551,18 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>D214E11E</checksum>
+    </file>
+    <file>
+      <filename>hpxml_schematron/EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6D2E6792</checksum>
+    </file>
+    <file>
+      <filename>test_validation.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>7D2B7C4B</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml
@@ -499,7 +499,6 @@
       <sch:assert role='ERROR' test='number(h:DistanceToBottomOfWindow) &gt; number(h:DistanceToTopOfWindow) or not(h:DistanceToBottomOfWindow) or not(h:DistanceToTopOfWindow)'>Expected DistanceToBottomOfWindow to be greater than DistanceToTopOfWindow</sch:assert>
       <!-- Warnings -->
       <sch:report role='WARN' test='number(h:DistanceToTopOfWindow) &gt; 12'>DistanceToTopOfWindow is greater than 12 feet; this may indicate incorrect units.</sch:report>
-      <sch:report role='WARN' test='number(h:DistanceToBottomOfWindow) &gt; 12'>DistanceToBottomOfWindow is greater than 12 feet; this may indicate incorrect units.</sch:report>
     </sch:rule>
   </sch:pattern>
 

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -560,8 +560,7 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
                               'wrong-units' => ['Thickness is greater than 12 inches; this may indicate incorrect units.',
                                                 'Thickness is less than 1 inch; this may indicate incorrect units.',
                                                 'Depth is greater than 72 feet; this may indicate incorrect units.',
-                                                'DistanceToTopOfWindow is greater than 12 feet; this may indicate incorrect units.',
-                                                'DistanceToBottomOfWindow is greater than 12 feet; this may indicate incorrect units.'] }
+                                                'DistanceToTopOfWindow is greater than 12 feet; this may indicate incorrect units.'] }
 
     all_expected_warnings.each_with_index do |(warning_case, expected_warnings), i|
       puts "[#{i + 1}/#{all_expected_warnings.size}] Testing #{warning_case}..."


### PR DESCRIPTION
## Pull Request Description

Follow up to #1062. No need to have a warning for `DistanceToBottomOfWindow` when there is a warning for `DistanceToTopOfWindow` and the former is highly dependent on window size. Reduces (but does eliminate) the possibility of warnings for legitimate situations.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] Checked the code coverage report on CI
- [ ] No unexpected changes to simulation results of sample files
