### PR TITLE
Fix has_fuel method for gas fired pool/hot tub heaters

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3b19531f-ccf8-46a9-b332-82d923e742c4</version_id>
-  <version_modified>2023-07-25T03:37:37Z</version_modified>
+  <version_id>55ac94cd-4816-46de-b41f-f51dcefe908e</version_id>
+  <version_modified>2023-07-25T15:30:06Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -238,7 +238,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>5E986A1F</checksum>
+      <checksum>A2730455</checksum>
     </file>
     <file>
       <filename>hpxml_defaults.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6e25a3e5-f445-46f5-99c0-1aebcfb68c5e</version_id>
-  <version_modified>2023-07-17T18:38:57Z</version_modified>
+  <version_id>3b19531f-ccf8-46a9-b332-82d923e742c4</version_id>
+  <version_modified>2023-07-25T03:37:37Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -238,7 +238,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>66E3FB20</checksum>
+      <checksum>5E986A1F</checksum>
     </file>
     <file>
       <filename>hpxml_defaults.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -500,8 +500,8 @@ class HPXML < Object
      'FuelType',
      'IntegratedHeatingSystemFuel',
      'Heater/Type'].each do |fuel_name|
-      if XMLHelper.has_element(hpxml_doc, "//#{fuel_name}[text() = '#{fuel}']") ||
-         (XMLHelper.has_element(hpxml_doc, "//#{fuel_name}[text() = '#{HPXML::HeaterTypeGas}']") && (fuel == HPXML::FuelTypeNaturalGas))
+      fuel = HPXML::HeaterTypeGas if fuel_name == 'Heater/Type' && fuel == HPXML::FuelTypeNaturalGas
+      if XMLHelper.has_element(hpxml_doc, "//#{fuel_name}[text() = '#{fuel}']")
         return true
       end
     end

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -498,8 +498,10 @@ class HPXML < Object
      'HeatPumpFuel',
      'BackupSystemFuel',
      'FuelType',
-     'IntegratedHeatingSystemFuel'].each do |fuel_name|
-      if XMLHelper.has_element(hpxml_doc, "//#{fuel_name}[text() = '#{fuel}']")
+     'IntegratedHeatingSystemFuel',
+     'Heater/Type'].each do |fuel_name|
+      if XMLHelper.has_element(hpxml_doc, "//#{fuel_name}[text() = '#{fuel}']") ||
+         (XMLHelper.has_element(hpxml_doc, "//#{fuel_name}[text() = '#{HPXML::HeaterTypeGas}']") && (fuel == HPXML::FuelTypeNaturalGas))
         return true
       end
     end


### PR DESCRIPTION
## Pull Request Description

Update hpxml.rb's `has_fuel` method to catch "gas fired" pool and hot tub heaters.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (via `tasks.rb`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
