### PR TITLE
Removes capacity ratio from `hvac_sizing.rb`

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>c499cb45-42e3-424b-b657-4c564e580e37</version_id>
-  <version_modified>2024-07-09T22:10:01Z</version_modified>
+  <version_id>dbc3dfc2-9c3a-4e90-93d5-3d8bab101ab7</version_id>
+  <version_modified>2024-07-09T22:21:06Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -387,7 +387,7 @@
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>DAB7BB03</checksum>
+      <checksum>BE86BF08</checksum>
     </file>
     <file>
       <filename>lighting.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>657677c3-58a6-4357-bfe1-fcd7f6b039eb</version_id>
-  <version_modified>2024-07-06T05:17:52Z</version_modified>
+  <version_id>c499cb45-42e3-424b-b657-4c564e580e37</version_id>
+  <version_modified>2024-07-09T22:10:01Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -387,7 +387,7 @@
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>3B3F9CA8</checksum>
+      <checksum>DAB7BB03</checksum>
     </file>
     <file>
       <filename>lighting.rb</filename>
@@ -622,24 +622,6 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>E12E2D75</checksum>
-    </file>
-    <file>
-      <filename>in.schedules.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>test</usage_type>
-      <checksum>2B9C5C95</checksum>
-    </file>
-    <file>
-      <filename>results_annual.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>test</usage_type>
-      <checksum>3C4C7BF6</checksum>
-    </file>
-    <file>
-      <filename>results_design_load_details.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>test</usage_type>
-      <checksum>0892DD62</checksum>
     </file>
     <file>
       <filename>test_airflow.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -3597,13 +3597,13 @@ module HVACSizing
       capacity_ratios = hvac_ap.heat_capacity_ratios
     end
     if not capacity_ratios.nil?
-      for speed in 0..(capacity_ratios.size - 1)
-        # Select curves for sizing using the speed with the capacity ratio of 1
-        next if capacity_ratios[speed] != 1
+      nominal_speed = capacity_ratios.index(1.0)
 
-        return speed
+      if nominal_speed.nil?
+        fail 'No nominal speed (with capacity ratio of 1.0) found.'
       end
-      fail 'No speed with capacity ratio of 1.0 found.'
+
+      return nominal_speed
     end
     return 0
   end


### PR DESCRIPTION
## Pull Request Description

We can simplify `hvac_sizing.rb` since [the capacity ratio is always 1 at the nominal speed](https://github.com/NREL/OpenStudio-HPXML/blob/96b31f5e59b024f2165d66ae55aa3c86debb4437/HPXMLtoOpenStudio/resources/hvac_sizing.rb#L3609). If this is correct, there should be no CI diffs. (We previously used to have situations where there wasn't a speed in the array where the capacity ratio was exactly 1.)

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
