### PR TITLE
Pierce thermal comfort model

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>72bd5ffd-d1c3-4128-9149-9e83db09cc53</version_id>
-  <version_modified>20230301T155644Z</version_modified>
+  <version_id>06b7be6f-26a2-4649-9632-f9fd45df8703</version_id>
+  <version_modified>20230301T173539Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -494,12 +494,6 @@
       <checksum>7D4FE81F</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D171C2F0</checksum>
-    </file>
-    <file>
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -581,6 +575,12 @@
       <filetype>csv</filetype>
       <usage_type>resource</usage_type>
       <checksum>4906D996</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C2829FF3</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/geometry.rb
+++ b/HPXMLtoOpenStudio/resources/geometry.rb
@@ -499,14 +499,43 @@ class Geometry
       runner.registerWarning("Both '#{people_col_name}' schedule file and monthly multipliers provided; the latter will be ignored.") if !hpxml.building_occupancy.monthly_multipliers.nil?
     end
 
+    # Add people definition for the occ
+    occ_def = OpenStudio::Model::PeopleDefinition.new(model)
+    occ = OpenStudio::Model::People.new(occ_def)
+
+    if !hpxml.header.power_outage_periods.empty?
+      # Work
+      work_schedule = OpenStudio::Model::ScheduleConstant.new(model)
+      work_schedule.setValue(0)
+      work_schedule.setName('Work Efficiency Schedule')
+
+      # Activity
+      activity_per_person = 100
+
+      # Air Velocity
+      air_velocity_schedule = OpenStudio::Model::ScheduleConstant.new(model)
+      air_velocity_schedule.setValue(0.1)
+      air_velocity_schedule.setName('Air Velocity Schedule')
+
+      # Clothing Insulation
+      clothing_insulation_schedule = OpenStudio::Model::ScheduleConstant.new(model)
+      clothing_insulation_schedule.setValue(0.6)
+      clothing_insulation_schedule.setName('Clothing Schedule')
+
+      # Set schedules
+      occ.setWorkEfficiencySchedule(work_schedule)
+      occ.setAirVelocitySchedule(air_velocity_schedule)
+      occ.setClothingInsulationSchedule(clothing_insulation_schedule)
+
+      # Add thermal model types
+      occ_def.pushThermalComfortModelType('Pierce')
+    end
+
     # Create schedule
     activity_sch = OpenStudio::Model::ScheduleConstant.new(model)
     activity_sch.setValue(activity_per_person)
     activity_sch.setName(Constants.ObjectNameOccupants + ' activity schedule')
 
-    # Add people definition for the occ
-    occ_def = OpenStudio::Model::PeopleDefinition.new(model)
-    occ = OpenStudio::Model::People.new(occ_def)
     occ.setName(Constants.ObjectNameOccupants)
     occ.setSpace(space)
     occ_def.setName(Constants.ObjectNameOccupants)


### PR DESCRIPTION
## Pull Request Description

When a power outage period is defined, add the following schedules to the `People` object:
* work efficiency (new schedule)
* activity level (existing schedule, but changing to `activity_per_persion=100`)
* air velocity (new schedule)
* clothing insulation (new schedule)

And push the `Pierce` thermal comfort model type, so that we can request the `Zone Thermal Comfort Pierce Model Standard Effective Temperature` output variable.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
