### PR TITLE
Fix some error checking for detailed schedules

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -121,10 +121,20 @@ jobs:
           tar -xzf Windows.tar.gz
           & .\OpenStudio-${env:OS_VERSION}+${env:OS_SHA}-Windows\bin\openstudio.exe workflow\run_simulation.rb -x workflow\sample_files\base.xml --hourly ALL --add-component-loads --add-stochastic-schedules
 
+  merge:
+    runs-on: ubuntu-latest
+    needs: [run-workflow1-tests, run-workflow2-tests, run-unit-tests]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: results
+          pattern: results-*
+
   compare-results:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    needs: [run-workflow1-tests, run-workflow2-tests, run-unit-tests]
+    needs: merge
     steps:
       - uses: actions/checkout@v4
         with:
@@ -150,8 +160,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: results
-          pattern: results-*
-          merge-multiple: true
+          name: results
 
       - name: Compare results
         run: |
@@ -175,7 +184,7 @@ jobs:
 
   update-results:
     runs-on: ubuntu-latest
-    needs: [run-workflow1-tests, run-workflow2-tests, run-unit-tests]
+    needs: merge
     steps:
       - uses: actions/checkout@v4
         with:
@@ -185,8 +194,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: results
-          pattern: results-*
-          merge-multiple: true
+          name: results
 
       - name: Commit latest results
         shell: bash        

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -130,6 +130,7 @@ jobs:
         with:
           name: results
           pattern: results-*
+          delete-merged: true
 
   compare-results:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: workflow/tests/results
-          name: results
+          name: results-unit-tests
 
       - name: Build documentation
         run: |
@@ -81,7 +81,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: workflow/tests/results
-          name: results
+          name: results-workflow1-tests
 
   run-workflow2-tests:
     runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: workflow/tests/results
-          name: results
+          name: results-workflow2-tests
 
   run-windows-tests:
     runs-on: windows-latest
@@ -143,16 +143,16 @@ jobs:
       - name: Download base results
         uses: actions/download-artifact@v4
         with:
-          path: |
-            base_results
+          path: base_results
           name: base_results
 
       - name: Download feature results
         uses: actions/download-artifact@v4
         with:
-          path: |
-            results
+          path: results
           name: results
+          pattern: results-*
+          merge-multiple: true
 
       - name: Compare results
         run: |
@@ -185,9 +185,10 @@ jobs:
       - name: Download feature results
         uses: actions/download-artifact@v4
         with:
-          path: |
-            results
+          path: results
           name: results
+          pattern: results-*
+          merge-multiple: true
 
       - name: Commit latest results
         shell: bash        

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -150,7 +150,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: results
-          name: results
           pattern: results-*
           merge-multiple: true
 
@@ -186,7 +185,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: results
-          name: results
           pattern: results-*
           merge-multiple: true
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: docker://nrel/openstudio:3.7.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
@@ -38,13 +38,13 @@ jobs:
           bundle exec rake test_measures
 
       - name: Store code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: coverage
           name: coverage
 
       - name: Store results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: workflow/tests/results
           name: results
@@ -55,7 +55,7 @@ jobs:
           make html SPHINXOPTS="-W --keep-going -n"
 
       - name: Save Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: docs/_build/html/
@@ -65,7 +65,7 @@ jobs:
     container:
       image: docker://nrel/openstudio:3.7.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
@@ -78,7 +78,7 @@ jobs:
           bundle exec rake test_workflow1
 
       - name: Store results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: workflow/tests/results
           name: results
@@ -88,7 +88,7 @@ jobs:
     container:
       image: docker://nrel/openstudio:3.7.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
@@ -101,7 +101,7 @@ jobs:
           bundle exec rake test_workflow2
 
       - name: Store results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: workflow/tests/results
           name: results
@@ -109,7 +109,7 @@ jobs:
   run-windows-tests:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
       - name: Install software and run test
@@ -126,29 +126,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run-workflow1-tests, run-workflow2-tests, run-unit-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Store base results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: workflow/tests/base_results
           name: base_results
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download base results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: |
             base_results
           name: base_results
 
       - name: Download feature results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: |
             results
@@ -169,7 +169,7 @@ jobs:
           python workflow/tests/compare.py -a visualize
 
       - name: Store comparisons
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: workflow/tests/comparisons
           name: comparisons
@@ -178,12 +178,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run-workflow1-tests, run-workflow2-tests, run-unit-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
       - name: Download feature results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: |
             results

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -121,7 +121,7 @@ jobs:
           tar -xzf Windows.tar.gz
           & .\OpenStudio-${env:OS_VERSION}+${env:OS_SHA}-Windows\bin\openstudio.exe workflow\run_simulation.rb -x workflow\sample_files\base.xml --hourly ALL --add-component-loads --add-stochastic-schedules
 
-  merge:
+  merge-results:
     runs-on: ubuntu-latest
     needs: [run-workflow1-tests, run-workflow2-tests, run-unit-tests]
     steps:
@@ -134,7 +134,7 @@ jobs:
   compare-results:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    needs: merge
+    needs: merge-results
     steps:
       - uses: actions/checkout@v4
         with:
@@ -184,7 +184,7 @@ jobs:
 
   update-results:
     runs-on: ubuntu-latest
-    needs: merge
+    needs: merge-results
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ __Bugfixes__
 - Fixes error if using AllowIncreasedFixedCapacities=true w/ HP detailed performance data.
 - Prevents mains water temperature from going below freezing (0 C).
 - Fixes error if HPXML has emissions scenario and abbreviated run period.
+- Fixes detailed schedule error-checking where schedules with MAX < 1 were incorrectly allowed.
 
 ## OpenStudio-HPXML v1.7.0
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>860eab8a-5f4e-4f75-8a12-384e41dbf639</version_id>
-  <version_modified>2024-01-29T19:27:51Z</version_modified>
+  <version_id>e968353c-74bc-498a-9d16-5853fc3bb9bd</version_id>
+  <version_modified>2024-01-29T20:22:44Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -520,7 +520,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>56DE3B28</checksum>
+      <checksum>4355018F</checksum>
     </file>
     <file>
       <filename>simcontrols.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>e968353c-74bc-498a-9d16-5853fc3bb9bd</version_id>
-  <version_modified>2024-01-29T20:22:44Z</version_modified>
+  <version_id>6ad02afc-fdfc-4687-a74b-66073db8c426</version_id>
+  <version_modified>2024-01-30T17:28:44Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -520,7 +520,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>4355018F</checksum>
+      <checksum>06478FFB</checksum>
     </file>
     <file>
       <filename>simcontrols.rb</filename>
@@ -664,7 +664,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>ECBF5CF7</checksum>
+      <checksum>EAD345DF</checksum>
     </file>
     <file>
       <filename>test_water_heater.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>4c55bc0c-c866-4124-844b-f7c8a762449d</version_id>
-  <version_modified>2024-01-29T19:20:16Z</version_modified>
+  <version_id>860eab8a-5f4e-4f75-8a12-384e41dbf639</version_id>
+  <version_modified>2024-01-29T19:27:51Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -427,12 +427,6 @@
       <checksum>D4373DC9</checksum>
     </file>
     <file>
-      <filename>schedule_files/occupancy-stochastic-double.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>DEED74EA</checksum>
-    </file>
-    <file>
       <filename>schedule_files/occupancy-stochastic.csv</filename>
       <filetype>csv</filetype>
       <usage_type>resource</usage_type>
@@ -526,7 +520,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>E1237611</checksum>
+      <checksum>56DE3B28</checksum>
     </file>
     <file>
       <filename>simcontrols.rb</filename>
@@ -670,7 +664,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>8D38CF92</checksum>
+      <checksum>ECBF5CF7</checksum>
     </file>
     <file>
       <filename>test_water_heater.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>361ac26a-360a-4cc1-8109-45c3ff202272</version_id>
-  <version_modified>2024-01-25T17:44:14Z</version_modified>
+  <version_id>4c55bc0c-c866-4124-844b-f7c8a762449d</version_id>
+  <version_modified>2024-01-29T19:20:16Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -427,6 +427,12 @@
       <checksum>D4373DC9</checksum>
     </file>
     <file>
+      <filename>schedule_files/occupancy-stochastic-double.csv</filename>
+      <filetype>csv</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>DEED74EA</checksum>
+    </file>
+    <file>
       <filename>schedule_files/occupancy-stochastic.csv</filename>
       <filetype>csv</filetype>
       <usage_type>resource</usage_type>
@@ -520,7 +526,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>8D557A2A</checksum>
+      <checksum>E1237611</checksum>
     </file>
     <file>
       <filename>simcontrols.rb</filename>
@@ -664,7 +670,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>913A9C1E</checksum>
+      <checksum>8D38CF92</checksum>
     </file>
     <file>
       <filename>test_water_heater.rb</filename>

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1414,7 +1414,7 @@ class SchedulesFile
         end
 
         if max_value_one[col_name]
-          if values.max > 1
+          if values.max > 1.01 || values.max < 0.99 # Allow some imprecision
             fail "Schedule max value for column '#{col_name}' must be 1. [context: #{schedules_path}]"
           end
         end
@@ -1427,7 +1427,7 @@ class SchedulesFile
 
         if min_value_neg_one[col_name]
           if values.min < -1
-            fail "Schedule min value for column '#{col_name}' must be -1. [context: #{schedules_path}]"
+            fail "Schedule min value for column '#{col_name}' must be greater than or equal to -1. [context: #{schedules_path}]"
           end
         end
 

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1424,9 +1424,12 @@ class SchedulesFile
           end
         end
 
-        if min_value_neg_one[col_name]
+        if value_neg_one_to_one[col_name]
           if values.min < -1
             fail "Schedule value for column '#{col_name}' must be greater than or equal to -1. [context: #{schedules_path}]"
+          end
+          if values.max > 1
+            fail "Schedule value for column '#{col_name}' must be less than or equal to 1. [context: #{schedules_path}]"
           end
         end
 
@@ -1824,7 +1827,7 @@ class SchedulesFile
     column_names = SchedulesFile.ColumnNames
     column_names.each do |column_name|
       max_value_one[column_name] = true
-      if SchedulesFile.SetpointColumnNames.include?(column_name) || SchedulesFile.OperatingModeColumnNames.include?(column_name)
+      if SchedulesFile.SetpointColumnNames.include?(column_name) || SchedulesFile.OperatingModeColumnNames.include?(column_name) || SchedulesFile.BatteryColumnNames.include?(column_name)
         max_value_one[column_name] = false
       end
     end
@@ -1843,16 +1846,16 @@ class SchedulesFile
     return min_value_zero
   end
 
-  def min_value_neg_one
-    min_value_neg_one = {}
+  def value_neg_one_to_one
+    value_neg_one_to_one = {}
     column_names = SchedulesFile.ColumnNames
     column_names.each do |column_name|
-      min_value_neg_one[column_name] = false
+      value_neg_one_to_one[column_name] = false
       if column_name == SchedulesFile::ColumnBattery
-        min_value_neg_one[column_name] = true
+        value_neg_one_to_one[column_name] = true
       end
     end
-    return min_value_neg_one
+    return value_neg_one_to_one
   end
 
   def only_zeros_and_ones

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1427,7 +1427,7 @@ class SchedulesFile
 
         if min_value_neg_one[col_name]
           if values.min < -1
-            fail "Schedule min value for column '#{col_name}' must be greater than or equal to -1. [context: #{schedules_path}]"
+            fail "Schedule value for column '#{col_name}' must be greater than or equal to -1. [context: #{schedules_path}]"
           end
         end
 

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -618,8 +618,7 @@ class Schedule
     # Get a 365-value array of which schedule is used on each day of the year,
     day_schs_used_each_day = schedule.getActiveRuleIndices(year_start_date, year_end_date)
     if !day_schs_used_each_day.length == 365
-      OpenStudio::logFree(OpenStudio::Error, 'openstudio.standards.ScheduleRuleset', "#{schedule.name} does not have 365 daily schedules accounted for, cannot accurately calculate annual EFLH.")
-      return 0
+      fail "#{schedule.name} does not have 365 daily schedules accounted for, cannot accurately calculate annual EFLH."
     end
 
     # Create a map that shows how many days each schedule is used
@@ -672,11 +671,11 @@ class Schedule
       annual_flh += daily_flh * number_of_days_sch_used
     end
 
-    # Warn if the max daily EFLH is more than 24,
+    # Check if the max daily EFLH is more than 24,
     # which would indicate that this isn't a
     # fractional schedule.
     if max_daily_flh > 24
-      OpenStudio::logFree(OpenStudio::Warn, 'openstudio.standards.ScheduleRuleset', "#{schedule.name} has more than 24 EFLH in one day schedule, indicating that it is not a fractional schedule.")
+      fail "#{schedule.name} has more than 24 EFLH in one day schedule, indicating that it is not a fractional schedule."
     end
 
     return annual_flh

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -914,7 +914,7 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
   def test_ruby_error_messages
     # Test case => Error message
     all_expected_errors = { 'battery-bad-values-max-not-one' => ["Schedule max value for column 'battery' must be 1."],
-                            'battery-bad-values-min-not-neg-one' => ["Schedule min value for column 'battery' must be greater than or equal to -1."],
+                            'battery-bad-values-min-less-than-neg-one' => ["Schedule value for column 'battery' must be greater than or equal to -1."],
                             'cfis-with-hydronic-distribution' => ["Attached HVAC distribution system 'HVACDistribution1' cannot be hydronic for ventilation fan 'VentilationFan1'."],
                             'cfis-invalid-supplemental-fan' => ["CFIS supplemental fan 'VentilationFan2' must be of type 'supply only' or 'exhaust only'."],
                             'cfis-invalid-supplemental-fan2' => ["CFIS supplemental fan 'VentilationFan2' must be set as used for whole building ventilation."],
@@ -1016,7 +1016,7 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
         csv_data[1][0] = 1.1
         File.write(@tmp_csv_path, csv_data.map(&:to_csv).join)
         hpxml_bldg.header.schedules_filepaths = [@tmp_csv_path]
-      elsif ['battery-bad-values-min-not-neg-one'].include? error_case
+      elsif ['battery-bad-values-min-less-than-neg-one'].include? error_case
         hpxml, hpxml_bldg = _create_hpxml('base-battery-scheduled.xml')
         csv_data = CSV.read(File.join(File.dirname(hpxml.hpxml_path), hpxml_bldg.header.schedules_filepaths[0]))
         csv_data[1][0] = -1.1

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -913,7 +913,7 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
 
   def test_ruby_error_messages
     # Test case => Error message
-    all_expected_errors = { 'battery-bad-values-max-not-one' => ["Schedule max value for column 'battery' must be 1."],
+    all_expected_errors = { 'battery-bad-values-max-greater-than-one' => ["Schedule value for column 'battery' must be less than or equal to 1."],
                             'battery-bad-values-min-less-than-neg-one' => ["Schedule value for column 'battery' must be greater than or equal to -1."],
                             'cfis-with-hydronic-distribution' => ["Attached HVAC distribution system 'HVACDistribution1' cannot be hydronic for ventilation fan 'VentilationFan1'."],
                             'cfis-invalid-supplemental-fan' => ["CFIS supplemental fan 'VentilationFan2' must be of type 'supply only' or 'exhaust only'."],
@@ -1010,7 +1010,7 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
       puts "[#{i + 1}/#{all_expected_errors.size}] Testing #{error_case}..."
       building_id = nil
       # Create HPXML object
-      if ['battery-bad-values-max-not-one'].include? error_case
+      if ['battery-bad-values-max-greater-than-one'].include? error_case
         hpxml, hpxml_bldg = _create_hpxml('base-battery-scheduled.xml')
         csv_data = CSV.read(File.join(File.dirname(hpxml.hpxml_path), hpxml_bldg.header.schedules_filepaths[0]))
         csv_data[1][0] = 1.1

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -914,7 +914,7 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
   def test_ruby_error_messages
     # Test case => Error message
     all_expected_errors = { 'battery-bad-values-max-not-one' => ["Schedule max value for column 'battery' must be 1."],
-                            'battery-bad-values-min-not-neg-one' => ["Schedule min value for column 'battery' must be -1."],
+                            'battery-bad-values-min-not-neg-one' => ["Schedule min value for column 'battery' must be greater than or equal to -1."],
                             'cfis-with-hydronic-distribution' => ["Attached HVAC distribution system 'HVACDistribution1' cannot be hydronic for ventilation fan 'VentilationFan1'."],
                             'cfis-invalid-supplemental-fan' => ["CFIS supplemental fan 'VentilationFan2' must be of type 'supply only' or 'exhaust only'."],
                             'cfis-invalid-supplemental-fan2' => ["CFIS supplemental fan 'VentilationFan2' must be set as used for whole building ventilation."],

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -2211,10 +2211,7 @@ Each ``HeatPump`` is expected to represent a single outdoor unit, whether connec
          HeatingDetailedPerformanceData must also be provided.
   .. [#] If HeatingDetailedPerformanceData is provided, see :ref:`htg_detailed_perf_data`.
          CoolingDetailedPerformanceData must also be provided.
-  .. [#] If neither extension/HeatingCapacityRetention nor HeatingCapacity17F nor HeatingDetailedPerformanceData provided, heating capacity retention defaults based on CompressorType:
-         
-         \- **variable speed**: 0.0461 * HSPF + 0.1594 (at 5F)
-         
+  .. [#] If neither extension/HeatingCapacityRetention nor HeatingCapacity17F nor HeatingDetailedPerformanceData provided, heating capacity retention defaults to 0.0461 * HSPF + 0.1594 (at 5F).
   .. [#] The extension/HeatingCapacityRetention input is a more flexible alternative to HeatingCapacity17F, as it can apply to autosized systems and allows the heating capacity retention to be defined at a user-specified temperature (instead of 17F).
          Either input approach can be used, but not both.
   .. [#] FanPowerWattsPerCFM defaults to 0.07 W/cfm for ductless systems and 0.18 W/cfm for ducted systems.

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -602,44 +602,44 @@ They can be used to reflect real-world or stochastic occupancy.
 Detailed schedule inputs are provided via one or more CSV file that should be referenced in the HPXML file as ``/HPXML/Building/BuildingDetails/BuildingSummary/extension/SchedulesFilePath`` elements.
 The column names available in the schedule CSV files are:
 
-  ===============================  =====  =================================================================================  ===============================
-  Column Name                      Units  Description                                                                        Can Be Stochastically Generated
-  ===============================  =====  =================================================================================  ===============================
-  ``occupants``                    frac   Occupant heat gain schedule.                                                       Yes
-  ``lighting_interior``            frac   Interior lighting energy use schedule.                                             Yes
-  ``lighting_exterior``            frac   Exterior lighting energy use schedule.                                             No
-  ``lighting_garage``              frac   Garage lighting energy use schedule.                                               Yes
-  ``lighting_exterior_holiday``    frac   Exterior holiday lighting energy use schedule.                                     No
-  ``cooking_range``                frac   Cooking range & oven energy use schedule.                                          Yes
-  ``refrigerator``                 frac   Primary refrigerator energy use schedule.                                          No
-  ``extra_refrigerator``           frac   Non-primary refrigerator energy use schedule.                                      No
-  ``freezer``                      frac   Freezer energy use schedule.                                                       No
-  ``dishwasher``                   frac   Dishwasher energy use schedule.                                                    Yes
-  ``clothes_washer``               frac   Clothes washer energy use schedule.                                                Yes
-  ``clothes_dryer``                frac   Clothes dryer energy use schedule.                                                 Yes
-  ``ceiling_fan``                  frac   Ceiling fan energy use schedule.                                                   Yes
-  ``plug_loads_other``             frac   Other plug load energy use schedule.                                               Yes
-  ``plug_loads_tv``                frac   Television plug load energy use schedule.                                          Yes
-  ``plug_loads_vehicle``           frac   Electric vehicle plug load energy use schedule.                                    No
-  ``plug_loads_well_pump``         frac   Well pump plug load energy use schedule.                                           No
-  ``fuel_loads_grill``             frac   Grill fuel load energy use schedule.                                               No
-  ``fuel_loads_lighting``          frac   Lighting fuel load energy use schedule.                                            No
-  ``fuel_loads_fireplace``         frac   Fireplace fuel load energy use schedule.                                           No
-  ``pool_pump``                    frac   Pool pump energy use schedule.                                                     No
-  ``pool_heater``                  frac   Pool heater energy use schedule.                                                   No
-  ``permanent_spa_pump``           frac   Permanent spa pump energy use schedule.                                            No
-  ``permanent_spa_heater``         frac   Permanent spa heater energy use schedule.                                          No
-  ``hot_water_dishwasher``         frac   Dishwasher hot water use schedule.                                                 Yes
-  ``hot_water_clothes_washer``     frac   Clothes washer hot water use schedule.                                             Yes
-  ``hot_water_fixtures``           frac   Fixtures (sinks, showers, baths) hot water use schedule.                           Yes
-  ``heating_setpoint``             F      Thermostat heating setpoint schedule.                                              No
-  ``cooling_setpoint``             F      Thermostat cooling setpoint schedule.                                              No
-  ``water_heater_setpoint``        F      Water heater setpoint schedule.                                                    No
-  ``water_heater_operating_mode``  0/1    Heat pump water heater operating mode schedule. 0=hybrid/auto, 1=heat pump only.   No
-  ``battery``                      frac   Battery schedule. Positive for charging, negative for discharging.                 No
-  ``vacancy``                      0/1    Vacancy schedule. 0=occupied, 1=vacant. Automatically overrides other columns.     N/A
-  ``outage``                       0/1    Power outage schedule. 0=power. 1=nopower. Automatically overrides other columns.  N/A
-  ===============================  =====  =================================================================================  ===============================
+  ===============================  =======  =================================================================================  ===============================
+  Column Name                      Units    Description                                                                        Can Be Stochastically Generated
+  ===============================  =======  =================================================================================  ===============================
+  ``occupants``                    frac     Occupant heat gain schedule.                                                       Yes
+  ``lighting_interior``            frac     Interior lighting energy use schedule.                                             Yes
+  ``lighting_exterior``            frac     Exterior lighting energy use schedule.                                             No
+  ``lighting_garage``              frac     Garage lighting energy use schedule.                                               Yes
+  ``lighting_exterior_holiday``    frac     Exterior holiday lighting energy use schedule.                                     No
+  ``cooking_range``                frac     Cooking range & oven energy use schedule.                                          Yes
+  ``refrigerator``                 frac     Primary refrigerator energy use schedule.                                          No
+  ``extra_refrigerator``           frac     Non-primary refrigerator energy use schedule.                                      No
+  ``freezer``                      frac     Freezer energy use schedule.                                                       No
+  ``dishwasher``                   frac     Dishwasher energy use schedule.                                                    Yes
+  ``clothes_washer``               frac     Clothes washer energy use schedule.                                                Yes
+  ``clothes_dryer``                frac     Clothes dryer energy use schedule.                                                 Yes
+  ``ceiling_fan``                  frac     Ceiling fan energy use schedule.                                                   Yes
+  ``plug_loads_other``             frac     Other plug load energy use schedule.                                               Yes
+  ``plug_loads_tv``                frac     Television plug load energy use schedule.                                          Yes
+  ``plug_loads_vehicle``           frac     Electric vehicle plug load energy use schedule.                                    No
+  ``plug_loads_well_pump``         frac     Well pump plug load energy use schedule.                                           No
+  ``fuel_loads_grill``             frac     Grill fuel load energy use schedule.                                               No
+  ``fuel_loads_lighting``          frac     Lighting fuel load energy use schedule.                                            No
+  ``fuel_loads_fireplace``         frac     Fireplace fuel load energy use schedule.                                           No
+  ``pool_pump``                    frac     Pool pump energy use schedule.                                                     No
+  ``pool_heater``                  frac     Pool heater energy use schedule.                                                   No
+  ``permanent_spa_pump``           frac     Permanent spa pump energy use schedule.                                            No
+  ``permanent_spa_heater``         frac     Permanent spa heater energy use schedule.                                          No
+  ``hot_water_dishwasher``         frac     Dishwasher hot water use schedule.                                                 Yes
+  ``hot_water_clothes_washer``     frac     Clothes washer hot water use schedule.                                             Yes
+  ``hot_water_fixtures``           frac     Fixtures (sinks, showers, baths) hot water use schedule.                           Yes
+  ``heating_setpoint``             F        Thermostat heating setpoint schedule.                                              No
+  ``cooling_setpoint``             F        Thermostat cooling setpoint schedule.                                              No
+  ``water_heater_setpoint``        F        Water heater setpoint schedule.                                                    No
+  ``water_heater_operating_mode``  0/1      Heat pump water heater operating mode schedule. 0=hybrid/auto, 1=heat pump only.   No
+  ``battery``                      -1 to 1  Battery schedule. Positive for charging, negative for discharging.                 No
+  ``vacancy``                      0/1      Vacancy schedule. 0=occupied, 1=vacant. Automatically overrides other columns.     N/A
+  ``outage``                       0/1      Power outage schedule. 0=power. 1=nopower. Automatically overrides other columns.  N/A
+  ===============================  =======  =================================================================================  ===============================
 
 Columns with units of `frac` must be normalized to MAX=1; that is, these schedules only define *when* energy is used, not *how much* energy is used.
 In other words, the amount of energy or hot water used in each simulation timestep is essentially the schedule value divided by the sum of all schedule values in the column, multiplied by the annual energy or hot water use.


### PR DESCRIPTION
## Pull Request Description

The documentation says that you must use MAX=1 for fractional schedules, but the code was only checking that the max was <= 1. Also fixes the battery schedule error message.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)~
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
