### PR TITLE
Dview non-hourly timeseries output bugfix

### DIFF
--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>c940c7b9-2611-4dfe-8e74-97d8da60ea6b</version_id>
-  <version_modified>20220521T212436Z</version_modified>
+  <version_id>8da86752-9133-4304-a6ba-ea86d63b9d19</version_id>
+  <version_modified>20220603T133314Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1588,7 +1588,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>5F314F91</checksum>
+      <checksum>3F99BC80</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Follow-up to #1087. Fixes timeseries output for DView when the timeseries frequency is not hourly (subhourly/daily/monthly).

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] ~Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)~
- [x] ~Documentation has been updated~
- [x] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] ~Checked the code coverage report on CI~
- [x] No unexpected changes to simulation results of sample files
