### PR TITLE
BuildResidentialHPXML: Fix finished attic over garage coordinates

### DIFF
--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>35aa6a0f-1652-40e5-a79d-19f78ec9b96e</version_id>
-  <version_modified>20230510T181859Z</version_modified>
+  <version_id>90ae6392-f25c-44c7-b799-419cdc731bdc</version_id>
+  <version_modified>20230512T164921Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6636,12 +6636,6 @@
   </attributes>
   <files>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D9E75C2E</checksum>
-    </file>
-    <file>
       <filename>build_residential_hpxml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -6657,6 +6651,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>74318562</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>864F8465</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>90ae6392-f25c-44c7-b799-419cdc731bdc</version_id>
-  <version_modified>20230512T164921Z</version_modified>
+  <version_id>20945cf9-0ecb-41c1-b8fe-5dc26ff5c5c4</version_id>
+  <version_modified>20230512T181528Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6636,12 +6636,6 @@
   </attributes>
   <files>
     <file>
-      <filename>build_residential_hpxml_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>7F6A3D85</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.9.0</identifier>
@@ -6657,6 +6651,24 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>864F8465</checksum>
+    </file>
+    <file>
+      <filename>build_residential_hpxml_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>5461EA7B</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-enclosure-garage-atticroof-conditioned.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>AF68B450</checksum>
+    </file>
+    <file>
+      <filename>extra_files/extra-enclosure-garage-atticroof-conditioned.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CC7D040C</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/resources/geometry.rb
+++ b/BuildResidentialHPXML/resources/geometry.rb
@@ -652,17 +652,10 @@ class Geometry
         end
 
         if num_floors == 1
-          if not attic_type == HPXML::AtticTypeConditioned
-            nw_point = OpenStudio::Point3d.new(nw_point.x, nw_point.y, living_space.zOrigin + nw_point.z)
-            ne_point = OpenStudio::Point3d.new(ne_point.x, ne_point.y, living_space.zOrigin + ne_point.z)
-            sw_point = OpenStudio::Point3d.new(sw_point.x, sw_point.y, living_space.zOrigin + sw_point.z)
-            se_point = OpenStudio::Point3d.new(se_point.x, se_point.y, living_space.zOrigin + se_point.z)
-          else
-            nw_point = OpenStudio::Point3d.new(nw_point.x, nw_point.y, nw_point.z - living_space.zOrigin)
-            ne_point = OpenStudio::Point3d.new(ne_point.x, ne_point.y, ne_point.z - living_space.zOrigin)
-            sw_point = OpenStudio::Point3d.new(sw_point.x, sw_point.y, sw_point.z - living_space.zOrigin)
-            se_point = OpenStudio::Point3d.new(se_point.x, se_point.y, se_point.z - living_space.zOrigin)
-          end
+          nw_point = OpenStudio::Point3d.new(nw_point.x, nw_point.y, living_space.zOrigin + nw_point.z)
+          ne_point = OpenStudio::Point3d.new(ne_point.x, ne_point.y, living_space.zOrigin + ne_point.z)
+          sw_point = OpenStudio::Point3d.new(sw_point.x, sw_point.y, living_space.zOrigin + sw_point.z)
+          se_point = OpenStudio::Point3d.new(se_point.x, se_point.y, living_space.zOrigin + se_point.z)
         else
           nw_point = OpenStudio::Point3d.new(nw_point.x, nw_point.y, num_floors * nw_point.z + rim_joist_height)
           ne_point = OpenStudio::Point3d.new(ne_point.x, ne_point.y, num_floors * ne_point.z + rim_joist_height)

--- a/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
+++ b/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
@@ -10,10 +10,11 @@ require 'fileutils'
 class BuildResidentialHPXMLTest < MiniTest::Test
   def setup
     @output_path = File.join(File.dirname(__FILE__), 'extra_files')
+    @model_save = false # true helpful for debugging, i.e., can render osm in 3D
   end
 
   def teardown
-    FileUtils.rm_rf(@output_path)
+    FileUtils.rm_rf(@output_path) if !@model_save
   end
 
   def test_workflows
@@ -288,6 +289,7 @@ class BuildResidentialHPXMLTest < MiniTest::Test
 
         # Apply measure
         success = apply_measures(measures_dir, measures, runner, model)
+        model.save(File.absolute_path(File.join(@output_path, hpxml_file.gsub('.xml', '.osm')))) if @model_save
 
         _test_measure(runner, expected_errors[hpxml_file], expected_warnings[hpxml_file])
 


### PR DESCRIPTION
## Pull Request Description

Some surfaces in the wrong place, as seen in rendering here: https://github.com/NREL/OpenStudio-HPXML/issues/1384

Also adding an optional argument to BuildResHPXML tests for saving `model`, so we can, e.g., look at 3D geometry.

BEFORE
![image](https://github.com/NREL/OpenStudio-HPXML/assets/8516790/5894ef17-fb83-4457-ae5a-330decf9a307)

AFTER
![image](https://github.com/NREL/OpenStudio-HPXML/assets/8516790/454c2185-967b-4e04-9b8c-e60affb4c1d9)

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [ ] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [ ] ~Documentation has been updated~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
