### PR TITLE
BuildResidentialScheduleFile: Clean up args

### DIFF
--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -46,11 +46,6 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     arg.setDescription("A comma-separated list of the column names to generate. If not provided, defaults to all columns. Possible column names are: #{ScheduleGenerator.export_columns.join(', ')}.")
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument.makeStringArgument('schedules_vacancy_period', false)
-    arg.setDisplayName('Schedules: Vacancy Period')
-    arg.setDescription('Specifies the vacancy period. Enter a date like "Dec 15 - Jan 15".')
-    args << arg
-
     arg = OpenStudio::Measure::OSArgument.makeIntegerArgument('schedules_random_seed', false)
     arg.setDisplayName('Schedules: Random Seed')
     arg.setUnits('#')

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>d09b6df4-4327-4fbf-ae2b-8972031b5c64</version_id>
-  <version_modified>20230103T162738Z</version_modified>
+  <version_id>2e7e9dee-6b6d-423e-a2a2-082bb3c606dc</version_id>
+  <version_modified>20230110T190141Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -23,14 +23,6 @@
       <name>schedules_column_names</name>
       <display_name>Schedules: Column Names</display_name>
       <description>A comma-separated list of the column names to generate. If not provided, defaults to all columns. Possible column names are: occupants, lighting_interior, lighting_exterior, lighting_garage, lighting_exterior_holiday, cooking_range, dishwasher, clothes_washer, clothes_dryer, ceiling_fan, plug_loads_other, hot_water_dishwasher, hot_water_clothes_washer, hot_water_fixtures.</description>
-      <type>String</type>
-      <required>false</required>
-      <model_dependent>false</model_dependent>
-    </argument>
-    <argument>
-      <name>schedules_vacancy_period</name>
-      <display_name>Schedules: Vacancy Period</display_name>
-      <description>Specifies the vacancy period. Enter a date like "Dec 15 - Jan 15".</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -880,17 +872,6 @@
       <checksum>AAB89065</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>3.2.0</identifier>
-        <min_compatible>3.2.0</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>9000E553</checksum>
-    </file>
-    <file>
       <filename>build_residential_schedule_file_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -901,6 +882,17 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>DAE98658</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.2.0</identifier>
+        <min_compatible>3.2.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>94C38C85</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Forgot to remove `schedules_vacancy_period` in https://github.com/NREL/OpenStudio-HPXML/pull/1199.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [ ] ~Sample files have been added/updated (via `tasks.rb`)~
- [ ] ~Unit tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests`)~
- [ ] ~Documentation has been updated~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
