### PR TITLE
BuildResidentialHPXML: Apply validation when applying defaults

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3012,7 +3012,7 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
 
     arg = OpenStudio::Measure::OSArgument::makeBoolArgument('apply_defaults', false)
     arg.setDisplayName('Apply Default Values?')
-    arg.setDescription('If true, applies OS-HPXML default values to the HPXML output file.')
+    arg.setDescription('If true, applies OS-HPXML default values to the HPXML output file. Setting to true will also force validation of the HPXML output file before applying OS-HPXML default values.')
     arg.setDefaultValue(false)
     args << arg
 
@@ -3388,7 +3388,7 @@ class HPXMLFile
     end
 
     # Check for errors in the HPXML object
-    if args[:apply_validation].is_initialized && args[:apply_validation].get
+    if (args[:apply_defaults].is_initialized && args[:apply_defaults].get) || (args[:apply_validation].is_initialized && args[:apply_validation].get)
       errors = hpxml.check_for_errors()
       if errors.size > 0
         fail "ERROR: Invalid HPXML object produced.\n#{errors}"

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3272,31 +3272,6 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
 
     return errors
   end
-
-  def validate_hpxml(runner, hpxml_path, hpxml_doc)
-    is_valid = true
-
-    # Validate input HPXML against schema
-    schema_dir = File.join(File.dirname(__FILE__), '../HPXMLtoOpenStudio/resources/hpxml_schema')
-    schema_path = File.join(schema_dir, 'HPXML.xsd')
-    xsd_errors, xsd_warnings = XMLValidator.validate_against_schema(hpxml_path, schema_path)
-
-    # Validate input HPXML against schematron docs
-    schematron_dir = File.join(File.dirname(__FILE__), '../HPXMLtoOpenStudio/resources/hpxml_schematron')
-    schematron_path = File.join(schematron_dir, 'EPvalidator.xml')
-    sct_errors, sct_warnings = XMLValidator.validate_against_schematron(hpxml_path, schematron_path, hpxml_doc)
-
-    # Handle errors/warnings
-    (xsd_errors + sct_errors).each do |error|
-      runner.registerError("#{hpxml_path}: #{error}")
-      is_valid = false
-    end
-    (xsd_warnings + sct_warnings).each do |warning|
-      runner.registerWarning("#{hpxml_path}: #{warning}")
-    end
-
-    return is_valid
-  end
 end
 
 class HPXMLFile
@@ -3413,6 +3388,31 @@ class HPXMLFile
     end
 
     return hpxml_doc
+  end
+
+  def self.validate_hpxml(runner, hpxml_path, hpxml_doc)
+    is_valid = true
+
+    # Validate input HPXML against schema
+    schema_dir = File.join(File.dirname(__FILE__), '../HPXMLtoOpenStudio/resources/hpxml_schema')
+    schema_path = File.join(schema_dir, 'HPXML.xsd')
+    xsd_errors, xsd_warnings = XMLValidator.validate_against_schema(hpxml_path, schema_path)
+
+    # Validate input HPXML against schematron docs
+    schematron_dir = File.join(File.dirname(__FILE__), '../HPXMLtoOpenStudio/resources/hpxml_schematron')
+    schematron_path = File.join(schematron_dir, 'EPvalidator.xml')
+    sct_errors, sct_warnings = XMLValidator.validate_against_schematron(hpxml_path, schematron_path, hpxml_doc)
+
+    # Handle errors/warnings
+    (xsd_errors + sct_errors).each do |error|
+      runner.registerError("#{hpxml_path}: #{error}")
+      is_valid = false
+    end
+    (xsd_warnings + sct_warnings).each do |warning|
+      runner.registerWarning("#{hpxml_path}: #{warning}")
+    end
+
+    return is_valid
   end
 
   def self.create_geometry_envelope(runner, model, args)

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3042,6 +3042,10 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     args = get_argument_values(runner, arguments(model), user_arguments)
     args = Hash[args.collect { |k, v| [k.to_sym, v] }]
 
+    args[:apply_validation] = args[:apply_validation].is_initialized ? args[:apply_validation].get : false
+    args[:apply_defaults] = args[:apply_defaults].is_initialized ? args[:apply_defaults].get : false
+    args[:apply_validation] = true if args[:apply_defaults]
+
     # Argument error checks
     warnings, errors = validate_arguments(args)
     unless warnings.empty?
@@ -3067,26 +3071,22 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     end
 
     # Create HPXML file
-    hpxml_doc = HPXMLFile.create(runner, model, args, epw_path)
-    if not hpxml_doc
-      runner.registerError('Unsuccessful creation of HPXML file.')
-      return false
-    end
-
     hpxml_path = args[:hpxml_path]
     unless (Pathname.new hpxml_path).absolute?
       hpxml_path = File.expand_path(hpxml_path)
     end
 
-    XMLHelper.write_file(hpxml_doc, hpxml_path)
-    runner.registerInfo("Wrote file: #{hpxml_path}")
-
-    # Check for invalid HPXML file
-    if args[:apply_validation].is_initialized && args[:apply_validation].get
-      if not validate_hpxml(runner, hpxml_path, hpxml_doc)
-        return false
-      end
+    hpxml_doc = HPXMLFile.create(runner, model, args, epw_path, hpxml_path)
+    if not hpxml_doc
+      runner.registerError('Unsuccessful creation of HPXML file.')
+      return false
     end
+
+    # Write HPXML file again if defaults applied
+    if args[:apply_defaults]
+      XMLHelper.write_file(hpxml_doc, hpxml_path)
+    end
+    runner.registerInfo("Wrote file: #{hpxml_path}")
 
     # Uncomment for debugging purposes
     # File.write(hpxml_path.gsub('.xml', '.osm'), model.to_s)
@@ -3300,9 +3300,9 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
 end
 
 class HPXMLFile
-  def self.create(runner, model, args, epw_path)
+  def self.create(runner, model, args, epw_path, hpxml_path)
     epw_file = OpenStudio::EpwFile.new(epw_path)
-    if (args[:hvac_control_heating_season_period].to_s == HPXML::BuildingAmerica) || (args[:hvac_control_cooling_season_period].to_s == HPXML::BuildingAmerica) || (args[:apply_defaults].is_initialized && args[:apply_defaults].get)
+    if (args[:hvac_control_heating_season_period].to_s == HPXML::BuildingAmerica) || (args[:hvac_control_cooling_season_period].to_s == HPXML::BuildingAmerica) || (args[:apply_defaults])
       weather = WeatherProcess.new(epw_path: epw_path)
     end
 
@@ -3388,19 +3388,29 @@ class HPXMLFile
     end
 
     # Check for errors in the HPXML object
-    if (args[:apply_defaults].is_initialized && args[:apply_defaults].get) || (args[:apply_validation].is_initialized && args[:apply_validation].get)
+    if args[:apply_validation]
       errors = hpxml.check_for_errors()
       if errors.size > 0
         fail "ERROR: Invalid HPXML object produced.\n#{errors}"
       end
     end
 
-    if args[:apply_defaults].is_initialized && args[:apply_defaults].get
-      eri_version = Constants.ERIVersions[-1]
-      HPXMLDefaults.apply(runner, hpxml, eri_version, weather, epw_file: epw_file)
-    end
-
     hpxml_doc = hpxml.to_oga()
+    XMLHelper.write_file(hpxml_doc, hpxml_path)
+
+    if args[:apply_validation] || args[:apply_defaults]
+
+      # Check for invalid HPXML file
+      if not validate_hpxml(runner, hpxml_path, hpxml_doc)
+        return false
+      end
+
+      if args[:apply_defaults]
+        eri_version = Constants.ERIVersions[-1]
+        HPXMLDefaults.apply(runner, hpxml, eri_version, weather, epw_file: epw_file)
+        hpxml_doc = hpxml.to_oga()
+      end
+    end
 
     return hpxml_doc
   end

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3362,35 +3362,32 @@ class HPXMLFile
       s.area = s.area.round(1)
     end
 
-    # Check for errors in the HPXML object
-    if args[:apply_validation]
-      errors = hpxml.check_for_errors()
-      if errors.size > 0
-        fail "ERROR: Invalid HPXML object produced.\n#{errors}"
-      end
-    end
-
     hpxml_doc = hpxml.to_oga()
     XMLHelper.write_file(hpxml_doc, hpxml_path)
 
-    if args[:apply_validation] || args[:apply_defaults]
-
+    if args[:apply_validation]
       # Check for invalid HPXML file
-      if not validate_hpxml(runner, hpxml_path, hpxml_doc)
+      if not validate_hpxml(runner, hpxml, hpxml_doc, hpxml_path)
         return false
       end
+    end
 
-      if args[:apply_defaults]
-        eri_version = Constants.ERIVersions[-1]
-        HPXMLDefaults.apply(runner, hpxml, eri_version, weather, epw_file: epw_file)
-        hpxml_doc = hpxml.to_oga()
-      end
+    if args[:apply_defaults]
+      eri_version = Constants.ERIVersions[-1]
+      HPXMLDefaults.apply(runner, hpxml, eri_version, weather, epw_file: epw_file)
+      hpxml_doc = hpxml.to_oga()
     end
 
     return hpxml_doc
   end
 
-  def self.validate_hpxml(runner, hpxml_path, hpxml_doc)
+  def self.validate_hpxml(runner, hpxml, hpxml_doc, hpxml_path)
+    # Check for errors in the HPXML object
+    errors = hpxml.check_for_errors()
+    if errors.size > 0
+      fail "ERROR: Invalid HPXML object produced.\n#{errors}"
+    end
+
     is_valid = true
 
     # Validate input HPXML against schema

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>e69850a6-e57b-4387-aece-7f0188004501</version_id>
-  <version_modified>20230228T220954Z</version_modified>
+  <version_id>d9e2d4fb-dddb-46ed-bcd9-a9299832febd</version_id>
+  <version_modified>20230228T231805Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6538,7 +6538,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0C312ECE</checksum>
+      <checksum>2985E277</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>ccd94c40-cc15-4d93-8a05-1679bbd03bf3</version_id>
-  <version_modified>20230228T195542Z</version_modified>
+  <version_id>e69850a6-e57b-4387-aece-7f0188004501</version_id>
+  <version_modified>20230228T220954Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6538,7 +6538,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>62896F94</checksum>
+      <checksum>0C312ECE</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>97d30187-0ce4-451a-8ee9-7ca41ad5c00c</version_id>
-  <version_modified>20230216T150917Z</version_modified>
+  <version_id>ccd94c40-cc15-4d93-8a05-1679bbd03bf3</version_id>
+  <version_modified>20230228T195542Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6468,7 +6468,7 @@
     <argument>
       <name>apply_defaults</name>
       <display_name>Apply Default Values?</display_name>
-      <description>If true, applies OS-HPXML default values to the HPXML output file.</description>
+      <description>If true, applies OS-HPXML default values to the HPXML output file. Setting to true will also force validation of the HPXML output file before applying OS-HPXML default values.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6538,7 +6538,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>EC5B5EE0</checksum>
+      <checksum>62896F94</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>d9e2d4fb-dddb-46ed-bcd9-a9299832febd</version_id>
-  <version_modified>20230228T231805Z</version_modified>
+  <version_id>5eacc58f-18e3-409f-a6b3-38a601fb5384</version_id>
+  <version_modified>20230301T153143Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6527,7 +6527,7 @@
       <filename>build_residential_hpxml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>B16976B9</checksum>
+      <checksum>EABC4B26</checksum>
     </file>
     <file>
       <version>
@@ -6538,7 +6538,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>2985E277</checksum>
+      <checksum>56885E00</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
+++ b/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
@@ -182,6 +182,7 @@ class BuildResidentialHPXMLTest < MiniTest::Test
       'error-invalid-window-aspect-ratio.xml' => 'base-sfd.xml',
       'error-garage-too-wide.xml' => 'base-sfd.xml',
       'error-garage-too-deep.xml' => 'base-sfd.xml',
+      'error-vented-attic-with-zero-floor-insulation.xml' => 'base-sfd.xml',
 
       'warning-non-electric-heat-pump-water-heater.xml' => 'base-sfd.xml',
       'warning-sfd-slab-non-zero-foundation-height.xml' => 'base-sfd.xml',
@@ -237,7 +238,8 @@ class BuildResidentialHPXMLTest < MiniTest::Test
       'error-invalid-door-area.xml' => 'Door area cannot be negative.',
       'error-invalid-window-aspect-ratio.xml' => 'Window aspect ratio must be greater than zero.',
       'error-garage-too-wide.xml' => 'Garage is as wide as the single-family detached unit.',
-      'error-garage-too-deep.xml' => 'Garage is as deep as the single-family detached unit.'
+      'error-garage-too-deep.xml' => 'Garage is as deep as the single-family detached unit.',
+      'error-vented-attic-with-zero-floor-insulation.xml' => "Element 'AssemblyEffectiveRValue': [facet 'minExclusive'] The value '0.0' must be greater than '0'."
     }
 
     expected_warnings = {
@@ -329,7 +331,6 @@ class BuildResidentialHPXMLTest < MiniTest::Test
   def _set_measure_argument_values(hpxml_file, args)
     args['hpxml_path'] = File.join(File.dirname(__FILE__), "extra_files/#{hpxml_file}")
     args['apply_defaults'] = true
-    args['apply_validation'] = true
 
     # Base
     if ['base-sfd.xml'].include? hpxml_file
@@ -1090,6 +1091,8 @@ class BuildResidentialHPXMLTest < MiniTest::Test
     elsif ['error-garage-too-deep.xml'].include? hpxml_file
       args['geometry_garage_width'] = 12
       args['geometry_garage_depth'] = 40
+    elsif ['error-vented-attic-with-zero-floor-insulation.xml'].include? hpxml_file
+      args['ceiling_assembly_r'] = 0
     end
 
     # Warning
@@ -1150,20 +1153,20 @@ class BuildResidentialHPXMLTest < MiniTest::Test
   def _test_measure(runner, expected_error, expected_warning)
     # check warnings/errors
     if not expected_error.nil?
-      if runner.result.stepErrors.select { |s| s == expected_error }.size <= 0
+      if runner.result.stepErrors.select { |s| s.include?(expected_error) }.size <= 0
         runner.result.stepErrors.each do |s|
           puts "ERROR: #{s}"
         end
       end
-      assert(runner.result.stepErrors.select { |s| s == expected_error }.size > 0)
+      assert(runner.result.stepErrors.select { |s| s.include?(expected_error) }.size > 0)
     end
     if not expected_warning.nil?
-      if runner.result.stepWarnings.select { |s| s == expected_warning }.size <= 0
+      if runner.result.stepWarnings.select { |s| s.include?(expected_warning) }.size <= 0
         runner.result.stepWarnings.each do |s|
           puts "WARNING: #{s}"
         end
       end
-      assert(runner.result.stepWarnings.select { |s| s == expected_warning }.size > 0)
+      assert(runner.result.stepWarnings.select { |s| s.include?(expected_warning) }.size > 0)
     end
   end
 end

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>fc8e8e1a-f6fd-4fe5-adfb-b22a5c0c9c07</version_id>
-  <version_modified>20230216T150920Z</version_modified>
+  <version_id>5303679c-6645-4573-be19-5bb7c15537a3</version_id>
+  <version_modified>20230228T195545Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -553,12 +553,6 @@
       <checksum>2FAC93B4</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>9D023BAA</checksum>
-    </file>
-    <file>
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -575,6 +569,12 @@
       <filetype>md</filetype>
       <usage_type>resource</usage_type>
       <checksum>D05DFB8A</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>0BE6113D</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

This will solve the issue described in https://github.com/NREL/OpenStudio-HPXML/issues/1295.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
