### PR TITLE
Document autosizing methodology for e.g. dual-fuel HPs

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>5db80f7a-58be-4b4a-9942-487602e5a6e4</version_id>
-  <version_modified>2023-09-13T20:50:01Z</version_modified>
+  <version_id>5b3130f2-b6cd-4fd4-ba8d-1cb3be263f93</version_id>
+  <version_modified>2023-09-19T21:08:31Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -280,7 +280,7 @@
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>44977F7D</checksum>
+      <checksum>6BA780E1</checksum>
     </file>
     <file>
       <filename>lighting.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -2010,7 +2010,7 @@ class HVACSizing
       end
     end
     if (not min_compressor_temp.nil?) && (min_compressor_temp > @hpxml.header.manualj_heating_design_temp)
-      # Calculate the heating load at the switchover temperature to limit uninitialized capacity
+      # Calculate the heating load at the switchover temperature to limit unutilized capacity
       temp_heat_design_temp = @hpxml.header.manualj_heating_design_temp
       @hpxml.header.manualj_heating_design_temp = min_compressor_temp
       _alternate_bldg_design_loads, alternate_all_hvac_sizing_values = calculate(weather, @hpxml, @cfa, [hvac_system])

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -423,7 +423,7 @@ HVAC Capacities
 ~~~~~~~~~~~~~~~
 
 System outputs are listed below.
-Capacities for individual HVAC systems can be found in the `in.xml` file.
+Capacities for individual HVAC systems can be found in the ``in.xml`` file.
 
    ====================================================  ====================
    Type                                                  Notes
@@ -447,7 +447,7 @@ HVAC Design Temperatures
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Design temperatures are used in the design load calculations for autosizing of HVAC equipment; see :ref:`hvac_sizing_control` for how they are derived.
-Design temperatures can also be found in the `in.xml` file.
+Design temperatures can also be found in the ``in.xml`` file.
 
    =====================================================================  ====================
    Type                                                                   Notes
@@ -462,8 +462,8 @@ HVAC Design Loads
 ~~~~~~~~~~~~~~~~~
 
 Design load outputs, used for autosizing of HVAC equipment, are listed below.
-Design loads are based on block load ACCA Manual J calculations using 1%/99% design temperatures.
-Design loads can also be found in the `in.xml` file.
+Design loads are based on block load ACCA Manual J calculations using :ref:`hvac_design_temps`.
+Design loads can also be found in the ``in.xml`` file.
 
    =====================================================================  ====================
    Type                                                                   Notes

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -423,7 +423,6 @@ HVAC Capacities
 ~~~~~~~~~~~~~~~
 
 System outputs are listed below.
-Autosized HVAC systems are based on HVAC design temperatures/loads described below.
 Capacities for individual HVAC systems can be found in the `in.xml` file.
 
    ====================================================  ====================
@@ -433,6 +432,16 @@ Capacities for individual HVAC systems can be found in the `in.xml` file.
    HVAC Capacity: Heating (Btu/h)                        Total HVAC heating capacity
    HVAC Capacity: Heat Pump Backup (Btu/h)               Total HVAC heat pump backup capacity
    ====================================================  ====================
+
+.. note::
+
+  Autosized HVAC systems are based on :ref:`hvac_design_temps` and :ref:`hvac_design_loads`.
+
+  For heat pumps with a minimum compressor lockout temperature greater than the heating design temperature (e.g., a dual-fuel heat pump in a cold climate), the compressor will be sized based on heating design loads calculated at the compressor lockout temperature.
+  This is done to prevent unutilized capacity at temperatures below the compressor lockout temperature.
+  Any heat pump backup will still be based on heating design loads calculated using the heating design temperature.
+  
+.. _hvac_design_temps:
 
 HVAC Design Temperatures
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -446,6 +455,8 @@ Design temperatures can also be found in the `in.xml` file.
    HVAC Design Temperature: Heating (F)                                   99% heating drybulb temperature
    HVAC Design Temperature: Cooling (F)                                   1% cooling drybulb temperature
    =====================================================================  ====================
+
+.. _hvac_design_loads:
 
 HVAC Design Loads
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Description

Closes #1484. Updated language ("For heat pumps with ..."):

![image](https://github.com/NREL/OpenStudio-HPXML/assets/5861765/6cb68482-7454-431b-aa0f-9fdcc9595526)

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (via `tasks.rb`)~
- [x] ~Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests` and/or `workflow/tests/hpxml_translator_test.rb`)~
- [x] Documentation has been updated
- [x] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] ~No unexpected changes to simulation results of sample files~
