### PR TITLE
Rename slab variables in BuildResidentialHPXML measure

### DIFF
--- a/BuildResidentialHPXML/README.md
+++ b/BuildResidentialHPXML/README.md
@@ -1011,7 +1011,7 @@ Nominal R-value of the vertical slab perimeter insulation. Applies to slab-on-gr
 
 Depth from grade to bottom of vertical slab perimeter insulation. Applies to slab-on-grade foundations and basement/crawlspace floors.
 
-- **Name:** ``slab_perimeter_depth``
+- **Name:** ``slab_perimeter_insulation_depth``
 - **Type:** ``Double``
 
 - **Units:** ``ft``
@@ -1037,7 +1037,7 @@ Nominal R-value of the horizontal under slab insulation. Applies to slab-on-grad
 
 Width from slab edge inward of horizontal under-slab insulation. Enter 999 to specify that the under slab insulation spans the entire slab. Applies to slab-on-grade foundations and basement/crawlspace floors.
 
-- **Name:** ``slab_under_width``
+- **Name:** ``slab_under_insulation_width``
 - **Type:** ``Double``
 
 - **Units:** ``ft``

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -632,7 +632,7 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue(0)
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('slab_perimeter_depth', true)
+    arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('slab_perimeter_insulation_depth', true)
     arg.setDisplayName('Slab: Perimeter Insulation Depth')
     arg.setUnits('ft')
     arg.setDescription('Depth from grade to bottom of vertical slab perimeter insulation. Applies to slab-on-grade foundations and basement/crawlspace floors.')
@@ -646,7 +646,7 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue(0)
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('slab_under_width', true)
+    arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('slab_under_insulation_width', true)
     arg.setDisplayName('Slab: Under Slab Insulation Width')
     arg.setUnits('ft')
     arg.setDescription('Width from slab edge inward of horizontal under-slab insulation. Enter 999 to specify that the under slab insulation spans the entire slab. Applies to slab-on-grade foundations and basement/crawlspace floors.')
@@ -5157,10 +5157,10 @@ module HPXMLFile
         exposed_perimeter -= Geometry.get_unexposed_garage_perimeter(**args)
       end
 
-      if args[:slab_under_width] >= 999
+      if args[:slab_under_insulation_width] >= 999
         under_slab_insulation_spans_entire_slab = true
       else
-        under_slab_insulation_width = args[:slab_under_width]
+        under_slab_insulation_width = args[:slab_under_insulation_width]
       end
 
       hpxml_bldg.slabs.add(id: "Slab#{hpxml_bldg.slabs.size + 1}",
@@ -5168,7 +5168,7 @@ module HPXMLFile
                            area: UnitConversions.convert(surface.grossArea, 'm^2', 'ft^2'),
                            thickness: args[:slab_thickness],
                            exposed_perimeter: exposed_perimeter,
-                           perimeter_insulation_depth: args[:slab_perimeter_depth],
+                           perimeter_insulation_depth: args[:slab_perimeter_insulation_depth],
                            under_slab_insulation_width: under_slab_insulation_width,
                            perimeter_insulation_r_value: args[:slab_perimeter_insulation_r],
                            under_slab_insulation_r_value: args[:slab_under_insulation_r],

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>525d3c0b-3d9e-4b1d-b3f7-8e8e45fbcab4</version_id>
-  <version_modified>2024-07-10T20:17:56Z</version_modified>
+  <version_id>635a8ab6-45f1-4969-b2c5-f308519438f8</version_id>
+  <version_modified>2024-07-11T16:09:59Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -1403,7 +1403,7 @@
       <default_value>0</default_value>
     </argument>
     <argument>
-      <name>slab_perimeter_depth</name>
+      <name>slab_perimeter_insulation_depth</name>
       <display_name>Slab: Perimeter Insulation Depth</display_name>
       <description>Depth from grade to bottom of vertical slab perimeter insulation. Applies to slab-on-grade foundations and basement/crawlspace floors.</description>
       <type>Double</type>
@@ -1423,7 +1423,7 @@
       <default_value>0</default_value>
     </argument>
     <argument>
-      <name>slab_under_width</name>
+      <name>slab_under_insulation_width</name>
       <display_name>Slab: Under Slab Insulation Width</display_name>
       <description>Width from slab edge inward of horizontal under-slab insulation. Enter 999 to specify that the under slab insulation spans the entire slab. Applies to slab-on-grade foundations and basement/crawlspace floors.</description>
       <type>Double</type>
@@ -7389,7 +7389,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>C1C29998</checksum>
+      <checksum>BD785B9E</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -7406,7 +7406,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>FE686F50</checksum>
+      <checksum>F41033B3</checksum>
     </file>
     <file>
       <filename>geometry.rb</filename>
@@ -7418,7 +7418,7 @@
       <filename>test_build_residential_hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>A40F646C</checksum>
+      <checksum>C0AF4CE1</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/tests/test_build_residential_hpxml.rb
+++ b/BuildResidentialHPXML/tests/test_build_residential_hpxml.rb
@@ -430,9 +430,9 @@ class BuildResidentialHPXMLTest < Minitest::Test
       args['foundation_wall_insulation_distance_to_bottom'] = 8.0
       args['rim_joist_assembly_r'] = 23.0
       args['slab_perimeter_insulation_r'] = 0
-      args['slab_perimeter_depth'] = 0
+      args['slab_perimeter_insulation_depth'] = 0
       args['slab_under_insulation_r'] = 0
-      args['slab_under_width'] = 0
+      args['slab_under_insulation_width'] = 0
       args['slab_thickness'] = 4.0
       args['slab_carpet_fraction'] = 0.0
       args['slab_carpet_r'] = 0.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,9 @@ __New Features__
   - Optional input `SimulationControl/AdvancedResearchFeatures/OnOffThermostatDeadbandTemperature` to model on/off thermostat deadband with start-up degradation for single and two speed AC/ASHP systems and time-based realistic staging for two speed AC/ASHP systems.
   - Optional input `SimulationControl/AdvancedResearchFeatures/HeatPumpBackupCapacityIncrement` to model multi-stage electric backup coils with time-based staging.
   - Maximum power ratio detailed schedule for variable-speed HVAC systems can now be used with `NumberofUnits` dwelling unit multiplier.
+- BuildResidentialScheduleFile measure:
+  - **Breaking change**: Replaced `slab_under_width` argument with `slab_under_insulation_width`.
+  - **Breaking change**: Replaced `slab_perimeter_depth` argument with `slab_perimeter_insulation_depth`.
 
 __Bugfixes__
 - Prevents possible error when using multiple `Attic`/`Foundation` elements for the same attic/foundation type.

--- a/workflow/hpxml_inputs.json
+++ b/workflow/hpxml_inputs.json
@@ -34,9 +34,9 @@
     "foundation_wall_insulation_distance_to_bottom": 0,
     "rim_joist_assembly_r": 5.01,
     "slab_perimeter_insulation_r": 0,
-    "slab_perimeter_depth": 0,
+    "slab_perimeter_insulation_depth": 0,
     "slab_under_insulation_r": 0,
-    "slab_under_width": 0,
+    "slab_under_insulation_width": 0,
     "slab_thickness": 4,
     "slab_carpet_fraction": 0,
     "slab_carpet_r": 0,
@@ -279,7 +279,7 @@
   "tests/ASHRAE_Standard_140/L304XC.xml": {
     "parent_hpxml": "tests/ASHRAE_Standard_140/L302XC.xml",
     "slab_perimeter_insulation_r": 5.4,
-    "slab_perimeter_depth": 2.5
+    "slab_perimeter_insulation_depth": 2.5
   },
   "tests/ASHRAE_Standard_140/L322XC.xml": {
     "parent_hpxml": "tests/ASHRAE_Standard_140/L100AC.xml",
@@ -639,9 +639,9 @@
     "foundation_wall_insulation_distance_to_bottom": 8,
     "rim_joist_assembly_r": 23,
     "slab_perimeter_insulation_r": 0,
-    "slab_perimeter_depth": 0,
+    "slab_perimeter_insulation_depth": 0,
     "slab_under_insulation_r": 0,
-    "slab_under_width": 0,
+    "slab_under_insulation_width": 0,
     "slab_thickness": 4,
     "slab_carpet_fraction": 0,
     "slab_carpet_r": 0,
@@ -1813,12 +1813,12 @@
   "sample_files/base-foundation-conditioned-basement-slab-insulation.xml": {
     "parent_hpxml": "sample_files/base.xml",
     "slab_under_insulation_r": 10,
-    "slab_under_width": 4
+    "slab_under_insulation_width": 4
   },
   "sample_files/base-foundation-conditioned-basement-slab-insulation-full.xml": {
     "parent_hpxml": "sample_files/base.xml",
     "slab_under_insulation_r": 10,
-    "slab_under_width": 999
+    "slab_under_insulation_width": 999
   },
   "sample_files/base-foundation-conditioned-basement-wall-insulation.xml": {
     "parent_hpxml": "sample_files/base.xml",
@@ -1847,7 +1847,7 @@
     "geometry_foundation_height": 0,
     "geometry_foundation_height_above_grade": 0,
     "slab_under_insulation_r": 5,
-    "slab_under_width": 999,
+    "slab_under_insulation_width": 999,
     "slab_carpet_fraction": 1,
     "slab_carpet_r": 2.5,
     "ducts_supply_location": "under slab",


### PR DESCRIPTION
## Pull Request Description

Closes #1772. Renames slab arguments in BuildResidentialHPXML measure for clarity.
  - **Breaking change**: Replaced `slab_under_width` argument with `slab_under_insulation_width`.
  - **Breaking change**: Replaced `slab_perimeter_depth` argument with `slab_perimeter_insulation_depth`.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
