### PR TITLE
Move appliance inputs validation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## OpenStudio-HPXML v1.8.0
 
 __New Features__
+- Updates to HPXML v4.0-rc3.
 - Replaces `BuildingSummary/Site/extension/GroundConductivity` with `BuildingSummary/Site/Soil/Conductivity`.
 - Allows radiant barriers for additional locations (attic gable walls and floor); reduced emissivity due to dust assumed for radiant barriers on attic floor.
 - Ground source heat pump enhancements:

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6988ecf9-3942-4f49-9538-a05ba47db196</version_id>
-  <version_modified>2024-01-18T02:10:40Z</version_modified>
+  <version_id>9fe90bc3-2a8c-4818-8806-48e7469ebf0c</version_id>
+  <version_modified>2024-01-19T17:39:23Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -316,7 +316,7 @@
       <filename>hpxml_schema/HPXML.xsd</filename>
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
-      <checksum>BB0FF5BB</checksum>
+      <checksum>572286DE</checksum>
     </file>
     <file>
       <filename>hpxml_schema/README.md</filename>
@@ -328,7 +328,7 @@
       <filename>hpxml_schematron/EPvalidator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
-      <checksum>C4F99B75</checksum>
+      <checksum>85D88CDE</checksum>
     </file>
     <file>
       <filename>hpxml_schematron/iso-schematron.xsd</filename>
@@ -664,7 +664,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>3B854F22</checksum>
+      <checksum>C564EC22</checksum>
     </file>
     <file>
       <filename>test_water_heater.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hpxml_schema/HPXML.xsd
+++ b/HPXMLtoOpenStudio/resources/hpxml_schema/HPXML.xsd
@@ -401,13 +401,13 @@
 							<xs:documentation>loads/week of actual usage by the occupants</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="EnergyFactor" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="EnergyFactor" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[lbs dry clothes/kWh] The energy performance metric for ENERGY STAR certified residential clothes dryers prior to September 13, 2013. The new metric is
 								Combined Energy Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="CombinedEnergyFactor" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="CombinedEnergyFactor" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[lbs dry clothes/kWh] The energy performance metric for ENERGY STAR certified residential clothes dryers as of September 13, 2013, it includes the active
 								drying cycle energy as well as energy consumed during Stand-by and Off modes.</xs:documentation>
@@ -431,24 +431,24 @@
 					</xs:choice>
 					<xs:element name="Type" type="ClothesWasherType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="Location" type="LaundryMachineLocation"/>
-					<xs:element name="ModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
+					<xs:element name="ModifiedEnergyFactor" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The energy performance metric for ENERGY STAR certified residential clothes washers prior to March 7, 2015. The new metric is Integrated Modified Energy
 								Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
+					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The energy performance metric for ENERGY STAR certified residential clothes washers as of March 7, 2015.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="WaterFactor" type="HPXMLDouble" minOccurs="0">
+					<xs:element name="WaterFactor" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The water performance metric for ENERGY STAR certified residential clothes washers prior to March 7, 2015. The new metric is Integrated Water
 								Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="IntegratedWaterFactor" type="HPXMLDouble" minOccurs="0">
+					<xs:element name="IntegratedWaterFactor" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The water performance metric for ENERGY STAR certified residential clothes washers as of March 7, 2015.</xs:documentation>
 						</xs:annotation>
@@ -463,27 +463,27 @@
 							<xs:documentation>kWh/yr</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>$/kWh</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelGasRate" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="LabelGasRate" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>$/therm</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>$</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>loads/week per the Energy Guide label; use Usage instead for loads/week of actual usage by the occupants</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="Capacity" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="Capacity" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>ft^3</xs:documentation>
 						</xs:annotation>
@@ -515,22 +515,22 @@
 							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>$/kWh</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelGasRate" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="LabelGasRate" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>$/therm</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>$</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDouble">
+					<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>loads/week per the Energy Guide label; use Usage instead for loads/week of actual usage by the occupants</xs:documentation>
 						</xs:annotation>
@@ -6282,6 +6282,18 @@
 	<xs:complexType name="HPXMLDouble">
 		<xs:simpleContent>
 			<xs:extension base="xs:double">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLDoubleGreaterThanZero_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLDoubleGreaterThanZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLDoubleGreaterThanZero_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/HPXMLtoOpenStudio/resources/hpxml_schema/HPXML.xsd
+++ b/HPXMLtoOpenStudio/resources/hpxml_schema/HPXML.xsd
@@ -2155,6 +2155,12 @@
 									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
+									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
+										<xs:annotation>
+											<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
 										<xs:annotation>

--- a/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml
+++ b/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml
@@ -2040,8 +2040,6 @@
       <sch:assert role='ERROR' test='count(h:Location) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Location</sch:assert>
       <sch:assert role='ERROR' test='h:Location[text()="conditioned space" or text()="basement - unconditioned" or text()="basement - conditioned" or text()="attic - unvented" or text()="attic - vented" or text()="garage" or text()="crawlspace - unvented" or text()="crawlspace - vented" or text()="crawlspace - conditioned" or text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"] or not(h:Location)'>Expected Location to be 'conditioned space' or 'basement - unconditioned' or 'basement - conditioned' or 'attic - unvented' or 'attic - vented' or 'garage' or 'crawlspace - unvented' or 'crawlspace - vented' or 'crawlspace - conditioned' or 'other housing unit' or 'other heated space' or 'other multifamily buffer space' or 'other non-freezing space'</sch:assert>
       <sch:assert role='ERROR' test='count(h:IntegratedModifiedEnergyFactor) + count(h:ModifiedEnergyFactor) &lt;= 1'>Expected 0 or 1 element(s) for xpath: IntegratedModifiedEnergyFactor | ModifiedEnergyFactor</sch:assert> <!-- See [ClothesWasherType=Detailed] -->
-      <sch:assert role='ERROR' test='number(h:IntegratedModifiedEnergyFactor) &gt; 0 or not(h:IntegratedModifiedEnergyFactor)'>Expected IntegratedModifiedEnergyFactor to be greater than 0</sch:assert>
-      <sch:assert role='ERROR' test='number(h:ModifiedEnergyFactor) &gt; 0 or not(h:ModifiedEnergyFactor)'>Expected ModifiedEnergyFactor to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:UsageMultiplier) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/UsageMultiplier</sch:assert>
       <sch:assert role='ERROR' test='number(h:extension/h:UsageMultiplier) &gt;= 0 or not(h:extension/h:UsageMultiplier)'>Expected extension/UsageMultiplier to be greater than or equal to 0</sch:assert>      
       <sch:assert role='ERROR' test='count(h:extension/h:WeekdayScheduleFractions) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/WeekdayScheduleFractions</sch:assert>
@@ -2055,15 +2053,10 @@
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Appliances/h:ClothesWasher[h:IntegratedModifiedEnergyFactor | h:ModifiedEnergyFactor]'>
       <sch:assert role='ERROR' test='count(h:RatedAnnualkWh) = 1'>Expected 1 element(s) for xpath: RatedAnnualkWh</sch:assert>
       <sch:assert role='ERROR' test='count(h:LabelElectricRate) = 1'>Expected 1 element(s) for xpath: LabelElectricRate</sch:assert>
-      <sch:assert role='ERROR' test='number(h:LabelElectricRate) &gt; 0 or not(h:LabelElectricRate)'>Expected LabelElectricRate to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:LabelGasRate) = 1'>Expected 1 element(s) for xpath: LabelGasRate</sch:assert>
-      <sch:assert role='ERROR' test='number(h:LabelGasRate) &gt; 0 or not(h:LabelGasRate)'>Expected LabelGasRate to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:LabelAnnualGasCost) = 1'>Expected 1 element(s) for xpath: LabelAnnualGasCost</sch:assert>
-      <sch:assert role='ERROR' test='number(h:LabelAnnualGasCost) &gt; 0 or not(h:LabelAnnualGasCost)'>Expected LabelAnnualGasCost to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:LabelUsage) = 1'>Expected 1 element(s) for xpath: LabelUsage</sch:assert>
-      <sch:assert role='ERROR' test='number(h:LabelUsage) &gt; 0 or not(h:LabelUsage)'>Expected LabelUsage to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:Capacity) = 1'>Expected 1 element(s) for xpath: Capacity</sch:assert>
-      <sch:assert role='ERROR' test='number(h:Capacity) &gt; 0 or not(h:Capacity)'>Expected Capacity to be greater than 0</sch:assert>
     </sch:rule>
   </sch:pattern>
 
@@ -2085,8 +2078,6 @@
       <sch:assert role='ERROR' test='count(h:FuelType) = 1'>Expected 1 element(s) for xpath: FuelType</sch:assert>
       <sch:assert role='ERROR' test='h:FuelType[text()="natural gas" or text()="fuel oil" or text()="fuel oil 1" or text()="fuel oil 2" or text()="fuel oil 4" or text()="fuel oil 5/6" or text()="diesel" or text()="propane" or text()="kerosene" or text()="coal" or text()="coke" or text()="bituminous coal" or text()="anthracite coal" or text()="electricity" or text()="wood" or text()="wood pellets"] or not(h:FuelType)'>Expected FuelType to be 'natural gas' or 'fuel oil' or 'fuel oil 1' or 'fuel oil 2' or 'fuel oil 4' or 'fuel oil 5/6' or 'diesel' or 'propane' or 'kerosene' or 'coal' or 'coke' or 'bituminous coal' or 'anthracite coal' or 'electricity' or 'wood' or 'wood pellets'</sch:assert>
       <sch:assert role='ERROR' test='count(h:CombinedEnergyFactor) + count(h:EnergyFactor) &lt;= 1'>Expected 0 or 1 element(s) for xpath: CombinedEnergyFactor | EnergyFactor</sch:assert>
-      <sch:assert role='ERROR' test='number(h:CombinedEnergyFactor) &gt; 0 or not(h:CombinedEnergyFactor)'>Expected CombinedEnergyFactor to be greater than 0</sch:assert>
-      <sch:assert role='ERROR' test='number(h:EnergyFactor) &gt; 0 or not(h:EnergyFactor)'>Expected EnergyFactor to be greater than 0</sch:assert>
       <sch:assert role='ERROR' test='count(h:Vented) &lt;= 1'>Expected 0 or 1 element(s) for xpath: Vented</sch:assert> <!-- See [ClothesDryerType=Vented] -->
       <sch:assert role='ERROR' test='count(h:extension/h:UsageMultiplier) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/UsageMultiplier</sch:assert>
       <sch:assert role='ERROR' test='number(h:extension/h:UsageMultiplier) &gt;= 0 or not(h:extension/h:UsageMultiplier)'>Expected extension/UsageMultiplier to be greater than or equal to 0</sch:assert>      
@@ -2132,13 +2123,9 @@
     <sch:title>[DishwasherType=Detailed]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Appliances/h:Dishwasher[h:RatedAnnualkWh | h:EnergyFactor]'>
       <sch:assert role='ERROR' test='count(h:LabelElectricRate) = 1'>Expected 1 element(s) for xpath: LabelElectricRate</sch:assert>
-      <sch:assert role='ERROR' test='number(h:LabelElectricRate) &gt; 0 or not(h:LabelElectricRate)'>Expected LabelElectricRate to be greater than 0</sch:assert>      
       <sch:assert role='ERROR' test='count(h:LabelGasRate) = 1'>Expected 1 element(s) for xpath: LabelGasRate</sch:assert>
-      <sch:assert role='ERROR' test='number(h:LabelGasRate) &gt; 0 or not(h:LabelGasRate)'>Expected LabelGasRate to be greater than 0</sch:assert>      
       <sch:assert role='ERROR' test='count(h:LabelAnnualGasCost) = 1'>Expected 1 element(s) for xpath: LabelAnnualGasCost</sch:assert>
-      <sch:assert role='ERROR' test='number(h:LabelAnnualGasCost) &gt; 0 or not(h:LabelAnnualGasCost)'>Expected LabelAnnualGasCost to be greater than 0</sch:assert>      
       <sch:assert role='ERROR' test='count(h:LabelUsage) = 1'>Expected 1 element(s) for xpath: LabelUsage</sch:assert>
-      <sch:assert role='ERROR' test='number(h:LabelUsage) &gt; 0 or not(h:LabelUsage)'>Expected LabelUsage to be greater than 0</sch:assert>      
       <sch:assert role='ERROR' test='count(h:PlaceSettingCapacity) = 1'>Expected 1 element(s) for xpath: PlaceSettingCapacity</sch:assert>
     </sch:rule>
   </sch:pattern>

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -132,9 +132,9 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
                             'invalid-battery-capacities-kwh' => ['Expected UsableCapacity to be less than NominalCapacity'],
                             'invalid-calendar-year-low' => ['Expected CalendarYear to be greater than or equal to 1600'],
                             'invalid-calendar-year-high' => ['Expected CalendarYear to be less than or equal to 9999'],
-                            'invalid-clothes-dryer-cef' => ['Expected CombinedEnergyFactor to be greater than 0'],
-                            'invalid-clothes-washer-imef' => ['Expected IntegratedModifiedEnergyFactor to be greater than 0'],
-                            'invalid-dishwasher-ler' => ['Expected LabelElectricRate to be greater than 0'],
+                            'invalid-clothes-dryer-cef' => ["Element 'CombinedEnergyFactor': [facet 'minExclusive'] The value '0.0' must be greater than '0'."],
+                            'invalid-clothes-washer-imef' => ["Element 'IntegratedModifiedEnergyFactor': [facet 'minExclusive'] The value '0.0' must be greater than '0'."],
+                            'invalid-dishwasher-ler' => ["Element 'LabelElectricRate': [facet 'minExclusive'] The value '0.0' must be greater than '0'."],
                             'invalid-duct-area-fractions' => ['Expected sum(Ducts/FractionDuctArea) for DuctType="supply" to be 1 [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACDistribution/DistributionSystemType/AirDistribution, id: "HVACDistribution1"]',
                                                               'Expected sum(Ducts/FractionDuctArea) for DuctType="return" to be 1 [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACDistribution/DistributionSystemType/AirDistribution, id: "HVACDistribution1"]'],
                             'invalid-facility-type' => ['Expected 1 element(s) for xpath: ../../../BuildingSummary/BuildingConstruction[ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]] [context: /HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem[IsSharedSystem="true"], id: "WaterHeatingSystem1"]',
@@ -400,7 +400,6 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
       elsif ['hvac-gshp-autosized-count-not-rectangle'].include? error_case
         hpxml, hpxml_bldg = _create_hpxml('base-hvac-ground-to-air-heat-pump-detailed-geothermal-loop.xml')
         hpxml_bldg.geothermal_loops[0].num_bore_holes = nil
-        puts hpxml_bldg.geothermal_loops
       elsif ['hvac-location-heating-system'].include? error_case
         hpxml, hpxml_bldg = _create_hpxml('base-hvac-boiler-oil-only.xml')
         hpxml_bldg.heating_systems[0].location = HPXML::LocationBasementUnconditioned


### PR DESCRIPTION
## Pull Request Description

Moves most of the appliance schematron validation to the HPXML schema itself.

This should wait on https://github.com/hpxmlwg/hpxml/pull/398 to be merged first.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] Schematron validator (`EPvalidator.xml`) has been updated
- [x] ~Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)~
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
