### PR TITLE
Suppress warnings when running tests

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>285299d4-3bbd-40c5-a9a4-ddcf8cb7bc1b</version_id>
-  <version_modified>2024-01-05T19:48:38Z</version_modified>
+  <version_id>63e6bf7b-325c-4241-baab-97825cbd9bcd</version_id>
+  <version_modified>2024-01-05T21:39:53Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -376,7 +376,7 @@
       <filename>minitest_helper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>C9FBB98E</checksum>
+      <checksum>923B05E5</checksum>
     </file>
     <file>
       <filename>misc_loads.rb</filename>
@@ -664,7 +664,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>3DA658D5</checksum>
+      <checksum>5E426D14</checksum>
     </file>
     <file>
       <filename>test_water_heater.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>737f07bd-6d0b-4841-a876-1600ab951fe3</version_id>
-  <version_modified>2024-01-05T19:45:29Z</version_modified>
+  <version_id>285299d4-3bbd-40c5-a9a4-ddcf8cb7bc1b</version_id>
+  <version_modified>2024-01-05T19:48:38Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -376,7 +376,7 @@
       <filename>minitest_helper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>923B05E5</checksum>
+      <checksum>C9FBB98E</checksum>
     </file>
     <file>
       <filename>misc_loads.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>89fe1a1e-70f0-49f6-902d-f0a132bb5dbd</version_id>
-  <version_modified>2024-01-04T19:49:59Z</version_modified>
+  <version_id>737f07bd-6d0b-4841-a876-1600ab951fe3</version_id>
+  <version_modified>2024-01-05T19:45:29Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -376,7 +376,7 @@
       <filename>minitest_helper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>CDB0A906</checksum>
+      <checksum>923B05E5</checksum>
     </file>
     <file>
       <filename>misc_loads.rb</filename>

--- a/HPXMLtoOpenStudio/resources/minitest_helper.rb
+++ b/HPXMLtoOpenStudio/resources/minitest_helper.rb
@@ -3,7 +3,7 @@
 called_from_cli = true
 begin
   OpenStudio.getOpenStudioCLI
-  OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
+  OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Error)
 rescue
   called_from_cli = false
 end

--- a/HPXMLtoOpenStudio/resources/minitest_helper.rb
+++ b/HPXMLtoOpenStudio/resources/minitest_helper.rb
@@ -3,6 +3,7 @@
 called_from_cli = true
 begin
   OpenStudio.getOpenStudioCLI
+  OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
 rescue
   called_from_cli = false
 end

--- a/HPXMLtoOpenStudio/resources/minitest_helper.rb
+++ b/HPXMLtoOpenStudio/resources/minitest_helper.rb
@@ -3,7 +3,7 @@
 called_from_cli = true
 begin
   OpenStudio.getOpenStudioCLI
-  OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Error)
+  OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
 rescue
   called_from_cli = false
 end

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -11,8 +11,6 @@ require_relative '../resources/xmlvalidator.rb'
 
 class HPXMLtoOpenStudioValidationTest < Minitest::Test
   def setup
-    OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
-
     @root_path = File.absolute_path(File.join(File.dirname(__FILE__), '..', '..'))
     @sample_files_path = File.join(@root_path, 'workflow', 'sample_files')
     schema_path = File.absolute_path(File.join(@root_path, 'HPXMLtoOpenStudio', 'resources', 'hpxml_schema', 'HPXML.xsd'))
@@ -70,7 +68,6 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
   end
 
   def test_schema_schematron_error_messages
-    OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
     # Test case => Error message
     all_expected_errors = { 'boiler-invalid-afue' => ['Expected AnnualHeatingEfficiency[Units="AFUE"]/Value to be less than or equal to 1'],
                             'clothes-dryer-location' => ['A location is specified as "garage" but no surfaces were found adjacent to this space type.'],
@@ -676,7 +673,6 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
   end
 
   def test_schema_schematron_warning_messages
-    OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
     # Test case => Warning message
     all_expected_warnings = { 'battery-pv-output-power-low' => ['Max power output should typically be greater than or equal to 500 W.',
                                                                 'Max power output should typically be greater than or equal to 500 W.',

--- a/tasks.rb
+++ b/tasks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
+
 Dir["#{File.dirname(__FILE__)}/HPXMLtoOpenStudio/resources/*.rb"].each do |resource_file|
   next if resource_file.include? 'minitest_helper.rb'
 
@@ -2585,7 +2587,6 @@ if ARGV[0].to_sym == :update_hpxmls
   ENV['HOMEDRIVE'] = 'C:\\' if !ENV['HOMEDRIVE'].nil? && ENV['HOMEDRIVE'].start_with?('U:')
 
   # Create sample/test HPXMLs
-  OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
   t = Time.now
   create_hpxmls()
   puts "Completed in #{(Time.now - t).round(1)}s"


### PR DESCRIPTION
## Pull Request Description

Our tests get overwhelmed with warnings like:
`[openstudio.EpwFile] <0> Successive data points (1995-Jan-31 to 1994-Feb-01, ending on line 753) are greater than 1 day apart in EPW file '/mnt/c/git/openstudio-eri-301-2022/rulesets/../weather/USA_CO_Denver.Intl.AP.725650_TMY3.epw'. Data will be treated as typical (TMY)`
or
`Cannot find current Workflow Step`

This suppresses those warnings. Fatals still come through.

Edit: It might only work on Linux. Sorry Windows users.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
