### PR TITLE
Throw error if results are Infinity

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7df07b86-8cab-4818-8891-294f6432459b</version_id>
-  <version_modified>20220617T192755Z</version_modified>
+  <version_id>278ef9b4-31f9-4a6e-ab58-ebf3fbdd29b4</version_id>
+  <version_modified>20220620T230236Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -581,6 +581,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>3FCCEA0E</checksum>
+    </file>
+    <file>
+      <filename>hpxml_schematron/EPvalidator_stylesheet.xslt</filename>
+      <filetype>xslt</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>23D0588A</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -1106,7 +1106,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     # Check if simulation successful
     all_total = @fuels.values.map { |x| x.annual_output.to_f }.sum(0.0)
     all_total += @ideal_system_loads.values.map { |x| x.annual_output.to_f }.sum(0.0)
-    if all_total == 0
+    if all_total == 0 || all_total.infinite?
       runner.registerError('Simulation unsuccessful.')
       return false
     end

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>1122877d-f4a7-48d6-bfef-564c65aad8f9</version_id>
-  <version_modified>20220615T231106Z</version_modified>
+  <version_id>1ce24336-cc63-49f5-b531-2c80ca250f67</version_id>
+  <version_modified>20220620T230238Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1577,7 +1577,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>A7F75A9B</checksum>
+      <checksum>4C130598</checksum>
     </file>
     <file>
       <version>
@@ -1588,7 +1588,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>49245E4A</checksum>
+      <checksum>0C94CC6F</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/tests/output_report_test.rb
+++ b/ReportSimulationOutput/tests/output_report_test.rb
@@ -6,8 +6,19 @@ require 'openstudio/measure/ShowRunnerOutput'
 require 'fileutils'
 require 'csv'
 require_relative '../measure.rb'
+require_relative '../../HPXMLtoOpenStudio/resources/xmlhelper.rb'
+require_relative '../../HPXMLtoOpenStudio/resources/constants.rb'
+require 'oga'
 
 class ReportSimulationOutputTest < MiniTest::Test
+  def setup
+    @tmp_hpxml_path = File.join(File.dirname(__FILE__), 'tmp.xml')
+  end
+
+  def teardown
+    File.delete(@tmp_hpxml_path) if File.exist? @tmp_hpxml_path
+  end
+
   AnnualRows = [
     'Energy Use: Total (MBtu)',
     'Energy Use: Net (MBtu)',
@@ -1165,33 +1176,39 @@ class ReportSimulationOutputTest < MiniTest::Test
 
   def test_eri_designs
     # Create derivative HPXML file w/ ERI design type set
-    require 'fileutils'
-    require_relative '../../HPXMLtoOpenStudio/resources/xmlhelper.rb'
-    require_relative '../../HPXMLtoOpenStudio/resources/constants.rb'
-    require 'oga'
-    old_hpxml_path = File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml')
-    [Constants.CalcTypeERIReferenceHome, Constants.CalcTypeERIReferenceHome].each do |eri_design|
-      new_hpxml_path = File.join(File.dirname(__FILE__), '../../workflow/tests/test-eri.xml')
-      FileUtils.cp(old_hpxml_path, new_hpxml_path)
-      hpxml = HPXML.new(hpxml_path: new_hpxml_path)
+    hpxml_path = File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml')
+    [Constants.CalcTypeERIReferenceHome, Constants.CalcTypeERIRatedHome].each do |eri_design|
+      hpxml = HPXML.new(hpxml_path: hpxml_path)
       hpxml.header.eri_design = eri_design
-      XMLHelper.write_file(hpxml.to_oga(), new_hpxml_path)
+      XMLHelper.write_file(hpxml.to_oga(), @tmp_hpxml_path)
 
       # Run tests
-      args_hash = { 'hpxml_path' => '../workflow/tests/test-eri.xml' }
-      annual_csv, timeseries_csv = _test_measure(args_hash, eri_design)
+      args_hash = { 'hpxml_path' => @tmp_hpxml_path }
+      annual_csv, timeseries_csv = _test_measure(args_hash, eri_design: eri_design)
       assert(File.exist?(annual_csv))
       assert(!File.exist?(timeseries_csv))
       actual_annual_rows = File.readlines(annual_csv).map { |x| x.split(',')[0].strip }.select { |x| !x.empty? }
       assert(actual_annual_rows.include? 'ERI: Building: CFA')
 
       # Cleanup
-      File.delete(new_hpxml_path)
       File.delete(annual_csv)
     end
   end
 
-  def _test_measure(args_hash, eri_design = nil)
+  def test_for_unsuccessful_simulation_infinity
+    # Create HPXML w/ AFUE=0 to generate Infinity result
+    hpxml_path = File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml')
+    hpxml = HPXML.new(hpxml_path: hpxml_path)
+    hpxml.heating_systems[0].heating_efficiency_afue = 0.0
+    XMLHelper.write_file(hpxml.to_oga(), @tmp_hpxml_path)
+
+    args_hash = { 'hpxml_path' => @tmp_hpxml_path }
+    annual_csv, timeseries_csv = _test_measure(args_hash, expect_success: false)
+    assert(!File.exist?(annual_csv))
+    assert(!File.exist?(timeseries_csv))
+  end
+
+  def _test_measure(args_hash, expect_success: true, eri_design: nil)
     # Run measure via OSW
     require 'json'
     template_osw = File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'template-run-hpxml.osw')
@@ -1222,17 +1239,15 @@ class ReportSimulationOutputTest < MiniTest::Test
 
     # Run OSW
     success = system("#{OpenStudio.getOpenStudioCLI} run -w \"#{osw_path}\"")
-    assert_equal(true, success)
+    assert_equal(expect_success, success)
 
     # Cleanup
     File.delete(osw_path)
 
     if not eri_design.nil?
-      output_dir = File.dirname(File.join(File.dirname(__FILE__), '..', args_hash['hpxml_path']))
-      hpxml_name = File.basename(args_hash['hpxml_path']).gsub('.xml', '')
-      annual_csv = File.join(output_dir, "#{hpxml_name}.csv")
-      timeseries_csv = File.join(output_dir, "#{hpxml_name}_Hourly.csv")
-      run_log = File.join(output_dir, 'run.log')
+      annual_csv = args_hash['hpxml_path'].gsub('.xml', '.csv')
+      timeseries_csv = args_hash['hpxml_path'].gsub('.xml', '_Hourly.csv')
+      run_log = File.join(File.dirname(args_hash['hpxml_path']), 'run.log')
     else
       annual_csv = File.join(File.dirname(template_osw), 'run', 'results_annual.csv')
       timeseries_csv = File.join(File.dirname(template_osw), 'run', 'results_timeseries.csv')


### PR DESCRIPTION
## Pull Request Description

Closes #1105. Throws an error in the reporting measure if we find that the simulation results are Infinity.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] ~Checked the code coverage report on CI~
- [ ] No unexpected changes to simulation results of sample files
