### PR TITLE
Support multiple IECC climate zones in HPXML class

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3831,8 +3831,8 @@ class HPXMLFile
     hpxml.climate_and_risk_zones.weather_station_id = 'WeatherStation'
 
     if args[:site_iecc_zone].is_initialized
-      hpxml.climate_and_risk_zones.iecc_zone = args[:site_iecc_zone].get
-      hpxml.climate_and_risk_zones.iecc_year = 2006
+      hpxml.climate_and_risk_zones.climate_zone_ieccs.add(zone: args[:site_iecc_zone].get,
+                                                          year: 2006)
     end
 
     weather_station_name = File.basename(args[:weather_station_epw_filepath]).gsub('.epw', '')

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>adadab12-4481-4c1f-bb0f-980c6dbdf441</version_id>
-  <version_modified>20220818T192810Z</version_modified>
+  <version_id>03a79ea8-0073-4958-a3bb-423259bbcdf9</version_id>
+  <version_modified>20220915T153454Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6404,7 +6404,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>788EEDBC</checksum>
+      <checksum>522E2920</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>84e8e4e9-c997-43d7-8a97-330eb72f09bd</version_id>
-  <version_modified>20220915T154111Z</version_modified>
+  <version_id>700496d3-089d-489d-a2cc-ad09d7869d03</version_id>
+  <version_modified>20220915T180012Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -440,12 +440,6 @@
       <checksum>DF9CC863</checksum>
     </file>
     <file>
-      <filename>test_validation.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>2302726B</checksum>
-    </file>
-    <file>
       <filename>test_pv.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -593,6 +587,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>6ED20DA1</checksum>
+    </file>
+    <file>
+      <filename>test_validation.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>84BC4702</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>22a4382c-e1f6-4fe6-aa03-b7e47e4194e1</version_id>
-  <version_modified>20220912T230453Z</version_modified>
+  <version_id>84e8e4e9-c997-43d7-8a97-330eb72f09bd</version_id>
+  <version_modified>20220915T154111Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -548,22 +548,10 @@
       <checksum>B6BC6A9D</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D6374C8B</checksum>
-    </file>
-    <file>
       <filename>test_airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>15015829</checksum>
-    </file>
-    <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C6A2AF80</checksum>
     </file>
     <file>
       <filename>weather.rb</filename>
@@ -578,12 +566,6 @@
       <checksum>A2B7F8E1</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>5694E794</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.3.0</identifier>
@@ -593,6 +575,24 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>4F98F3F7</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>0D60DE1E</checksum>
+    </file>
+    <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>7950A1A2</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6ED20DA1</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -494,18 +494,13 @@ class HPXMLDefaults
   end
 
   def self.apply_climate_and_risk_zones(hpxml, epw_file)
-    if (not epw_file.nil?) && (hpxml.climate_and_risk_zones.iecc_zone.nil? || hpxml.climate_and_risk_zones.iecc_year.nil?)
-      if hpxml.climate_and_risk_zones.iecc_zone.nil?
-        climate_zone_iecc = Location.get_climate_zone_iecc(epw_file.wmoNumber)
-        if Constants.IECCZones.include? climate_zone_iecc
-          hpxml.climate_and_risk_zones.iecc_zone = climate_zone_iecc
-          hpxml.climate_and_risk_zones.iecc_zone_isdefaulted = true
-        end
-      end
-
-      if (not hpxml.climate_and_risk_zones.iecc_zone.nil?) && hpxml.climate_and_risk_zones.iecc_year.nil?
-        hpxml.climate_and_risk_zones.iecc_year = 2006
-        hpxml.climate_and_risk_zones.iecc_year_isdefaulted = true
+    if (not epw_file.nil?) && hpxml.climate_and_risk_zones.climate_zone_ieccs.empty?
+      zone = Location.get_climate_zone_iecc(epw_file.wmoNumber)
+      if not zone.nil?
+        hpxml.climate_and_risk_zones.climate_zone_ieccs.add(zone: zone,
+                                                            year: 2006,
+                                                            zone_isdefaulted: true,
+                                                            year_isdefaulted: true)
       end
     end
   end
@@ -1701,7 +1696,7 @@ class HPXMLDefaults
         end
       end
       if water_heating_system.location.nil?
-        water_heating_system.location = Waterheater.get_default_location(hpxml, hpxml.climate_and_risk_zones.iecc_zone)
+        water_heating_system.location = Waterheater.get_default_location(hpxml, hpxml.climate_and_risk_zones.climate_zone_ieccs[0].zone)
         water_heating_system.location_isdefaulted = true
       end
       next unless water_heating_system.usage_bin.nil? && (not water_heating_system.uniform_energy_factor.nil?) # FHR & UsageBin only applies to UEF

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -389,23 +389,20 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
   def test_climate_and_risk_zones
     # Test inputs not overridden by defaults
     hpxml = _create_hpxml('base.xml')
-    hpxml.climate_and_risk_zones.iecc_year = 2009
-    hpxml.climate_and_risk_zones.iecc_zone = '2B'
+    hpxml.climate_and_risk_zones.climate_zone_ieccs[0].year = 2009
+    hpxml.climate_and_risk_zones.climate_zone_ieccs[0].zone = '2B'
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_climate_and_risk_zones_values(hpxml_default, 2009, '2B')
 
     # Test defaults
-    hpxml.climate_and_risk_zones.iecc_year = nil
-    hpxml.climate_and_risk_zones.iecc_zone = nil
+    hpxml.climate_and_risk_zones.climate_zone_ieccs[0].delete
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_climate_and_risk_zones_values(hpxml_default, 2006, '5B')
 
     # Test defaults - invalid IECC zone
     hpxml = _create_hpxml('base-location-capetown-zaf.xml')
-    hpxml.climate_and_risk_zones.iecc_year = nil
-    hpxml.climate_and_risk_zones.iecc_zone = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_climate_and_risk_zones_values(hpxml_default, nil, nil)
@@ -3470,14 +3467,14 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
 
   def _test_default_climate_and_risk_zones_values(hpxml, iecc_year, iecc_zone)
     if iecc_year.nil?
-      assert_nil(hpxml.climate_and_risk_zones.iecc_year)
+      assert_equal(0, hpxml.climate_and_risk_zones.climate_zone_ieccs.size)
     else
-      assert_equal(iecc_year, hpxml.climate_and_risk_zones.iecc_year)
+      assert_equal(iecc_year, hpxml.climate_and_risk_zones.climate_zone_ieccs[0].year)
     end
     if iecc_zone.nil?
-      assert_nil(hpxml.climate_and_risk_zones.iecc_zone)
+      assert_equal(0, hpxml.climate_and_risk_zones.climate_zone_ieccs.size)
     else
-      assert_equal(iecc_zone, hpxml.climate_and_risk_zones.iecc_zone)
+      assert_equal(iecc_zone, hpxml.climate_and_risk_zones.climate_zone_ieccs[0].zone)
     end
   end
 

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -398,7 +398,7 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
         hpxml = HPXML.new(hpxml_path: File.join(@sample_files_path, 'base.xml'))
         hpxml.header.transaction = 'modify'
         hpxml.site.site_type = 'mountain'
-        hpxml.climate_and_risk_zones.iecc_year = 2020
+        hpxml.climate_and_risk_zones.climate_zone_ieccs[0].year = 2020
         hpxml.roofs.each do |roof|
           roof.radiant_barrier_grade = 4
         end

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -530,19 +530,19 @@ HPXML Climate Zones
 HPXML Climate Zone IECC
 ***********************
 
-Climate zone information can be entered as an ``/HPXML/Building/BuildingDetails/ClimateandRiskZones/ClimateZoneIECC``.
+Climate zone information can be optionally entered as an ``/HPXML/Building/BuildingDetails/ClimateandRiskZones/ClimateZoneIECC``.
 
   =================================  ========  =====  ===========  ========  ========  ===============
   Element                            Type      Units  Constraints  Required  Default   Description
   =================================  ========  =====  ===========  ========  ========  ===============
-  ``Year``                           integer          See [#]_     No        2006      IECC year
-  ``ClimateZone``                    string           See [#]_     No        See [#]_  IECC zone
+  ``Year``                           integer          See [#]_     Yes                 IECC year
+  ``ClimateZone``                    string           See [#]_     Yes                 IECC zone
   =================================  ========  =====  ===========  ========  ========  ===============
 
   .. [#] Year choices are 2003, 2006, 2009, 2012, 2015, 2018, or 2021.
   .. [#] ClimateZone choices are "1A", "1B", "1C", "2A", "2B", "2C", "3A", "3B", "3C", "4A", "4B", "4C", "5A", "5B", "5C", "6A", "6B", "6C", "7", or "8".
-  .. [#] If ClimateZone not provided, defaults according to the EPW weather file header.
 
+If Climate zone information not provided, defaults according to the EPW weather file header.
 
 Weather information is entered in ``/HPXML/Building/BuildingDetails/ClimateandRiskZones/WeatherStation``.
 

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -132,7 +132,7 @@ So the sum of all end uses for a given fuel (e.g., sum of all "End Use: Natural 
    End Use: Electricity: Hot Water Solar Thermal Pump (MBtu)            Non-zero only when using detailed (not simple) solar thermal inputs
    End Use: Electricity: Lighting Interior (MBtu)
    End Use: Electricity: Lighting Garage (MBtu)
-   End Use: Electricity: Lighting Exterior (MBtu)
+   End Use: Electricity: Lighting Exterior (MBtu)                       Includes exterior holiday lighting
    End Use: Electricity: Mech Vent (MBtu)                               Excludes preheating/precooling
    End Use: Electricity: Mech Vent Preheating (MBtu)
    End Use: Electricity: Mech Vent Precooling (MBtu)


### PR DESCRIPTION
## Pull Request Description

Needed to support the use of multiple climate zones in ENERGY STAR and ZERH. OS-HPXML will continue to only allow a single climate zone to be provided (to prevent confusion as to which is used if there were multiple).

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [x] Documentation has been updated
- [x] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
