### PR TITLE
Allow simulating whole SFA/MF buildings

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6e25a3e5-f445-46f5-99c0-1aebcfb68c5e</version_id>
-  <version_modified>2023-07-17T18:38:57Z</version_modified>
+  <version_id>09d1d5f4-3cea-4bbc-9677-03621d2d8f90</version_id>
+  <version_modified>2023-07-24T23:14:50Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -130,7 +130,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>9F4FD400</checksum>
+      <checksum>FD1BF6D6</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
@@ -304,7 +304,7 @@
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>26D01154</checksum>
+      <checksum>4461180A</checksum>
     </file>
     <file>
       <filename>minitest_helper.rb</filename>

--- a/HPXMLtoOpenStudio/resources/meta_measure.rb
+++ b/HPXMLtoOpenStudio/resources/meta_measure.rb
@@ -50,15 +50,16 @@ def run_hpxml_workflow(rundir, measures, measures_dir, debug: false, output_vars
 
   # Remove unused objects automatically added by OpenStudio?
   remove_objects = []
-  if model.alwaysOnContinuousSchedule.directUseCount == 0
-    remove_objects << ['Schedule:Constant', model.alwaysOnContinuousSchedule.name.to_s]
-  end
-  if model.alwaysOnDiscreteSchedule.directUseCount == 0
-    remove_objects << ['Schedule:Constant', model.alwaysOnDiscreteSchedule.name.to_s]
-  end
-  if model.alwaysOffDiscreteSchedule.directUseCount == 0
-    remove_objects << ['Schedule:Constant', model.alwaysOffDiscreteSchedule.name.to_s]
-  end
+  # FIXME: Need to revert this code
+  # if model.alwaysOnContinuousSchedule.directUseCount == 0
+  #  remove_objects << ['Schedule:Constant', model.alwaysOnContinuousSchedule.name.to_s]
+  # end
+  # if model.alwaysOnDiscreteSchedule.directUseCount == 0
+  #  remove_objects << ['Schedule:Constant', model.alwaysOnDiscreteSchedule.name.to_s]
+  # end
+  # if model.alwaysOffDiscreteSchedule.directUseCount == 0
+  #  remove_objects << ['Schedule:Constant', model.alwaysOffDiscreteSchedule.name.to_s]
+  # end
 
   # Translate model to workspace
   forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>96cc272b-f80b-4ba5-ae10-938296253360</version_id>
-  <version_modified>2023-07-20T21:55:05Z</version_modified>
+  <version_id>cbbad4f6-ba92-4729-a6fa-bd469154d190</version_id>
+  <version_modified>2023-07-24T23:08:27Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1917,7 +1917,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>AA9428A1</checksum>
+      <checksum>6C7C9807</checksum>
     </file>
     <file>
       <filename>output_report_test.rb</filename>

--- a/workflow/tests/hpxml_translator_test.rb
+++ b/workflow/tests/hpxml_translator_test.rb
@@ -292,7 +292,7 @@ class HPXMLTest < MiniTest::Test
     end
   end
 
-  def test_multiple_building_ids
+  def test_multiple_buildings
     rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
     xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base-multiple-buildings.xml')
     csv_output_path = File.join(File.dirname(xml), 'run', 'results_annual.csv')
@@ -317,6 +317,14 @@ class HPXMLTest < MiniTest::Test
     system(command, err: File::NULL)
     assert_equal(false, File.exist?(csv_output_path))
     assert_equal(1, File.readlines(run_log).select { |l| l.include? 'Multiple Building elements defined in HPXML file; Building ID argument must be provided.' }.size)
+
+    # Check successful simulation when running whole building
+    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --building-id ALL"
+    system(command, err: File::NULL)
+    assert_equal(true, File.exist?(csv_output_path))
+
+    # Check that we now have three warnings, one for each Building element
+    assert_equal(3, File.readlines(run_log).select { |l| l.include? 'Warning: No clothes dryer specified, the model will not include clothes dryer energy use.' }.size)
   end
 
   def test_release_zips


### PR DESCRIPTION
## Pull Request Description

Addresses #1376.

If an HPXML file is submitted where there are multiple `Building` elements, each representing an individual dwelling unit, you can now tell OS-HPXML that you want to run ALL units, which creates a single OS/E+ model. The ability to just run one of the `Building` IDs is also still available.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
