### PR TITLE
Change window shading EMS program calling point

### DIFF
--- a/HPXMLtoOpenStudio/resources/constructions.rb
+++ b/HPXMLtoOpenStudio/resources/constructions.rb
@@ -1406,7 +1406,7 @@ class Constructions
 
         program_cm = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
         program_cm.setName("#{program.name} calling manager")
-        program_cm.setCallingPoint('BeginZoneTimestepAfterInitHeatBalance') # https://github.com/NREL/EnergyPlus/pull/8477#discussion_r567320478
+        program_cm.setCallingPoint('EndOfSystemSizing') # https://github.com/NREL/EnergyPlus/pull/8477#discussion_r567320478
         program_cm.addProgram(program)
       else
         shading_ems[:program].addLine("Set #{actuator.name} = #{default_vf_to_ground}*#{shading_coeff}")


### PR DESCRIPTION
## Pull Request Description

Change window shading ems program calling point to "EndOfSystemSizing"
Fix the sum of sky diffuse and ground diffuse not matching the total

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] Checked the code coverage report on CI
- [ ] No unexpected changes to simulation results of sample files
