### PR TITLE
Fix missing table in docs

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build documentation
         run: |
           cd docs
-          make html
+          make html SPHINXOPTS="-W --keep-going -n"
 
       - name: Save Docs
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Pull Request Description

A malformed table is only a warning, not an error, so the docs built successfully but were missing the table. Attempting to [treat warnings as errors](https://stackoverflow.com/questions/38048945/how-to-turn-warnings-into-errors-when-building-sphinx-documentation-with-setupto) and then will fix the issue.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] Checked the code coverage report on CI
- [ ] No unexpected changes to simulation results of sample files
