### PR TITLE
Allow timeseries CSV output for DView

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## OpenStudio-HPXML v1.5.0
+
+__New Features__
+- Allows CSV timeseries output to be formatted for use with the DView application.
+
+__Bugfixes__
+
 ## OpenStudio-HPXML v1.4.0
 
 __New Features__

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>8a9787b1-69d2-4520-8f30-1e4932510366</version_id>
-  <version_modified>20220505T171642Z</version_modified>
+  <version_id>a41d9c34-5f15-45c7-a973-90c3997ab2a5</version_id>
+  <version_modified>20220517T002216Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1577,7 +1577,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>8256A761</checksum>
+      <checksum>A6D58B56</checksum>
     </file>
     <file>
       <version>
@@ -1588,7 +1588,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>93F56EC9</checksum>
+      <checksum>7407285C</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/tests/output_report_test.rb
+++ b/ReportSimulationOutput/tests/output_report_test.rb
@@ -1004,6 +1004,18 @@ class ReportSimulationOutputTest < MiniTest::Test
     assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
   end
 
+  def test_timeseries_for_dview
+    args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
+                  'output_format' => 'csv_dview',
+                  'timeseries_frequency' => 'timestep',
+                  'include_timeseries_fuel_consumptions' => true,
+                  'add_timeseries_dst_column' => true }
+    annual_csv, timeseries_csv = _test_measure(args_hash)
+    assert(File.exist?(annual_csv))
+    assert(File.exist?(timeseries_csv))
+    assert_equal('wxDVFileHeaderVer.1', CSV.readlines(timeseries_csv)[0][0].strip)
+  end
+
   def test_timeseries_local_time_dst
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
                   'timeseries_frequency' => 'timestep',
@@ -1152,6 +1164,8 @@ class ReportSimulationOutputTest < MiniTest::Test
     steps = OpenStudio::WorkflowStepVector.new
     found_args = []
     json['steps'].each do |json_step|
+      next unless ['HPXMLtoOpenStudio', 'ReportSimulationOutput'].include? json_step['measure_dir_name']
+
       step = OpenStudio::MeasureStep.new(json_step['measure_dir_name'])
       json_step['arguments'].each do |json_arg_name, json_arg_val|
         if args_hash.keys.include? json_arg_name

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -59,6 +59,8 @@ def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseri
   args['user_output_variables'] = timeseries_output_variables.join(', ') unless timeseries_output_variables.empty?
   update_args_hash(measures, measure_subdir, args)
 
+  output_format = 'csv' if output_format == 'csv_dview'
+
   # Add hpxml output measure to workflow
   measure_subdir = 'ReportHPXMLOutput'
   args = {}
@@ -92,7 +94,7 @@ OptionParser.new do |opts|
     options[:output_dir] = t
   end
 
-  opts.on('--output-format TYPE', ['csv', 'json', 'msgpack'], 'Output file format type (csv, json, msgpack)') do |t|
+  opts.on('--output-format TYPE', ['csv', 'json', 'msgpack', 'csv_dview'], 'Output file format type (csv, json, msgpack, csv_dview)') do |t|
     options[:output_format] = t
   end
 
@@ -238,8 +240,8 @@ rundir = File.join(options[:output_dir], 'run')
 puts "HPXML: #{options[:hpxml]}"
 success = run_workflow(basedir, rundir, options[:hpxml], options[:debug], timeseries_output_freq, timeseries_outputs,
                        options[:skip_validation], options[:add_comp_loads], options[:add_utility_bills], options[:output_format], options[:building_id],
-                       options[:ep_input_format], options[:detailed_schedules_type],
-                       options[:timeseries_time_column_types], options[:timeseries_output_variables])
+                       options[:ep_input_format], options[:detailed_schedules_type], options[:timeseries_time_column_types],
+                       options[:timeseries_output_variables])
 
 if not success
   exit! 1

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -75,11 +75,13 @@ class HPXMLTest < MiniTest::Test
 
   def test_run_simulation_output_formats
     # Check that the simulation produces outputs in the appropriate format
-    ['csv', 'json', 'msgpack'].each do |output_format|
+    ['csv', 'json', 'msgpack', 'csv_dview'].each do |output_format|
       rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
       xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
       command = "#{OpenStudio.getOpenStudioCLI} #{rb_path} -x #{xml} --debug --hourly ALL --add-utility-bills --output-format #{output_format}"
       system(command, err: File::NULL)
+
+      output_format = 'csv' if output_format == 'csv_dview'
 
       # Check for output files
       assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))


### PR DESCRIPTION
## Pull Request Description

Closes #1082. Allows requesting that timeseries CSV output be formatted for reading in the [DView application](https://github.com/NREL/wex/releases/tag/v1.0.0). Handles:
- Aggregating outputs into collapsible groups
- Subhourly timesteps
- Non-annual run periods

For example:
`openstudio workflow/run_simulation.rb -x workflow/sample_files/base-simcontrol-timestep-10-mins.xml --output-format csv_dview --timestep ALL`

Produces:

![image](https://user-images.githubusercontent.com/5861765/168703235-d91ff1e5-2ea8-414f-8385-6d3ee752a2c7.png)

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] ~Checked the code coverage report on CI~
- [x] No unexpected changes to simulation results of sample files
