### PR TITLE
Revert XMLValidator workaround

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>63e6bf7b-325c-4241-baab-97825cbd9bcd</version_id>
-  <version_modified>2024-01-05T21:39:53Z</version_modified>
+  <version_id>b66c15dc-f4ad-45c0-a075-6ce259ac9e8d</version_id>
+  <version_modified>2024-01-16T17:03:31Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -574,7 +574,7 @@
       <filename>xmlvalidator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>84D0E4E1</checksum>
+      <checksum>87937B84</checksum>
     </file>
     <file>
       <filename>test_airflow.rb</filename>

--- a/HPXMLtoOpenStudio/resources/xmlvalidator.rb
+++ b/HPXMLtoOpenStudio/resources/xmlvalidator.rb
@@ -21,13 +21,7 @@ class XMLValidator
   end
 
   def self.get_schematron_validator(schematron_path)
-    # First create XSLT at our specified output path to avoid possible errors due
-    # to https://github.com/NREL/OpenStudio/issues/4824.
-    xslt_dir = Dir.mktmpdir('xmlvalidation-')
-    OpenStudio::XMLValidator::schematronToXslt(schematron_path, xslt_dir)
-    xslt_path = File.join(xslt_dir, File.basename(schematron_path, '.xml') + '_stylesheet.xslt')
-
-    return OpenStudio::XMLValidator.new(xslt_path)
+    return OpenStudio::XMLValidator.new(schematron_path)
   end
 
   def self.validate_against_schematron(hpxml_path, validator, hpxml_doc, errors = [], warnings = [])


### PR DESCRIPTION
## Pull Request Description

Avoid creating our own temp xmlvalidation directories for schematron validation, which was a workaround several years ago to prevent [errors due to collisions](https://github.com/NREL/OpenStudio/issues/4824).

I previously [tried removing the workaround](https://github.com/NREL/OpenStudio-HPXML/pull/1476/commits/5e218b5d148effc86f12cbdeb682c21fe8a63db1) but subsequently had to [revert it](https://github.com/NREL/OpenStudio-HPXML/pull/1476/commits/4aac7fc52678ea5ce32c26b9146419b83334b6ed) because it was failing on the CI. I forget exactly what the issue was. But this time, it looks like the CI is happy. It's possible that the CI issue was addressed by [this change](https://github.com/NREL/OpenStudio-HPXML/pull/1371)?

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
