### PR TITLE
Fix use of hourly msgpack file

### DIFF
--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -581,8 +581,11 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     if File.exist? msgpack_timeseries_path
       @msgpackDataTimeseries = MessagePack.unpack(File.read(msgpack_timeseries_path, mode: 'rb'))
     end
-    if (not @emissions.empty?) || ((not @resilience[RT::Battery].variables.empty?) && (args[:timeseries_frequency] != 'timestep'))
-      @msgpackDataHourly = MessagePack.unpack(File.read(File.join(output_dir, 'eplusout_hourly.msgpack'), mode: 'rb'))
+    if args[:timeseries_frequency] != 'hourly'
+      msgpack_hourly_path = File.join(output_dir, 'eplusout_hourly.msgpack')
+      if File.exist? msgpack_hourly_path
+        @msgpackDataHourly = MessagePack.unpack(File.read(msgpack_hourly_path, mode: 'rb'))
+      end
     end
 
     # Set paths

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>c1cc3d4c-41a5-4b4b-aa67-293c49b14496</version_id>
-  <version_modified>2023-11-03T20:37:27Z</version_modified>
+  <version_id>24e7b614-2b4f-4273-ba8a-e3617d8d0409</version_id>
+  <version_modified>2023-11-06T20:36:46Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1929,7 +1929,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>155FED88</checksum>
+      <checksum>BF3DF39A</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>


### PR DESCRIPTION
## Pull Request Description

Hit this error in a BEopt test now that most of our end uses are derived from Output:Meters instead of Output:Variables as a result of #1456. One can replicate the issue by having no hourly Output:Variable requests (e.g., remove any HVAC systems) but request emissions calculations (which require hourly data).

Test file:
[test.xml](https://github.com/NREL/OpenStudio-HPXML/files/13272324/test.xml.txt)

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
