### PR TITLE
Bugfix for results_design_load_details.csv

### DIFF
--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -301,7 +301,8 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     # This needs to come before we collapse enclosure surfaces
     design_loads_results_out = []
     hpxml.buildings.each do |hpxml_bldg|
-      HVACSizing.append_detailed_output(hpxml_bldg, hpxml_all_zone_loads[hpxml_bldg], hpxml_all_space_loads[hpxml_bldg], design_loads_results_out)
+      HVACSizing.append_detailed_output(args[:output_format], hpxml_bldg, hpxml_all_zone_loads[hpxml_bldg],
+                                        hpxml_all_space_loads[hpxml_bldg], design_loads_results_out)
     end
 
     return hpxml_sch_map, design_loads_results_out

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -121,7 +121,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
       # Do these once upfront for the entire HPXML object
       epw_path, weather = process_weather(runner, hpxml, args)
       process_whole_sfa_mf_inputs(hpxml)
-      hpxml_sch_map, hpxml_all_zone_loads, hpxml_all_space_loads = process_defaults_schedules_emissions_files(runner, weather, hpxml, args)
+      hpxml_sch_map, design_loads_results_out = process_defaults_schedules_emissions_files(runner, weather, hpxml, args)
 
       # Write updated HPXML object (w/ defaults) to file for inspection
       XMLHelper.write_file(hpxml.to_doc, args[:hpxml_defaults_path])
@@ -157,16 +157,13 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
 
       # Write annual results output file
       # This is helpful if the user wants to get these results right away (e.g.,
-      # they might be using the run_simulation.rb --skip-simulation argument.
-      results_out = []
-      Outputs.append_sizing_results(hpxml.buildings, results_out)
-      Outputs.write_results_out_to_file(results_out, args[:output_format], args[:annual_output_file_path])
+      # they might be using the run_simulation.rb --skip-simulation argument).
+      annual_results_out = []
+      Outputs.append_sizing_results(hpxml.buildings, annual_results_out)
+      Outputs.write_results_out_to_file(annual_results_out, args[:output_format], args[:annual_output_file_path])
 
       # Write design load details output file
-      hpxml.buildings.each do |hpxml_bldg|
-        HVACSizing.write_detailed_output(args[:output_format], args[:design_load_details_output_file_path],
-                                         hpxml_bldg, hpxml_all_zone_loads[hpxml_bldg], hpxml_all_space_loads[hpxml_bldg])
-      end
+      HVACSizing.write_detailed_output(design_loads_results_out, args[:output_format], args[:design_load_details_output_file_path])
     rescue Exception => e
       runner.registerError("#{e.message}\n#{e.backtrace.join("\n")}")
       return false
@@ -273,7 +270,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
   # @param weather [WeatherFile] Weather object containing EPW information
   # @param hpxml [HPXML] HPXML object
   # @param args [Hash] Map of :argument_name => value
-  # @return [Array<Hash, Hash, Hash>] Maps of HPXML Building => SchedulesFile object, HPXML Building => (Map of HPXML::Zones => DesignLoadValues object), HPXML Building => (Map of HPXML::Spaces => DesignLoadValues object)
+  # @return [Array<Hash, Array>] Maps of HPXML Building => SchedulesFile object, Rows of design loads output data
   def process_defaults_schedules_emissions_files(runner, weather, hpxml, args)
     hpxml_sch_map = {}
     hpxml_all_zone_loads = {}
@@ -300,7 +297,14 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     Schedule.check_emissions_references(hpxml.header, args[:hpxml_path])
     Schedule.validate_emissions_files(hpxml.header)
 
-    return hpxml_sch_map, hpxml_all_zone_loads, hpxml_all_space_loads
+    # Compile design load outputs for subsequent writing
+    # This needs to come before we collapse enclosure surfaces
+    design_loads_results_out = []
+    hpxml.buildings.each do |hpxml_bldg|
+      HVACSizing.append_detailed_output(hpxml_bldg, hpxml_all_zone_loads[hpxml_bldg], hpxml_all_space_loads[hpxml_bldg], design_loads_results_out)
+    end
+
+    return hpxml_sch_map, design_loads_results_out
   end
 
   # Creates a full OpenStudio model that represents the given HPXML individual dwelling by

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>64c3bdea-b4b3-4254-9b2a-23987ae4e9f3</version_id>
-  <version_modified>2024-10-25T00:51:54Z</version_modified>
+  <version_id>3fc03854-d418-4b79-a205-a24e0a715c1e</version_id>
+  <version_modified>2024-10-30T01:52:33Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -183,7 +183,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E1E63AE7</checksum>
+      <checksum>779C018D</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
@@ -393,7 +393,7 @@
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>CD77F9C7</checksum>
+      <checksum>485A43BF</checksum>
     </file>
     <file>
       <filename>internal_gains.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3fc03854-d418-4b79-a205-a24e0a715c1e</version_id>
-  <version_modified>2024-10-30T01:52:33Z</version_modified>
+  <version_id>0afcab4c-84c4-48d2-bba4-8be0c8e3f1e1</version_id>
+  <version_modified>2024-10-30T03:25:11Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -183,7 +183,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>779C018D</checksum>
+      <checksum>D7F18DFB</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
@@ -393,7 +393,7 @@
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>485A43BF</checksum>
+      <checksum>10626CF1</checksum>
     </file>
     <file>
       <filename>internal_gains.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>0afcab4c-84c4-48d2-bba4-8be0c8e3f1e1</version_id>
-  <version_modified>2024-10-30T03:25:11Z</version_modified>
+  <version_id>af21de2e-e4ba-4fda-9f29-f4ad94d0475c</version_id>
+  <version_modified>2024-10-30T04:55:55Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -693,7 +693,7 @@
       <filename>test_hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>C88CFFFC</checksum>
+      <checksum>475611E3</checksum>
     </file>
     <file>
       <filename>test_lighting.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -4895,13 +4895,19 @@ module HVACSizing
   # Appends additional detailed information needed to fill out, e.g., an ACCA Form J1 to the provided array
   # for eventual writing to an output file.
   #
+  # @param output_format [String] Detailed output file format ('csv', 'json', or 'msgpack')
   # @param hpxml_bldg [HPXML::Building] HPXML Building object representing an individual dwelling unit
   # @param all_zone_loads [Hash] Map of HPXML::Zones => DesignLoadValues object
   # @param all_space_loads [Hash] Map of HPXML::Spaces => DesignLoadValues object
   # @param results_out [Array] Rows of output data
   # @return [nil]
-  def self.append_detailed_output(hpxml_bldg, all_zone_loads, all_space_loads, results_out)
+  def self.append_detailed_output(output_format, hpxml_bldg, all_zone_loads, all_space_loads, results_out)
     line_break = nil
+
+    if (output_format == 'csv') && (not results_out.empty?)
+      # Separate from existing data with line break
+      results_out << [line_break]
+    end
 
     orientation_map = { HPXML::OrientationEast => 'E',
                         HPXML::OrientationNorth => 'N',
@@ -5056,11 +5062,8 @@ module HVACSizing
   # @param output_file_path [String] Detailed output file path
   # @return [nil]
   def self.write_detailed_output(results_out, output_format, output_file_path)
+    line_break = nil
     if ['csv'].include? output_format
-      if File.exist? output_file_path
-        # Separate from existing data
-        results_out.insert(0, [line_break])
-      end
       CSV.open(output_file_path, 'a') { |csv| results_out.to_a.each { |elem| csv << elem } }
     elsif ['json', 'msgpack'].include? output_format
       h = {}
@@ -5086,10 +5089,6 @@ module HVACSizing
           items[columns[i - 1]] = out[i]
         end
         h[report][name] = items
-      end
-
-      if File.exist? output_file_path
-        h = JSON.parse(File.read(output_file_path)).merge(h)
       end
 
       if output_format == 'json'

--- a/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -4892,17 +4892,16 @@ module HVACSizing
     end
   end
 
-  # Writes a output file with additional detailed information needed to fill out, e.g., an ACCA Form J1.
+  # Appends additional detailed information needed to fill out, e.g., an ACCA Form J1 to the provided array
+  # for eventual writing to an output file.
   #
-  # @param output_format [String] Detailed output file format ('csv', 'json', or 'msgpack')
-  # @param output_file_path [String] Detailed output file path
   # @param hpxml_bldg [HPXML::Building] HPXML Building object representing an individual dwelling unit
   # @param all_zone_loads [Hash] Map of HPXML::Zones => DesignLoadValues object
   # @param all_space_loads [Hash] Map of HPXML::Spaces => DesignLoadValues object
+  # @param results_out [Array] Rows of output data
   # @return [nil]
-  def self.write_detailed_output(output_format, output_file_path, hpxml_bldg, all_zone_loads, all_space_loads)
+  def self.append_detailed_output(hpxml_bldg, all_zone_loads, all_space_loads, results_out)
     line_break = nil
-    results_out = []
 
     orientation_map = { HPXML::OrientationEast => 'E',
                         HPXML::OrientationNorth => 'N',
@@ -5048,7 +5047,15 @@ module HVACSizing
     all_space_loads.values.each_with_index do |space_loads, i|
       results_out << [space_col_names[i]] + space_loads.HourlyFenestrationLoads.map { |l| l.round }
     end
+  end
 
+  # Writes an output file for the given rows of output data.
+  #
+  # @param results_out [Array] Rows of output data
+  # @param output_format [String] Detailed output file format ('csv', 'json', or 'msgpack')
+  # @param output_file_path [String] Detailed output file path
+  # @return [nil]
+  def self.write_detailed_output(results_out, output_format, output_file_path)
     if ['csv'].include? output_format
       if File.exist? output_file_path
         # Separate from existing data


### PR DESCRIPTION
## Pull Request Description

Fixes possibility of missing surfaces in the `results_design_load_details.csv` output file. Bug introduced in #1836.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
