### PR TITLE
BuildResidentialHPXML measure: Duct area fractions

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -1496,8 +1496,14 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
 
     arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('ducts_supply_surface_area', false)
     arg.setDisplayName('Ducts: Supply Surface Area')
-    arg.setDescription('The surface area of the supply ducts. If not provided, the OS-HPXML default is used.')
+    arg.setDescription('The supply ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default is used.')
     arg.setUnits('ft^2')
+    args << arg
+
+    arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('ducts_supply_surface_area_fraction', false)
+    arg.setDisplayName('Ducts: Supply Area Fraction')
+    arg.setDescription('The fraction of supply ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default is used.')
+    arg.setUnits('frac')
     args << arg
 
     arg = OpenStudio::Measure::OSArgument::makeChoiceArgument('ducts_return_location', duct_location_choices, false)
@@ -1519,8 +1525,14 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
 
     arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('ducts_return_surface_area', false)
     arg.setDisplayName('Ducts: Return Surface Area')
-    arg.setDescription('The surface area of the return ducts. If not provided, the OS-HPXML default is used.')
+    arg.setDescription('The return ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default is used.')
     arg.setUnits('ft^2')
+    args << arg
+
+    arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('ducts_return_surface_area_fraction', false)
+    arg.setDisplayName('Ducts: Return Area Fraction')
+    arg.setDescription('The fraction of return ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default is used.')
+    arg.setUnits('frac')
     args << arg
 
     arg = OpenStudio::Measure::OSArgument::makeIntegerArgument('ducts_number_of_return_registers', false)
@@ -3179,6 +3191,10 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
   def argument_warnings(args)
     warnings = []
 
+    max_uninsulated_floor_rvalue = 6.0
+    max_uninsulated_ceiling_rvalue = 3.0
+    max_uninsulated_roof_rvalue = 3.0
+
     warning = ([HPXML::WaterHeaterTypeHeatPump].include?(args[:water_heater_type]) && (args[:water_heater_fuel_type] != HPXML::FuelTypeElectricity))
     warnings << 'Cannot model a heat pump water heater with non-electric fuel type.' if warning
 
@@ -3188,19 +3204,16 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     warning = (args[:geometry_foundation_type] == HPXML::FoundationTypeSlab) && (args[:geometry_foundation_height_above_grade] > 0)
     warnings << 'Specified a slab foundation type with a non-zero height above grade.' if warning
 
-    warning = (args[:heating_system_2_type] != 'none') && (args[:heating_system_2_fraction_heat_load_served] >= 0.5) && (args[:heating_system_2_fraction_heat_load_served] < 1.0)
-    warnings << 'The fraction of heat load served by the second heating system is greater than or equal to 50%.' if warning
-
-    warning = [HPXML::FoundationTypeCrawlspaceVented, HPXML::FoundationTypeCrawlspaceUnvented, HPXML::FoundationTypeBasementUnconditioned].include?(args[:geometry_foundation_type]) && ((args[:foundation_wall_insulation_r] > 0) || args[:foundation_wall_assembly_r].is_initialized) && (args[:floor_over_foundation_assembly_r] > 2.1)
+    warning = [HPXML::FoundationTypeCrawlspaceVented, HPXML::FoundationTypeCrawlspaceUnvented, HPXML::FoundationTypeBasementUnconditioned].include?(args[:geometry_foundation_type]) && ((args[:foundation_wall_insulation_r] > 0) || args[:foundation_wall_assembly_r].is_initialized) && (args[:floor_over_foundation_assembly_r] > max_uninsulated_floor_rvalue)
     warnings << 'Home with unconditioned basement/crawlspace foundation type has both foundation wall insulation and floor insulation.' if warning
 
-    warning = [HPXML::AtticTypeVented, HPXML::AtticTypeUnvented].include?(args[:geometry_attic_type]) && (args[:ceiling_assembly_r] > 2.1) && (args[:roof_assembly_r] > 2.3)
+    warning = [HPXML::AtticTypeVented, HPXML::AtticTypeUnvented].include?(args[:geometry_attic_type]) && (args[:ceiling_assembly_r] > max_uninsulated_ceiling_rvalue) && (args[:roof_assembly_r] > max_uninsulated_roof_rvalue)
     warnings << 'Home with unconditioned attic type has both ceiling insulation and roof insulation.' if warning
 
-    warning = (args[:geometry_foundation_type] == HPXML::FoundationTypeBasementConditioned) && (args[:floor_over_foundation_assembly_r] > 2.1)
+    warning = (args[:geometry_foundation_type] == HPXML::FoundationTypeBasementConditioned) && (args[:floor_over_foundation_assembly_r] > max_uninsulated_floor_rvalue)
     warnings << 'Home with conditioned basement has floor insulation.' if warning
 
-    warning = (args[:geometry_attic_type] == HPXML::AtticTypeConditioned) && (args[:ceiling_assembly_r] > 2.1)
+    warning = (args[:geometry_attic_type] == HPXML::AtticTypeConditioned) && (args[:ceiling_assembly_r] > max_uninsulated_ceiling_rvalue)
     warnings << 'Home with conditioned attic has ceiling insulation.' if warning
 
     return warnings
@@ -3220,12 +3233,6 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
 
     error = (args[:geometry_unit_type] == HPXML::ResidentialTypeApartment) && ([HPXML::FoundationTypeBasementConditioned, HPXML::FoundationTypeCrawlspaceConditioned].include? args[:geometry_foundation_type])
     errors << 'Conditioned basement/crawlspace foundation type for apartment units is not currently supported.' if error
-
-    error = (args[:ducts_supply_location].is_initialized != args[:ducts_supply_surface_area].is_initialized) || (args[:ducts_return_location].is_initialized != args[:ducts_return_surface_area].is_initialized)
-    errors << 'Duct location and surface area not both defaulted or not both specified.' if error
-
-    error = (args[:heating_system_2_type] != 'none') && (args[:heating_system_2_fraction_heat_load_served] == 1.0)
-    errors << 'The fraction of heat load served by the second heating system is 100%.' if error
 
     error = (args[:heating_system_type] == 'none') && (args[:heat_pump_type] == 'none') && (args[:heating_system_2_type] != 'none')
     errors << 'A second heating system was specified without a primary heating system.' if error
@@ -5080,8 +5087,34 @@ class HPXMLFile
       ducts_supply_surface_area = args[:ducts_supply_surface_area].get
     end
 
+    if args[:ducts_supply_surface_area_fraction].is_initialized
+      ducts_supply_area_fraction = args[:ducts_supply_surface_area_fraction].get
+    end
+
     if args[:ducts_return_surface_area].is_initialized
       ducts_return_surface_area = args[:ducts_return_surface_area].get
+    end
+
+    if args[:ducts_return_surface_area_fraction].is_initialized
+      ducts_return_area_fraction = args[:ducts_return_surface_area_fraction].get
+    end
+
+    if (not ducts_supply_location.nil?) && ducts_supply_surface_area.nil? && ducts_supply_area_fraction.nil?
+      # Supply duct location without any area inputs provided; set area fraction
+      if ducts_supply_location == HPXML::LocationLivingSpace
+        ducts_supply_area_fraction = 1.0
+      else
+        ducts_supply_area_fraction = HVAC.get_default_duct_fraction_outside_conditioned_space(args[:geometry_unit_num_floors_above_grade])
+      end
+    end
+
+    if (not ducts_return_location.nil?) && ducts_return_surface_area.nil? && ducts_return_area_fraction.nil?
+      # Supply duct location without any area inputs provided; set area fraction
+      if ducts_return_location == HPXML::LocationLivingSpace
+        ducts_return_area_fraction = 1.0
+      else
+        ducts_return_area_fraction = HVAC.get_default_duct_fraction_outside_conditioned_space(args[:geometry_unit_num_floors_above_grade])
+      end
     end
 
     if args[:ducts_supply_buried_insulation_level].is_initialized
@@ -5097,7 +5130,8 @@ class HPXMLFile
                                 duct_insulation_r_value: args[:ducts_supply_insulation_r],
                                 duct_buried_insulation_level: ducts_supply_buried_insulation_level,
                                 duct_location: ducts_supply_location,
-                                duct_surface_area: ducts_supply_surface_area)
+                                duct_surface_area: ducts_supply_surface_area,
+                                duct_fraction_area: ducts_supply_area_fraction)
 
     if not ([HPXML::HVACTypeEvaporativeCooler].include?(args[:cooling_system_type]) && args[:cooling_system_is_ducted])
       hvac_distribution.ducts.add(id: "Ducts#{hvac_distribution.ducts.size + 1}",
@@ -5105,7 +5139,26 @@ class HPXMLFile
                                   duct_insulation_r_value: args[:ducts_return_insulation_r],
                                   duct_buried_insulation_level: ducts_return_buried_insulation_level,
                                   duct_location: ducts_return_location,
-                                  duct_surface_area: ducts_return_surface_area)
+                                  duct_surface_area: ducts_return_surface_area,
+                                  duct_fraction_area: ducts_return_area_fraction)
+    end
+
+    if (not ducts_supply_area_fraction.nil?) && (ducts_supply_area_fraction < 1)
+      hvac_distribution.ducts.add(id: "Ducts#{hvac_distribution.ducts.size + 1}",
+                                  duct_type: HPXML::DuctTypeSupply,
+                                  duct_insulation_r_value: 0.0,
+                                  duct_location: HPXML::LocationLivingSpace,
+                                  duct_fraction_area: 1.0 - ducts_supply_area_fraction)
+    end
+
+    if not hvac_distribution.ducts.find { |d| d.duct_type == HPXML::DuctTypeReturn }.nil?
+      if (not ducts_return_area_fraction.nil?) && (ducts_return_area_fraction < 1)
+        hvac_distribution.ducts.add(id: "Ducts#{hvac_distribution.ducts.size + 1}",
+                                    duct_type: HPXML::DuctTypeReturn,
+                                    duct_insulation_r_value: 0.0,
+                                    duct_location: HPXML::LocationLivingSpace,
+                                    duct_fraction_area: 1.0 - ducts_return_area_fraction)
+      end
     end
 
     # If duct surface areas are defaulted, set CFA served

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -5109,7 +5109,7 @@ class HPXMLFile
     end
 
     if (not ducts_return_location.nil?) && ducts_return_surface_area.nil? && ducts_return_area_fraction.nil?
-      # Supply duct location without any area inputs provided; set area fraction
+      # Return duct location without any area inputs provided; set area fraction
       if ducts_return_location == HPXML::LocationLivingSpace
         ducts_return_area_fraction = 1.0
       else
@@ -5144,6 +5144,7 @@ class HPXMLFile
     end
 
     if (not ducts_supply_area_fraction.nil?) && (ducts_supply_area_fraction < 1)
+      # OS-HPXML needs duct fractions to sum to 1; add remaining ducts in living space.
       hvac_distribution.ducts.add(id: "Ducts#{hvac_distribution.ducts.size + 1}",
                                   duct_type: HPXML::DuctTypeSupply,
                                   duct_insulation_r_value: 0.0,
@@ -5153,6 +5154,7 @@ class HPXMLFile
 
     if not hvac_distribution.ducts.find { |d| d.duct_type == HPXML::DuctTypeReturn }.nil?
       if (not ducts_return_area_fraction.nil?) && (ducts_return_area_fraction < 1)
+        # OS-HPXML needs duct fractions to sum to 1; add remaining ducts in living space.
         hvac_distribution.ducts.add(id: "Ducts#{hvac_distribution.ducts.size + 1}",
                                     duct_type: HPXML::DuctTypeReturn,
                                     duct_insulation_r_value: 0.0,

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>5ae1a868-e105-44c0-aad0-ee9f90c339ca</version_id>
-  <version_modified>2023-07-31T17:28:14Z</version_modified>
+  <version_id>a5a42263-d8b3-45cc-a81f-0348eaabd6ba</version_id>
+  <version_modified>2023-07-31T19:28:38Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6709,7 +6709,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>AD2ACE9D</checksum>
+      <checksum>85ADFF0F</checksum>
     </file>
     <file>
       <filename>geometry.rb</filename>

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>1fcda896-05c3-49a8-93d6-3d49c15fa301</version_id>
-  <version_modified>2023-07-26T21:30:02Z</version_modified>
+  <version_id>5ae1a868-e105-44c0-aad0-ee9f90c339ca</version_id>
+  <version_modified>2023-07-31T17:28:14Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -3101,9 +3101,18 @@
     <argument>
       <name>ducts_supply_surface_area</name>
       <display_name>Ducts: Supply Surface Area</display_name>
-      <description>The surface area of the supply ducts. If not provided, the OS-HPXML default is used.</description>
+      <description>The supply ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default is used.</description>
       <type>Double</type>
       <units>ft^2</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>ducts_supply_surface_area_fraction</name>
+      <display_name>Ducts: Supply Area Fraction</display_name>
+      <description>The fraction of supply ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default is used.</description>
+      <type>Double</type>
+      <units>frac</units>
       <required>false</required>
       <model_dependent>false</model_dependent>
     </argument>
@@ -3228,9 +3237,18 @@
     <argument>
       <name>ducts_return_surface_area</name>
       <display_name>Ducts: Return Surface Area</display_name>
-      <description>The surface area of the return ducts. If not provided, the OS-HPXML default is used.</description>
+      <description>The return ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default is used.</description>
       <type>Double</type>
       <units>ft^2</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>ducts_return_surface_area_fraction</name>
+      <display_name>Ducts: Return Area Fraction</display_name>
+      <description>The fraction of return ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default is used.</description>
+      <type>Double</type>
+      <units>frac</units>
       <required>false</required>
       <model_dependent>false</model_dependent>
     </argument>
@@ -6691,7 +6709,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>DA29841B</checksum>
+      <checksum>AD2ACE9D</checksum>
     </file>
     <file>
       <filename>geometry.rb</filename>
@@ -6703,7 +6721,7 @@
       <filename>build_residential_hpxml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>F156DFA0</checksum>
+      <checksum>E0489256</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
+++ b/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
@@ -27,6 +27,7 @@ class BuildResidentialHPXMLTest < Minitest::Test
 
       # Extra files to test
       'extra-auto.xml' => 'base-sfd.xml',
+      'extra-auto-duct-locations.xml' => 'extra-auto.xml',
       'extra-pv-roofpitch.xml' => 'base-sfd.xml',
       'extra-dhw-solar-latitude.xml' => 'base-sfd.xml',
       'extra-second-refrigerator.xml' => 'base-sfd.xml',
@@ -150,8 +151,6 @@ class BuildResidentialHPXMLTest < Minitest::Test
       'error-sfd-conditioned-basement-zero-foundation-height.xml' => 'base-sfd.xml',
       'error-sfd-adiabatic-walls.xml' => 'base-sfd.xml',
       'error-mf-bottom-crawlspace-zero-foundation-height.xml' => 'base-mf.xml',
-      'error-ducts-location-and-areas-not-same-type.xml' => 'base-sfd.xml',
-      'error-second-heating-system-serves-total-heat-load.xml' => 'base-sfd.xml',
       'error-second-heating-system-but-no-primary-heating.xml' => 'base-sfd.xml',
       'error-second-heating-system-ducted-with-ducted-primary-heating.xml' => 'base-sfd.xml',
       'error-sfa-no-building-num-units.xml' => 'base-sfa.xml',
@@ -190,7 +189,6 @@ class BuildResidentialHPXMLTest < Minitest::Test
       'warning-sfd-slab-non-zero-foundation-height.xml' => 'base-sfd.xml',
       'warning-mf-bottom-slab-non-zero-foundation-height.xml' => 'base-mf.xml',
       'warning-slab-non-zero-foundation-height-above-grade.xml' => 'base-sfd.xml',
-      'warning-second-heating-system-serves-majority-heat.xml' => 'base-sfd.xml',
       'warning-vented-crawlspace-with-wall-and-ceiling-insulation.xml' => 'base-sfd.xml',
       'warning-unvented-crawlspace-with-wall-and-ceiling-insulation.xml' => 'base-sfd.xml',
       'warning-unconditioned-basement-with-wall-and-ceiling-insulation.xml' => 'base-sfd.xml',
@@ -208,8 +206,6 @@ class BuildResidentialHPXMLTest < Minitest::Test
       'error-mf-conditioned-basement' => 'Conditioned basement/crawlspace foundation type for apartment units is not currently supported.',
       'error-mf-conditioned-crawlspace' => 'Conditioned basement/crawlspace foundation type for apartment units is not currently supported.',
       'error-mf-bottom-crawlspace-zero-foundation-height.xml' => "Foundation type of 'UnventedCrawlspace' cannot have a height of zero.",
-      'error-ducts-location-and-areas-not-same-type.xml' => 'Duct location and surface area not both defaulted or not both specified.',
-      'error-second-heating-system-serves-total-heat-load.xml' => 'The fraction of heat load served by the second heating system is 100%.',
       'error-second-heating-system-but-no-primary-heating.xml' => 'A second heating system was specified without a primary heating system.',
       'error-second-heating-system-ducted-with-ducted-primary-heating.xml' => "A ducted heat pump with 'separate' ducted backup is not supported.",
       'error-sfa-no-building-num-units.xml' => 'Did not specify the number of units in the building for single-family attached or apartment units.',
@@ -250,7 +246,6 @@ class BuildResidentialHPXMLTest < Minitest::Test
       'warning-sfd-slab-non-zero-foundation-height.xml' => "Foundation type of 'SlabOnGrade' cannot have a non-zero height. Assuming height is zero.",
       'warning-mf-bottom-slab-non-zero-foundation-height.xml' => "Foundation type of 'SlabOnGrade' cannot have a non-zero height. Assuming height is zero.",
       'warning-slab-non-zero-foundation-height-above-grade.xml' => 'Specified a slab foundation type with a non-zero height above grade.',
-      'warning-second-heating-system-serves-majority-heat.xml' => 'The fraction of heat load served by the second heating system is greater than or equal to 50%.',
       'warning-vented-crawlspace-with-wall-and-ceiling-insulation.xml' => 'Home with unconditioned basement/crawlspace foundation type has both foundation wall insulation and floor insulation.',
       'warning-unvented-crawlspace-with-wall-and-ceiling-insulation.xml' => 'Home with unconditioned basement/crawlspace foundation type has both foundation wall insulation and floor insulation.',
       'warning-unconditioned-basement-with-wall-and-ceiling-insulation.xml' => 'Home with unconditioned basement/crawlspace foundation type has both foundation wall insulation and floor insulation.',
@@ -662,6 +657,9 @@ class BuildResidentialHPXMLTest < Minitest::Test
       args.delete('clothes_washer_location')
       args.delete('clothes_dryer_location')
       args.delete('refrigerator_location')
+    elsif ['extra-auto-duct-locations.xml'].include? hpxml_file
+      args['ducts_supply_location'] = HPXML::LocationAtticUnvented
+      args['ducts_return_location'] = HPXML::LocationAtticUnvented
     elsif ['extra-pv-roofpitch.xml'].include? hpxml_file
       args['pv_system_module_type'] = HPXML::PVModuleTypeStandard
       args['pv_system_2_module_type'] = HPXML::PVModuleTypeStandard
@@ -1008,11 +1006,6 @@ class BuildResidentialHPXMLTest < Minitest::Test
       args['geometry_foundation_height'] = 0.0
       args['geometry_attic_type'] = HPXML::AtticTypeBelowApartment
       args.delete('foundation_wall_insulation_distance_to_bottom')
-    elsif ['error-ducts-location-and-areas-not-same-type.xml'].include? hpxml_file
-      args.delete('ducts_supply_location')
-    elsif ['error-second-heating-system-serves-total-heat-load.xml'].include? hpxml_file
-      args['heating_system_2_type'] = HPXML::HVACTypeFireplace
-      args['heating_system_2_fraction_heat_load_served'] = 1.0
     elsif ['error-second-heating-system-but-no-primary-heating.xml'].include? hpxml_file
       args['heating_system_type'] = 'none'
       args['heating_system_2_type'] = HPXML::HVACTypeFireplace
@@ -1123,10 +1116,6 @@ class BuildResidentialHPXMLTest < Minitest::Test
       args['geometry_foundation_type'] = HPXML::FoundationTypeSlab
       args['geometry_foundation_height'] = 0.0
       args.delete('foundation_wall_insulation_distance_to_bottom')
-    elsif ['warning-second-heating-system-serves-majority-heat.xml'].include? hpxml_file
-      args['heating_system_fraction_heat_load_served'] = 0.4
-      args['heating_system_2_type'] = HPXML::HVACTypeFireplace
-      args['heating_system_2_fraction_heat_load_served'] = 0.6
     elsif ['warning-vented-crawlspace-with-wall-and-ceiling-insulation.xml'].include? hpxml_file
       args['geometry_foundation_type'] = HPXML::FoundationTypeCrawlspaceVented
       args['geometry_foundation_height'] = 3.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ __New Features__
   - Adds battery resilience hours output; allows requesting timeseries output.
   - ReportUtilityBills measure: Allows reporting monthly utility bills in addition to (or instead of) annual bills.
 - Update to 2022 EIA energy costs.
+- BuildResidentialHPXML measure: Allow duct area fractions (as an alternative to duct areas in ft^2).
 
 __Bugfixes__
 - Fixes lighting multipliers not being applied when kWh/yr inputs are used.

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,9 @@ __New Features__
   - Adds battery resilience hours output; allows requesting timeseries output.
   - ReportUtilityBills measure: Allows reporting monthly utility bills in addition to (or instead of) annual bills.
 - Update to 2022 EIA energy costs.
-- BuildResidentialHPXML measure: Allow duct area fractions (as an alternative to duct areas in ft^2).
+- BuildResidentialHPXML measure:
+  - Allow duct area fractions (as an alternative to duct areas in ft^2).
+  - Allow duct locations to be provided while defaulting duct areas (i.e., without providing duct area/fraction inputs).
 
 __Bugfixes__
 - Fixes lighting multipliers not being applied when kWh/yr inputs are used.

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>ea35a4ec-0d8b-4b76-aab9-be13b33c3860</version_id>
-  <version_modified>2023-07-31T16:52:03Z</version_modified>
+  <version_id>ff18138e-a233-4bf4-a79d-88bfe798002a</version_id>
+  <version_modified>2023-07-31T23:29:26Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -244,7 +244,7 @@
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>01987A0E</checksum>
+      <checksum>AC964052</checksum>
     </file>
     <file>
       <filename>hpxml_schema/HPXML.xsd</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>d39e4e63-ebe0-4d8b-9e76-751299a87885</version_id>
-  <version_modified>2023-07-26T21:30:07Z</version_modified>
+  <version_id>ea35a4ec-0d8b-4b76-aab9-be13b33c3860</version_id>
+  <version_modified>2023-07-31T16:52:03Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -274,7 +274,7 @@
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>26725D20</checksum>
+      <checksum>8B94E964</checksum>
     </file>
     <file>
       <filename>hvac_sizing.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -1654,10 +1654,18 @@ class HPXMLDefaults
         next unless duct.duct_fraction_area.nil?
 
         if duct.duct_type == HPXML::DuctTypeSupply
-          duct.duct_fraction_area = (duct.duct_surface_area / total_supply_area).round(3)
+          if total_supply_area > 0
+            duct.duct_fraction_area = (duct.duct_surface_area / total_supply_area).round(3)
+          else
+            duct.duct_fraction_area = (1.0 / supply_ducts.size).round(3) # Arbitrary
+          end
           duct.duct_fraction_area_isdefaulted = true
         elsif duct.duct_type == HPXML::DuctTypeReturn
-          duct.duct_fraction_area = (duct.duct_surface_area / total_return_area).round(3)
+          if total_return_area > 0
+            duct.duct_fraction_area = (duct.duct_surface_area / total_return_area).round(3)
+          else
+            duct.duct_fraction_area = (1.0 / return_ducts.size).round(3) # Arbitrary
+          end
           duct.duct_fraction_area_isdefaulted = true
         end
       end

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -3628,9 +3628,19 @@ class HVAC
     end
   end
 
-  def self.get_default_duct_surface_area(duct_type, ncfl_ag, cfa_served, n_returns)
-    # Fraction of primary ducts (ducts outside conditioned space)
+  def self.get_default_duct_fraction_outside_conditioned_space(ncfl_ag)
+    # Equation based on ASHRAE 152
+    # https://www.energy.gov/eere/buildings/downloads/ashrae-standard-152-spreadsheet
     f_out = (ncfl_ag <= 1) ? 1.0 : 0.75
+    return f_out
+  end
+
+  def self.get_default_duct_surface_area(duct_type, ncfl_ag, cfa_served, n_returns)
+    # Equations based on ASHRAE 152
+    # https://www.energy.gov/eere/buildings/downloads/ashrae-standard-152-spreadsheet
+
+    # Fraction of primary ducts (ducts outside conditioned space)
+    f_out = get_default_duct_fraction_outside_conditioned_space(ncfl_ag)
 
     if duct_type == HPXML::DuctTypeSupply
       primary_duct_area = 0.27 * cfa_served * f_out

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -2217,7 +2217,8 @@ Additional information is entered in each ``Ducts``.
   .. [#] If DuctLocation not provided, defaults to the first present space type: "basement - conditioned", "basement - unconditioned", "crawlspace - conditioned", "crawlspace - vented", "crawlspace - unvented", "attic - vented", "attic - unvented", "garage", or "living space".
          If NumberofConditionedFloorsAboveGrade > 1, secondary ducts will be located in "living space".
   .. [#] The sum of all ``FractionDuctArea`` must each equal to 1, both for the supply side and return side.
-  .. [#] FractionDuctArea and/or DuctSurfaceArea are required if DuctLocation is provided.
+  .. [#] FractionDuctArea or DuctSurfaceArea are required if DuctLocation is provided.
+         If both are provided, DuctSurfaceArea will be used in the model.
   .. [#] | If neither DuctSurfaceArea nor FractionDuctArea provided, duct surface areas will be calculated based on `ASHRAE Standard 152 <https://www.energy.gov/eere/buildings/downloads/ashrae-standard-152-spreadsheet>`_:
          | - **Primary supply duct area**: 0.27 * F_out * ConditionedFloorAreaServed
          | - **Secondary supply duct area**: 0.27 * (1 - F_out) * ConditionedFloorAreaServed

--- a/tasks.rb
+++ b/tasks.rb
@@ -1380,9 +1380,11 @@ def apply_hpxml_modification(hpxml_file, hpxml)
         hpxml.heating_systems[i].fraction_heat_load_served = 0.35
       end
     end
+  elsif ['base-hvac-ducts-area-fractions.xml'].include? hpxml_file
+    hpxml.hvac_distributions[0].ducts[2].duct_location = HPXML::LocationExteriorWall
+    hpxml.hvac_distributions[0].ducts[2].duct_insulation_r_value = 4.0
   elsif ['base-enclosure-2stories.xml',
-         'base-enclosure-2stories-garage.xml',
-         'base-hvac-ducts-area-fractions.xml'].include? hpxml_file
+         'base-enclosure-2stories-garage.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].ducts << hpxml.hvac_distributions[0].ducts[0].dup
     hpxml.hvac_distributions[0].ducts[-1].id = "Ducts#{hpxml.hvac_distributions[0].ducts.size}"
     hpxml.hvac_distributions[0].ducts << hpxml.hvac_distributions[0].ducts[1].dup
@@ -1391,18 +1393,6 @@ def apply_hpxml_modification(hpxml_file, hpxml)
     hpxml.hvac_distributions[0].ducts[2].duct_surface_area = 37.5
     hpxml.hvac_distributions[0].ducts[3].duct_location = HPXML::LocationLivingSpace
     hpxml.hvac_distributions[0].ducts[3].duct_surface_area = 12.5
-    if hpxml_file == 'base-hvac-ducts-area-fractions.xml'
-      hpxml.hvac_distributions[0].ducts[0].duct_surface_area = nil
-      hpxml.hvac_distributions[0].ducts[1].duct_surface_area = nil
-      hpxml.hvac_distributions[0].ducts[2].duct_surface_area = nil
-      hpxml.hvac_distributions[0].ducts[3].duct_surface_area = nil
-      hpxml.hvac_distributions[0].ducts[0].duct_fraction_area = 0.75
-      hpxml.hvac_distributions[0].ducts[1].duct_fraction_area = 0.75
-      hpxml.hvac_distributions[0].ducts[2].duct_fraction_area = 0.25
-      hpxml.hvac_distributions[0].ducts[3].duct_fraction_area = 0.25
-      hpxml.hvac_distributions[0].conditioned_floor_area_served = 4050.0
-      hpxml.hvac_distributions[0].number_of_return_registers = 3
-    end
   elsif ['base-hvac-ducts-effective-rvalue.xml'].include? hpxml_file
     hpxml.hvac_distributions[0].ducts[0].duct_insulation_r_value = nil
     hpxml.hvac_distributions[0].ducts[1].duct_insulation_r_value = nil

--- a/workflow/hpxml_inputs.json
+++ b/workflow/hpxml_inputs.json
@@ -2251,7 +2251,11 @@
     "ducts_return_leakage_to_outside_value": 0.05
   },
   "sample_files/base-hvac-ducts-area-fractions.xml": {
-    "parent_hpxml": "sample_files/base-enclosure-2stories.xml"
+    "parent_hpxml": "sample_files/base-enclosure-2stories.xml",
+    "ducts_supply_surface_area": null,
+    "ducts_supply_surface_area_fraction": 0.75,
+    "ducts_return_surface_area": null,
+    "ducts_return_surface_area_fraction": 0.75
   },
   "sample_files/base-hvac-ducts-area-multipliers.xml": {
     "parent_hpxml": "sample_files/base.xml"

--- a/workflow/sample_files/base-hvac-ducts-area-fractions.xml
+++ b/workflow/sample_files/base-hvac-ducts-area-fractions.xml
@@ -417,7 +417,6 @@
                   <DuctLocation>living space</DuctLocation>
                   <FractionDuctArea>0.25</FractionDuctArea>
                 </Ducts>
-                <NumberofReturnRegisters>3</NumberofReturnRegisters>
               </AirDistribution>
             </DistributionSystemType>
             <ConditionedFloorAreaServed>4050.0</ConditionedFloorAreaServed>


### PR DESCRIPTION
## Pull Request Description

Allow duct area fractions (as an alternative to duct areas in ft^2) in the BuildResidentialHPXML measure. In addition, duct locations can now be provided without specifying duct areas/fractions; the measure will calculate default duct area fractions in this case.

Also closes #1454.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] Sample files have been added/updated (via `tasks.rb`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
