### PR TITLE
Utility bill fixed charge bugfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ __Bugfixes__
 - Fixes error if calculating utility bills for an all-electric home with a detailed JSON utility rate.
 - BuildResidentialScheduleFile measure now excludes columns for end uses that are not stochastically generated.
 - Fixes operational calculation when the number of residents is set to zero.
+- Fixes possible utility bill calculation error for a home with PV using a detailed electric utility rate.
 
 ## OpenStudio-HPXML v1.5.1
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>fc8e8e1a-f6fd-4fe5-adfb-b22a5c0c9c07</version_id>
-  <version_modified>20230216T150920Z</version_modified>
+  <version_id>9af4b561-6193-46e3-8be7-85b4d309ca6d</version_id>
+  <version_modified>20230228T153526Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -553,12 +553,6 @@
       <checksum>2FAC93B4</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>9D023BAA</checksum>
-    </file>
-    <file>
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -575,6 +569,12 @@
       <filetype>md</filetype>
       <usage_type>resource</usage_type>
       <checksum>D05DFB8A</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>0BE6113D</checksum>
     </file>
   </files>
 </measure>

--- a/ReportUtilityBills/measure.rb
+++ b/ReportUtilityBills/measure.rb
@@ -311,9 +311,9 @@ class ReportUtilityBills < OpenStudio::Measure::ReportingMeasure
           tariff = tariff[:items][0]
           fields = tariff.keys
 
+          rate.fixedmonthlycharge = 0.0
           if fields.include?(:fixedchargeunits)
             if tariff[:fixedchargeunits] == '$/month'
-              rate.fixedmonthlycharge = 0.0 if fields.include?(:fixedchargefirstmeter) || fields.include?(:fixedchargeeaaddl)
               rate.fixedmonthlycharge += tariff[:fixedchargefirstmeter] if fields.include?(:fixedchargefirstmeter)
               rate.fixedmonthlycharge += tariff[:fixedchargeeaaddl] if fields.include?(:fixedchargeeaaddl)
             else

--- a/ReportUtilityBills/measure.xml
+++ b/ReportUtilityBills/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>report_utility_bills</name>
   <uid>ca88a425-e59a-4bc4-af51-c7e7d1e960fe</uid>
-  <version_id>d038c4e6-ece0-4eb9-be8a-05c37ec4e492</version_id>
-  <version_modified>20221214T064430Z</version_modified>
+  <version_id>d9f07e4d-f633-45e4-8f61-92979fdc6ce9</version_id>
+  <version_modified>20230228T153528Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>ReportUtilityBills</class_name>
   <display_name>Utility Bills Report</display_name>
@@ -217,6 +217,12 @@
       <checksum>387337AD</checksum>
     </file>
     <file>
+      <filename>util.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>041AE7DE</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.3.0</identifier>
@@ -225,19 +231,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>8DBDE597</checksum>
+      <checksum>F24C177B</checksum>
     </file>
     <file>
       <filename>utility_bills_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>D59E7385</checksum>
-    </file>
-    <file>
-      <filename>util.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>041AE7DE</checksum>
+      <checksum>C97F597D</checksum>
     </file>
   </files>
 </measure>

--- a/ReportUtilityBills/tests/utility_bills_test.rb
+++ b/ReportUtilityBills/tests/utility_bills_test.rb
@@ -1011,6 +1011,7 @@ class ReportUtilityBillsTest < MiniTest::Test
     require 'zip'
     require 'tempfile'
 
+    @hpxml.pv_systems.each { |pv_system| pv_system.max_power_output = 1000.0 / @hpxml.pv_systems.size }
     @hpxml.header.utility_bill_scenarios.each do |utility_bill_scenario|
       Zip.on_exists_proc = true
       Zip::File.open(File.join(File.dirname(__FILE__), '../resources/detailed_rates/openei_rates.zip')) do |zip_file|
@@ -1026,7 +1027,7 @@ class ReportUtilityBillsTest < MiniTest::Test
 
             utility_bill_scenario.elec_tariff_filepath = tmp_path
             File.delete(@bills_csv) if File.exist? @bills_csv
-            actual_bills = _bill_calcs(@fuels_pv_none_detailed, @hpxml.header, [], utility_bill_scenario)
+            actual_bills = _bill_calcs(@fuels_pv_1kw_detailed, @hpxml.header, @hpxml.pv_systems, utility_bill_scenario)
             if !File.exist?(@bills_csv)
               puts entry.name
               assert(false)


### PR DESCRIPTION
## Pull Request Description

Fixes possible utility bill calculation error for a home with PV using a detailed electric utility rate. Reported at https://unmethours.com/question/88346/solar-pv-addition-to-home-causes-simulation-to-fail/

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
