### PR TITLE
Allow user-specified precision for timeseries outputs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 __New Features__
 - Allows modeling one or more occupant vacancy periods (`VacancyPeriods` in the HPXML file).
+- ReportSimulationOutput measure: Allows specifying the number of decimal places for timeseries output.
 
 __Bugfixes__
 - Fixes error if calculating utility bills for an all-electric home with a detailed JSON utility rate.

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>24d488e9-5b33-4811-a163-66ed62eedf78</version_id>
-  <version_modified>20221216T235444Z</version_modified>
+  <version_id>5bb6fc29-4b96-4538-8185-b90e6aabcd0c</version_id>
+  <version_modified>20221229T154041Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -334,6 +334,14 @@
           <display_name>end</display_name>
         </choice>
       </choices>
+    </argument>
+    <argument>
+      <name>timeseries_num_decimal_places</name>
+      <display_name>Generate Timeseries Output: Number of Decimal Places</display_name>
+      <description>Allows overriding the default number of decimal places for timeseries output.</description>
+      <type>Integer</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
     </argument>
     <argument>
       <name>add_timeseries_dst_column</name>
@@ -1526,6 +1534,12 @@
   </attributes>
   <files>
     <file>
+      <filename>output_report_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A4AABBCA</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.9.1</identifier>
@@ -1534,13 +1548,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>74074359</checksum>
-    </file>
-    <file>
-      <filename>output_report_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>A4AABBCA</checksum>
+      <checksum>264F815D</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Closes #1259. ReportSimulationOutput measure: Allows specifying the number of decimal places for timeseries output. Also increases the number of default decimal places by 1.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] ~Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)~
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
