### PR TITLE
Clean up xmlvalidator tmp dir left behind by OS

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6600e0c5-d9b6-465e-ac84-30da41fdfe12</version_id>
-  <version_modified>20221206T195230Z</version_modified>
+  <version_id>a9916620-7476-4633-a679-917da762f8be</version_id>
+  <version_modified>20221209T225045Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -386,12 +386,6 @@
       <checksum>2785B05C</checksum>
     </file>
     <file>
-      <filename>xmlvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>8DB5DD87</checksum>
-    </file>
-    <file>
       <filename>psychrometrics.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -587,6 +581,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>80B2ED97</checksum>
+    </file>
+    <file>
+      <filename>xmlvalidator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>87F79365</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/xmlvalidator.rb
+++ b/HPXMLtoOpenStudio/resources/xmlvalidator.rb
@@ -62,6 +62,18 @@ class XMLValidator
         end
       end
     end
+    cleanup_openstudio_tmp_dir(validator, schematron_path)
     return errors, warnings
+  end
+
+  def self.cleanup_openstudio_tmp_dir(validator, schema_path)
+    # Workaround for https://github.com/NREL/OpenStudio/issues/4761
+    # Remove this method if the issue is addressed
+    if validator.schemaPath.to_s != schema_path
+      # OpenStudio created a temp dir; delete it now
+      tmp_path = File.dirname(validator.schemaPath.to_s)
+      require 'fileutils'
+      FileUtils.rm_r(tmp_path)
+    end
   end
 end


### PR DESCRIPTION
## Pull Request Description

Can eat up lots of disk space. Workaround for https://github.com/NREL/OpenStudio/issues/4761.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
