### PR TITLE
User choice of columns in the BuildResScheduleFile measure

### DIFF
--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -53,7 +53,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
 
     arg = OpenStudio::Measure::OSArgument.makeStringArgument('schedules_column_names', false)
     arg.setDisplayName('Schedules: Column Names')
-    arg.setDescription('A comma-separated list of the column names to generate. If not provided, defaults to all columns.')
+    arg.setDescription("A comma-separated list of the column names to generate. If not provided, defaults to all columns. Possible column names are: #{SchedulesFile.OccupancyColumnNames.join(', ')}.")
     args << arg
 
     arg = OpenStudio::Measure::OSArgument.makeStringArgument('schedules_vacancy_period', false)

--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -51,6 +51,11 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue('smooth')
     args << arg
 
+    arg = OpenStudio::Measure::OSArgument.makeStringArgument('schedules_column_names', false)
+    arg.setDisplayName('Schedules: Column Names')
+    arg.setDescription('A comma-separated list of the column names to generate. If not provided, defaults to all columns.')
+    args << arg
+
     arg = OpenStudio::Measure::OSArgument.makeStringArgument('schedules_vacancy_period', false)
     arg.setDisplayName('Schedules: Vacancy Period')
     arg.setDescription('Specifies the vacancy period. Enter a date like "Dec 15 - Jan 15".')
@@ -161,6 +166,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     info_msgs << "RandomSeed=#{args[:random_seed]}" if args[:schedules_random_seed].is_initialized
     info_msgs << "GeometryNumOccupants=#{args[:geometry_num_occupants]}"
     info_msgs << "VacancyPeriod=#{args[:schedules_vacancy_period].get}" if args[:schedules_vacancy_period].is_initialized
+    info_msgs << "ColumnNames=#{args[:column_names]}" if args[:schedules_column_names].is_initialized
 
     runner.registerInfo("Created #{args[:schedules_type]} schedule with #{info_msgs.join(', ')}")
 
@@ -188,6 +194,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     args[:state] = hpxml.header.state_code if !hpxml.header.state_code.nil?
 
     args[:random_seed] = args[:schedules_random_seed].get if args[:schedules_random_seed].is_initialized
+    args[:column_names] = args[:schedules_column_names].get.split(',').map(&:strip) if args[:schedules_column_names].is_initialized
 
     if hpxml.building_occupancy.number_of_residents.nil?
       args[:geometry_num_occupants] = Geometry.get_occupancy_default_num(hpxml.building_construction.number_of_bedrooms)

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>b9ab9559-30d8-4b1c-9757-8c911f80e937</version_id>
-  <version_modified>20221031T233528Z</version_modified>
+  <version_id>19e3ab7a-48d3-4816-85dd-57fbd8fd91f9</version_id>
+  <version_modified>20221130T163723Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -37,6 +37,14 @@
           <display_name>stochastic</display_name>
         </choice>
       </choices>
+    </argument>
+    <argument>
+      <name>schedules_column_names</name>
+      <display_name>Schedules: Column Names</display_name>
+      <description>A comma-separated list of the column names to generate. If not provided, defaults to all columns.</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
     </argument>
     <argument>
       <name>schedules_vacancy_period</name>
@@ -891,12 +899,6 @@
       <checksum>127D96AC</checksum>
     </file>
     <file>
-      <filename>build_residential_schedule_file_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>41CA164F</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.2.0</identifier>
@@ -905,13 +907,19 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>8FF07C66</checksum>
+      <checksum>1EC35CBD</checksum>
+    </file>
+    <file>
+      <filename>build_residential_schedule_file_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>8CE52A5A</checksum>
     </file>
     <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>F2E6EBB8</checksum>
+      <checksum>AC348B70</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>19e3ab7a-48d3-4816-85dd-57fbd8fd91f9</version_id>
-  <version_modified>20221130T163723Z</version_modified>
+  <version_id>3a88a262-1431-4bb9-a577-cd235aed6b1e</version_id>
+  <version_modified>20221201T013247Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -41,7 +41,7 @@
     <argument>
       <name>schedules_column_names</name>
       <display_name>Schedules: Column Names</display_name>
-      <description>A comma-separated list of the column names to generate. If not provided, defaults to all columns.</description>
+      <description>A comma-separated list of the column names to generate. If not provided, defaults to all columns. Possible column names are: occupants, lighting_interior, lighting_exterior, lighting_garage, lighting_exterior_holiday, cooking_range, refrigerator, extra_refrigerator, freezer, dishwasher, clothes_washer, clothes_dryer, ceiling_fan, plug_loads_other, plug_loads_tv, plug_loads_vehicle, plug_loads_well_pump, fuel_loads_grill, fuel_loads_lighting, fuel_loads_fireplace, pool_pump, pool_heater, hot_tub_pump, hot_tub_heater, hot_water_dishwasher, hot_water_clothes_washer, hot_water_fixtures.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -899,6 +899,18 @@
       <checksum>127D96AC</checksum>
     </file>
     <file>
+      <filename>schedules.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>AC348B70</checksum>
+    </file>
+    <file>
+      <filename>build_residential_schedule_file_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>10DD8842</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.2.0</identifier>
@@ -907,19 +919,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>1EC35CBD</checksum>
-    </file>
-    <file>
-      <filename>build_residential_schedule_file_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>8CE52A5A</checksum>
-    </file>
-    <file>
-      <filename>schedules.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>AC348B70</checksum>
+      <checksum>3D8ADC7F</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialScheduleFile/tests/build_residential_schedule_file_test.rb
+++ b/BuildResidentialScheduleFile/tests/build_residential_schedule_file_test.rb
@@ -217,7 +217,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
 
     @args_hash['schedules_type'] = 'stochastic'
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
-    @args_hash['schedules_column_names'] = 'foobar, foobar2'
+    @args_hash['schedules_column_names'] = "foobar, #{SchedulesFile::ColumnCookingRange}, foobar2"
     _model, _hpxml, result = _test_measure(expect_fail: true)
 
     error_msgs = result.errors.map { |x| x.logMessage }

--- a/BuildResidentialScheduleFile/tests/build_residential_schedule_file_test.rb
+++ b/BuildResidentialScheduleFile/tests/build_residential_schedule_file_test.rb
@@ -180,6 +180,51 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert(!sf.schedules.keys.include?(SchedulesFile::ColumnVacancy))
   end
 
+  def test_stochastic_subset_of_columns
+    hpxml = _create_hpxml('base.xml')
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+
+    columns = [SchedulesFile::ColumnCookingRange,
+               SchedulesFile::ColumnDishwasher,
+               SchedulesFile::ColumnHotWaterDishwasher,
+               SchedulesFile::ColumnClothesWasher,
+               SchedulesFile::ColumnHotWaterClothesWasher,
+               SchedulesFile::ColumnClothesDryer,
+               SchedulesFile::ColumnHotWaterFixtures]
+
+    @args_hash['schedules_type'] = 'stochastic'
+    @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
+    @args_hash['schedules_column_names'] = columns.join(', ')
+    model, hpxml, result = _test_measure()
+
+    info_msgs = result.info.map { |x| x.logMessage }
+    assert(info_msgs.any? { |info_msg| info_msg.include?('ColumnNames') })
+
+    sf = SchedulesFile.new(model: model, schedules_paths: hpxml.header.schedules_filepaths)
+    sf.validate_schedules(year: 2007)
+
+    columns.each do |column|
+      assert(sf.schedules.keys.include?(column))
+    end
+    (SchedulesFile.ColumnNames - columns).each do |column|
+      assert(!sf.schedules.keys.include?(column))
+    end
+  end
+
+  def test_stochastic_subset_of_columns_invalid_name
+    hpxml = _create_hpxml('base.xml')
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+
+    @args_hash['schedules_type'] = 'stochastic'
+    @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
+    @args_hash['schedules_column_names'] = 'foobar, foobar2'
+    _model, _hpxml, result = _test_measure(expect_fail: true)
+
+    error_msgs = result.errors.map { |x| x.logMessage }
+    assert(error_msgs.any? { |error_msg| error_msg.include?("Invalid column name specified: 'foobar'.") })
+    assert(error_msgs.any? { |error_msg| error_msg.include?("Invalid column name specified: 'foobar2'.") })
+  end
+
   def test_stochastic_vacancy
     hpxml = _create_hpxml('base.xml')
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
@@ -508,7 +553,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     end
   end
 
-  def _test_measure()
+  def _test_measure(expect_fail: false)
     # create an instance of the measure
     measure = BuildResidentialScheduleFile.new
 
@@ -532,11 +577,14 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     measure.run(model, runner, argument_map)
     result = runner.result
 
-    # show the output
-    show_output(result) unless result.value.valueName == 'Success'
-
     # assert that it ran correctly
-    assert_equal('Success', result.value.valueName)
+    if expect_fail
+      show_output(result) unless result.value.valueName == 'Fail'
+      assert_equal('Fail', result.value.valueName)
+    else
+      show_output(result) unless result.value.valueName == 'Success'
+      assert_equal('Success', result.value.valueName)
+    end
 
     hpxml = HPXML.new(hpxml_path: @tmp_hpxml_path)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## OpenStudio-HPXML v1.6.0
+
+__New Features__
+- BuildResidentialScheduleFile measure:
+  - Allows requesting a subset of enduses/columns to be generated.
+
+__Bugfixes__
+
 ## OpenStudio-HPXML v1.5.0
 
 __New Features__

--- a/docs/source/usage_instructions.rst
+++ b/docs/source/usage_instructions.rst
@@ -55,7 +55,8 @@ A template OSW that simply runs the HPXMLtoOpenStudio, ReportSimulationOutput, a
 
 | Another example:
 | ``openstudio run -w workflow/template-run-hpxml-with-stochastic-occupancy.osw``
-| This workflow automatically generates and uses a CSV file with stochastic occupancy schedules before running the EnergyPlus simulation.
+| ``openstudio run -w workflow/template-run-hpxml-with-stochastic-occupancy-subset.osw``
+| This workflow automatically generates and uses a CSV file with stochastic occupancy schedules (either with all possible columns or a user-specified subset of columns) before running the EnergyPlus simulation.
 
 | And another example:
 | ``openstudio run -w workflow/template-build-and-run-hpxml-with-stochastic-occupancy.osw``

--- a/workflow/template-run-hpxml-with-stochastic-occupancy-subset.osw
+++ b/workflow/template-run-hpxml-with-stochastic-occupancy-subset.osw
@@ -9,7 +9,8 @@
         "hpxml_path": "../../sample_files/base.xml",
         "schedules_type": "stochastic",
         "output_csv_path": "stochastic.csv",
-        "hpxml_output_path": "../built-stochastic-schedules.xml"
+        "hpxml_output_path": "../built-stochastic-schedules.xml",
+        "schedules_column_names": "cooking_range, dishwasher, hot_water_dishwasher, clothes_washer, hot_water_clothes_washer, clothes_dryer, hot_water_fixtures"
       },
       "measure_dir_name": "BuildResidentialScheduleFile"
     },

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -210,127 +210,53 @@ class HPXMLTest < MiniTest::Test
     end
   end
 
-  def test_template_osw
-    # Check that simulation works using template-run-hpxml.osw
+  def test_template_osws
+    # Check that simulation works using template-*.osw
     require 'json'
 
-    osw_path = File.join(File.dirname(__FILE__), '..', 'template-run-hpxml.osw')
+    ['template-run-hpxml.osw',
+     'template-run-hpxml-with-stochastic-occupancy.osw',
+     'template-run-hpxml-with-stochastic-occupancy-subset.osw',
+     'template-build-and-run-hpxml-with-stochastic-occupancy.osw'].each do |osw_name|
+      osw_path = File.join(File.dirname(__FILE__), '..', osw_name)
 
-    # Create derivative OSW for testing
-    osw_path_test = osw_path.gsub('.osw', '_test.osw')
-    FileUtils.cp(osw_path, osw_path_test)
+      # Create derivative OSW for testing
+      osw_path_test = osw_path.gsub('.osw', '_test.osw')
+      FileUtils.cp(osw_path, osw_path_test)
 
-    # Turn on debug mode
-    json = JSON.parse(File.read(osw_path_test), symbolize_names: true)
-    json[:steps][0][:arguments][:debug] = true
+      # Turn on debug mode
+      json = JSON.parse(File.read(osw_path_test), symbolize_names: true)
+      measure_index = json[:steps].find_index { |m| m[:measure_dir_name] == 'HPXMLtoOpenStudio' }
+      json[:steps][measure_index][:arguments][:debug] = true
 
-    if Dir.exist? File.join(File.dirname(__FILE__), '..', '..', 'project')
-      # CI checks out the repo as "project", so update dir name
-      json[:steps][0][:measure_dir_name] = 'project'
+      if Dir.exist? File.join(File.dirname(__FILE__), '..', '..', 'project')
+        # CI checks out the repo as "project", so update dir name
+        json[:steps][measure_index][:measure_dir_name] = 'project'
+      end
+
+      File.open(osw_path_test, 'w') do |f|
+        f.write(JSON.pretty_generate(json))
+      end
+
+      command = "\"#{OpenStudio.getOpenStudioCLI}\" run -w \"#{osw_path_test}\""
+      system(command, err: File::NULL)
+
+      # Check for output files
+      assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'eplusout.msgpack'))
+      assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'results_annual.csv'))
+
+      # Check for debug files
+      assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'in.osm'))
+      hpxml_defaults_path = File.join(File.dirname(osw_path_test), 'run', 'in.xml')
+      assert(File.exist? hpxml_defaults_path)
+
+      # Cleanup
+      File.delete(osw_path_test)
+      xml_path_test = File.join(File.dirname(__FILE__), '..', 'run', 'built.xml')
+      File.delete(xml_path_test) if File.exist?(xml_path_test)
+      xml_path_test = File.join(File.dirname(__FILE__), '..', 'run', 'built-stochastic-schedules.xml')
+      File.delete(xml_path_test) if File.exist?(xml_path_test)
     end
-
-    File.open(osw_path_test, 'w') do |f|
-      f.write(JSON.pretty_generate(json))
-    end
-
-    command = "\"#{OpenStudio.getOpenStudioCLI}\" run -w \"#{osw_path_test}\""
-    system(command, err: File::NULL)
-
-    # Check for output files
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'eplusout.msgpack'))
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'results_annual.csv'))
-
-    # Check for debug files
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'in.osm'))
-    hpxml_defaults_path = File.join(File.dirname(osw_path_test), 'run', 'in.xml')
-    assert(File.exist? hpxml_defaults_path)
-
-    # Cleanup
-    File.delete(osw_path_test)
-  end
-
-  def test_template_osw_with_schedule
-    # Check that simulation works using template-run-hpxml-with-stochastic-occupancy.osw
-    require 'json'
-
-    osw_path = File.join(File.dirname(__FILE__), '..', 'template-run-hpxml-with-stochastic-occupancy.osw')
-
-    # Create derivative OSW for testing
-    osw_path_test = osw_path.gsub('.osw', '_test.osw')
-    FileUtils.cp(osw_path, osw_path_test)
-
-    # Turn on debug mode
-    json = JSON.parse(File.read(osw_path_test), symbolize_names: true)
-    json[:steps][1][:arguments][:debug] = true
-
-    if Dir.exist? File.join(File.dirname(__FILE__), '..', '..', 'project')
-      # CI checks out the repo as "project", so update dir name
-      json[:steps][1][:measure_dir_name] = 'project'
-    end
-
-    File.open(osw_path_test, 'w') do |f|
-      f.write(JSON.pretty_generate(json))
-    end
-
-    command = "\"#{OpenStudio.getOpenStudioCLI}\" run -w \"#{osw_path_test}\""
-    system(command, err: File::NULL)
-
-    # Check for output files
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'eplusout.msgpack'))
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'results_annual.csv'))
-
-    # Check for debug files
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'in.osm'))
-    hpxml_defaults_path = File.join(File.dirname(osw_path_test), 'run', 'in.xml')
-    assert(File.exist? hpxml_defaults_path)
-
-    # Cleanup
-    File.delete(osw_path_test)
-    xml_path_test = File.join(File.dirname(__FILE__), '..', 'run', 'base-stochastic-schedules.xml')
-    File.delete(xml_path_test)
-  end
-
-  def test_template_osw_with_build_hpxml_and_schedule
-    # Check that simulation works using template-build-and-run-hpxml-with-stochastic-occupancy.osw
-    require 'json'
-
-    osw_path = File.join(File.dirname(__FILE__), '..', 'template-build-and-run-hpxml-with-stochastic-occupancy.osw')
-
-    # Create derivative OSW for testing
-    osw_path_test = osw_path.gsub('.osw', '_test.osw')
-    FileUtils.cp(osw_path, osw_path_test)
-
-    # Turn on debug mode
-    json = JSON.parse(File.read(osw_path_test), symbolize_names: true)
-    json[:steps][2][:arguments][:debug] = true
-
-    if Dir.exist? File.join(File.dirname(__FILE__), '..', '..', 'project')
-      # CI checks out the repo as "project", so update dir name
-      json[:steps][1][:measure_dir_name] = 'project'
-    end
-
-    File.open(osw_path_test, 'w') do |f|
-      f.write(JSON.pretty_generate(json))
-    end
-
-    command = "\"#{OpenStudio.getOpenStudioCLI}\" run -w \"#{osw_path_test}\""
-    system(command, err: File::NULL)
-
-    # Check for output files
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'eplusout.msgpack'))
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'results_annual.csv'))
-
-    # Check for debug files
-    assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'in.osm'))
-    hpxml_defaults_path = File.join(File.dirname(osw_path_test), 'run', 'in.xml')
-    assert(File.exist? hpxml_defaults_path)
-
-    # Cleanup
-    File.delete(osw_path_test)
-    xml_path_test = File.join(File.dirname(__FILE__), '..', 'run', 'built.xml')
-    File.delete(xml_path_test)
-    xml_path_test = File.join(File.dirname(__FILE__), '..', 'run', 'built-stochastic-schedules.xml')
-    File.delete(xml_path_test)
   end
 
   def test_multiple_building_ids


### PR DESCRIPTION
## Pull Request Description

Closes #1064. Allows requesting a subset of enduses/columns to be generated in the BuildResidentialScheduleFile measure.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
