### PR TITLE
clarify emissions factor table in ANSI/RESNET/ICCC 301

### DIFF
--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -294,8 +294,6 @@ Default Values
 ~~~~~~~~~~~~~~
 
 If EmissionsType is "CO2e", "NOx" or "SO2" and a given fuel's emissions factor is not entered, they will be defaulted as follows.
-Values are based on ANSI/RESNET/ICC 301 and include both combustion and pre-combustion (e.g., methane leakage for natural gas) emissions.
-If no default value is available, a warning will be issued.
 
   ============  ==============  =============  =============
   Fuel Type     CO2e [lb/MBtu]  NOx [lb/MBtu]  SO2 [lb/MBtu]
@@ -307,6 +305,10 @@ If no default value is available, a warning will be issued.
   wood          --              --             --
   wood pellets  --              --             --
   ============  ==============  =============  =============
+
+Default values are from *Table 5.1.2(1) National Average Emission Factors for Household Fuels* from *ANSI/RESNET/ICCC 301 Standard for the Calculation and Labeling of the Energy Performance of Dwelling and Sleeping Units using an Energy Rating Index* and include both combustion and pre-combustion (e.g., methane leakage for natural gas) emissions.
+
+If no default value is available, a warning will be issued.
 
 .. _buildingsite:
 


### PR DESCRIPTION
## Pull Request Description

A minor documentation change to clarify where the default emissions factors come from

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

~~- [ ] Schematron validator (`EPvalidator.xml`) has been updated~~
~~- [ ] Sample files have been added/updated (via `tasks.rb`)~~
~~- [ ] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)~~
- [ x ] Documentation has been updated
~~- [ ] Changelog has been updated~~
~~- [ ] `openstudio tasks.rb update_measures` has been run~~
~~- [ ] Checked the code coverage report on CI~~
~~- [ ] No unexpected changes to simulation results of sample files~~
