### PR TITLE
Allows requesting timeseries outputs with different frequencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,12 +43,15 @@ __New Features__
   - Miscellaneous improvements.
 - Adds more error-checking for inappropriate inputs (e.g., HVAC SHR=0 or clothes washer IMEF=0).
 - Allow alternative label energy use (W) input for ceiling fans.
-- Adds an optional `--skip-simulation` argument to the run_simulation.rb script that allows skipping the EnergyPlus simulation.
+- Updates to run_simulation.rb script:
+  - Allows requesting timeseries outputs with different frequencies (e.g., `--hourly enduses --monthly temperatures`).
+  - **Breaking change**: Deprecates `--add-timeseries-output-variable`; EnergyPlus output variables can now be requested like other timeseries categories (using e.g. `--hourly 'Zone People Occupant Count'`).
+  - Adds an optional `--skip-simulation` argument that allows skipping the EnergyPlus simulation.
 - BuildResidentialScheduleFile measure:
   - Allows appending columns to an existing CSV file rather than overwriting.
   - Other plug load schedules now use Other schedule fractions per ANSI/RESNET/ICC 301-2022 Addendum C.
-  - TV plug load schedules now use TV schedule fractions from the American Time Use Survey (instead of mirroring miscellaneous plug load schedules) and monthly multipliers from the 2010 Building America Analysis Spreadsheets.
-  - Ceiling fan schedules now use ceiling fan schedule fractions and monthly multipliers based on monthly average outdoor temperatures per ANSI/RESNET/ICC 301-2022 Addendum C.
+  - TV plug load schedules now use TV schedule fractions from the American Time Use Survey and monthly multipliers from the 2010 Building America Analysis Spreadsheets.
+  - Ceiling fan schedules now use ceiling fan schedule fractions and monthly multipliers from ANSI/RESNET/ICC 301-2022 Addendum C.
 
 __Bugfixes__
 - Fixes error if using AllowIncreasedFixedCapacities=true w/ HP detailed performance data.

--- a/docs/source/usage_instructions.rst
+++ b/docs/source/usage_instructions.rst
@@ -35,6 +35,8 @@ You can also request generation of timeseries output CSV/JSON/MessagePack files 
 | ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --hourly ALL``
 | Or to request one or more specific monthly output types in JSON format:
 | ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --monthly fuels --monthly temperatures --output-format json``
+| Or to request both monthly and hourly outputs (including an EnergyPlus output variable):
+| ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --monthly fuels --hourly temperatures --hourly 'Zone People Occupant Count'``
 
 | You can also add a detailed schedule as part of the simulation by using:
 | ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --add-stochastic-schedules``
@@ -68,5 +70,6 @@ Outputs
 A variety of high-level annual outputs are conveniently reported in the resulting ``run/results_annual.csv`` (or ``run/results_annual.json`` or ``run/results_annual.msgpack``) file.
 
 When timeseries outputs are requested, they will be found in the ``run/results_timeseries.csv`` (or ``run/results_timeseries.json`` or ``run/results_timeseries.msgpack``) file.
+If multiple timeseries frequencies are requested (e.g., hourly and daily), the timeseries output filenames will include the frequency (e.g., ``run/results_timeseries_daily.csv``).
 
 See :ref:`workflow_outputs` for a description of all available outputs available.

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -506,6 +506,7 @@ Timeseries Outputs
 
 OpenStudio-HPXML can optionally generate a timeseries output file.
 The timeseries output file is called ``results_timeseries.csv`` (or ``results_timeseries.json`` or ``results_timeseries.msgpack``) and located in the run directory.
+If multiple timeseries frequencies are requested (e.g., hourly and daily), the timeseries output filenames will include the frequency (e.g., ``run/results_timeseries_daily.csv``).
 
 Depending on the outputs requested, the file may include:
 
@@ -527,7 +528,7 @@ Depending on the outputs requested, the file may include:
    Airflows                             Airflow rates (in cfm) for infiltration, mechanical ventilation (including clothes dryer exhaust), natural ventilation, whole house fans.
    Weather                              Weather file data including outdoor temperatures, relative humidity, wind speed, and solar.
    Resilience                           Resilience outputs (currently only average resilience hours for battery storage).
-   EnergyPlus Output Variables          These are optional and can be requested with the ReportSimulationOutput ``user_output_variables`` argument.
+   EnergyPlus Output Variables          Any user-specified EnergyPlus output variables (e.g., 'Zone People Occupant Count').
    ===================================  ==================================================================================================================================
 
 Timeseries outputs can be one of the following frequencies: hourly, daily, monthly, or timestep (i.e., equal to the simulation timestep, which defaults to an hour but can be sub-hourly).

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -11,11 +11,16 @@ require_relative '../HPXMLtoOpenStudio/resources/version'
 
 basedir = File.expand_path(File.dirname(__FILE__))
 
-def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseries_outputs, skip_validation, add_comp_loads,
-                 output_format, building_id, ep_input_format, stochastic_schedules, timeseries_output_variables,
-                 skip_simulation)
-  measures_dir = File.join(basedir, '..')
+$timeseries_types = ['ALL', 'total', 'fuels', 'enduses', 'systemuses', 'emissions', 'emissionfuels',
+                     'emissionenduses', 'hotwater', 'loads', 'componentloads',
+                     'unmethours', 'temperatures', 'airflows', 'weather', 'resilience']
 
+def run_workflow(basedir, rundir, hpxml, debug, skip_validation, add_comp_loads,
+                 output_format, building_id, ep_input_format, stochastic_schedules,
+                 hourly_outputs, daily_outputs, monthly_outputs, timestep_outputs,
+                 skip_simulation)
+
+  measures_dir = File.join(basedir, '..')
   measures = {}
 
   # Optionally add schedule file measure to workflow
@@ -36,34 +41,57 @@ def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseri
   args['hpxml_path'] = hpxml
   args['output_dir'] = rundir
   args['debug'] = debug
-  args['add_component_loads'] = (add_comp_loads || timeseries_outputs.include?('componentloads'))
+  args['add_component_loads'] = (add_comp_loads || (hourly_outputs + daily_outputs + monthly_outputs + timestep_outputs).include?('componentloads'))
   args['skip_validation'] = skip_validation
   args['building_id'] = building_id
   update_args_hash(measures, measure_subdir, args)
 
   if not skip_simulation
-    # Add reporting measure to workflow
-    measure_subdir = 'ReportSimulationOutput'
-    args = {}
-    args['output_format'] = output_format
-    args['timeseries_frequency'] = timeseries_output_freq
-    args['include_timeseries_total_consumptions'] = timeseries_outputs.include? 'total'
-    args['include_timeseries_fuel_consumptions'] = timeseries_outputs.include? 'fuels'
-    args['include_timeseries_end_use_consumptions'] = timeseries_outputs.include? 'enduses'
-    args['include_timeseries_system_use_consumptions'] = timeseries_outputs.include? 'systemuses'
-    args['include_timeseries_emissions'] = timeseries_outputs.include? 'emissions'
-    args['include_timeseries_emission_fuels'] = timeseries_outputs.include? 'emissionfuels'
-    args['include_timeseries_emission_end_uses'] = timeseries_outputs.include? 'emissionenduses'
-    args['include_timeseries_hot_water_uses'] = timeseries_outputs.include? 'hotwater'
-    args['include_timeseries_total_loads'] = timeseries_outputs.include? 'loads'
-    args['include_timeseries_component_loads'] = timeseries_outputs.include? 'componentloads'
-    args['include_timeseries_unmet_hours'] = timeseries_outputs.include? 'unmethours'
-    args['include_timeseries_zone_temperatures'] = timeseries_outputs.include? 'temperatures'
-    args['include_timeseries_airflows'] = timeseries_outputs.include? 'airflows'
-    args['include_timeseries_weather'] = timeseries_outputs.include? 'weather'
-    args['include_timeseries_resilience'] = timeseries_outputs.include? 'resilience'
-    args['user_output_variables'] = timeseries_output_variables.join(', ') unless timeseries_output_variables.empty?
-    update_args_hash(measures, measure_subdir, args)
+    n_timeseries_freqs = [hourly_outputs, daily_outputs, monthly_outputs, timestep_outputs].map { |o| !o.empty? }.count(true)
+
+    { 'none' => [],
+      'hourly' => hourly_outputs,
+      'daily' => daily_outputs,
+      'monthly' => monthly_outputs,
+      'timestep' => timestep_outputs }.each do |timeseries_output_freq, timeseries_outputs|
+      next if (timeseries_outputs.empty? && timeseries_output_freq != 'none')
+
+      if timeseries_outputs.include? 'ALL'
+        # Replace 'ALL' with all individual timeseries types
+        timeseries_outputs.delete('ALL')
+        $timeseries_types.each do |timeseries_type|
+          timeseries_outputs << timeseries_type
+        end
+      end
+
+      # Add reporting measure to workflow
+      measure_subdir = 'ReportSimulationOutput'
+      args = {}
+      args['output_format'] = output_format
+      args['timeseries_frequency'] = timeseries_output_freq
+      args['include_timeseries_total_consumptions'] = timeseries_outputs.include? 'total'
+      args['include_timeseries_fuel_consumptions'] = timeseries_outputs.include? 'fuels'
+      args['include_timeseries_end_use_consumptions'] = timeseries_outputs.include? 'enduses'
+      args['include_timeseries_system_use_consumptions'] = timeseries_outputs.include? 'systemuses'
+      args['include_timeseries_emissions'] = timeseries_outputs.include? 'emissions'
+      args['include_timeseries_emission_fuels'] = timeseries_outputs.include? 'emissionfuels'
+      args['include_timeseries_emission_end_uses'] = timeseries_outputs.include? 'emissionenduses'
+      args['include_timeseries_hot_water_uses'] = timeseries_outputs.include? 'hotwater'
+      args['include_timeseries_total_loads'] = timeseries_outputs.include? 'loads'
+      args['include_timeseries_component_loads'] = timeseries_outputs.include? 'componentloads'
+      args['include_timeseries_unmet_hours'] = timeseries_outputs.include? 'unmethours'
+      args['include_timeseries_zone_temperatures'] = timeseries_outputs.include? 'temperatures'
+      args['include_timeseries_airflows'] = timeseries_outputs.include? 'airflows'
+      args['include_timeseries_weather'] = timeseries_outputs.include? 'weather'
+      args['include_timeseries_resilience'] = timeseries_outputs.include? 'resilience'
+      user_output_variables = timeseries_outputs - $timeseries_types
+      args['user_output_variables'] = user_output_variables.join(', ') unless user_output_variables.empty?
+      if n_timeseries_freqs > 1
+        # Need to use different timeseries filenames
+        args['timeseries_output_file_name'] = "results_timeseries_#{timeseries_output_freq}.#{output_format}"
+      end
+      update_args_hash(measures, measure_subdir, args)
+    end
 
     output_format = 'csv' if output_format == 'csv_dview'
 
@@ -79,13 +107,9 @@ def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseri
   return results[:success]
 end
 
-timeseries_types = ['ALL', 'total', 'fuels', 'enduses', 'systemuses', 'emissions', 'emissionfuels',
-                    'emissionenduses', 'hotwater', 'loads', 'componentloads',
-                    'unmethours', 'temperatures', 'airflows', 'weather', 'resilience']
-
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "Usage: #{File.basename(__FILE__)} -x building.xml"
+  opts.banner = "Usage: #{File.basename(__FILE__)} -x building.xml [OPTIONS]"
 
   opts.on('-x', '--xml <FILE>', 'HPXML file') do |t|
     options[:hpxml] = t
@@ -95,27 +119,28 @@ OptionParser.new do |opts|
     options[:output_dir] = t
   end
 
+  options[:output_format] = 'csv'
   opts.on('--output-format TYPE', ['csv', 'json', 'msgpack', 'csv_dview'], 'Output file format type (csv, json, msgpack, csv_dview)') do |t|
     options[:output_format] = t
   end
 
   options[:hourly_outputs] = []
-  opts.on('--hourly TYPE', timeseries_types, "Request hourly output type (#{timeseries_types.join(', ')}); can be called multiple times") do |t|
+  opts.on('--hourly NAME', 'Request hourly output category* or EnergyPlus output variable; can be called multiple times') do |t|
     options[:hourly_outputs] << t
   end
 
   options[:daily_outputs] = []
-  opts.on('--daily TYPE', timeseries_types, "Request daily output type (#{timeseries_types.join(', ')}); can be called multiple times") do |t|
+  opts.on('--daily NAME', 'Request daily output category* or EnergyPlus output variable; can be called multiple times') do |t|
     options[:daily_outputs] << t
   end
 
   options[:monthly_outputs] = []
-  opts.on('--monthly TYPE', timeseries_types, "Request monthly output type (#{timeseries_types.join(', ')}); can be called multiple times") do |t|
+  opts.on('--monthly NAME', 'Request monthly output category* or EnergyPlus output variable; can be called multiple times') do |t|
     options[:monthly_outputs] << t
   end
 
   options[:timestep_outputs] = []
-  opts.on('--timestep TYPE', timeseries_types, "Request timestep output type (#{timeseries_types.join(', ')}); can be called multiple times") do |t|
+  opts.on('--timestep NAME', 'Request timestep output category* or EnergyPlus output variable; can be called multiple times') do |t|
     options[:timestep_outputs] << t
   end
 
@@ -139,17 +164,12 @@ OptionParser.new do |opts|
     options[:stochastic_schedules] = true
   end
 
-  options[:timeseries_output_variables] = []
-  opts.on('-t', '--add-timeseries-output-variable NAME', 'Add timeseries output variable; can be called multiple times') do |t|
-    options[:timeseries_output_variables] << t
-  end
-
   options[:ep_input_format] = 'idf'
   opts.on('--ep-input-format TYPE', 'EnergyPlus input file format (idf, epjson)') do |t|
     options[:ep_input_format] = t
   end
 
-  opts.on('-b', '--building-id ID', 'ID of Building to simulate (required if the HPXML has multiple Building elements and WholeSFAorMFBuildingSimulation is not true)') do |t|
+  opts.on('-b', '--building-id ID', 'ID of HPXML Building to simulate') do |t|
     options[:building_id] = t
   end
 
@@ -159,7 +179,7 @@ OptionParser.new do |opts|
   end
 
   options[:debug] = false
-  opts.on('-d', '--debug', 'Generate additional debug output/files') do |_t|
+  opts.on('-d', '--debug', 'Generate additional OpenStudio/EnergyPlus output files for debugging') do |_t|
     options[:debug] = true
   end
 
@@ -167,6 +187,8 @@ OptionParser.new do |opts|
     puts opts
     exit!
   end
+
+  opts.on_tail("* Valid output categories are: #{$timeseries_types.join(', ')}")
 end.parse!
 
 if options[:version]
@@ -176,42 +198,6 @@ if options[:version]
 else
   if not options[:hpxml]
     fail "HPXML argument is required. Call #{File.basename(__FILE__)} -h for usage."
-  end
-
-  timeseries_output_freq = 'none'
-  timeseries_outputs = []
-  n_freq = 0
-  if not options[:hourly_outputs].empty?
-    n_freq += 1
-    timeseries_output_freq = 'hourly'
-    timeseries_outputs = options[:hourly_outputs]
-  end
-  if not options[:daily_outputs].empty?
-    n_freq += 1
-    timeseries_output_freq = 'daily'
-    timeseries_outputs = options[:daily_outputs]
-  end
-  if not options[:monthly_outputs].empty?
-    n_freq += 1
-    timeseries_output_freq = 'monthly'
-    timeseries_outputs = options[:monthly_outputs]
-  end
-  if not options[:timestep_outputs].empty?
-    n_freq += 1
-    timeseries_output_freq = 'timestep'
-    timeseries_outputs = options[:timestep_outputs]
-  end
-
-  if not options[:timeseries_output_variables].empty?
-    timeseries_output_freq = 'timestep' if timeseries_output_freq == 'none'
-  end
-
-  if n_freq > 1
-    fail 'Multiple timeseries frequencies (hourly, daily, monthly, timestep) are not supported.'
-  end
-
-  if timeseries_outputs.include? 'ALL'
-    timeseries_outputs = timeseries_types[1..-1]
   end
 
   unless (Pathname.new options[:hpxml]).absolute?
@@ -238,9 +224,9 @@ else
   if not options[:building_id].nil?
     puts "BuildingID: #{options[:building_id]}"
   end
-  success = run_workflow(basedir, rundir, options[:hpxml], options[:debug], timeseries_output_freq, timeseries_outputs,
-                         options[:skip_validation], options[:add_comp_loads], options[:output_format], options[:building_id],
-                         options[:ep_input_format], options[:stochastic_schedules], options[:timeseries_output_variables],
+  success = run_workflow(basedir, rundir, options[:hpxml], options[:debug], options[:skip_validation], options[:add_comp_loads],
+                         options[:output_format], options[:building_id], options[:ep_input_format], options[:stochastic_schedules],
+                         options[:hourly_outputs], options[:daily_outputs], options[:monthly_outputs], options[:timestep_outputs],
                          options[:skip_simulation])
 
   if not success

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -132,30 +132,60 @@ class WorkflowOtherTest < Minitest::Test
       command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\""
       if not invalid_variable_only
         command += ' --hourly ALL'
-        command += " --add-timeseries-output-variable 'Zone People Occupant Count'"
-        command += " --add-timeseries-output-variable 'Zone People Total Heating Energy'"
+        command += " --hourly 'Zone People Occupant Count'"
+        command += " --hourly 'Zone People Total Heating Energy'"
       end
-      command += " --add-timeseries-output-variable 'Foobar Variable'" # Test invalid output variable request
+      command += " --hourly 'Foobar Variable'" # Test invalid output variable request
       system(command, err: File::NULL)
 
       # Check for output files
       assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
       assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+
+      timeseries_output_path = File.join(File.dirname(xml), 'run', 'results_timeseries.csv')
       if not invalid_variable_only
-        assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
+        assert(File.exist? timeseries_output_path)
         # Check timeseries columns exist
-        timeseries_rows = CSV.read(File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
+        timeseries_rows = CSV.read(timeseries_output_path)
         assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
         assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Occupant Count: Conditioned Space' }.size)
         assert_equal(1, timeseries_rows[0].select { |r| r == 'Zone People Total Heating Energy: Conditioned Space' }.size)
       else
-        refute(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries.csv'))
+        refute(File.exist? timeseries_output_path)
       end
 
       # Check run.log has warning about missing Foobar Variable
       assert(File.exist? File.join(File.dirname(xml), 'run', 'run.log'))
       log_lines = File.readlines(File.join(File.dirname(xml), 'run', 'run.log')).map(&:strip)
       assert(log_lines.include? "Warning: Request for output variable 'Foobar Variable' returned no key values.")
+    end
+  end
+
+  def test_run_simulation_mixed_timeseries_frequencies
+    # Check that we can correctly skip the EnergyPlus simulation and reporting measures
+    rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
+    xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
+    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --timestep weather --hourly enduses --daily temperatures --monthly ALL --monthly 'Zone People Total Heating Energy'"
+    system(command, err: File::NULL)
+
+    # Check for output files
+    assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries_timestep.csv'))
+    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries_hourly.csv'))
+    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries_daily.csv'))
+    assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries_monthly.csv'))
+
+    # Check timeseries columns exist
+    { 'timestep' => ['Weather:'],
+      'hourly' => ['End Use:'],
+      'daily' => ['Temperature:'],
+      'monthly' => ['End Use:', 'Fuel Use:', 'Zone People Total Heating Energy:'] }.each do |freq, col_names|
+      timeseries_rows = CSV.read(File.join(File.dirname(xml), 'run', "results_timeseries_#{freq}.csv"))
+      assert_equal(1, timeseries_rows[0].select { |r| r == 'Time' }.size)
+      col_names.each do |col_name|
+        assert(timeseries_rows[0].select { |r| r.start_with? col_name }.size > 0)
+      end
     end
   end
 


### PR DESCRIPTION
## Pull Request Description

Closes #1507. Allows requesting timeseries outputs with different frequencies (e.g., `--hourly enduses --monthly temperatures`).

**Breaking change**: Deprecates `run_simulation.rb --add-timeseries-output-variable`; EnergyPlus output variables can now be requested like other timeseries categories (using e.g. `--hourly 'Zone People Occupant Count'`).

For example, now you can do:
`openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --monthly fuels --hourly temperatures --hourly 'Zone People Occupant Count'`

If multiple timeseries frequencies are requested (e.g., hourly and daily), the timeseries output filenames will include the frequency (e.g., ``run/results_timeseries_daily.csv``).

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [x] ~Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)~
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
