### PR TITLE
Prevent partial outputs when error

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3818f9b2-1396-4d2f-8556-5245f035f8e2</version_id>
-  <version_modified>2024-09-17T21:45:12Z</version_modified>
+  <version_id>05f72384-5d38-4f10-81d0-1fda7397f468</version_id>
+  <version_modified>2024-09-17T23:36:16Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -183,7 +183,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>AE303996</checksum>
+      <checksum>1C013D19</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
@@ -357,7 +357,7 @@
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>4F6E5BAE</checksum>
+      <checksum>87C6D4D7</checksum>
     </file>
     <file>
       <filename>hpxml_schema/HPXML.xsd</filename>
@@ -393,7 +393,7 @@
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>9E3F6A59</checksum>
+      <checksum>830F4353</checksum>
     </file>
     <file>
       <filename>internal_gains.rb</filename>
@@ -453,7 +453,7 @@
       <filename>output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>67DCE0D1</checksum>
+      <checksum>F19EA74F</checksum>
     </file>
     <file>
       <filename>psychrometrics.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>05f72384-5d38-4f10-81d0-1fda7397f468</version_id>
-  <version_modified>2024-09-17T23:36:16Z</version_modified>
+  <version_id>e75588d5-a38c-480a-a4fb-3379313018a1</version_id>
+  <version_modified>2024-09-17T23:57:51Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -393,7 +393,7 @@
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>830F4353</checksum>
+      <checksum>9EDA01CC</checksum>
     </file>
     <file>
       <filename>internal_gains.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>e75588d5-a38c-480a-a4fb-3379313018a1</version_id>
-  <version_modified>2024-09-17T23:57:51Z</version_modified>
+  <version_id>4aeccf55-7efe-4b55-b392-a9d5bd7ae8d2</version_id>
+  <version_modified>2024-09-18T00:03:05Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -453,7 +453,7 @@
       <filename>output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>F19EA74F</checksum>
+      <checksum>94DB6377</checksum>
     </file>
     <file>
       <filename>psychrometrics.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -11,12 +11,8 @@ module HVACSizing
   # @param hpxml_bldg [HPXML::Building] HPXML Building object representing an individual dwelling unit
   # @param hvac_systems [Array<Hash>] List of HPXML HVAC (heating and/or cooling) systems
   # @param update_hpxml [Boolean] Whether to update the HPXML object so that in.xml reports capacities/airflows
-  # @param output_format [String] Detailed output file format ('csv', 'json', or 'msgpack')
-  # @param output_file_path [String] Detailed output file path
-  # @return [Hash] Map of HVAC systems => HVACSizingValues objects
-  def self.calculate(runner, weather, hpxml_bldg, hvac_systems, update_hpxml: true,
-                     output_format: 'csv', output_file_path: nil)
-
+  # @return [Array<Hash, Hash, Hash>] Maps of HVAC systems => HVACSizingValues objects, HPXML::Zones => DesignLoadValues object, HPXML::Spaces => DesignLoadValues object
+  def self.calculate(runner, weather, hpxml_bldg, hvac_systems, update_hpxml: true)
     check_for_errors(hpxml_bldg, hvac_systems)
 
     mj = MJValues.new
@@ -111,12 +107,7 @@ module HVACSizing
       end
     end
 
-    # Write detailed outputs (useful for Form J1)
-    if not output_file_path.nil?
-      write_detailed_output(output_format, output_file_path, hpxml_bldg, all_zone_loads, all_space_loads)
-    end
-
-    return @all_hvac_sizings
+    return @all_hvac_sizings, all_zone_loads, all_space_loads
   end
 
   # Checks whether we will be performing sizing calculations on the given HPXML HVAC system.
@@ -3162,7 +3153,7 @@ module HVACSizing
       # Calculate the heating load at the switchover temperature to limit unutilized capacity
       temp_heat_design_temp = hpxml_bldg.header.manualj_heating_design_temp
       hpxml_bldg.header.manualj_heating_design_temp = min_compressor_temp
-      alternate_all_hvac_sizings = calculate(runner, weather, hpxml_bldg, [hvac_system], update_hpxml: false)
+      alternate_all_hvac_sizings = calculate(runner, weather, hpxml_bldg, [hvac_system], update_hpxml: false)[0]
       heating_load = alternate_all_hvac_sizings[hvac_system].Heat_Load
       heating_temp = min_compressor_temp
       hpxml_bldg.header.manualj_heating_design_temp = temp_heat_design_temp
@@ -4794,8 +4785,8 @@ module HVACSizing
     end
 
     # Note: Every report name must have the HPXML BuildingID in it in case we are running a whole MF building with multiple Building elements.
-    if hpxml_bldg.conditioned_zones[0].id.start_with?(Constants::AutomaticallyAdded)
-      zone_col_names = ["#{hpxml_bldg.building_id}"] # Leave out name of automatically added zone
+    if hpxml_bldg.conditioned_zones.empty?
+      zone_col_names = ["#{hpxml_bldg.building_id}"]
     else
       zone_col_names = all_zone_loads.keys.map { |zone| "#{hpxml_bldg.building_id}: #{zone.id}" }
     end

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -4824,27 +4824,32 @@ module HVACSizing
 
     # Zone results
     all_zone_loads.keys.each_with_index do |zone, i|
+      if hpxml_bldg.conditioned_zones.empty?
+        zone_or_bldg = hpxml_bldg
+      else
+        zone_or_bldg = zone
+      end
       results_out << [line_break]
       results_out << ["Report: #{zone_col_names[i]}: Loads", 'Area (ft^2)', 'Length (ft)', 'Wall Area Ratio', 'Heating (Btuh)', 'Cooling Sensible (Btuh)', 'Cooling Latent (Btuh)']
-      get_surfaces_with_property(zone, :detailed_output_values_windows).each do |window, fj1|
+      get_surfaces_with_property(zone_or_bldg, :detailed_output_values_windows).each do |window, fj1|
         results_out << ["Windows: #{window.id}", fj1.Area, fj1.Length, nil, fj1.Heat_Load, fj1.Cool_Load_Sens]
       end
-      get_surfaces_with_property(zone, :detailed_output_values_skylights).each do |skylight, fj1|
+      get_surfaces_with_property(zone_or_bldg, :detailed_output_values_skylights).each do |skylight, fj1|
         results_out << ["Skylights: #{skylight.id}", fj1.Area, fj1.Length, nil, fj1.Heat_Load, fj1.Cool_Load_Sens]
       end
-      get_surfaces_with_property(zone, :detailed_output_values_doors).each do |door, fj1|
+      get_surfaces_with_property(zone_or_bldg, :detailed_output_values_doors).each do |door, fj1|
         results_out << ["Doors: #{door.id}", fj1.Area, fj1.Length, nil, fj1.Heat_Load, fj1.Cool_Load_Sens]
       end
-      get_surfaces_with_property(zone, :detailed_output_values_above_grade_walls).each do |wall, fj1|
+      get_surfaces_with_property(zone_or_bldg, :detailed_output_values_above_grade_walls).each do |wall, fj1|
         results_out << ["Above Grade Walls: #{wall.id}", fj1.Area, fj1.Length, nil, fj1.Heat_Load, fj1.Cool_Load_Sens]
       end
-      get_surfaces_with_property(zone, :detailed_output_values_below_grade_walls).each do |wall, fj1|
+      get_surfaces_with_property(zone_or_bldg, :detailed_output_values_below_grade_walls).each do |wall, fj1|
         results_out << ["Below Grade Walls: #{wall.id}", fj1.Area, fj1.Length, nil, fj1.Heat_Load, fj1.Cool_Load_Sens]
       end
-      get_surfaces_with_property(zone, :detailed_output_values_ceilings).each do |ceiling, fj1|
+      get_surfaces_with_property(zone_or_bldg, :detailed_output_values_ceilings).each do |ceiling, fj1|
         results_out << ["Ceilings: #{ceiling.id}", fj1.Area, fj1.Length, nil, fj1.Heat_Load, fj1.Cool_Load_Sens]
       end
-      get_surfaces_with_property(zone, :detailed_output_values_floors).each do |floor, fj1|
+      get_surfaces_with_property(zone_or_bldg, :detailed_output_values_floors).each do |floor, fj1|
         results_out << ["Floors: #{floor.id}", fj1.Area, fj1.Length, nil, fj1.Heat_Load, fj1.Cool_Load_Sens]
       end
       zone_loads = all_zone_loads[zone]

--- a/HPXMLtoOpenStudio/resources/output.rb
+++ b/HPXMLtoOpenStudio/resources/output.rb
@@ -1220,6 +1220,7 @@ module Outputs
         require 'json'
         File.open(output_file_path, mode) { |json| json.write(JSON.pretty_generate(h)) }
       elsif output_format == 'msgpack'
+        require 'msgpack'
         File.open(output_file_path, "#{mode}b") { |json| h.to_msgpack(json) }
       end
     end

--- a/HPXMLtoOpenStudio/resources/output.rb
+++ b/HPXMLtoOpenStudio/resources/output.rb
@@ -917,7 +917,7 @@ module Outputs
   # @param model [OpenStudio::Model::Model] OpenStudio Model object
   # @param debug [Boolean] If true,  writes in.osm, generates additional log output, and creates all E+ output files
   # @return [nil]
-  def self.apply_output_files(model, debug)
+  def self.apply_output_file_controls(model, debug)
     oj = model.getOutputJSON
     oj.setOptionType('TimeSeriesAndTabular')
     oj.setOutputJSON(debug)


### PR DESCRIPTION
## Pull Request Description

Fixes #1835. We now write the output files at the very end of the HPXMLtoOpenStudio measure.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
