### PR TITLE
Fix whole MF buildings -- timeseries temperature outputs

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>d52cfc78-4726-417a-a202-353922442ca0</version_id>
-  <version_modified>2023-11-10T02:13:31Z</version_modified>
+  <version_id>7a10799f-a5e9-4579-8668-64fa401efc75</version_id>
+  <version_modified>2023-11-10T22:41:43Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -142,7 +142,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>AFA848DB</checksum>
+      <checksum>04D14D5A</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -496,9 +496,10 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
               HPXML::LocationExteriorWall,
               HPXML::LocationUnderSlab]
       keys.each do |key|
-        next if @model.getScheduleConstants.select { |o| o.name.to_s == key }.size == 0
+        schedules = @model.getScheduleConstants.select { |sch| sch.additionalProperties.getFeatureAsString('ObjectType').to_s == key }
+        next if schedules.empty?
 
-        result << OpenStudio::IdfObject.load("Output:Variable,#{key},Schedule Value,#{args[:timeseries_frequency]};").get
+        result << OpenStudio::IdfObject.load("Output:Variable,#{schedules[0].name.to_s.upcase},Schedule Value,#{args[:timeseries_frequency]};").get
       end
       # Also report thermostat setpoints
       heated_zones.each do |heated_zone|
@@ -605,7 +606,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     end
 
     # Retrieve outputs
-    outputs = get_outputs(runner, args)
+    outputs = get_outputs(runner, args, building_id)
 
     if not check_for_errors(runner, outputs)
       return false
@@ -709,7 +710,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     return ts_output
   end
 
-  def get_outputs(runner, args)
+  def get_outputs(runner, args, building_id)
     outputs = {}
 
     args = setup_timeseries_includes(@emissions, args)
@@ -1066,37 +1067,67 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
 
     # Zone temperatures
     if args[:include_timeseries_zone_temperatures]
-      zone_names = []
-      scheduled_temperature_names = []
-      @model.getThermalZones.each do |zone|
-        if zone.floorArea > 1
-          zone_names << zone.name.to_s.upcase
-        end
+      def sanitize_name(name)
+        return name.gsub('_', ' ').split.map(&:capitalize).join(' ')
       end
-      @model.getScheduleConstants.each do |schedule|
-        next unless [HPXML::LocationOtherHeatedSpace, HPXML::LocationOtherMultifamilyBufferSpace, HPXML::LocationOtherNonFreezingSpace,
-                     HPXML::LocationOtherHousingUnit, HPXML::LocationExteriorWall, HPXML::LocationUnderSlab].include? schedule.name.to_s
 
-        scheduled_temperature_names << schedule.name.to_s.upcase
+      # Zone temperatures
+      zone_names = []
+      @model.getThermalZones.each do |zone|
+        next if zone.floorArea <= 1
+
+        zone_names << zone.name.to_s.upcase
       end
       zone_names.sort.each do |zone_name|
         @zone_temps[zone_name] = ZoneTemp.new
-        @zone_temps[zone_name].name = "Temperature: #{zone_name.split.map(&:capitalize).join(' ')}"
+        @zone_temps[zone_name].name = "Temperature: #{sanitize_name(zone_name)}"
         @zone_temps[zone_name].timeseries_units = 'F'
         @zone_temps[zone_name].timeseries_output = get_report_variable_data_timeseries([zone_name], ['Zone Mean Air Temperature'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
       end
-      scheduled_temperature_names.sort.each do |scheduled_temperature_name|
-        @zone_temps[scheduled_temperature_name] = ZoneTemp.new
-        @zone_temps[scheduled_temperature_name].name = "Temperature: #{scheduled_temperature_name.split.map(&:capitalize).join(' ')}"
-        @zone_temps[scheduled_temperature_name].timeseries_units = 'F'
-        @zone_temps[scheduled_temperature_name].timeseries_output = get_report_variable_data_timeseries([scheduled_temperature_name], ['Schedule Value'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
+
+      # Scheduled temperatures
+      [HPXML::LocationOtherHeatedSpace, HPXML::LocationOtherMultifamilyBufferSpace,
+       HPXML::LocationOtherNonFreezingSpace, HPXML::LocationOtherHousingUnit,
+       HPXML::LocationExteriorWall, HPXML::LocationUnderSlab].each do |sch_location|
+        @model.getScheduleConstants.each do |schedule|
+          next unless schedule.additionalProperties.getFeatureAsString('ObjectType').to_s == sch_location
+
+          sch_name = schedule.name.to_s.upcase
+          @zone_temps[sch_name] = ZoneTemp.new
+          @zone_temps[sch_name].name = "Temperature: #{sanitize_name(sch_name)}"
+          @zone_temps[sch_name].timeseries_units = 'F'
+          @zone_temps[sch_name].timeseries_output = get_report_variable_data_timeseries([sch_name], ['Schedule Value'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
+
+          break
+        end
       end
-      { 'Heating Setpoint' => 'Zone Thermostat Heating Setpoint Temperature',
-        'Cooling Setpoint' => 'Zone Thermostat Cooling Setpoint Temperature' }.each do |sp_name, sp_var|
-        @zone_temps[sp_name] = ZoneTemp.new
-        @zone_temps[sp_name].name = "Temperature: #{sp_name}"
-        @zone_temps[sp_name].timeseries_units = 'F'
-        @zone_temps[sp_name].timeseries_output = get_report_variable_data_timeseries([HPXML::LocationConditionedSpace.upcase], [sp_var], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
+
+      # Heating Setpoints
+      heated_zones = eval(@model.getBuilding.additionalProperties.getFeatureAsString('heated_zones').get)
+      heated_zones.each do |heated_zone|
+        var_name = 'Temperature: Heating Setpoint'
+        if building_id == 'ALL'
+          unit_num = @model.getThermalZones.find { |z| z.name.to_s == heated_zone }.spaces[0].buildingUnit.get.additionalProperties.getFeatureAsInteger('unit_num').get
+          var_name = "Temperature: Unit#{unit_num} Heating Setpoint"
+        end
+        @zone_temps["#{heated_zone} Heating Setpoint"] = ZoneTemp.new
+        @zone_temps["#{heated_zone} Heating Setpoint"].name = var_name
+        @zone_temps["#{heated_zone} Heating Setpoint"].timeseries_units = 'F'
+        @zone_temps["#{heated_zone} Heating Setpoint"].timeseries_output = get_report_variable_data_timeseries([heated_zone.upcase], ['Zone Thermostat Heating Setpoint Temperature'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
+      end
+
+      # Cooling Setpoints
+      cooled_zones = eval(@model.getBuilding.additionalProperties.getFeatureAsString('cooled_zones').get)
+      cooled_zones.each do |cooled_zone|
+        var_name = 'Temperature: Cooling Setpoint'
+        if building_id == 'ALL'
+          unit_num = @model.getThermalZones.find { |z| z.name.to_s == cooled_zone }.spaces[0].buildingUnit.get.additionalProperties.getFeatureAsInteger('unit_num').get
+          var_name = "Temperature: Unit#{unit_num} Cooling Setpoint"
+        end
+        @zone_temps["#{cooled_zone} Cooling Setpoint"] = ZoneTemp.new
+        @zone_temps["#{cooled_zone} Cooling Setpoint"].name = var_name
+        @zone_temps["#{cooled_zone} Cooling Setpoint"].timeseries_units = 'F'
+        @zone_temps["#{cooled_zone} Cooling Setpoint"].timeseries_output = get_report_variable_data_timeseries([cooled_zone.upcase], ['Zone Thermostat Cooling Setpoint Temperature'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
       end
     end
 

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>24e7b614-2b4f-4273-ba8a-e3617d8d0409</version_id>
-  <version_modified>2023-11-06T20:36:46Z</version_modified>
+  <version_id>ccfaa47b-cf8d-4947-9eb7-6c5dcdf89e92</version_id>
+  <version_modified>2023-11-10T22:41:45Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1929,13 +1929,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>BF3DF39A</checksum>
+      <checksum>8CE20783</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>CFAF52E1</checksum>
+      <checksum>2E2543E8</checksum>
     </file>
   </files>
 </measure>

--- a/tasks.rb
+++ b/tasks.rb
@@ -67,7 +67,7 @@ def create_hpxmls
         measures['BuildResidentialHPXML'][0]['schedules_filepaths'] = "../../HPXMLtoOpenStudio/resources/schedule_files/occupancy-stochastic#{suffix}.csv"
       end
       if hpxml_path.include?('base-multiple-mf-units')
-        measures['BuildResidentialHPXML'][0]['geometry_foundation_type'] = (i <= 1 ? 'UnconditionedBasement' : 'AboveApartment')
+        measures['BuildResidentialHPXML'][0]['geometry_foundation_type'] = (i <= 2 ? 'UnconditionedBasement' : 'AboveApartment')
         measures['BuildResidentialHPXML'][0]['geometry_attic_type'] = (i >= 5 ? 'VentedAttic' : 'BelowApartment')
       end
 

--- a/workflow/sample_files/base-multiple-mf-units.xml
+++ b/workflow/sample_files/base-multiple-mf-units.xml
@@ -545,7 +545,7 @@
         <Site>
           <SiteType>suburban</SiteType>
           <Surroundings>attached on one side</Surroundings>
-          <VerticalSurroundings>unit above and below</VerticalSurroundings>
+          <VerticalSurroundings>unit above</VerticalSurroundings>
           <AzimuthOfFrontOfHome>180</AzimuthOfFrontOfHome>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
@@ -603,10 +603,45 @@
           <Foundation>
             <SystemIdentifier id='Foundation1_2'/>
             <FoundationType>
-              <AboveApartment/>
+              <Basement>
+                <Conditioned>false</Conditioned>
+              </Basement>
             </FoundationType>
+            <AttachedToRimJoist idref='RimJoist1_2'/>
+            <AttachedToRimJoist idref='RimJoist2_2'/>
+            <AttachedToFoundationWall idref='FoundationWall1_2'/>
+            <AttachedToFoundationWall idref='FoundationWall2_2'/>
+            <AttachedToFloor idref='Floor1_2'/>
+            <AttachedToSlab idref='Slab1_2'/>
           </Foundation>
         </Foundations>
+        <RimJoists>
+          <RimJoist>
+            <SystemIdentifier id='RimJoist1_2'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - unconditioned</InteriorAdjacentTo>
+            <Area>77.1</Area>
+            <Siding>wood siding</Siding>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoist1Insulation_2'/>
+              <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+          <RimJoist>
+            <SystemIdentifier id='RimJoist2_2'/>
+            <ExteriorAdjacentTo>basement - unconditioned</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - unconditioned</InteriorAdjacentTo>
+            <Area>30.8</Area>
+            <SolarAbsorptance>0.7</SolarAbsorptance>
+            <Emittance>0.92</Emittance>
+            <Insulation>
+              <SystemIdentifier id='RimJoist2Insulation_2'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </RimJoist>
+        </RimJoists>
         <Walls>
           <Wall>
             <SystemIdentifier id='Wall1_2'/>
@@ -646,10 +681,60 @@
             </Insulation>
           </Wall>
         </Walls>
+        <FoundationWalls>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall1_2'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - unconditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>800.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <InteriorFinish>
+              <Type>none</Type>
+            </InteriorFinish>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall1Insulation_2'/>
+              <Layer>
+                <InstallationType>continuous - exterior</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+                <DistanceToTopOfInsulation>0.0</DistanceToTopOfInsulation>
+                <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
+              </Layer>
+              <Layer>
+                <InstallationType>continuous - interior</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall2_2'/>
+            <ExteriorAdjacentTo>basement - unconditioned</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - unconditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>320.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <InteriorFinish>
+              <Type>none</Type>
+            </InteriorFinish>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall2Insulation_2'/>
+              <Layer>
+                <InstallationType>continuous - exterior</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+              <Layer>
+                <InstallationType>continuous - interior</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+        </FoundationWalls>
         <Floors>
           <Floor>
             <SystemIdentifier id='Floor1_2'/>
-            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
+            <ExteriorAdjacentTo>basement - unconditioned</ExteriorAdjacentTo>
             <InteriorAdjacentTo>conditioned space</InteriorAdjacentTo>
             <FloorOrCeiling>floor</FloorOrCeiling>
             <FloorType>
@@ -658,7 +743,7 @@
             <Area>1200.0</Area>
             <Insulation>
               <SystemIdentifier id='Floor1Insulation_2'/>
-              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
+              <AssemblyEffectiveRValue>22.84</AssemblyEffectiveRValue>
             </Insulation>
           </Floor>
           <Floor>
@@ -679,6 +764,33 @@
             </Insulation>
           </Floor>
         </Floors>
+        <Slabs>
+          <Slab>
+            <SystemIdentifier id='Slab1_2'/>
+            <InteriorAdjacentTo>basement - unconditioned</InteriorAdjacentTo>
+            <Area>1200.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>100.0</ExposedPerimeter>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab1PerimeterInsulation_2'/>
+              <Layer>
+                <NominalRValue>0.0</NominalRValue>
+                <InsulationDepth>0.0</InsulationDepth>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab1UnderSlabInsulation_2'/>
+              <Layer>
+                <NominalRValue>0.0</NominalRValue>
+                <InsulationWidth>0.0</InsulationWidth>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+        </Slabs>
         <Windows>
           <Window>
             <SystemIdentifier id='Window1_2'/>

--- a/workflow/template-run-hpxml.osw
+++ b/workflow/template-run-hpxml.osw
@@ -10,7 +10,8 @@
         "output_dir": "..",
         "debug": false,
         "add_component_loads": false,
-        "skip_validation": false
+        "skip_validation": false,
+        "building_id": ""
       },
       "measure_dir_name": "HPXMLtoOpenStudio"
     },


### PR DESCRIPTION
## Pull Request Description

Fix missing timeseries temperature outputs when running whole MF buildings. Space temperatures for each thermal zone were being output, but scheduled temperatures and setpoints were missing. Add test.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] ~Documentation has been updated~
- [x] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
