### PR TITLE
Fix `HeatingPerformanceDataPoint.delete` method

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>1424b04d-aae3-4360-9d50-3324d0babb33</version_id>
-  <version_modified>2024-10-05T18:13:33Z</version_modified>
+  <version_id>16835647-9a13-44b7-b907-a57abf30a8d4</version_id>
+  <version_modified>2024-10-11T14:51:15Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -357,7 +357,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>278B0E8F</checksum>
+      <checksum>AF9C179B</checksum>
     </file>
     <file>
       <filename>hpxml_schema/HPXML.xsd</filename>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -11132,7 +11132,7 @@ class HPXML < Object
     # @return [nil]
     def delete
       (@parent_object.heating_systems + @parent_object.heat_pumps).each do |heating_system|
-        heating_system.cooling_detailed_performance_data.delete(self)
+        heating_system.heating_detailed_performance_data.delete(self)
       end
     end
 

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -3977,9 +3977,7 @@ Each conventional storage water heater is entered as a ``/HPXML/Building/Buildin
          If neither UsageBin nor FirstHourRating provided, UsageBin defaults to "medium".
          If FirstHourRating provided and UsageBin not provided, UsageBin is determined based on the FirstHourRating value.
   .. [#] RecoveryEfficiency must also be greater than the EnergyFactor (or UniformEnergyFactor).
-  .. [#] If RecoveryEfficiency not provided, defaults as follows based on a regression analysis of `AHRI certified water heaters <https://www.ahridirectory.org/NewSearch?programId=24&searchTypeId=3>`_:
-         
-         \- **Electric**: 0.98
+  .. [#] If RecoveryEfficiency not provided, defaults to 0.98 if the fuel type is electric, otherwise based on a regression analysis of `AHRI certified water heaters <https://www.ahridirectory.org/NewSearch?programId=24&searchTypeId=3>`_:
          
          \- **Non-electric, EnergyFactor < 0.75**: 0.252 * EnergyFactor + 0.608
          


### PR DESCRIPTION
## Pull Request Description

Spotted by @joseph-robertson. Most likely we aren't using the method right now or we would have hit an issue with it.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
