### PR TITLE
Allow appending columns in BuildResidentialScheduleFile measure

### DIFF
--- a/BuildResidentialScheduleFile/README.md
+++ b/BuildResidentialScheduleFile/README.md
@@ -70,7 +70,7 @@ Absolute/relative output path of the HPXML file. This HPXML file will include th
 
 **Append Output?**
 
-If true and the output CSV file exists, appends columns to the file rather than overwriting.
+If true and the output CSV file already exists, appends columns to the file rather than overwriting it. The existing output CSV file must have the same number of rows (i.e., timeseries frequency) as the new columns being appended.
 
 - **Name:** ``append_output``
 - **Type:** ``Boolean``

--- a/BuildResidentialScheduleFile/README.md
+++ b/BuildResidentialScheduleFile/README.md
@@ -35,7 +35,7 @@ A comma-separated list of the column names to generate. If not provided, default
 
 **Schedules: Random Seed**
 
-This numeric field is the seed for the random number generator. Only applies if the schedules type is 'stochastic'.
+This numeric field is the seed for the random number generator.
 
 - **Name:** ``schedules_random_seed``
 - **Type:** ``Integer``
@@ -68,9 +68,20 @@ Absolute/relative output path of the HPXML file. This HPXML file will include th
 
 <br/>
 
+**Append Output?**
+
+If true and the output CSV file exists, appends columns to the file rather than overwriting.
+
+- **Name:** ``append_output``
+- **Type:** ``Boolean``
+
+- **Required:** ``false``
+
+<br/>
+
 **Debug Mode?**
 
-Applicable when schedules type is stochastic. If true: Write extra state column(s).
+If true, writes extra column(s) for informational purposes.
 
 - **Name:** ``debug``
 - **Type:** ``Boolean``

--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -64,7 +64,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
 
     arg = OpenStudio::Measure::OSArgument.makeBoolArgument('append_output', false)
     arg.setDisplayName('Append Output?')
-    arg.setDescription('If true and the output CSV file exists, appends columns to the file rather than overwriting.')
+    arg.setDescription('If true and the output CSV file already exists, appends columns to the file rather than overwriting it. The existing output CSV file must have the same number of rows (i.e., timeseries frequency) as the new columns being appended.')
     arg.setDefaultValue(false)
     args << arg
 

--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -49,7 +49,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     arg = OpenStudio::Measure::OSArgument.makeIntegerArgument('schedules_random_seed', false)
     arg.setDisplayName('Schedules: Random Seed')
     arg.setUnits('#')
-    arg.setDescription("This numeric field is the seed for the random number generator. Only applies if the schedules type is 'stochastic'.")
+    arg.setDescription('This numeric field is the seed for the random number generator.')
     args << arg
 
     arg = OpenStudio::Measure::OSArgument.makeStringArgument('output_csv_path', true)
@@ -62,9 +62,15 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     arg.setDescription('Absolute/relative output path of the HPXML file. This HPXML file will include the output CSV path.')
     args << arg
 
+    arg = OpenStudio::Measure::OSArgument.makeBoolArgument('append_output', false)
+    arg.setDisplayName('Append Output?')
+    arg.setDescription('If true and the output CSV file exists, appends columns to the file rather than overwriting.')
+    arg.setDefaultValue(false)
+    args << arg
+
     arg = OpenStudio::Measure::OSArgument.makeBoolArgument('debug', false)
     arg.setDisplayName('Debug Mode?')
-    arg.setDescription('Applicable when schedules type is stochastic. If true: Write extra state column(s).')
+    arg.setDescription('If true, writes extra column(s) for informational purposes.')
     arg.setDefaultValue(false)
     args << arg
 
@@ -102,14 +108,9 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     end
     args[:hpxml_output_path] = hpxml_output_path
 
-    building_id = nil
-    building_id = args[:building_id].get if args[:building_id].is_initialized
-
-    debug = false
-    if args[:debug].is_initialized
-      debug = args[:debug].get
-    end
-    args[:debug] = debug
+    args[:building_id] = args[:building_id].is_initialized ? args[:building_id].get : nil
+    args[:debug] = args[:debug].is_initialized ? args[:debug].get : false
+    args[:append_output] = args[:append_output].is_initialized ? args[:append_output].get : false
 
     # random seed
     if args[:schedules_random_seed].is_initialized
@@ -130,7 +131,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
     doc_buildings.each_with_index do |building, i|
       doc_building_id = XMLHelper.get_attribute_value(XMLHelper.get_element(building, 'BuildingID'), 'id')
 
-      next if doc_buildings.size > 1 && building_id != 'ALL' && building_id != doc_building_id
+      next if doc_buildings.size > 1 && args[:building_id] != 'ALL' && args[:building_id] != doc_building_id
 
       hpxml = HPXML.new(hpxml_path: hpxml_path, building_id: doc_building_id)
       hpxml_bldg = hpxml.buildings[0]
@@ -151,7 +152,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
 
       # output csv path
       args[:output_csv_path] = "#{output_csv_basename}.csv"
-      args[:output_csv_path] = "#{output_csv_basename}_#{i + 1}.csv" if i > 0 && building_id == 'ALL'
+      args[:output_csv_path] = "#{output_csv_basename}_#{i + 1}.csv" if i > 0 && args[:building_id] == 'ALL'
 
       # create the schedules
       success = create_schedules(runner, hpxml, hpxml_bldg, epw_file, args)

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>7dd347b4-2557-4600-9fe4-c35c427bbf05</version_id>
-  <version_modified>2024-02-29T22:52:11Z</version_modified>
+  <version_id>f441e7c7-e558-4a59-8fc6-90a62c583572</version_id>
+  <version_modified>2024-03-13T18:19:12Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -30,7 +30,7 @@
     <argument>
       <name>schedules_random_seed</name>
       <display_name>Schedules: Random Seed</display_name>
-      <description>This numeric field is the seed for the random number generator. Only applies if the schedules type is 'stochastic'.</description>
+      <description>This numeric field is the seed for the random number generator.</description>
       <type>Integer</type>
       <units>#</units>
       <required>false</required>
@@ -53,9 +53,28 @@
       <model_dependent>false</model_dependent>
     </argument>
     <argument>
+      <name>append_output</name>
+      <display_name>Append Output?</display_name>
+      <description>If true and the output CSV file exists, appends columns to the file rather than overwriting.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
       <name>debug</name>
       <display_name>Debug Mode?</display_name>
-      <description>Applicable when schedules type is stochastic. If true: Write extra state column(s).</description>
+      <description>If true, writes extra column(s) for informational purposes.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -97,7 +116,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>824BFECD</checksum>
+      <checksum>95694124</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -114,7 +133,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>53FA82A5</checksum>
+      <checksum>C1B64595</checksum>
     </file>
     <file>
       <filename>README.md</filename>
@@ -204,7 +223,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>BE50C471</checksum>
+      <checksum>4079EA38</checksum>
     </file>
     <file>
       <filename>schedules_config.md</filename>
@@ -912,7 +931,7 @@
       <filename>test_build_residential_schedule_file.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>3BE20192</checksum>
+      <checksum>9568ACE2</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>f441e7c7-e558-4a59-8fc6-90a62c583572</version_id>
-  <version_modified>2024-03-13T18:19:12Z</version_modified>
+  <version_id>78f9b229-27a1-4ddf-a0e1-ff89cf6ed9c0</version_id>
+  <version_modified>2024-03-13T20:51:13Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -223,7 +223,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>4079EA38</checksum>
+      <checksum>DDED037B</checksum>
     </file>
     <file>
       <filename>schedules_config.md</filename>
@@ -931,7 +931,7 @@
       <filename>test_build_residential_schedule_file.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>9568ACE2</checksum>
+      <checksum>419E4E08</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>78f9b229-27a1-4ddf-a0e1-ff89cf6ed9c0</version_id>
-  <version_modified>2024-03-13T20:51:13Z</version_modified>
+  <version_id>4294cc7b-e471-4c34-899a-05c66d13f88b</version_id>
+  <version_modified>2024-03-14T21:44:14Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -55,7 +55,7 @@
     <argument>
       <name>append_output</name>
       <display_name>Append Output?</display_name>
-      <description>If true and the output CSV file exists, appends columns to the file rather than overwriting.</description>
+      <description>If true and the output CSV file already exists, appends columns to the file rather than overwriting it. The existing output CSV file must have the same number of rows (i.e., timeseries frequency) as the new columns being appended.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -116,7 +116,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>95694124</checksum>
+      <checksum>5852D2EF</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -133,7 +133,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>C1B64595</checksum>
+      <checksum>205465AA</checksum>
     </file>
     <file>
       <filename>README.md</filename>

--- a/BuildResidentialScheduleFile/resources/schedules.rb
+++ b/BuildResidentialScheduleFile/resources/schedules.rb
@@ -16,6 +16,7 @@ class ScheduleGenerator
                  sim_year:,
                  sim_start_day:,
                  debug:,
+                 append_output:,
                  **)
     @runner = runner
     @state = state
@@ -29,6 +30,7 @@ class ScheduleGenerator
     @sim_year = sim_year
     @sim_start_day = sim_start_day
     @debug = debug
+    @append_output = append_output
   end
 
   def self.export_columns
@@ -743,11 +745,17 @@ class ScheduleGenerator
     (SchedulesFile::Columns.values.map { |c| c.name } - @column_names).each do |col_to_remove|
       @schedules.delete(col_to_remove)
     end
+    schedule_keys = @schedules.keys
+    schedule_rows = @schedules.values.transpose.map { |row| row.map { |x| '%.3g' % x } }
+    if @append_output && File.exist?(schedules_path)
+      table = CSV.read(schedules_path)
+      schedule_keys = table[0] + schedule_keys
+      schedule_rows = schedule_rows.map.with_index { |row, i| table[i + 1] + row }
+    end
     CSV.open(schedules_path, 'w') do |csv|
-      csv << @schedules.keys
-      rows = @schedules.values.transpose
-      rows.each do |row|
-        csv << row.map { |x| '%.3g' % x }
+      csv << schedule_keys
+      schedule_rows.each do |row|
+        csv << row
       end
     end
     return true

--- a/BuildResidentialScheduleFile/resources/schedules.rb
+++ b/BuildResidentialScheduleFile/resources/schedules.rb
@@ -749,6 +749,10 @@ class ScheduleGenerator
     schedule_rows = @schedules.values.transpose.map { |row| row.map { |x| '%.3g' % x } }
     if @append_output && File.exist?(schedules_path)
       table = CSV.read(schedules_path)
+      if table.size != schedule_rows.size + 1
+        @runner.registerError("Invalid number of rows (#{table.size}) in file.csv. Expected #{schedule_rows.size + 1} rows (including the header row).")
+        return false
+      end
       schedule_keys = table[0] + schedule_keys
       schedule_rows = schedule_rows.map.with_index { |row, i| table[i + 1] + row }
     end

--- a/BuildResidentialScheduleFile/tests/test_build_residential_schedule_file.rb
+++ b/BuildResidentialScheduleFile/tests/test_build_residential_schedule_file.rb
@@ -497,6 +497,18 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     expected_cols = orig_cols + ScheduleGenerator.export_columns
     assert_equal(expected_cols, outdata[0].strip.split(',')) # Header
     assert_equal(expected_cols.size, outdata[1].split(',').size) # Data
+
+    # Test w/ append_output=true and inconsistent data
+    existing_csv_path = File.join(File.dirname(__FILE__), '..', '..', 'HPXMLtoOpenStudio', 'resources', 'schedule_files', 'setpoints-10-mins.csv')
+    hpxml = _create_hpxml('base.xml')
+    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
+    FileUtils.cp(existing_csv_path, @tmp_schedule_file_path)
+    @args_hash['output_csv_path'] = @tmp_schedule_file_path
+    @args_hash['append_output'] = true
+    _hpxml, result = _test_measure(expect_fail: true)
+
+    error_msgs = result.errors.map { |x| x.logMessage }
+    assert(error_msgs.any? { |error_msg| error_msg.include?('Invalid number of rows (52561) in file.csv. Expected 8761 rows (including the header row).') })
   end
 
   def _test_measure(expect_fail: false)

--- a/Changelog.md
+++ b/Changelog.md
@@ -42,6 +42,8 @@ __New Features__
   - Miscellaneous improvements.
 - Adds more error-checking for inappropriate inputs (e.g., HVAC SHR=0 or clothes washer IMEF=0).
 - Allow alternative label energy use (W) input for ceiling fans.
+- BuildResidentialScheduleFile measure:
+  - Allows appending columns to an existing CSV file rather than overwriting.
 
 __Bugfixes__
 - Fixes error if using AllowIncreasedFixedCapacities=true w/ HP detailed performance data.


### PR DESCRIPTION
## Pull Request Description

BuildResidentialScheduleFile measure: Allows appending columns to an existing CSV file rather than overwriting. This is useful if you have an existing CSV of non-stochastic detailed schedules (e.g., HVAC setpoints) and want to add the stochastic schedules into the file rather than creating an additional CSV file.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)~
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
