### PR TITLE
Small utility bill enhancements for BEopt

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>97c28235-28b7-4234-ac22-4271a57e832e</version_id>
-  <version_modified>20220630T181502Z</version_modified>
+  <version_id>187d5993-8bbd-4824-b0ec-9705e7f1a157</version_id>
+  <version_modified>20220701T000406Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -553,12 +553,6 @@
       <checksum>4EC931C2</checksum>
     </file>
     <file>
-      <filename>utility_bills.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B1272D18</checksum>
-    </file>
-    <file>
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -577,16 +571,22 @@
       <checksum>6EA33127</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>7C7E33D1</checksum>
-    </file>
-    <file>
       <filename>hpxml_schematron/EPvalidator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
       <checksum>A74A923A</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>BFD61DAF</checksum>
+    </file>
+    <file>
+      <filename>utility_bills.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>E7DA6FFC</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>a3819423-f8e3-455b-b7af-3e50e3e4a99e</version_id>
-  <version_modified>20220701T010632Z</version_modified>
+  <version_id>c4161445-346d-4934-8dea-68455acae3f6</version_id>
+  <version_modified>20220701T011702Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -586,7 +586,7 @@
       <filename>utility_bills.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>513117A0</checksum>
+      <checksum>A561B041</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>bbe3fa28-aefc-4340-8ae7-9d4e5df15476</version_id>
-  <version_modified>20220701T002731Z</version_modified>
+  <version_id>5337b405-48f7-4c77-8040-021b2c51548e</version_id>
+  <version_modified>20220701T004818Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -586,7 +586,7 @@
       <filename>utility_bills.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>6D7442BA</checksum>
+      <checksum>C95E50D1</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>5337b405-48f7-4c77-8040-021b2c51548e</version_id>
-  <version_modified>20220701T004818Z</version_modified>
+  <version_id>a3819423-f8e3-455b-b7af-3e50e3e4a99e</version_id>
+  <version_modified>20220701T010632Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -586,7 +586,7 @@
       <filename>utility_bills.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>C95E50D1</checksum>
+      <checksum>513117A0</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>187d5993-8bbd-4824-b0ec-9705e7f1a157</version_id>
-  <version_modified>20220701T000406Z</version_modified>
+  <version_id>bbe3fa28-aefc-4340-8ae7-9d4e5df15476</version_id>
+  <version_modified>20220701T002731Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -586,7 +586,7 @@
       <filename>utility_bills.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>E7DA6FFC</checksum>
+      <checksum>6D7442BA</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -286,7 +286,7 @@ class HPXMLDefaults
           scenario.elec_fixed_charge_isdefaulted = true
         end
         if scenario.elec_marginal_rate.nil?
-          scenario.elec_marginal_rate = UtilityBills.get_auto_marginal_rate(runner, hpxml.header.state_code, HPXML::FuelTypeElectricity, scenario.elec_fixed_charge)
+          scenario.elec_marginal_rate, _ = UtilityBills.get_rates_from_eia_data(runner, hpxml.header.state_code, HPXML::FuelTypeElectricity, scenario.elec_fixed_charge)
           scenario.elec_marginal_rate_isdefaulted = true
         end
       end
@@ -297,7 +297,7 @@ class HPXMLDefaults
           scenario.natural_gas_fixed_charge_isdefaulted = true
         end
         if scenario.natural_gas_marginal_rate.nil?
-          scenario.natural_gas_marginal_rate = UtilityBills.get_auto_marginal_rate(runner, hpxml.header.state_code, HPXML::FuelTypeNaturalGas, scenario.natural_gas_fixed_charge)
+          scenario.natural_gas_marginal_rate, _ = UtilityBills.get_rates_from_eia_data(runner, hpxml.header.state_code, HPXML::FuelTypeNaturalGas, scenario.natural_gas_fixed_charge)
           scenario.natural_gas_marginal_rate_isdefaulted = true
         end
       end
@@ -308,7 +308,7 @@ class HPXMLDefaults
           scenario.propane_fixed_charge_isdefaulted = true
         end
         if scenario.propane_marginal_rate.nil?
-          scenario.propane_marginal_rate = UtilityBills.get_auto_marginal_rate(runner, hpxml.header.state_code, HPXML::FuelTypePropane, nil)
+          scenario.propane_marginal_rate, _ = UtilityBills.get_rates_from_eia_data(runner, hpxml.header.state_code, HPXML::FuelTypePropane, nil)
           scenario.propane_marginal_rate_isdefaulted = true
         end
       end
@@ -319,7 +319,7 @@ class HPXMLDefaults
           scenario.fuel_oil_fixed_charge_isdefaulted = true
         end
         if scenario.fuel_oil_marginal_rate.nil?
-          scenario.fuel_oil_marginal_rate = UtilityBills.get_auto_marginal_rate(runner, hpxml.header.state_code, HPXML::FuelTypeOil, nil)
+          scenario.fuel_oil_marginal_rate, _ = UtilityBills.get_rates_from_eia_data(runner, hpxml.header.state_code, HPXML::FuelTypeOil, nil)
           scenario.fuel_oil_marginal_rate_isdefaulted = true
         end
       end

--- a/HPXMLtoOpenStudio/resources/utility_bills.rb
+++ b/HPXMLtoOpenStudio/resources/utility_bills.rb
@@ -179,9 +179,9 @@ if ARGV.size == 8
     state_code, fixed_charge, marginal_rate = values
     marginal_rate, average_rate = UtilityBills.get_rates_from_eia_data(runner, state_code, fuel_type, fixed_charge, marginal_rate)
     if (not marginal_rate.nil?) && average_rate.nil?
-      puts "#{fuel_type} #{marginal_rate.round(4)} #{marginal_rate.round(4)}"
+      puts "#{fuel_type} #{marginal_rate.round(6)} #{marginal_rate.round(6)}"
     else
-      puts "#{fuel_type} #{marginal_rate.round(4)} #{average_rate.round(4)}"
+      puts "#{fuel_type} #{marginal_rate.round(6)} #{average_rate.round(6)}"
     end
   end
 end

--- a/HPXMLtoOpenStudio/resources/utility_bills.rb
+++ b/HPXMLtoOpenStudio/resources/utility_bills.rb
@@ -169,6 +169,8 @@ if ARGV.size == 8
   gas_marginal_rate = nil if gas_marginal_rate <= 0
   elec_state = 'US' if Constants.StateCodesMap[elec_state].nil?
   gas_state = 'US' if Constants.StateCodesMap[gas_state].nil?
+  oil_state = 'US' if Constants.StateCodesMap[oil_state].nil?
+  propane_state = 'US' if Constants.StateCodesMap[propane_state].nil?
 
   { HPXML::FuelTypeElectricity => [elec_state, elec_fixed_charge, elec_marginal_rate],
     HPXML::FuelTypeNaturalGas => [gas_state, gas_fixed_charge, gas_marginal_rate],

--- a/ReportUtilityBills/measure.xml
+++ b/ReportUtilityBills/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_utility_bills</name>
   <uid>ca88a425-e59a-4bc4-af51-c7e7d1e960fe</uid>
-  <version_id>08f333e0-1d62-4c5f-84a9-d1f3730439fa</version_id>
-  <version_modified>20220701T002733Z</version_modified>
+  <version_id>42856ace-4eff-4733-8853-de1c944bc59e</version_id>
+  <version_modified>20220701T004930Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>ReportUtilityBills</class_name>
   <display_name>Utility Bills Report</display_name>
@@ -123,7 +123,7 @@
       <filename>utility_bills_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>9C67F27C</checksum>
+      <checksum>25E68510</checksum>
     </file>
   </files>
 </measure>

--- a/ReportUtilityBills/measure.xml
+++ b/ReportUtilityBills/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_utility_bills</name>
   <uid>ca88a425-e59a-4bc4-af51-c7e7d1e960fe</uid>
-  <version_id>0785e004-7cf3-474b-8a5e-6c578534b650</version_id>
-  <version_modified>20220701T000409Z</version_modified>
+  <version_id>08f333e0-1d62-4c5f-84a9-d1f3730439fa</version_id>
+  <version_modified>20220701T002733Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>ReportUtilityBills</class_name>
   <display_name>Utility Bills Report</display_name>
@@ -123,7 +123,7 @@
       <filename>utility_bills_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>B8414188</checksum>
+      <checksum>9C67F27C</checksum>
     </file>
   </files>
 </measure>

--- a/ReportUtilityBills/measure.xml
+++ b/ReportUtilityBills/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_utility_bills</name>
   <uid>ca88a425-e59a-4bc4-af51-c7e7d1e960fe</uid>
-  <version_id>42856ace-4eff-4733-8853-de1c944bc59e</version_id>
-  <version_modified>20220701T004930Z</version_modified>
+  <version_id>f17f2a22-0978-4fd0-ae81-ad90242b0d23</version_id>
+  <version_modified>20220701T011705Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>ReportUtilityBills</class_name>
   <display_name>Utility Bills Report</display_name>
@@ -123,7 +123,7 @@
       <filename>utility_bills_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>25E68510</checksum>
+      <checksum>86C9774F</checksum>
     </file>
   </files>
 </measure>

--- a/ReportUtilityBills/measure.xml
+++ b/ReportUtilityBills/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_utility_bills</name>
   <uid>ca88a425-e59a-4bc4-af51-c7e7d1e960fe</uid>
-  <version_id>2f998db2-2d09-4abe-894d-e24ba091d58f</version_id>
-  <version_modified>20220630T181843Z</version_modified>
+  <version_id>0785e004-7cf3-474b-8a5e-6c578534b650</version_id>
+  <version_modified>20220701T000409Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>ReportUtilityBills</class_name>
   <display_name>Utility Bills Report</display_name>
@@ -123,7 +123,7 @@
       <filename>utility_bills_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>EB0A59FC</checksum>
+      <checksum>B8414188</checksum>
     </file>
   </files>
 </measure>

--- a/ReportUtilityBills/tests/utility_bills_test.rb
+++ b/ReportUtilityBills/tests/utility_bills_test.rb
@@ -367,36 +367,46 @@ class ReportUtilityBillsTest < MiniTest::Test
     # This is used by BEopt v3
 
     # Test retrieval of marginal/average rates for user-specified fixed charges
-    elec_state = 'CO'
+    elec_state = 'CT'
     elec_fixed_charge = 12.0
     elec_marginal_rate = 0.0
     gas_state = 'US'
     gas_fixed_charge = 12.0
     gas_marginal_rate = 0.0
+    oil_state = 'CT'
+    propane_state = 'US'
     utility_bills_rb = File.join(File.dirname(__FILE__), '../../HPXMLtoOpenStudio/resources/utility_bills.rb')
     io = IO.popen([OpenStudio.getOpenStudioCLI.to_s, utility_bills_rb,
                    elec_state, elec_fixed_charge.to_s, elec_marginal_rate.to_s,
-                   gas_state, gas_fixed_charge.to_s, gas_marginal_rate.to_s])
+                   gas_state, gas_fixed_charge.to_s, gas_marginal_rate.to_s,
+                   oil_state, propane_state])
     out_lines = io.read.split("\n")
-    assert_equal(2, out_lines.size)
-    assert_equal("#{HPXML::FuelTypeElectricity} 0.1136 0.1313", out_lines[0])
+    assert_equal(4, out_lines.size)
+    assert_equal("#{HPXML::FuelTypeElectricity} 0.2022 0.2186", out_lines[0])
     assert_equal("#{HPXML::FuelTypeNaturalGas} 0.9878 1.1803", out_lines[1])
+    assert_equal("#{HPXML::FuelTypeOil} 3.4361 3.4361", out_lines[2])
+    assert_equal("#{HPXML::FuelTypePropane} 2.6954 2.6954", out_lines[3])
 
     # Test retrieval of average rates for user-specified fixed charges and marginal rates
     elec_state = 'US'
     elec_fixed_charge = 12.0
     elec_marginal_rate = 0.12
-    gas_state = 'CO'
+    gas_state = 'CT'
     gas_fixed_charge = 12.0
     gas_marginal_rate = 0.8
+    oil_state = 'US'
+    propane_state = 'CT'
     utility_bills_rb = File.join(File.dirname(__FILE__), '../../HPXMLtoOpenStudio/resources/utility_bills.rb')
     io = IO.popen([OpenStudio.getOpenStudioCLI.to_s, utility_bills_rb,
                    elec_state, elec_fixed_charge.to_s, elec_marginal_rate.to_s,
-                   gas_state, gas_fixed_charge.to_s, gas_marginal_rate.to_s])
+                   gas_state, gas_fixed_charge.to_s, gas_marginal_rate.to_s,
+                   oil_state, propane_state])
     out_lines = io.read.split("\n")
-    assert_equal(2, out_lines.size)
+    assert_equal(4, out_lines.size)
     assert_equal("#{HPXML::FuelTypeElectricity} #{elec_marginal_rate} 0.133", out_lines[0])
-    assert_equal("#{HPXML::FuelTypeNaturalGas} #{gas_marginal_rate} 0.9692", out_lines[1])
+    assert_equal("#{HPXML::FuelTypeNaturalGas} #{gas_marginal_rate} 0.9558", out_lines[1])
+    assert_equal("#{HPXML::FuelTypeOil} 3.4953 3.4953", out_lines[2])
+    assert_equal("#{HPXML::FuelTypePropane} 3.6287 3.6287", out_lines[3])
   end
 
   def _check_bills(expected_bills, actual_bills)

--- a/ReportUtilityBills/tests/utility_bills_test.rb
+++ b/ReportUtilityBills/tests/utility_bills_test.rb
@@ -382,10 +382,10 @@ class ReportUtilityBillsTest < MiniTest::Test
                    oil_state, propane_state])
     out_lines = io.read.split("\n")
     assert_equal(4, out_lines.size)
-    assert_equal("#{HPXML::FuelTypeElectricity} 0.2022 0.2186", out_lines[0])
-    assert_equal("#{HPXML::FuelTypeNaturalGas} 0.9878 1.1803", out_lines[1])
-    assert_equal("#{HPXML::FuelTypeOil} 3.4361 3.4361", out_lines[2])
-    assert_equal("#{HPXML::FuelTypePropane} 2.6954 2.6954", out_lines[3])
+    assert_equal("#{HPXML::FuelTypeElectricity} 0.202184 0.2186", out_lines[0])
+    assert_equal("#{HPXML::FuelTypeNaturalGas} 0.987814 1.180328", out_lines[1])
+    assert_equal("#{HPXML::FuelTypeOil} 3.436115 3.436115", out_lines[2])
+    assert_equal("#{HPXML::FuelTypePropane} 2.695423 2.695423", out_lines[3])
 
     # Test retrieval of average rates for user-specified fixed charges and marginal rates
     elec_state = 'US'
@@ -403,10 +403,10 @@ class ReportUtilityBillsTest < MiniTest::Test
                    oil_state, propane_state])
     out_lines = io.read.split("\n")
     assert_equal(4, out_lines.size)
-    assert_equal("#{HPXML::FuelTypeElectricity} #{elec_marginal_rate} 0.133", out_lines[0])
-    assert_equal("#{HPXML::FuelTypeNaturalGas} #{gas_marginal_rate} 0.9558", out_lines[1])
-    assert_equal("#{HPXML::FuelTypeOil} 3.4953 3.4953", out_lines[2])
-    assert_equal("#{HPXML::FuelTypePropane} 3.6287 3.6287", out_lines[3])
+    assert_equal("#{HPXML::FuelTypeElectricity} #{elec_marginal_rate} 0.133043", out_lines[0])
+    assert_equal("#{HPXML::FuelTypeNaturalGas} #{gas_marginal_rate} 0.955844", out_lines[1])
+    assert_equal("#{HPXML::FuelTypeOil} 3.495346 3.495346", out_lines[2])
+    assert_equal("#{HPXML::FuelTypePropane} 3.628692 3.628692", out_lines[3])
   end
 
   def _check_bills(expected_bills, actual_bills)

--- a/ReportUtilityBills/tests/utility_bills_test.rb
+++ b/ReportUtilityBills/tests/utility_bills_test.rb
@@ -275,14 +275,14 @@ class ReportUtilityBillsTest < MiniTest::Test
     # and every fuel type.
     Constants.StateCodesMap.keys.each do |state_code|
       fuel_types.each do |fuel_type|
-        flatratebuy = UtilityBills.get_auto_marginal_rate(nil, state_code, fuel_type, 0)
+        flatratebuy, _ = UtilityBills.get_rates_from_eia_data(nil, state_code, fuel_type, 0)
         refute_nil(flatratebuy)
       end
     end
 
     # Check that any other state code is gracefully handled (no error)
     fuel_types.each do |fuel_type|
-      UtilityBills.get_auto_marginal_rate(nil, 'XX', fuel_type, 0)
+      UtilityBills.get_rates_from_eia_data(nil, 'XX', fuel_type, 0)
     end
   end
 
@@ -355,6 +355,36 @@ class ReportUtilityBillsTest < MiniTest::Test
     assert_equal(1.0, CalculateUtilityBill.calculate_monthly_prorate(header, 3))
     assert_equal(10 / 30.0, CalculateUtilityBill.calculate_monthly_prorate(header, 4))
     assert_equal(0.0, CalculateUtilityBill.calculate_monthly_prorate(header, 5))
+  end
+
+  def test_call_from_cli
+    # This is used by BEopt v3
+
+    state_code = 'CO'
+    elec_fixed_charge = 12.0
+    gas_fixed_charge = 12.0
+
+    # Test retrieval of marginal/average rates for user-specified fixed charges
+    elec_marginal_rate = 0.0
+    gas_marginal_rate = 0.0
+    utility_bills_rb = File.join(File.dirname(__FILE__), '../../HPXMLtoOpenStudio/resources/utility_bills.rb')
+    io = IO.popen([OpenStudio.getOpenStudioCLI.to_s, utility_bills_rb, state_code,
+                   elec_fixed_charge.to_s, gas_fixed_charge.to_s, elec_marginal_rate.to_s, gas_marginal_rate.to_s])
+    out_lines = io.read.split("\n")
+    assert_equal(2, out_lines.size)
+    assert_equal("#{HPXML::FuelTypeElectricity} 0.1136 0.1313", out_lines[0])
+    assert_equal("#{HPXML::FuelTypeNaturalGas} 0.717 0.8862", out_lines[1])
+
+    # Test retrieval of average rates for user-specified fixed charges and marginal rates
+    elec_marginal_rate = 0.12
+    gas_marginal_rate = 0.8
+    utility_bills_rb = File.join(File.dirname(__FILE__), '../../HPXMLtoOpenStudio/resources/utility_bills.rb')
+    io = IO.popen([OpenStudio.getOpenStudioCLI.to_s, utility_bills_rb, state_code,
+                   elec_fixed_charge.to_s, gas_fixed_charge.to_s, elec_marginal_rate.to_s, gas_marginal_rate.to_s])
+    out_lines = io.read.split("\n")
+    assert_equal(2, out_lines.size)
+    assert_equal("#{HPXML::FuelTypeElectricity} #{elec_marginal_rate} 0.1377", out_lines[0])
+    assert_equal("#{HPXML::FuelTypeNaturalGas} #{gas_marginal_rate} 0.9692", out_lines[1])
   end
 
   def _check_bills(expected_bills, actual_bills)


### PR DESCRIPTION
## Pull Request Description

1. Allow utility_bills.rb to be called from the command line
2. Allow US (national) values to be retrieved

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [x] ~Documentation has been updated~
- [x] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] ~Checked the code coverage report on CI~
- [x] No unexpected changes to simulation results of sample files
