### PR TITLE
Speed up HPXML files w/ multiple `Building` elements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@ __New Features__
 - **Breaking change**: Updates component loads outputs:
   - Replaces `Windows` and `Skylights` with `Windows Conduction`, `Windows Solar`, `Skylights Conduction`, and `Skylights Solar`.
   - Disaggregates `Lighting` from `Internal Gains`.
+- Performance improvement for HPXML files w/ large numbers of `Building` elements.
 
 __Bugfixes__
 - Fixes `BackupHeatingSwitchoverTemperature` for a heat pump w/ *separate* backup system; now correctly ceases backup operation above this temperature.
@@ -37,6 +38,7 @@ __Bugfixes__
 - Fixes operational calculation when the number of residents is set to zero.
 - Fixes possible utility bill calculation error for a home with PV using a detailed electric utility rate.
 - Fixes defaulted mechanical ventilation flow rate for SFA/MF buildings, with respect to infiltration credit.
+- HPXML files w/ multiple `Building` elements now only show warnings for the single `Building` being simulated.
 
 ## OpenStudio-HPXML v1.5.1
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7e74ed1d-aafd-41e1-9614-76cda6d48803</version_id>
-  <version_modified>20230323T222109Z</version_modified>
+  <version_id>7b6192c5-a5a0-4ba7-a3d0-994c401a4dc6</version_id>
+  <version_modified>20230328T223912Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -541,12 +541,6 @@
       <checksum>3FD8D019</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>A40418CD</checksum>
-    </file>
-    <file>
       <filename>test_schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -581,6 +575,12 @@
       <filetype>csv</filetype>
       <usage_type>resource</usage_type>
       <checksum>1362DD15</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>CE61207A</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7b6192c5-a5a0-4ba7-a3d0-994c401a4dc6</version_id>
-  <version_modified>20230328T223912Z</version_modified>
+  <version_id>be03c8d5-fc5f-4f3e-b037-e1f671d829aa</version_id>
+  <version_modified>20230329T014032Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -547,12 +547,6 @@
       <checksum>8053DF5D</checksum>
     </file>
     <file>
-      <filename>test_validation.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>5BF3A285</checksum>
-    </file>
-    <file>
       <filename>airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -581,6 +575,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>CE61207A</checksum>
+    </file>
+    <file>
+      <filename>test_validation.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>FA853CB6</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -30,25 +30,6 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
     FileUtils.rm_rf(@tmp_output_path)
   end
 
-  def test_validation_of_sample_files
-    xmls = []
-    Dir["#{@root_path}/workflow/**/*.xml"].sort.each do |xml|
-      next if xml.split('/').include? 'run'
-
-      xmls << xml
-    end
-
-    xmls.each_with_index do |xml, i|
-      puts "[#{i + 1}/#{xmls.size}] Testing #{File.basename(xml)}..."
-
-      # Test validation
-      _test_schema_validation(xml, @hpxml_schema_path)
-      hpxml_doc = HPXML.new(hpxml_path: xml, building_id: 'MyBuilding').to_oga()
-      _test_schematron_validation(xml, hpxml_doc, expected_errors: []) # Ensure no errors
-    end
-    puts
-  end
-
   def test_validation_of_schematron_doc
     # Check that the schematron file is valid
     schematron_schema_path = File.absolute_path(File.join(@root_path, 'HPXMLtoOpenStudio', 'resources', 'hpxml_schematron', 'iso-schematron.xsd'))
@@ -1342,16 +1323,6 @@ class HPXMLtoOpenStudioValidationTest < MiniTest::Test
   end
 
   private
-
-  def _test_schematron_validation(hpxml_path, hpxml_doc, expected_errors: nil, expected_warnings: nil)
-    errors, warnings = XMLValidator.validate_against_schematron(hpxml_path, @epvalidator_stron_path, hpxml_doc)
-    if not expected_errors.nil?
-      _compare_errors_or_warnings('error', errors, expected_errors)
-    end
-    if not expected_warnings.nil?
-      _compare_errors_or_warnings('warning', warnings, expected_warnings)
-    end
-  end
 
   def _test_schema_validation(hpxml_path, schema_path)
     errors, _warnings = XMLValidator.validate_against_schema(hpxml_path, schema_path)

--- a/tasks.rb
+++ b/tasks.rb
@@ -2449,6 +2449,8 @@ def set_measure_argument_values(hpxml_file, args, sch_args, orig_parent)
     args['misc_plug_loads_other_annual_kwh'] = 0.0
     args.delete('misc_plug_loads_other_frac_sensible')
     args.delete('misc_plug_loads_other_frac_latent')
+  elsif ['base-multiple-buildings.xml'].include? hpxml_file
+    args['clothes_dryer_present'] = false
   end
 
   # PV

--- a/workflow/sample_files/base-multiple-buildings.xml
+++ b/workflow/sample_files/base-multiple-buildings.xml
@@ -447,14 +447,6 @@
           <LabelUsage>6.0</LabelUsage>
           <Capacity>3.2</Capacity>
         </ClothesWasher>
-        <ClothesDryer>
-          <SystemIdentifier id='ClothesDryer1'/>
-          <Location>living space</Location>
-          <FuelType>electricity</FuelType>
-          <CombinedEnergyFactor>3.73</CombinedEnergyFactor>
-          <Vented>true</Vented>
-          <VentedFlowRate>150.0</VentedFlowRate>
-        </ClothesDryer>
         <Dishwasher>
           <SystemIdentifier id='Dishwasher1'/>
           <Location>living space</Location>
@@ -982,14 +974,6 @@
           <LabelUsage>6.0</LabelUsage>
           <Capacity>3.2</Capacity>
         </ClothesWasher>
-        <ClothesDryer>
-          <SystemIdentifier id='ClothesDryer1_2'/>
-          <Location>living space</Location>
-          <FuelType>electricity</FuelType>
-          <CombinedEnergyFactor>3.73</CombinedEnergyFactor>
-          <Vented>true</Vented>
-          <VentedFlowRate>150.0</VentedFlowRate>
-        </ClothesDryer>
         <Dishwasher>
           <SystemIdentifier id='Dishwasher1_2'/>
           <Location>living space</Location>
@@ -1517,14 +1501,6 @@
           <LabelUsage>6.0</LabelUsage>
           <Capacity>3.2</Capacity>
         </ClothesWasher>
-        <ClothesDryer>
-          <SystemIdentifier id='ClothesDryer1_3'/>
-          <Location>living space</Location>
-          <FuelType>electricity</FuelType>
-          <CombinedEnergyFactor>3.73</CombinedEnergyFactor>
-          <Vented>true</Vented>
-          <VentedFlowRate>150.0</VentedFlowRate>
-        </ClothesDryer>
         <Dishwasher>
           <SystemIdentifier id='Dishwasher1_3'/>
           <Location>living space</Location>

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -278,17 +278,20 @@ class HPXMLTest < MiniTest::Test
     system(command, err: File::NULL)
     assert_equal(true, File.exist?(csv_output_path))
 
+    # Check that we have exactly one warning (i.e., check we are only validating a single Building element against schematron)
+    assert_equal(1, File.readlines(run_log).select { |l| l.include? 'Warning: No clothes dryer specified, the model will not include clothes dryer energy use.' }.size)
+
     # Check unsuccessful simulation when providing incorrect building ID
     command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --building-id MyFoo"
     system(command, err: File::NULL)
     assert_equal(false, File.exist?(csv_output_path))
-    assert(File.readlines(run_log).select { |l| l.include? "Could not find Building element with ID 'MyFoo'." }.size > 0)
+    assert_equal(1, File.readlines(run_log).select { |l| l.include? "Could not find Building element with ID 'MyFoo'." }.size)
 
     # Check unsuccessful simulation when not providing building ID
     command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\""
     system(command, err: File::NULL)
     assert_equal(false, File.exist?(csv_output_path))
-    assert(File.readlines(run_log).select { |l| l.include? 'Multiple Building elements defined in HPXML file; Building ID argument must be provided.' }.size > 0)
+    assert_equal(1, File.readlines(run_log).select { |l| l.include? 'Multiple Building elements defined in HPXML file; Building ID argument must be provided.' }.size)
   end
 
   def test_release_zips


### PR DESCRIPTION
## Pull Request Description

Speed up schematron validation when running simulations for HPXML files with multiple `Building` elements; now we only do schematron validation on the single `Building` element of interest. This also means we now get warnings specific to the single `Building` of interest too, which is desirable.

For a test HPXML file with 21 `Building` elements:

  | Schematron Validation runtime | Total runtime
-- | -- | --
Before | 2.2s | 7.9s
After | 0.3s | 6.0s

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
