### PR TITLE
Add warning if there are multiple design conditions

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>981460f1-76ce-499c-adb3-29e501834778</version_id>
-  <version_modified>2024-03-26T16:29:09Z</version_modified>
+  <version_id>b5a60b85-bf65-46bb-b3d4-e3b4dbc61460</version_id>
+  <version_modified>2024-03-28T23:07:18Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -568,7 +568,7 @@
       <filename>weather.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>EA6C1204</checksum>
+      <checksum>29B9C210</checksum>
     </file>
     <file>
       <filename>xmlhelper.rb</filename>


### PR DESCRIPTION
## Pull Request Description

I don't think I've ever seen an EPW with multiple design conditions, but the EPW format allows it so erring on the side of caution. Noticed while looking into a question from @joseph-robertson.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
