### PR TITLE
Very high duct LtO warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ __New Features__
   - **Breaking change**: Replaced `slab_under_width` argument with `slab_under_insulation_width`.
   - **Breaking change**: Replaced `slab_perimeter_depth` argument with `slab_perimeter_insulation_depth`.
 - **Breaking change**: Disaggregates "Walls" into "Above Grade Walls" and "Below Grade Walls" in results_design_load_details.csv output file.
+- Adds a warning if the sum of supply/return duct leakage to outside values is very high.
 
 __Bugfixes__
 - Prevents possible error when using multiple `Attic`/`Foundation` elements for the same attic/foundation type.

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -2243,24 +2243,37 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
       next unless hvac_distribution.distribution_system_type == HPXML::HVACDistributionTypeAir
       next if hvac_distribution.duct_leakage_measurements.empty?
 
-      # Skip if there's a duct outside conditioned space
-      next if hvac_distribution.ducts.select { |d| !HPXML::conditioned_locations_this_unit.include?(d.duct_location) }.size > 0
-
-      # Issue warning if duct leakage to outside above a certain threshold and ducts completely in conditioned space
-      issue_warning = false
       units = hvac_distribution.duct_leakage_measurements[0].duct_leakage_units
       lto_measurements = hvac_distribution.duct_leakage_measurements.select { |dlm| dlm.duct_leakage_total_or_to_outside == HPXML::DuctLeakageToOutside }
       sum_lto = lto_measurements.map { |dlm| dlm.duct_leakage_value }.sum(0.0)
-      if units == HPXML::UnitsCFM25
-        issue_warning = true if sum_lto > 0.04 * @cfa
-      elsif units == HPXML::UnitsCFM50
-        issue_warning = true if sum_lto > 0.06 * @cfa
-      elsif units == HPXML::UnitsPercent
-        issue_warning = true if sum_lto > 0.05
-      end
-      next unless issue_warning
 
-      runner.registerWarning('Ducts are entirely within conditioned space but there is moderate leakage to the outside. Leakage to the outside is typically zero or near-zero in these situations, consider revising leakage values. Leakage will be modeled as heat lost to the ambient environment.')
+      if hvac_distribution.ducts.select { |d| !HPXML::conditioned_locations_this_unit.include?(d.duct_location) }.size == 0
+        # If ducts completely in conditioned space, issue warning if duct leakage to outside above a certain threshold (e.g., 5%)
+        issue_warning = false
+        if units == HPXML::UnitsCFM25
+          issue_warning = true if sum_lto > 0.04 * @cfa
+        elsif units == HPXML::UnitsCFM50
+          issue_warning = true if sum_lto > 0.06 * @cfa
+        elsif units == HPXML::UnitsPercent
+          issue_warning = true if sum_lto > 0.05
+        end
+        next unless issue_warning
+
+        runner.registerWarning('Ducts are entirely within conditioned space but there is moderate leakage to the outside. Leakage to the outside is typically zero or near-zero in these situations, consider revising leakage values. Leakage will be modeled as heat lost to the ambient environment.')
+      else
+        # If ducts in unconditioned space, issue warning if duct leakage to outside above a certain threshold (e.g., 40%)
+        issue_warning = false
+        if units == HPXML::UnitsCFM25
+          issue_warning = true if sum_lto >= 0.32 * @cfa
+        elsif units == HPXML::UnitsCFM50
+          issue_warning = true if sum_lto >= 0.48 * @cfa
+        elsif units == HPXML::UnitsPercent
+          issue_warning = true if sum_lto >= 0.4
+        end
+        next unless issue_warning
+
+        runner.registerWarning('Very high sum of supply + return duct leakage to the outside; double-check inputs.')
+      end
     end
 
     # Create HVAC availability sensor

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>db434054-c05b-45ce-8134-a195100fecaf</version_id>
-  <version_modified>2024-08-06T21:58:01Z</version_modified>
+  <version_id>1e53409d-e1f7-4601-b844-44334353a9d3</version_id>
+  <version_modified>2024-08-07T23:14:09Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -183,7 +183,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F1B9845C</checksum>
+      <checksum>B94E724C</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
@@ -381,7 +381,7 @@
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>5C9B0A1C</checksum>
+      <checksum>621EB8F8</checksum>
     </file>
     <file>
       <filename>hvac_sizing.rb</filename>
@@ -723,7 +723,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>CFDFF5FB</checksum>
+      <checksum>D243A782</checksum>
     </file>
     <file>
       <filename>test_water_heater.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -5027,7 +5027,7 @@ module HVAC
       end
 
       if seer_eq <= 0
-        fail "Negative SEER equivalent calculated for cooling system '#{cooling_system.id}', double check inputs."
+        fail "Negative SEER equivalent calculated for cooling system '#{cooling_system.id}', double-check inputs."
       end
 
       cooling_system.cooling_system_type = HPXML::HVACTypeCentralAirConditioner


### PR DESCRIPTION
## Pull Request Description

Closes #1790. Adds a warning if the sum of supply/return duct leakage to outside values is very high.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
