### PR TITLE
Update comments in hvac.rb

### DIFF
--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -3020,7 +3020,7 @@ class HVAC
 
       clg_ap.cool_rated_shrs_gross = []
       clg_ap.cool_capacity_ratios.each_with_index do |capacity_ratio, i|
-        # Calculate the SHR for each speed. Use minimum value of 0.98 to prevent E+ bypass factor calculation errors
+        # Calculate the SHR for each speed. Use maximum value of 0.98 to prevent E+ bypass factor calculation errors
         clg_ap.cool_rated_shrs_gross << [Psychrometrics.CalculateSHR(runner, dB_rated, p_atm, UnitConversions.convert(capacity_ratio, 'ton', 'kBtu/hr'), clg_ap.cool_rated_cfm_per_ton[i] * capacity_ratio, ao, win), 0.98].min
       end
     end


### PR DESCRIPTION
looking at the line where clg_ap.cool_rated_shrs_gross is assigned, it is clear that 0.98 is an upper bound on the SHR, not a lower bound.

## change comments in hvac.rb master? can't edit directly b.c. it is a protected branch. not sure if a PR is the best mechanism for this but wanted to notify OS-HPXML team of this error.

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] ~~Schematron validator (`EPvalidator.xml`) has been updated~~
- [ ] ~~Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)~~
- [ ] ~~Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)~~
- [ ] ~~Documentation has been updated~~
- [ ] ~~Changelog has been updated~~
- [ ] ~~`openstudio tasks.rb update_measures` has been run~~
- [ ] ~~No unexpected changes to simulation results of sample files~~
