### PR TITLE
Fix for deleting validator tmp path 

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>710b037b-f7d8-4129-a70a-f594317294ce</version_id>
-  <version_modified>20230104T171227Z</version_modified>
+  <version_id>36348fb1-469a-4ba3-a973-911bd241558b</version_id>
+  <version_modified>20230105T210335Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -440,12 +440,6 @@
       <checksum>170774C2</checksum>
     </file>
     <file>
-      <filename>xmlvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>87F79365</checksum>
-    </file>
-    <file>
       <filename>util.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -581,6 +575,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>537559BF</checksum>
+    </file>
+    <file>
+      <filename>xmlvalidator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>BA80F690</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/xmlvalidator.rb
+++ b/HPXMLtoOpenStudio/resources/xmlvalidator.rb
@@ -73,7 +73,10 @@ class XMLValidator
       # OpenStudio created a temp dir; delete it now
       tmp_path = File.dirname(validator.schemaPath.to_s)
       require 'fileutils'
-      FileUtils.rm_r(tmp_path)
+      begin
+        FileUtils.rm_r(tmp_path)
+      rescue
+      end
     end
   end
 end


### PR DESCRIPTION
## Pull Request Description

Uncovered an issue in ResStock where `tmp_path` is missing (expected behavior) when using OpenStudio v3.5.1. The problem is that users are still permitted to use v3.5.0 where `tmp_path` may need to be deleted.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [ ] ~Sample files have been added/updated (via `tasks.rb`)~
- [ ] ~Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)~
- [ ] ~Documentation has been updated~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
