### PR TITLE
Handle non-integer number of occupants

### DIFF
--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -201,6 +201,10 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     else
       args[:geometry_num_occupants] = hpxml.building_occupancy.number_of_residents
     end
+    # Stochastic occupancy required integer number of occupants
+    if args[:schedules_type] == 'stochastic'
+      args[:geometry_num_occupants] = Float(Integer(args[:geometry_num_occupants]))
+    end
 
     if args[:schedules_vacancy_period].is_initialized
       begin_month, begin_day, end_month, end_day = Schedule.parse_date_range(args[:schedules_vacancy_period].get)

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>3b3aaa95-30bb-4a4c-b82b-e60b63c3f0fa</version_id>
-  <version_modified>20220518T171703Z</version_modified>
+  <version_id>c79c9593-ddaa-43a2-8b88-1c4d160b8fb8</version_id>
+  <version_modified>20220519T224856Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -16,14 +16,19 @@
       <display_name>HPXML File Path</display_name>
       <description>Absolute/relative path of the HPXML file.</description>
       <type>String</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
+      <default_value></default_value>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>schedules_type</name>
       <display_name>Schedules: Type</display_name>
       <description>The type of occupant-related schedules to use.</description>
       <type>Choice</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>smooth</default_value>
@@ -37,14 +42,20 @@
           <display_name>stochastic</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>schedules_vacancy_period</name>
       <display_name>Schedules: Vacancy Period</display_name>
       <description>Specifies the vacancy period. Enter a date like "Dec 15 - Jan 15".</description>
       <type>String</type>
+      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
+      <default_value></default_value>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>schedules_random_seed</name>
@@ -54,28 +65,40 @@
       <units>#</units>
       <required>false</required>
       <model_dependent>false</model_dependent>
+      <default_value></default_value>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>output_csv_path</name>
       <display_name>Schedules: Output CSV Path</display_name>
       <description>Absolute/relative path of the csv file containing user-specified occupancy schedules. Relative paths are relative to the HPXML output path.</description>
       <type>String</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
+      <default_value></default_value>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>hpxml_output_path</name>
       <display_name>HPXML Output File Path</display_name>
       <description>Absolute/relative output path of the HPXML file. This HPXML file will include the output CSV path.</description>
       <type>String</type>
+      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
+      <default_value></default_value>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
     <argument>
       <name>debug</name>
       <display_name>Debug Mode?</display_name>
       <description>Applicable when schedules type is stochastic. If true: Write extra state column(s).</description>
       <type>Boolean</type>
+      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
       <default_value>false</default_value>
@@ -89,6 +112,8 @@
           <display_name>false</display_name>
         </choice>
       </choices>
+      <min_value></min_value>
+      <max_value></max_value>
     </argument>
   </arguments>
   <outputs />
@@ -891,16 +916,16 @@
       <checksum>127D96AC</checksum>
     </file>
     <file>
-      <filename>build_residential_schedule_file_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F134FEA4</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>E756AD7B</checksum>
+    </file>
+    <file>
+      <filename>build_residential_schedule_file_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A91B202C</checksum>
     </file>
     <file>
       <version>
@@ -911,7 +936,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>2BEEAED3</checksum>
+      <checksum>73CC305B</checksum>
     </file>
   </files>
 </measure>

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,8 @@ __New Features__
   - **Breaking change**: Replaces arguments using 'auto' for defaults with optional arguments of the appropriate data type.
 
 __Bugfixes__
-- Fixes heating (or cooling) setpoints from affecting the conditioned space temperature outside the heating (or cooling) season.
+- Fixes heating (or cooling) setpoints affecting the conditioned space temperature outside the heating (or cooling) season.
+- Fixes handling non-integer number of occupants when using the stochastic occupancy schedule generator.
 
 ## OpenStudio-HPXML v1.4.0
 


### PR DESCRIPTION
## Pull Request Description

Closes #1093. Fixes handling non-integer number of occupants when using the stochastic occupancy schedule generator.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] ~Checked the code coverage report on CI~
- [x] No unexpected changes to simulation results of sample files
