### PR TITLE
Add `--skip-simulation` argument

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,7 @@ __New Features__
   - Miscellaneous improvements.
 - Adds more error-checking for inappropriate inputs (e.g., HVAC SHR=0 or clothes washer IMEF=0).
 - Allow alternative label energy use (W) input for ceiling fans.
+- Adds an optional `--skip-simulation` argument to the run_simulation.rb script that allows skipping the EnergyPlus simulation.
 - BuildResidentialScheduleFile measure:
   - Allows appending columns to an existing CSV file rather than overwriting.
   - Other plug load schedules now use Other schedule fractions per ANSI/RESNET/ICC 301-2022 Addendum C.

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -159,6 +159,22 @@ class WorkflowOtherTest < Minitest::Test
     end
   end
 
+  def test_run_simulation_skip_simulation
+    # Check that we can correctly skip the EnergyPlus simulation and reporting measures
+    rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
+    xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
+    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --skip-simulation"
+    system(command, err: File::NULL)
+
+    # Check for in.xml HPXML file
+    assert(File.exist? File.join(File.dirname(xml), 'run', 'in.xml'))
+
+    # Check for no idf or output file
+    refute(File.exist? File.join(File.dirname(xml), 'run', 'in.idf'))
+    refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+    refute(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+  end
+
   def test_run_defaulted_in_xml
     # Check that if we simulate the in.xml file (HPXML w/ defaults), we get
     # the same results as the original HPXML.


### PR DESCRIPTION
## Pull Request Description

Adds an optional `--skip-simulation` argument to the run_simulation.rb script that allows skipping the EnergyPlus simulation.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)~
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
