### PR TITLE
Speed up measure tests for reporting measures

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7a10799f-a5e9-4579-8668-64fa401efc75</version_id>
-  <version_modified>2023-11-10T22:41:43Z</version_modified>
+  <version_id>c9fd1ac0-cb9b-485c-ac6c-b21d2b97084a</version_id>
+  <version_modified>2023-11-13T18:23:37Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -142,7 +142,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>04D14D5A</checksum>
+      <checksum>9D4F624A</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -1871,8 +1871,10 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
         if args[:timeseries_frequency] == 'timestep' || args[:timeseries_frequency] == 'hourly'
           if @hpxml_bldgs[0].dst_enabled
             dst_start_ix, dst_end_ix = get_dst_start_end_indexes(@timestamps, timestamps_dst)
-            dst_end_ix.downto(dst_start_ix + 1) do |i|
-              data[i + 1] = data[i]
+            if !dst_start_ix.nil? && !dst_end_ix.nil?
+              dst_end_ix.downto(dst_start_ix + 1) do |i|
+                data[i + 1] = data[i]
+              end
             end
           end
         end
@@ -1918,7 +1920,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
       dst_end_ix = i if ts[0] == ts[1] && dst_end_ix.nil? && !dst_start_ix.nil?
     end
 
-    dst_end_ix = timestamps.size - 1 if dst_end_ix.nil? # run period ends before DST ends
+    dst_end_ix = timestamps.size - 1 if dst_end_ix.nil? && !dst_start_ix.nil? # run period ends before DST ends
 
     return dst_start_ix, dst_end_ix
   end

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>ccfaa47b-cf8d-4947-9eb7-6c5dcdf89e92</version_id>
-  <version_modified>2023-11-10T22:41:45Z</version_modified>
+  <version_id>74ea2d73-d2f2-4e45-91d7-c092bb16e8ce</version_id>
+  <version_modified>2023-11-13T18:36:20Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1935,7 +1935,7 @@
       <filename>test_report_sim_output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E2543E8</checksum>
+      <checksum>637B509E</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>74ea2d73-d2f2-4e45-91d7-c092bb16e8ce</version_id>
-  <version_modified>2023-11-13T18:36:20Z</version_modified>
+  <version_id>24baa8d8-1e28-4b9b-a3fc-bea5adb1f3e7</version_id>
+  <version_modified>2023-11-13T18:56:05Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1929,7 +1929,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>8CE20783</checksum>
+      <checksum>9820E474</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>

--- a/ReportSimulationOutput/tests/test_report_sim_output.rb
+++ b/ReportSimulationOutput/tests/test_report_sim_output.rb
@@ -346,12 +346,9 @@ class ReportSimulationOutputTest < Minitest::Test
     "Weather: #{WT::DirectSolar}",
   ]
 
-  BaseHPXMLTimeseriesColsStandardOutputVariables = [
+  BaseHPXMLTimeseriesColsEnergyPlusOutputVariables = [
     'Zone People Occupant Count: Conditioned Space',
-    'Zone People Total Heating Energy: Conditioned Space'
-  ]
-
-  BaseHPXMLTimeseriesColsAdvancedOutputVariables = [
+    'Zone People Total Heating Energy: Conditioned Space',
     'Surface Construction Index: Door1',
     'Surface Construction Index: Foundationwall1',
     'Surface Construction Index: Floor1',
@@ -662,24 +659,6 @@ class ReportSimulationOutputTest < Minitest::Test
   end
 
   def test_timeseries_hourly_total_energy
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_total_consumptions' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsEnergy
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, ["Energy Use: #{TE::Total}"])
-  end
-
-  def test_timeseries_hourly_total_energy_pv
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-pv.xml'),
                   'skip_validation' => true,
                   'timeseries_frequency' => 'hourly',
@@ -699,24 +678,6 @@ class ReportSimulationOutputTest < Minitest::Test
   end
 
   def test_timeseries_hourly_fuels
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_fuel_consumptions' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsFuels
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, ["Fuel Use: #{FT::Elec}: #{TE::Total}"])
-  end
-
-  def test_timeseries_hourly_fuels_pv
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-pv.xml'),
                   'skip_validation' => true,
                   'timeseries_frequency' => 'hourly',
@@ -827,67 +788,6 @@ class ReportSimulationOutputTest < Minitest::Test
     _check_for_nonzero_timeseries_values(timeseries_csv, ["End Use: #{FT::Elec}: #{EUT::Refrigerator}"])
   end
 
-  def test_timeseries_hourly_enduses_power_outage
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-schedules-simple-power-outage.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_end_use_consumptions' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsEndUses
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_zero_timeseries_values(timeseries_csv, ["End Use: #{FT::Elec}: #{EUT::PlugLoads}"], (31 + 28 + 31 + 30 + 31 + 30) * 24 + 4, (31 + 28 + 31 + 30 + 31 + 30 + 31) * 24 - 12) # Jul
-  end
-
-  def test_timeseries_hourly_enduses_power_outage_natvent_availability
-    hpxml_path = File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-schedules-simple-power-outage.xml')
-    natvent_cfm_col = "Airflow: #{AFT::NaturalVentilation}"
-
-    args_hash = { 'hpxml_path' => hpxml_path,
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_airflows' => true }
-    _annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(timeseries_csv))
-    values = _get_values(timeseries_csv, [natvent_cfm_col])
-    schedule_regular_airflow = values[natvent_cfm_col].sum(0.0) / values[natvent_cfm_col].size
-
-    # Run w/ natural ventilation always available
-    hpxml = HPXML.new(hpxml_path: hpxml_path)
-    hpxml.header.unavailable_periods[0].natvent_availability = HPXML::ScheduleAvailable
-    XMLHelper.write_file(hpxml.to_doc(), @tmp_hpxml_path)
-    args_hash = { 'hpxml_path' => @tmp_hpxml_path,
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_airflows' => true }
-    _annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(timeseries_csv))
-    values = _get_values(timeseries_csv, [natvent_cfm_col])
-    schedule_available_airflow = values[natvent_cfm_col].sum(0.0) / values[natvent_cfm_col].size
-
-    # Run w/ natural ventilation always unavailable
-    hpxml = HPXML.new(hpxml_path: hpxml_path)
-    hpxml.header.unavailable_periods[0].natvent_availability = HPXML::ScheduleUnavailable
-    XMLHelper.write_file(hpxml.to_doc(), @tmp_hpxml_path)
-    args_hash = { 'hpxml_path' => @tmp_hpxml_path,
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_airflows' => true }
-    _annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(timeseries_csv))
-    values = _get_values(timeseries_csv, [natvent_cfm_col])
-    schedule_unavailable_airflow = values[natvent_cfm_col].sum(0.0) / values[natvent_cfm_col].size
-
-    assert_operator(schedule_available_airflow, :>, schedule_regular_airflow)
-    assert_operator(schedule_unavailable_airflow, :<, schedule_regular_airflow)
-  end
-
   def test_timeseries_hourly_system_uses
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
                   'skip_validation' => true,
@@ -906,7 +806,7 @@ class ReportSimulationOutputTest < Minitest::Test
     _check_for_nonzero_avg_timeseries_value(timeseries_csv, ["System Use: HeatingSystem1: #{FT::Gas}: #{EUT::Heating}"])
   end
 
-  def test_timeseries_hourly_hotwateruses
+  def test_timeseries_hourly_hotwater_uses
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
                   'skip_validation' => true,
                   'timeseries_frequency' => 'hourly',
@@ -983,24 +883,6 @@ class ReportSimulationOutputTest < Minitest::Test
   end
 
   def test_timeseries_hourly_zone_temperatures
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_zone_temperatures' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsZoneTemps
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsZoneTemps)
-  end
-
-  def test_timeseries_hourly_zone_temperatures_without_cooling
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-hvac-furnace-gas-only.xml'),
                   'skip_validation' => true,
                   'timeseries_frequency' => 'hourly',
@@ -1018,7 +900,7 @@ class ReportSimulationOutputTest < Minitest::Test
     _check_for_nonzero_avg_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsZoneTemps - ['Temperature: Cooling Setpoint'])
   end
 
-  def test_timeseries_hourly_zone_temperatures_mf_space
+  def test_timeseries_hourly_zone_temperatures_mf_spaces
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-bldgtype-mf-unit-adjacent-to-multiple.xml'),
                   'skip_validation' => true,
                   'timeseries_frequency' => 'hourly',
@@ -1026,21 +908,19 @@ class ReportSimulationOutputTest < Minitest::Test
     annual_csv, timeseries_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
+    cols_temps = BaseHPXMLTimeseriesColsZoneTemps - ['Temperature: Attic - Unvented']
+    cols_temps_other_side = ['Temperature: Other Multifamily Buffer Space',
+                             'Temperature: Other Non-freezing Space',
+                             'Temperature: Other Housing Unit',
+                             'Temperature: Other Heated Space']
+    expected_timeseries_cols = ['Time'] + cols_temps + cols_temps_other_side
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    cols_temps_other_side = [
-      'Temperature: Other Multifamily Buffer Space',
-      'Temperature: Other Non-freezing Space',
-      'Temperature: Other Housing Unit',
-      'Temperature: Other Heated Space'
-    ]
-    cols_temps_other_side.each do |expected_col|
-      assert(actual_timeseries_cols.include? expected_col)
-    end
+    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     timeseries_rows = CSV.read(timeseries_csv)
     assert_equal(8760, timeseries_rows.size - 2)
     timeseries_cols = timeseries_rows.transpose
     assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, cols_temps_other_side)
+    _check_for_nonzero_avg_timeseries_value(timeseries_csv, cols_temps + cols_temps_other_side)
   end
 
   def test_timeseries_hourly_zone_temperatures_whole_mf_building
@@ -1069,82 +949,26 @@ class ReportSimulationOutputTest < Minitest::Test
     assert_equal(8760, timeseries_rows.size - 2)
   end
 
-  def test_timeseries_hourly_airflows_with_exhaust_mechvent
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-mechvent-exhaust.xml'),
+  def test_timeseries_hourly_airflows_with_mechvent
+    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-mechvent-multiple.xml'),
                   'skip_validation' => true,
                   'timeseries_frequency' => 'hourly',
                   'include_timeseries_airflows' => true }
     annual_csv, timeseries_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows
+    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows - ['Airflow: Natural Ventilation'] + ['Airflow: Whole House Fan']
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     timeseries_rows = CSV.read(timeseries_csv)
     assert_equal(8760, timeseries_rows.size - 2)
     timeseries_cols = timeseries_rows.transpose
     assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsAirflows.select { |t| t != 'Airflow: Whole House Fan' })
-  end
-
-  def test_timeseries_hourly_airflows_with_whf
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-mechvent-whole-house-fan.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_airflows' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    add_cols = ['Airflow: Whole House Fan']
-    remove_cols = ['Airflow: Natural Ventilation']
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows + add_cols - remove_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, add_cols)
+    _check_for_nonzero_avg_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsAirflows - ['Airflow: Natural Ventilation'] + ['Airflow: Whole House Fan'])
   end
 
   def test_timeseries_hourly_airflows_with_clothes_dryer_exhaust
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-appliances-gas.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_airflows' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, ["Airflow: #{AFT::MechanicalVentilation}"])
-  end
-
-  def test_timeseries_hourly_airflows_with_balanced_mechvent
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-mechvent-balanced.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'include_timeseries_airflows' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAirflows
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, ["Airflow: #{AFT::MechanicalVentilation}"])
-  end
-
-  def test_timeseries_hourly_airflows_with_cfis
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-mechvent-cfis.xml'),
                   'skip_validation' => true,
                   'timeseries_frequency' => 'hourly',
                   'include_timeseries_airflows' => true }
@@ -1313,7 +1137,9 @@ class ReportSimulationOutputTest < Minitest::Test
   def test_timeseries_timestep
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
                   'timeseries_frequency' => 'timestep',
-                  'include_timeseries_fuel_consumptions' => true }
+                  'include_timeseries_fuel_consumptions' => true,
+                  'add_timeseries_dst_column' => true,
+                  'add_timeseries_utc_column' => true }
     annual_csv, timeseries_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
@@ -1321,7 +1147,12 @@ class ReportSimulationOutputTest < Minitest::Test
     assert_equal(8760, timeseries_rows.size - 2)
     timeseries_cols = timeseries_rows.transpose
     assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-  end
+    assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
+    assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeDST' }.size)
+    assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeUTC' }.size)
+    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
+    assert_equal(3, _check_for_constant_timeseries_step(timeseries_cols[1]))
+    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[2])) end
 
   def test_timeseries_timestep_emissions
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base-misc-emissions.xml'),
@@ -1361,9 +1192,7 @@ class ReportSimulationOutputTest < Minitest::Test
   end
 
   def test_timeseries_hourly_runperiod_1month
-    expected_values = { 'timestep' => 28 * 24,
-                        'hourly' => 28 * 24,
-                        'daily' => 28,
+    expected_values = { 'hourly' => 28 * 24,
                         'monthly' => 1 }
 
     expected_values.each do |timeseries_frequency, expected_value|
@@ -1400,8 +1229,6 @@ class ReportSimulationOutputTest < Minitest::Test
   def test_timeseries_timestamp_convention
     # Expected values are arrays of time offsets (in seconds) for each reported row of output
     expected_values_array = { 'timestep' => [30 * 60] * 17520,
-                              'hourly' => [60 * 60] * 8760,
-                              'daily' => [60 * 60 * 24] * 365,
                               'monthly' => Constants.NumDaysInMonths(1999).map { |n_days| n_days * 60 * 60 * 24 } }
 
     expected_values_array.each do |timeseries_frequency, expected_values|
@@ -1453,99 +1280,24 @@ class ReportSimulationOutputTest < Minitest::Test
     assert_equal(Float(timeseries_csv[5000 + 1][col_ix].strip), Float(timeseries_csv2[5000][col_ix].strip)) # in dst period, values are shifted forward
   end
 
-  def test_timeseries_local_time_dst
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'timestep',
-                  'include_timeseries_fuel_consumptions' => true,
-                  'add_timeseries_dst_column' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeDST' }.size)
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    assert_equal(3, _check_for_constant_timeseries_step(timeseries_cols[1]))
-  end
-
-  def test_timeseries_local_time_utc
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'timestep',
-                  'include_timeseries_fuel_consumptions' => true,
-                  'add_timeseries_utc_column' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeUTC' }.size)
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[1]))
-  end
-
-  def test_timeseries_local_time_dst_and_utc
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'timestep',
-                  'include_timeseries_fuel_consumptions' => true,
-                  'add_timeseries_dst_column' => true,
-                  'add_timeseries_utc_column' => true }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeDST' }.size)
-    assert_equal(1, timeseries_rows[0].select { |r| r == 'TimeUTC' }.size)
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    assert_equal(3, _check_for_constant_timeseries_step(timeseries_cols[1]))
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[2]))
-  end
-
-  def test_timeseries_user_defined_standard_output_variables
-    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
-                  'skip_validation' => true,
-                  'timeseries_frequency' => 'hourly',
-                  'user_output_variables' => 'Zone People Occupant Count, Zone People Total Heating Energy, Foo' }
-    annual_csv, timeseries_csv, run_log = _test_measure(args_hash)
-    assert(File.exist?(annual_csv))
-    assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsStandardOutputVariables
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
-    timeseries_rows = CSV.read(timeseries_csv)
-    assert_equal(8760, timeseries_rows.size - 2)
-    timeseries_cols = timeseries_rows.transpose
-    assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsStandardOutputVariables)
-    assert(File.readlines(run_log).any? { |line| line.include?("Request for output variable 'Foo'") })
-  end
-
-  def test_timeseries_user_defined_advanced_output_variables
+  def test_timeseries_energyplus_output_variables
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
                   'skip_validation' => true,
                   'add_component_loads' => true,
                   'timeseries_frequency' => 'hourly',
-                  'user_output_variables' => 'Surface Construction Index' }
-    annual_csv, timeseries_csv = _test_measure(args_hash)
+                  'user_output_variables' => 'Zone People Occupant Count, Zone People Total Heating Energy, Foo, Surface Construction Index' }
+    annual_csv, timeseries_csv, run_log = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsAdvancedOutputVariables
+    expected_timeseries_cols = ['Time'] + BaseHPXMLTimeseriesColsEnergyPlusOutputVariables
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     timeseries_rows = CSV.read(timeseries_csv)
     assert_equal(8760, timeseries_rows.size - 2)
     timeseries_cols = timeseries_rows.transpose
     assert_equal(1, _check_for_constant_timeseries_step(timeseries_cols[0]))
-    _check_for_nonzero_avg_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsAdvancedOutputVariables)
+    _check_for_nonzero_avg_timeseries_value(timeseries_csv, BaseHPXMLTimeseriesColsEnergyPlusOutputVariables)
+    assert(File.readlines(run_log).any? { |line| line.include?("Request for output variable 'Foo'") })
   end
 
   def test_for_unsuccessful_simulation_infinity

--- a/ReportUtilityBills/measure.xml
+++ b/ReportUtilityBills/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_utility_bills</name>
   <uid>ca88a425-e59a-4bc4-af51-c7e7d1e960fe</uid>
-  <version_id>65fc31a4-1c57-4d29-9bd4-ef00e35c5c5f</version_id>
-  <version_modified>2023-11-02T14:40:05Z</version_modified>
+  <version_id>35c428ae-4beb-465f-ba07-e521f7bf46a7</version_id>
+  <version_modified>2023-11-13T18:23:41Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>ReportUtilityBills</class_name>
   <display_name>Utility Bills Report</display_name>
@@ -322,7 +322,7 @@
       <filename>test_report_utility_bills.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>217F2392</checksum>
+      <checksum>C1365144</checksum>
     </file>
   </files>
 </measure>

--- a/ReportUtilityBills/tests/test_report_utility_bills.rb
+++ b/ReportUtilityBills/tests/test_report_utility_bills.rb
@@ -1045,7 +1045,8 @@ class ReportUtilityBillsTest < Minitest::Test
     utility_bill_scenario = @hpxml_header.utility_bill_scenarios[0]
     Zip.on_exists_proc = true
     Zip::File.open(File.join(File.dirname(__FILE__), '../resources/detailed_rates/openei_rates.zip')) do |zip_file|
-      zip_file.each do |entry|
+      zip_file.each_with_index do |entry, i|
+        break if i >= 1000 # No need to run *every* file, that will take a while
         next unless entry.file?
 
         tmpdir = Dir.tmpdir
@@ -1060,8 +1061,7 @@ class ReportUtilityBillsTest < Minitest::Test
           File.delete(@bills_monthly_csv) if File.exist? @bills_monthly_csv
           actual_bills, actual_monthly_bills = _bill_calcs(@fuels_pv_1kw_detailed, @hpxml_header, @hpxml.buildings, utility_bill_scenario)
           if !File.exist?(@bills_csv)
-            puts entry.name
-            assert(false)
+            flunk "#{entry.name} was not successful."
           end
           if entry.name.include? 'North Slope Borough Power Light - Aged or Handicappedseniors over 60'
             # No cost if < 600 kWh/month, which is the case for PV_None.csv


### PR DESCRIPTION
## Pull Request Description

Addresses #1535.

- ReportSimulationOutput measure: 10 min => 6.5 min
- ReportUtilityBills measure: 7.5 min => 3 min

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
