### PR TITLE
Use diffusivity in kiva settings

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -1078,7 +1078,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     Constructions.apply_foundation_wall(model, [surface], "#{foundation_wall.id} construction",
                                         ext_rigid_offset, int_rigid_offset, ext_rigid_height, int_rigid_height,
                                         ext_rigid_r, int_rigid_r, mat_int_finish, mat_wall, height_ag,
-                                        soil_k_in)
+                                        soil_k_in, @hpxml_bldg.site.ground_diffusivity)
 
     if not assembly_r.nil?
       Constructions.check_surface_assembly_rvalue(runner, [surface], inside_film, nil, assembly_r, match)
@@ -1146,7 +1146,8 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     Constructions.apply_foundation_slab(model, surface, "#{slab.id} construction",
                                         slab_under_r, slab_under_width, slab_gap_r, slab_perim_r,
                                         slab_perim_depth, slab_whole_r, slab.thickness,
-                                        exposed_length, mat_carpet, soil_k_in, kiva_foundation)
+                                        exposed_length, mat_carpet, soil_k_in, @hpxml_bldg.site.ground_diffusivity,
+                                        kiva_foundation)
 
     kiva_foundation = surface.adjacentFoundation.get
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b4651456-b458-4d8e-960b-7b755f1c8f60</version_id>
-  <version_modified>2023-11-13T15:10:36Z</version_modified>
+  <version_id>b10ac12e-a3bf-4d3d-8ecf-88a07248a37e</version_id>
+  <version_modified>2023-11-13T17:30:41Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -142,7 +142,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>CF4007EE</checksum>
+      <checksum>F220C944</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
@@ -166,7 +166,7 @@
       <filename>constructions.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D28BD90F</checksum>
+      <checksum>E9F9E4EA</checksum>
     </file>
     <file>
       <filename>data/Xing_okstate_0664D_13659_Table_A-3.csv</filename>
@@ -364,7 +364,7 @@
       <filename>materials.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>24DCB986</checksum>
+      <checksum>AF16F15E</checksum>
     </file>
     <file>
       <filename>meta_measure.rb</filename>

--- a/HPXMLtoOpenStudio/resources/materials.rb
+++ b/HPXMLtoOpenStudio/resources/materials.rb
@@ -399,8 +399,13 @@ class BaseMaterial
     return new(rho: (self.InsulationFiberglassLoosefill.rho + self.InsulationCelluloseLoosefill.rho) / 2.0, cp: 0.25)
   end
 
-  def self.Soil(k_in)
-    return new(rho: 115.0, cp: 0.1, k_in: k_in)
+  def self.Soil(k_in, diffusivity = nil)
+    rho = 115.0
+    cp = 0.1
+    if !diffusivity.nil?
+      rho = (diffusivity * k_in) / cp
+    end
+    return new(rho: rho, cp: cp, k_in: k_in)
   end
 
   def self.Brick


### PR DESCRIPTION
## Pull Request Description

Add new optional `diffusivity` argument to the material `Soil` method. When provided, `rho` is re-calculated according to `diffusivity = k_in / (rho * cp)`.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
