### PR TITLE
Reporting measure runner registered values

### DIFF
--- a/ReportHPXMLOutput/measure.xml
+++ b/ReportHPXMLOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_hpxml_output</name>
   <uid>9561a0d7-60ad-48c5-8337-2461df044d80</uid>
-  <version_id>65499b15-96e4-4328-8f9c-21f55042dd37</version_id>
-  <version_modified>20220621T182652Z</version_modified>
+  <version_id>1ff88d00-e5b1-4ff8-a4a6-a0da2f6fccc3</version_id>
+  <version_modified>20220623T212639Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportHPXMLOutput</class_name>
   <display_name>HPXML Output Report</display_name>
@@ -79,7 +79,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F2F01FF5</checksum>
+      <checksum>3CB6117D</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -183,7 +183,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     output_names = []
     all_outputs.each do |outputs|
       outputs.values.each do |obj|
-        output_names << get_runner_output_name(obj)
+        output_names << get_runner_output_name(obj.name, obj.annual_units)
       end
     end
 
@@ -1265,9 +1265,9 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     all_outputs.each do |o|
       o.each do |key, obj|
         if obj.is_a?(Emission)
-          runner_output_name = "#{get_runner_output_name(obj)}: Total"
+          runner_output_name = get_runner_output_name("#{obj.name}: Total", obj.annual_units)
         else
-          runner_output_name = get_runner_output_name(obj)
+          runner_output_name = get_runner_output_name(obj.name, obj.annual_units)
         end
         output_name = OpenStudio::toUnderscoreCase(runner_output_name)
         output_val = obj.annual_output.to_f.round(n_digits)
@@ -1277,7 +1277,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
         if obj.is_a?(Emission)
           # Include disaggregated by fuel
           obj.annual_output_by_fuel.each do |fuel, annual_output|
-            output_name = OpenStudio::toUnderscoreCase("#{get_runner_output_name(obj)}: #{fuel}: Total")
+            output_name = OpenStudio::toUnderscoreCase(get_runner_output_name("#{obj.name}: #{fuel}: Total", obj.annual_units))
             output_val = annual_output.to_f.round(n_digits)
             runner.registerValue(output_name, output_val)
             runner.registerInfo("Registering #{output_val} for #{output_name}.")
@@ -1285,7 +1285,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
           # Include disaggregated by end use
           obj.annual_output_by_end_use.each do |key, annual_output|
             fuel_type, end_use_type = key
-            output_name = OpenStudio::toUnderscoreCase("#{get_runner_output_name(obj)}: #{fuel_type}: #{end_use_type}")
+            output_name = OpenStudio::toUnderscoreCase(get_runner_output_name("#{obj.name}: #{fuel_type}: #{end_use_type}", obj.annual_units))
             output_val = annual_output.to_f.round(n_digits)
             runner.registerValue(output_name, output_val)
             runner.registerInfo("Registering #{output_val} for #{output_name}.")
@@ -1301,8 +1301,8 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     end
   end
 
-  def get_runner_output_name(obj)
-    return "#{obj.name} #{obj.annual_units}"
+  def get_runner_output_name(name, annual_units)
+    return "#{name} #{annual_units}"
   end
 
   def append_eri_results(results_out, line_break)

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>aac6a233-89e8-4abb-b987-22935d64d4b5</version_id>
-  <version_modified>20220621T170015Z</version_modified>
+  <version_id>ed412b0e-7440-478d-8277-a799d47a57c5</version_id>
+  <version_modified>20220623T212639Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1577,7 +1577,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>99C628E3</checksum>
+      <checksum>AC09C4E4</checksum>
     </file>
     <file>
       <version>
@@ -1588,7 +1588,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F735363E</checksum>
+      <checksum>89E8A26C</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/tests/output_report_test.rb
+++ b/ReportSimulationOutput/tests/output_report_test.rb
@@ -428,6 +428,7 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_annual_rows = AnnualRows
     actual_annual_rows = File.readlines(annual_csv).map { |x| x.split(',')[0].strip }.select { |x| !x.empty? }
     assert_equal(expected_annual_rows.sort, actual_annual_rows.sort)
+    _check_for_runner_registered_values(File.join(File.dirname(annual_csv), 'results.json'), expected_annual_rows)
   end
 
   def test_annual_only2
@@ -453,6 +454,7 @@ class ReportSimulationOutputTest < MiniTest::Test
     expected_annual_rows = AnnualRows + emission_annual_cols
     actual_annual_rows = File.readlines(annual_csv).map { |x| x.split(',')[0].strip }.select { |x| !x.empty? }
     assert_equal(expected_annual_rows.sort, actual_annual_rows.sort)
+    _check_for_runner_registered_values(File.join(File.dirname(annual_csv), 'results.json'), expected_annual_rows)
   end
 
   def test_timeseries_hourly_total_energy
@@ -1316,6 +1318,18 @@ class ReportSimulationOutputTest < MiniTest::Test
     timeseries_cols.each do |col|
       has_no_zero_timeseries_value = !values[col].include?(0.0)
       assert(has_no_zero_timeseries_value)
+    end
+  end
+
+  def _check_for_runner_registered_values(results_json, expected_annual_rows)
+    expected_registered_values = expected_annual_rows.map { |c| OpenStudio::toUnderscoreCase(c).chomp('_') }
+
+    require 'json'
+    json = JSON.parse(File.read(results_json))
+    actual_registered_values = json['ReportSimulationOutput'].keys
+
+    expected_registered_values.each do |val|
+      assert(actual_registered_values.include? val)
     end
   end
 end


### PR DESCRIPTION
## Pull Request Description

Adds tests to ensure that ReportSimulationOutput runner registered value names are perfectly consistent with the results_annual.csv row names and never become out of sync. Fixes a couple emission registered value names that became inconsistent due to https://github.com/NREL/OpenStudio-HPXML/pull/1123.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [x] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] Checked the code coverage report on CI
- [x] No unexpected changes to simulation results of sample files
