### PR TITLE
Simplify asset vs operational calculation, take 2

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -316,6 +316,13 @@ class OSModel
     @hpxml.collapse_enclosure_surfaces() # Speeds up simulation
     @hpxml.delete_adiabatic_subsurfaces() # EnergyPlus doesn't allow this
 
+    # We don't want this to be written to in.xml, because then if you ran the in.xml
+    # file, you would get different results (operational calculation) relative to the
+    # original file (asset calculation).
+    if @hpxml.building_occupancy.number_of_residents.nil?
+      @hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(@nbeds)
+    end
+
     # If zero occupants, ensure end uses of interest are zeroed out
     if (@hpxml.building_occupancy.number_of_residents == 0) && (not @apply_ashrae140_assumptions)
       @hpxml.header.unavailable_periods.add(column_name: 'Vacancy',

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>66c68c09-a150-417e-afbf-664cae97ad1f</version_id>
-  <version_modified>20230501T215011Z</version_modified>
+  <version_id>4816c10b-5a41-436e-a355-cfd8edd5b044</version_id>
+  <version_modified>20230502T201104Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -542,18 +542,6 @@
       <checksum>EA5F3E1B</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>5E9D5E71</checksum>
-    </file>
-    <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>BD9AFB46</checksum>
-    </file>
-    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -572,6 +560,12 @@
       <checksum>F0B3DCEF</checksum>
     </file>
     <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F1FEF43F</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.3.0</identifier>
@@ -580,7 +574,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>B7619853</checksum>
+      <checksum>1E7FB5AF</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>A466A879</checksum>
     </file>
   </files>
 </measure>

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -27,7 +27,7 @@ class HPXMLDefaults
     apply_utility_bill_scenarios(runner, hpxml, has_fuel)
     apply_site(hpxml)
     apply_neighbor_buildings(hpxml)
-    apply_building_occupancy(hpxml, nbeds, schedules_file)
+    apply_building_occupancy(hpxml, schedules_file)
     apply_building_construction(hpxml, cfa, nbeds, infil_measurement)
     apply_climate_and_risk_zones(hpxml, epw_file)
     apply_infiltration(hpxml, infil_measurement)
@@ -502,10 +502,8 @@ class HPXMLDefaults
     end
   end
 
-  def self.apply_building_occupancy(hpxml, nbeds, schedules_file)
+  def self.apply_building_occupancy(hpxml, schedules_file)
     if hpxml.building_occupancy.number_of_residents.nil?
-      hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(nbeds)
-      hpxml.building_occupancy.number_of_residents_isdefaulted = true
       hpxml.building_construction.additional_properties.adjusted_number_of_bedrooms = hpxml.building_construction.number_of_bedrooms
     else
       # Set adjusted number of bedrooms for operational calculation; this is an adjustment on
@@ -2896,16 +2894,13 @@ class HPXMLDefaults
 
   def self.get_nbeds_adjusted_for_operational_calculation(hpxml)
     n_occs = hpxml.building_occupancy.number_of_residents
-    if not n_occs.nil?
-      unit_type = hpxml.building_construction.residential_facility_type
-      if [HPXML::ResidentialTypeApartment, HPXML::ResidentialTypeSFA].include? unit_type
-        return -0.68 + 1.09 * n_occs
-      elsif [HPXML::ResidentialTypeSFD, HPXML::ResidentialTypeManufactured].include? unit_type
-        return -1.47 + 1.69 * n_occs
-      else
-        fail "Unexpected residential facility type: #{unit_type}."
-      end
+    unit_type = hpxml.building_construction.residential_facility_type
+    if [HPXML::ResidentialTypeApartment, HPXML::ResidentialTypeSFA].include? unit_type
+      return -0.68 + 1.09 * n_occs
+    elsif [HPXML::ResidentialTypeSFD, HPXML::ResidentialTypeManufactured].include? unit_type
+      return -1.47 + 1.69 * n_occs
+    else
+      fail "Unexpected residential facility type: #{unit_type}."
     end
-    return hpxml.building_construction.number_of_bedrooms
   end
 end

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -361,22 +361,20 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
   def test_occupancy
     # Test inputs not overridden by defaults
     hpxml = _create_hpxml('base.xml')
-    hpxml.building_occupancy.number_of_residents = 1
     hpxml.building_occupancy.weekday_fractions = ConstantDaySchedule
     hpxml.building_occupancy.weekend_fractions = ConstantDaySchedule
     hpxml.building_occupancy.monthly_multipliers = ConstantMonthSchedule
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_occupancy_values(hpxml_default, 1, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
+    _test_default_occupancy_values(hpxml_default, ConstantDaySchedule, ConstantDaySchedule, ConstantMonthSchedule)
 
     # Test defaults
-    hpxml.building_occupancy.number_of_residents = nil
     hpxml.building_occupancy.weekday_fractions = nil
     hpxml.building_occupancy.weekend_fractions = nil
     hpxml.building_occupancy.monthly_multipliers = nil
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_occupancy_values(hpxml_default, 3, Schedule.OccupantsWeekdayFractions, Schedule.OccupantsWeekendFractions, Schedule.OccupantsMonthlyMultipliers)
+    _test_default_occupancy_values(hpxml_default, Schedule.OccupantsWeekdayFractions, Schedule.OccupantsWeekendFractions, Schedule.OccupantsMonthlyMultipliers)
   end
 
   def test_building_construction
@@ -3529,8 +3527,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     end
   end
 
-  def _test_default_occupancy_values(hpxml, num_occupants, weekday_sch, weekend_sch, monthly_mults)
-    assert_equal(num_occupants, hpxml.building_occupancy.number_of_residents)
+  def _test_default_occupancy_values(hpxml, weekday_sch, weekend_sch, monthly_mults)
     if weekday_sch.nil?
       assert_nil(hpxml.building_occupancy.weekday_fractions)
     else

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -224,6 +224,29 @@ class HPXMLTest < MiniTest::Test
     end
   end
 
+  def test_run_defaulted_in_xml
+    # Check that if we simulate the in.xml file (HPXML w/ defaults), we get
+    # the same results as the original HPXML.
+
+    # Run base.xml
+    rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
+    xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
+    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\""
+    system(command, err: File::NULL)
+    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+    base_results = CSV.read(File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+
+    # Run in.xml (generated from base.xml)
+    xml2 = File.join(File.dirname(xml), 'run', 'in.xml')
+    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml2}\""
+    system(command, err: File::NULL)
+    assert(File.exist? File.join(File.dirname(xml2), 'run', 'results_annual.csv'))
+    default_results = CSV.read(File.join(File.dirname(xml2), 'run', 'results_annual.csv'))
+
+    # Check two output files are identical
+    assert_equal(base_results, default_results)
+  end
+
   def test_template_osws
     # Check that simulation works using template-*.osw
     require 'json'


### PR DESCRIPTION
## Pull Request Description

For asset calculations, don't default number of occupants in hpxml_defaults.rb. That would be misleading/confusing, and if you run the simulation after the defaults are applied (e.g., running `in.xml`), it would now give operational calculation results, which is not what we want. Added a test to demonstrate that running an HPXML and then running the in.xml generated from it now produce the same results.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
