### PR TITLE
Fix BuildResidentialHPXML docs links

### DIFF
--- a/BuildResidentialHPXML/README.md
+++ b/BuildResidentialHPXML/README.md
@@ -101,7 +101,7 @@ Specifies the unavailable period date ranges. Enter a date range like "Dec 15 - 
 
 **Schedules: Unavailable Period Window Natural Ventilation Availabilities**
 
-The availability of the natural ventilation schedule during unavailable periods. Valid choices are: regular schedule, always available, always unavailable. If multiple periods, use a comma-separated list. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-unavailable-periods'>HPXML Unavailable Periods</a>) is used.
+The availability of the natural ventilation schedule during unavailable periods. Valid choices are: regular schedule, always available, always unavailable. If multiple periods, use a comma-separated list. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-unavailable-periods'>HPXML Unavailable Periods</a>) is used.
 
 - **Name:** ``schedules_unavailable_period_window_natvent_availabilities``
 - **Type:** ``String``
@@ -112,7 +112,7 @@ The availability of the natural ventilation schedule during unavailable periods.
 
 **Simulation Control: Timestep**
 
-Value must be a divisor of 60. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
+Value must be a divisor of 60. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
 
 - **Name:** ``simulation_control_timestep``
 - **Type:** ``Integer``
@@ -125,7 +125,7 @@ Value must be a divisor of 60. If not provided, the OS-HPXML default (see <a hre
 
 **Simulation Control: Run Period**
 
-Enter a date range like 'Jan 1 - Dec 31'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
+Enter a date range like 'Jan 1 - Dec 31'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
 
 - **Name:** ``simulation_control_run_period``
 - **Type:** ``String``
@@ -136,7 +136,7 @@ Enter a date range like 'Jan 1 - Dec 31'. If not provided, the OS-HPXML default 
 
 **Simulation Control: Run Period Calendar Year**
 
-This numeric field should contain the calendar year that determines the start day of week. If you are running simulations using AMY weather files, the value entered for calendar year will not be used; it will be overridden by the actual year found in the AMY weather file. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
+This numeric field should contain the calendar year that determines the start day of week. If you are running simulations using AMY weather files, the value entered for calendar year will not be used; it will be overridden by the actual year found in the AMY weather file. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
 
 - **Name:** ``simulation_control_run_period_calendar_year``
 - **Type:** ``Integer``
@@ -149,7 +149,7 @@ This numeric field should contain the calendar year that determines the start da
 
 **Simulation Control: Daylight Saving Enabled**
 
-Whether to use daylight saving. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-site'>HPXML Building Site</a>) is used.
+Whether to use daylight saving. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-site'>HPXML Building Site</a>) is used.
 
 - **Name:** ``simulation_control_daylight_saving_enabled``
 - **Type:** ``Boolean``
@@ -160,7 +160,7 @@ Whether to use daylight saving. If not provided, the OS-HPXML default (see <a hr
 
 **Simulation Control: Daylight Saving Period**
 
-Enter a date range like 'Mar 15 - Dec 15'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-site'>HPXML Building Site</a>) is used.
+Enter a date range like 'Mar 15 - Dec 15'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-site'>HPXML Building Site</a>) is used.
 
 - **Name:** ``simulation_control_daylight_saving_period``
 - **Type:** ``String``
@@ -171,7 +171,7 @@ Enter a date range like 'Mar 15 - Dec 15'. If not provided, the OS-HPXML default
 
 **Simulation Control: Temperature Capacitance Multiplier**
 
-Affects the transient calculation of indoor air temperatures. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
+Affects the transient calculation of indoor air temperatures. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
 
 - **Name:** ``simulation_control_temperature_capacitance_multiplier``
 - **Type:** ``String``
@@ -182,7 +182,7 @@ Affects the transient calculation of indoor air temperatures. If not provided, t
 
 **Simulation Control: Defrost Model Type**
 
-Research feature to select the type of defrost model. Use standard for default E+ defrost setting. Use advanced for an improved model that better accounts for load and energy use during defrost; using advanced may impact simulation runtime. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
+Research feature to select the type of defrost model. Use standard for default E+ defrost setting. Use advanced for an improved model that better accounts for load and energy use during defrost; using advanced may impact simulation runtime. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
 
 - **Name:** ``simulation_control_defrost_model_type``
 - **Type:** ``Choice``
@@ -221,7 +221,7 @@ Research feature to model capacity increment of multi-stage heat pump backup sys
 
 **Site: Type**
 
-The type of site. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
+The type of site. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
 
 - **Name:** ``site_type``
 - **Type:** ``Choice``
@@ -234,7 +234,7 @@ The type of site. If not provided, the OS-HPXML default (see <a href='https://op
 
 **Site: Shielding of Home**
 
-Presence of nearby buildings, trees, obstructions for infiltration model. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
+Presence of nearby buildings, trees, obstructions for infiltration model. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
 
 - **Name:** ``site_shielding_of_home``
 - **Type:** ``Choice``
@@ -247,7 +247,7 @@ Presence of nearby buildings, trees, obstructions for infiltration model. If not
 
 **Site: Soil and Moisture Type**
 
-Type of soil and moisture. This is used to inform ground conductivity and diffusivity. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
+Type of soil and moisture. This is used to inform ground conductivity and diffusivity. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
 
 - **Name:** ``site_soil_and_moisture_type``
 - **Type:** ``Choice``
@@ -310,7 +310,7 @@ City/municipality of the home address.
 
 **Site: State Code**
 
-State code of the home address. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
+State code of the home address. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
 
 - **Name:** ``site_state_code``
 - **Type:** ``Choice``
@@ -334,7 +334,7 @@ Zip code of the home address. Either this or the Weather Station: EnergyPlus Wea
 
 **Site: Time Zone UTC Offset**
 
-Time zone UTC offset of the home address. Must be between -12 and 14. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
+Time zone UTC offset of the home address. Must be between -12 and 14. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
 
 - **Name:** ``site_time_zone_utc_offset``
 - **Type:** ``Double``
@@ -347,7 +347,7 @@ Time zone UTC offset of the home address. Must be between -12 and 14. If not pro
 
 **Site: Elevation**
 
-Elevation of the home address. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
+Elevation of the home address. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
 
 - **Name:** ``site_elevation``
 - **Type:** ``Double``
@@ -360,7 +360,7 @@ Elevation of the home address. If not provided, the OS-HPXML default (see <a hre
 
 **Site: Latitude**
 
-Latitude of the home address. Must be between -90 and 90. Use negative values for southern hemisphere. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
+Latitude of the home address. Must be between -90 and 90. Use negative values for southern hemisphere. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
 
 - **Name:** ``site_latitude``
 - **Type:** ``Double``
@@ -373,7 +373,7 @@ Latitude of the home address. Must be between -90 and 90. Use negative values fo
 
 **Site: Longitude**
 
-Longitude of the home address. Must be between -180 and 180. Use negative values for the western hemisphere. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
+Longitude of the home address. Must be between -180 and 180. Use negative values for the western hemisphere. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'>HPXML Site</a>) is used.
 
 - **Name:** ``site_longitude``
 - **Type:** ``Double``
@@ -541,7 +541,7 @@ The number of bedrooms in the unit.
 
 **Geometry: Unit Number of Bathrooms**
 
-The number of bathrooms in the unit. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-construction'>HPXML Building Construction</a>) is used.
+The number of bathrooms in the unit. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-construction'>HPXML Building Construction</a>) is used.
 
 - **Name:** ``geometry_unit_num_bathrooms``
 - **Type:** ``Integer``
@@ -593,7 +593,7 @@ Average distance from the floor to the ceiling.
 
 **Geometry: Unit Height Above Grade**
 
-Describes the above-grade height of apartment units on upper floors or homes above ambient or belly-and-wing foundations. It is defined as the height of the lowest conditioned floor above grade and is used to calculate the wind speed for the infiltration model. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-construction'>HPXML Building Construction</a>) is used.
+Describes the above-grade height of apartment units on upper floors or homes above ambient or belly-and-wing foundations. It is defined as the height of the lowest conditioned floor above grade and is used to calculate the wind speed for the infiltration model. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-construction'>HPXML Building Construction</a>) is used.
 
 - **Name:** ``geometry_unit_height_above_grade``
 - **Type:** ``Double``
@@ -814,7 +814,7 @@ The distance between the unit and the neighboring building to the right (not inc
 
 **Neighbor: Front Height**
 
-The height of the neighboring building to the front. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-neighbor-buildings'>HPXML Neighbor Building</a>) is used.
+The height of the neighboring building to the front. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-neighbor-buildings'>HPXML Neighbor Building</a>) is used.
 
 - **Name:** ``neighbor_front_height``
 - **Type:** ``Double``
@@ -827,7 +827,7 @@ The height of the neighboring building to the front. If not provided, the OS-HPX
 
 **Neighbor: Back Height**
 
-The height of the neighboring building to the back. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-neighbor-buildings'>HPXML Neighbor Building</a>) is used.
+The height of the neighboring building to the back. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-neighbor-buildings'>HPXML Neighbor Building</a>) is used.
 
 - **Name:** ``neighbor_back_height``
 - **Type:** ``Double``
@@ -840,7 +840,7 @@ The height of the neighboring building to the back. If not provided, the OS-HPXM
 
 **Neighbor: Left Height**
 
-The height of the neighboring building to the left. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-neighbor-buildings'>HPXML Neighbor Building</a>) is used.
+The height of the neighboring building to the left. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-neighbor-buildings'>HPXML Neighbor Building</a>) is used.
 
 - **Name:** ``neighbor_left_height``
 - **Type:** ``Double``
@@ -853,7 +853,7 @@ The height of the neighboring building to the left. If not provided, the OS-HPXM
 
 **Neighbor: Right Height**
 
-The height of the neighboring building to the right. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-neighbor-buildings'>HPXML Neighbor Building</a>) is used.
+The height of the neighboring building to the right. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-neighbor-buildings'>HPXML Neighbor Building</a>) is used.
 
 - **Name:** ``neighbor_right_height``
 - **Type:** ``Double``
@@ -905,7 +905,7 @@ The type of floors.
 
 **Foundation Wall: Type**
 
-The material type of the foundation wall. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-foundation-walls'>HPXML Foundation Walls</a>) is used.
+The material type of the foundation wall. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-foundation-walls'>HPXML Foundation Walls</a>) is used.
 
 - **Name:** ``foundation_wall_type``
 - **Type:** ``Choice``
@@ -918,7 +918,7 @@ The material type of the foundation wall. If not provided, the OS-HPXML default 
 
 **Foundation Wall: Thickness**
 
-The thickness of the foundation wall. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-foundation-walls'>HPXML Foundation Walls</a>) is used.
+The thickness of the foundation wall. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-foundation-walls'>HPXML Foundation Walls</a>) is used.
 
 - **Name:** ``foundation_wall_thickness``
 - **Type:** ``Double``
@@ -957,7 +957,7 @@ Whether the insulation is on the interior or exterior of the foundation wall. On
 
 **Foundation Wall: Insulation Distance To Top**
 
-The distance from the top of the foundation wall to the top of the foundation wall insulation. Only applies to basements/crawlspaces. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-foundation-walls'>HPXML Foundation Walls</a>) is used.
+The distance from the top of the foundation wall to the top of the foundation wall insulation. Only applies to basements/crawlspaces. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-foundation-walls'>HPXML Foundation Walls</a>) is used.
 
 - **Name:** ``foundation_wall_insulation_distance_to_top``
 - **Type:** ``Double``
@@ -970,7 +970,7 @@ The distance from the top of the foundation wall to the top of the foundation wa
 
 **Foundation Wall: Insulation Distance To Bottom**
 
-The distance from the top of the foundation wall to the bottom of the foundation wall insulation. Only applies to basements/crawlspaces. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-foundation-walls'>HPXML Foundation Walls</a>) is used.
+The distance from the top of the foundation wall to the bottom of the foundation wall insulation. Only applies to basements/crawlspaces. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-foundation-walls'>HPXML Foundation Walls</a>) is used.
 
 - **Name:** ``foundation_wall_insulation_distance_to_bottom``
 - **Type:** ``Double``
@@ -1100,7 +1100,7 @@ Width from slab edge inward of horizontal under-slab insulation. Enter 999 to sp
 
 **Slab: Thickness**
 
-The thickness of the slab. Zero can be entered if there is a dirt floor instead of a slab. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-slabs'>HPXML Slabs</a>) is used.
+The thickness of the slab. Zero can be entered if there is a dirt floor instead of a slab. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-slabs'>HPXML Slabs</a>) is used.
 
 - **Name:** ``slab_thickness``
 - **Type:** ``Double``
@@ -1113,7 +1113,7 @@ The thickness of the slab. Zero can be entered if there is a dirt floor instead 
 
 **Slab: Carpet Fraction**
 
-Fraction of the slab floor area that is carpeted. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-slabs'>HPXML Slabs</a>) is used.
+Fraction of the slab floor area that is carpeted. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-slabs'>HPXML Slabs</a>) is used.
 
 - **Name:** ``slab_carpet_fraction``
 - **Type:** ``Double``
@@ -1126,7 +1126,7 @@ Fraction of the slab floor area that is carpeted. If not provided, the OS-HPXML 
 
 **Slab: Carpet R-value**
 
-R-value of the slab carpet. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-slabs'>HPXML Slabs</a>) is used.
+R-value of the slab carpet. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-slabs'>HPXML Slabs</a>) is used.
 
 - **Name:** ``slab_carpet_r``
 - **Type:** ``Double``
@@ -1152,7 +1152,7 @@ Assembly R-value for the ceiling (attic floor).
 
 **Roof: Material Type**
 
-The material type of the roof. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-roofs'>HPXML Roofs</a>) is used.
+The material type of the roof. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-roofs'>HPXML Roofs</a>) is used.
 
 - **Name:** ``roof_material_type``
 - **Type:** ``Choice``
@@ -1165,7 +1165,7 @@ The material type of the roof. If not provided, the OS-HPXML default (see <a hre
 
 **Roof: Color**
 
-The color of the roof. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-roofs'>HPXML Roofs</a>) is used.
+The color of the roof. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-roofs'>HPXML Roofs</a>) is used.
 
 - **Name:** ``roof_color``
 - **Type:** ``Choice``
@@ -1204,7 +1204,7 @@ The location of the radiant barrier in the attic.
 
 **Attic: Radiant Barrier Grade**
 
-The grade of the radiant barrier in the attic. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-roofs'>HPXML Roofs</a>) is used.
+The grade of the radiant barrier in the attic. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-roofs'>HPXML Roofs</a>) is used.
 
 - **Name:** ``radiant_barrier_grade``
 - **Type:** ``Choice``
@@ -1230,7 +1230,7 @@ The type of walls.
 
 **Wall: Siding Type**
 
-The siding type of the walls. Also applies to rim joists. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-walls'>HPXML Walls</a>) is used.
+The siding type of the walls. Also applies to rim joists. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-walls'>HPXML Walls</a>) is used.
 
 - **Name:** ``wall_siding_type``
 - **Type:** ``Choice``
@@ -1243,7 +1243,7 @@ The siding type of the walls. Also applies to rim joists. If not provided, the O
 
 **Wall: Color**
 
-The color of the walls. Also applies to rim joists. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-walls'>HPXML Walls</a>) is used.
+The color of the walls. Also applies to rim joists. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-walls'>HPXML Walls</a>) is used.
 
 - **Name:** ``wall_color``
 - **Type:** ``Choice``
@@ -1386,7 +1386,7 @@ Ratio of window height to width.
 
 **Windows: Fraction Operable**
 
-Fraction of windows that are operable. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-windows'>HPXML Windows</a>) is used.
+Fraction of windows that are operable. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-windows'>HPXML Windows</a>) is used.
 
 - **Name:** ``window_fraction_operable``
 - **Type:** ``Double``
@@ -1399,7 +1399,7 @@ Fraction of windows that are operable. If not provided, the OS-HPXML default (se
 
 **Windows: Natural Ventilation Availability**
 
-For operable windows, the number of days/week that windows can be opened by occupants for natural ventilation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-windows'>HPXML Windows</a>) is used.
+For operable windows, the number of days/week that windows can be opened by occupants for natural ventilation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-windows'>HPXML Windows</a>) is used.
 
 - **Name:** ``window_natvent_availability``
 - **Type:** ``Integer``
@@ -1436,7 +1436,7 @@ Full-assembly NFRC solar heat gain coefficient.
 
 **Windows: Interior Shading Type**
 
-Type of window interior shading. Summer/winter shading coefficients can be provided below instead. If neither is provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-interior-shading'>HPXML Interior Shading</a>) is used.
+Type of window interior shading. Summer/winter shading coefficients can be provided below instead. If neither is provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-interior-shading'>HPXML Interior Shading</a>) is used.
 
 - **Name:** ``window_interior_shading_type``
 - **Type:** ``Choice``
@@ -1449,7 +1449,7 @@ Type of window interior shading. Summer/winter shading coefficients can be provi
 
 **Windows: Winter Interior Shading Coefficient**
 
-Interior shading coefficient for the winter season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-interior-shading'>HPXML Interior Shading</a>) is used.
+Interior shading coefficient for the winter season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-interior-shading'>HPXML Interior Shading</a>) is used.
 
 - **Name:** ``window_interior_shading_winter``
 - **Type:** ``Double``
@@ -1462,7 +1462,7 @@ Interior shading coefficient for the winter season, which if provided overrides 
 
 **Windows: Summer Interior Shading Coefficient**
 
-Interior shading coefficient for the summer season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-interior-shading'>HPXML Interior Shading</a>) is used.
+Interior shading coefficient for the summer season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-interior-shading'>HPXML Interior Shading</a>) is used.
 
 - **Name:** ``window_interior_shading_summer``
 - **Type:** ``Double``
@@ -1475,7 +1475,7 @@ Interior shading coefficient for the summer season, which if provided overrides 
 
 **Windows: Exterior Shading Type**
 
-Type of window exterior shading. Summer/winter shading coefficients can be provided below instead. If neither is provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-exterior-shading'>HPXML Exterior Shading</a>) is used.
+Type of window exterior shading. Summer/winter shading coefficients can be provided below instead. If neither is provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-exterior-shading'>HPXML Exterior Shading</a>) is used.
 
 - **Name:** ``window_exterior_shading_type``
 - **Type:** ``Choice``
@@ -1488,7 +1488,7 @@ Type of window exterior shading. Summer/winter shading coefficients can be provi
 
 **Windows: Winter Exterior Shading Coefficient**
 
-Exterior shading coefficient for the winter season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-exterior-shading'>HPXML Exterior Shading</a>) is used.
+Exterior shading coefficient for the winter season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-exterior-shading'>HPXML Exterior Shading</a>) is used.
 
 - **Name:** ``window_exterior_shading_winter``
 - **Type:** ``Double``
@@ -1501,7 +1501,7 @@ Exterior shading coefficient for the winter season, which if provided overrides 
 
 **Windows: Summer Exterior Shading Coefficient**
 
-Exterior shading coefficient for the summer season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-exterior-shading'>HPXML Exterior Shading</a>) is used.
+Exterior shading coefficient for the summer season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-exterior-shading'>HPXML Exterior Shading</a>) is used.
 
 - **Name:** ``window_exterior_shading_summer``
 - **Type:** ``Double``
@@ -1514,7 +1514,7 @@ Exterior shading coefficient for the summer season, which if provided overrides 
 
 **Windows: Shading Summer Season**
 
-Enter a date range like 'May 1 - Sep 30'. Defines the summer season for purposes of shading coefficients; the rest of the year is assumed to be winter. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-windows'>HPXML Windows</a>) is used.
+Enter a date range like 'May 1 - Sep 30'. Defines the summer season for purposes of shading coefficients; the rest of the year is assumed to be winter. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-windows'>HPXML Windows</a>) is used.
 
 - **Name:** ``window_shading_summer_season``
 - **Type:** ``String``
@@ -1885,7 +1885,7 @@ Type of air leakage if providing a numeric air leakage value. If 'unit total', r
 
 **Air Leakage: Has Flue or Chimney in Conditioned Space**
 
-Presence of flue or chimney with combustion air from conditioned space; used for infiltration model. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#flue-or-chimney'>Flue or Chimney</a>) is used.
+Presence of flue or chimney with combustion air from conditioned space; used for infiltration model. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#flue-or-chimney'>Flue or Chimney</a>) is used.
 
 - **Name:** ``air_leakage_has_flue_or_chimney_in_conditioned_space``
 - **Type:** ``Boolean``
@@ -1935,7 +1935,7 @@ The rated heating efficiency value of the heating system.
 
 **Heating System: Heating Capacity**
 
-The output heating capacity of the heating system. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-heating-systems'>HPXML Heating Systems</a>) is used.
+The output heating capacity of the heating system. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-heating-systems'>HPXML Heating Systems</a>) is used.
 
 - **Name:** ``heating_system_heating_capacity``
 - **Type:** ``Double``
@@ -2048,7 +2048,7 @@ The rated efficiency value of the cooling system. Ignored for evaporative cooler
 
 **Cooling System: Cooling Compressor Type**
 
-The compressor type of the cooling system. Only applies to central air conditioner and mini-split. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#central-air-conditioner'>Central Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-air-conditioner'>Mini-Split Air Conditioner</a>) is used.
+The compressor type of the cooling system. Only applies to central air conditioner and mini-split. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#central-air-conditioner'>Central Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-air-conditioner'>Mini-Split Air Conditioner</a>) is used.
 
 - **Name:** ``cooling_system_cooling_compressor_type``
 - **Type:** ``Choice``
@@ -2061,7 +2061,7 @@ The compressor type of the cooling system. Only applies to central air condition
 
 **Cooling System: Cooling Sensible Heat Fraction**
 
-The sensible heat fraction of the cooling system. Ignored for evaporative cooler. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#central-air-conditioner'>Central Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner'>Room Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-air-conditioner'>Packaged Terminal Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-air-conditioner'>Mini-Split Air Conditioner</a>) is used.
+The sensible heat fraction of the cooling system. Ignored for evaporative cooler. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#central-air-conditioner'>Central Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner'>Room Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-air-conditioner'>Packaged Terminal Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-air-conditioner'>Mini-Split Air Conditioner</a>) is used.
 
 - **Name:** ``cooling_system_cooling_sensible_heat_fraction``
 - **Type:** ``Double``
@@ -2074,7 +2074,7 @@ The sensible heat fraction of the cooling system. Ignored for evaporative cooler
 
 **Cooling System: Cooling Capacity**
 
-The output cooling capacity of the cooling system. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#central-air-conditioner'>Central Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner'>Room Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-air-conditioner'>Packaged Terminal Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#evaporative-cooler'>Evaporative Cooler</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-air-conditioner'>Mini-Split Air Conditioner</a>) is used.
+The output cooling capacity of the cooling system. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#central-air-conditioner'>Central Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner'>Room Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-air-conditioner'>Packaged Terminal Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#evaporative-cooler'>Evaporative Cooler</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-air-conditioner'>Mini-Split Air Conditioner</a>) is used.
 
 - **Name:** ``cooling_system_cooling_capacity``
 - **Type:** ``Double``
@@ -2161,7 +2161,7 @@ The refrigerant charge defect ratio, defined as (InstalledCharge - DesignCharge)
 
 **Cooling System: Crankcase Heater Power Watts**
 
-Cooling system crankcase heater power consumption in Watts. Applies only to central air conditioner, room air conditioner, packaged terminal air conditioner and mini-split. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#central-air-conditioner'>Central Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner'>Room Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-air-conditioner'>Packaged Terminal Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-air-conditioner'>Mini-Split Air Conditioner</a>) is used.
+Cooling system crankcase heater power consumption in Watts. Applies only to central air conditioner, room air conditioner, packaged terminal air conditioner and mini-split. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#central-air-conditioner'>Central Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner'>Room Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-air-conditioner'>Packaged Terminal Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-air-conditioner'>Mini-Split Air Conditioner</a>) is used.
 
 - **Name:** ``cooling_system_crankcase_heater_watts``
 - **Type:** ``Double``
@@ -2200,7 +2200,7 @@ The rated heating efficiency value of the heating system integrated into cooling
 
 **Cooling System: Integrated Heating System Heating Capacity**
 
-The output heating capacity of the heating system integrated into cooling system. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner'>Room Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-air-conditioner'>Packaged Terminal Air Conditioner</a>) is used. Only used for room air conditioner and packaged terminal air conditioner.
+The output heating capacity of the heating system integrated into cooling system. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner'>Room Air Conditioner</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-air-conditioner'>Packaged Terminal Air Conditioner</a>) is used. Only used for room air conditioner and packaged terminal air conditioner.
 
 - **Name:** ``cooling_system_integrated_heating_system_capacity``
 - **Type:** ``Double``
@@ -2287,7 +2287,7 @@ The rated cooling efficiency value of the heat pump.
 
 **Heat Pump: Cooling Compressor Type**
 
-The compressor type of the heat pump. Only applies to air-to-air and mini-split. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>) is used.
+The compressor type of the heat pump. Only applies to air-to-air and mini-split. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>) is used.
 
 - **Name:** ``heat_pump_cooling_compressor_type``
 - **Type:** ``Choice``
@@ -2300,7 +2300,7 @@ The compressor type of the heat pump. Only applies to air-to-air and mini-split.
 
 **Heat Pump: Cooling Sensible Heat Fraction**
 
-The sensible heat fraction of the heat pump. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#ground-to-air-heat-pump'>Ground-to-Air Heat Pump</a>) is used.
+The sensible heat fraction of the heat pump. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#ground-to-air-heat-pump'>Ground-to-Air Heat Pump</a>) is used.
 
 - **Name:** ``heat_pump_cooling_sensible_heat_fraction``
 - **Type:** ``Double``
@@ -2313,7 +2313,7 @@ The sensible heat fraction of the heat pump. If not provided, the OS-HPXML defau
 
 **Heat Pump: Heating Capacity**
 
-The output heating capacity of the heat pump. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#ground-to-air-heat-pump'>Ground-to-Air Heat Pump</a>) is used.
+The output heating capacity of the heat pump. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#ground-to-air-heat-pump'>Ground-to-Air Heat Pump</a>) is used.
 
 - **Name:** ``heat_pump_heating_capacity``
 - **Type:** ``Double``
@@ -2350,7 +2350,7 @@ The maximum capacity limit applied to the auto-sizing methodology. If not provid
 
 **Heat Pump: Heating Capacity Retention Fraction**
 
-The output heating capacity of the heat pump at a user-specified temperature (e.g., 17F or 5F) divided by the above nominal heating capacity. Applies to all heat pump types except ground-to-air. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>) is used.
+The output heating capacity of the heat pump at a user-specified temperature (e.g., 17F or 5F) divided by the above nominal heating capacity. Applies to all heat pump types except ground-to-air. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>) is used.
 
 - **Name:** ``heat_pump_heating_capacity_retention_fraction``
 - **Type:** ``Double``
@@ -2376,7 +2376,7 @@ The user-specified temperature (e.g., 17F or 5F) for the above heating capacity 
 
 **Heat Pump: Cooling Capacity**
 
-The output cooling capacity of the heat pump. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#ground-to-air-heat-pump'>Ground-to-Air Heat Pump</a>) is used.
+The output cooling capacity of the heat pump. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#ground-to-air-heat-pump'>Ground-to-Air Heat Pump</a>) is used.
 
 - **Name:** ``heat_pump_cooling_capacity``
 - **Type:** ``Double``
@@ -2439,7 +2439,7 @@ The cooling load served by the heat pump.
 
 **Heat Pump: Compressor Lockout Temperature**
 
-The temperature below which the heat pump compressor is disabled. If both this and Backup Heating Lockout Temperature are provided and use the same value, it essentially defines a switchover temperature (for, e.g., a dual-fuel heat pump). Applies to all heat pump types other than ground-to-air. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>) is used.
+The temperature below which the heat pump compressor is disabled. If both this and Backup Heating Lockout Temperature are provided and use the same value, it essentially defines a switchover temperature (for, e.g., a dual-fuel heat pump). Applies to all heat pump types other than ground-to-air. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>) is used.
 
 - **Name:** ``heat_pump_compressor_lockout_temp``
 - **Type:** ``Double``
@@ -2513,7 +2513,7 @@ The backup rated efficiency value of the heat pump. Percent for electricity fuel
 
 **Heat Pump: Backup Heating Capacity**
 
-The backup output heating capacity of the heat pump. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#backup'>Backup</a>) is used. Only applies if Backup Type is 'integrated'.
+The backup output heating capacity of the heat pump. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#backup'>Backup</a>) is used. Only applies if Backup Type is 'integrated'.
 
 - **Name:** ``heat_pump_backup_heating_capacity``
 - **Type:** ``Double``
@@ -2526,7 +2526,7 @@ The backup output heating capacity of the heat pump. If not provided, the OS-HPX
 
 **Heat Pump: Backup Heating Lockout Temperature**
 
-The temperature above which the heat pump backup system is disabled. If both this and Compressor Lockout Temperature are provided and use the same value, it essentially defines a switchover temperature (for, e.g., a dual-fuel heat pump). Applies for both Backup Type of 'integrated' and 'separate'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#backup'>Backup</a>) is used.
+The temperature above which the heat pump backup system is disabled. If both this and Compressor Lockout Temperature are provided and use the same value, it essentially defines a switchover temperature (for, e.g., a dual-fuel heat pump). Applies for both Backup Type of 'integrated' and 'separate'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#backup'>Backup</a>) is used.
 
 - **Name:** ``heat_pump_backup_heating_lockout_temp``
 - **Type:** ``Double``
@@ -2539,7 +2539,7 @@ The temperature above which the heat pump backup system is disabled. If both thi
 
 **Heat Pump: Sizing Methodology**
 
-The auto-sizing methodology to use when the heat pump capacity is not provided. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hvac-sizing-control'>HPXML HVAC Sizing Control</a>) is used.
+The auto-sizing methodology to use when the heat pump capacity is not provided. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hvac-sizing-control'>HPXML HVAC Sizing Control</a>) is used.
 
 - **Name:** ``heat_pump_sizing_methodology``
 - **Type:** ``Choice``
@@ -2552,7 +2552,7 @@ The auto-sizing methodology to use when the heat pump capacity is not provided. 
 
 **Heat Pump: Backup Sizing Methodology**
 
-The auto-sizing methodology to use when the heat pump backup capacity is not provided. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hvac-sizing-control'>HPXML HVAC Sizing Control</a>) is used.
+The auto-sizing methodology to use when the heat pump backup capacity is not provided. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hvac-sizing-control'>HPXML HVAC Sizing Control</a>) is used.
 
 - **Name:** ``heat_pump_backup_sizing_methodology``
 - **Type:** ``Choice``
@@ -2602,7 +2602,7 @@ The refrigerant charge defect ratio, defined as (InstalledCharge - DesignCharge)
 
 **Heat Pump: Crankcase Heater Power Watts**
 
-Heat Pump crankcase heater power consumption in Watts. Applies only to air-to-air, mini-split, packaged terminal heat pump and room air conditioner with reverse cycle. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>) is used.
+Heat Pump crankcase heater power consumption in Watts. Applies only to air-to-air, mini-split, packaged terminal heat pump and room air conditioner with reverse cycle. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'>Air-to-Air Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'>Mini-Split Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'>Packaged Terminal Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'>Room Air Conditioner w/ Reverse Cycle</a>) is used.
 
 - **Name:** ``heat_pump_crankcase_heater_watts``
 - **Type:** ``Double``
@@ -2738,7 +2738,7 @@ Maximum speed efficiency COP values of cooling detailed performance data if avai
 
 **Geothermal Loop: Configuration**
 
-Configuration of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#ground-to-air-heat-pump'>Ground-to-Air Heat Pump</a>) is used.
+Configuration of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#ground-to-air-heat-pump'>Ground-to-Air Heat Pump</a>) is used.
 
 - **Name:** ``geothermal_loop_configuration``
 - **Type:** ``Choice``
@@ -2751,7 +2751,7 @@ Configuration of the geothermal loop. Only applies to ground-to-air heat pump ty
 
 **Geothermal Loop: Borefield Configuration**
 
-Borefield configuration of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Borefield configuration of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_borefield_configuration``
 - **Type:** ``Choice``
@@ -2764,7 +2764,7 @@ Borefield configuration of the geothermal loop. Only applies to ground-to-air he
 
 **Geothermal Loop: Loop Flow**
 
-Water flow rate through the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Water flow rate through the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_loop_flow``
 - **Type:** ``Double``
@@ -2777,7 +2777,7 @@ Water flow rate through the geothermal loop. Only applies to ground-to-air heat 
 
 **Geothermal Loop: Boreholes Count**
 
-Number of boreholes. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Number of boreholes. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_boreholes_count``
 - **Type:** ``Integer``
@@ -2790,7 +2790,7 @@ Number of boreholes. Only applies to ground-to-air heat pump type. If not provid
 
 **Geothermal Loop: Boreholes Length**
 
-Average length of each borehole (vertical). Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Average length of each borehole (vertical). Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_boreholes_length``
 - **Type:** ``Double``
@@ -2803,7 +2803,7 @@ Average length of each borehole (vertical). Only applies to ground-to-air heat p
 
 **Geothermal Loop: Boreholes Spacing**
 
-Distance between bores. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Distance between bores. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_boreholes_spacing``
 - **Type:** ``Double``
@@ -2816,7 +2816,7 @@ Distance between bores. Only applies to ground-to-air heat pump type. If not pro
 
 **Geothermal Loop: Boreholes Diameter**
 
-Diameter of bores. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Diameter of bores. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_boreholes_diameter``
 - **Type:** ``Double``
@@ -2829,7 +2829,7 @@ Diameter of bores. Only applies to ground-to-air heat pump type. If not provided
 
 **Geothermal Loop: Grout Type**
 
-Grout type of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Grout type of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_grout_type``
 - **Type:** ``Choice``
@@ -2842,7 +2842,7 @@ Grout type of the geothermal loop. Only applies to ground-to-air heat pump type.
 
 **Geothermal Loop: Pipe Type**
 
-Pipe type of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Pipe type of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_pipe_type``
 - **Type:** ``Choice``
@@ -2855,7 +2855,7 @@ Pipe type of the geothermal loop. Only applies to ground-to-air heat pump type. 
 
 **Geothermal Loop: Pipe Diameter**
 
-Pipe diameter of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
+Pipe diameter of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'>HPXML Geothermal Loops</a>) is used.
 
 - **Name:** ``geothermal_loop_pipe_diameter``
 - **Type:** ``Choice``
@@ -2907,7 +2907,7 @@ The rated heating efficiency value of the second heating system.
 
 **Heating System 2: Heating Capacity**
 
-The output heating capacity of the second heating system. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-heating-systems'>HPXML Heating Systems</a>) is used.
+The output heating capacity of the second heating system. If not provided, the OS-HPXML autosized default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-heating-systems'>HPXML Heating Systems</a>) is used.
 
 - **Name:** ``heating_system_2_heating_capacity``
 - **Type:** ``Double``
@@ -3001,7 +3001,7 @@ Specify the constant or 24-hour comma-separated weekend cooling setpoint schedul
 
 **HVAC Control: Heating Season Period**
 
-Enter a date range like 'Nov 1 - Jun 30'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hvac-control'>HPXML HVAC Control</a>) is used. Can also provide 'BuildingAmerica' to use automatic seasons from the Building America House Simulation Protocols.
+Enter a date range like 'Nov 1 - Jun 30'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hvac-control'>HPXML HVAC Control</a>) is used. Can also provide 'BuildingAmerica' to use automatic seasons from the Building America House Simulation Protocols.
 
 - **Name:** ``hvac_control_heating_season_period``
 - **Type:** ``String``
@@ -3012,7 +3012,7 @@ Enter a date range like 'Nov 1 - Jun 30'. If not provided, the OS-HPXML default 
 
 **HVAC Control: Cooling Season Period**
 
-Enter a date range like 'Jun 1 - Oct 31'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hvac-control'>HPXML HVAC Control</a>) is used. Can also provide 'BuildingAmerica' to use automatic seasons from the Building America House Simulation Protocols.
+Enter a date range like 'Jun 1 - Oct 31'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hvac-control'>HPXML HVAC Control</a>) is used. Can also provide 'BuildingAmerica' to use automatic seasons from the Building America House Simulation Protocols.
 
 - **Name:** ``hvac_control_cooling_season_period``
 - **Type:** ``String``
@@ -3023,7 +3023,7 @@ Enter a date range like 'Jun 1 - Oct 31'. If not provided, the OS-HPXML default 
 
 **HVAC Blower: Fan Efficiency**
 
-The blower fan efficiency at maximum fan speed. Applies only to split (not packaged) systems (i.e., applies to ducted systems as well as ductless mini-split systems). If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-heating-systems'>HPXML Heating Systems</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooling-systems'>HPXML Cooling Systems</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-heat-pumps'>HPXML Heat Pumps</a>) is used.
+The blower fan efficiency at maximum fan speed. Applies only to split (not packaged) systems (i.e., applies to ducted systems as well as ductless mini-split systems). If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-heating-systems'>HPXML Heating Systems</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooling-systems'>HPXML Cooling Systems</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-heat-pumps'>HPXML Heat Pumps</a>) is used.
 
 - **Name:** ``hvac_blower_fan_watts_per_cfm``
 - **Type:** ``Double``
@@ -3060,7 +3060,7 @@ The leakage value to outside for the supply ducts.
 
 **Ducts: Supply Location**
 
-The location of the supply ducts. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The location of the supply ducts. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_supply_location``
 - **Type:** ``Choice``
@@ -3099,7 +3099,7 @@ Whether the supply ducts are buried in, e.g., attic loose-fill insulation. Parti
 
 **Ducts: Supply Surface Area**
 
-The supply ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The supply ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_supply_surface_area``
 - **Type:** ``Double``
@@ -3112,7 +3112,7 @@ The supply ducts surface area in the given location. If neither Surface Area nor
 
 **Ducts: Supply Area Fraction**
 
-The fraction of supply ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The fraction of supply ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_supply_surface_area_fraction``
 - **Type:** ``Double``
@@ -3125,7 +3125,7 @@ The fraction of supply ducts surface area in the given location. Only used if Su
 
 **Ducts: Supply Fraction Rectangular**
 
-The fraction of supply ducts that are rectangular (as opposed to round); this affects the duct effective R-value used for modeling. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The fraction of supply ducts that are rectangular (as opposed to round); this affects the duct effective R-value used for modeling. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_supply_fraction_rectangular``
 - **Type:** ``Double``
@@ -3149,7 +3149,7 @@ The leakage value to outside for the return ducts.
 
 **Ducts: Return Location**
 
-The location of the return ducts. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The location of the return ducts. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_return_location``
 - **Type:** ``Choice``
@@ -3188,7 +3188,7 @@ Whether the return ducts are buried in, e.g., attic loose-fill insulation. Parti
 
 **Ducts: Return Surface Area**
 
-The return ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The return ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_return_surface_area``
 - **Type:** ``Double``
@@ -3201,7 +3201,7 @@ The return ducts surface area in the given location. If neither Surface Area nor
 
 **Ducts: Return Area Fraction**
 
-The fraction of return ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The fraction of return ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_return_surface_area_fraction``
 - **Type:** ``Double``
@@ -3214,7 +3214,7 @@ The fraction of return ducts surface area in the given location. Only used if Su
 
 **Ducts: Number of Return Registers**
 
-The number of return registers of the ducts. Only used to calculate default return duct surface area. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The number of return registers of the ducts. Only used to calculate default return duct surface area. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_number_of_return_registers``
 - **Type:** ``Integer``
@@ -3227,7 +3227,7 @@ The number of return registers of the ducts. Only used to calculate default retu
 
 **Ducts: Return Fraction Rectangular**
 
-The fraction of return ducts that are rectangular (as opposed to round); this affects the duct effective R-value used for modeling. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
+The fraction of return ducts that are rectangular (as opposed to round); this affects the duct effective R-value used for modeling. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'>Air Distribution</a>) is used.
 
 - **Name:** ``ducts_return_fraction_rectangular``
 - **Type:** ``Double``
@@ -3253,7 +3253,7 @@ The type of the mechanical ventilation. Use 'none' if there is no mechanical ven
 
 **Mechanical Ventilation: Flow Rate**
 
-The flow rate of the mechanical ventilation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-mechanical-ventilation-fans'>HPXML Mechanical Ventilation Fans</a>) is used.
+The flow rate of the mechanical ventilation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-mechanical-ventilation-fans'>HPXML Mechanical Ventilation Fans</a>) is used.
 
 - **Name:** ``mech_vent_flow_rate``
 - **Type:** ``Double``
@@ -3266,7 +3266,7 @@ The flow rate of the mechanical ventilation. If not provided, the OS-HPXML defau
 
 **Mechanical Ventilation: Hours In Operation**
 
-The hours in operation of the mechanical ventilation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-mechanical-ventilation-fans'>HPXML Mechanical Ventilation Fans</a>) is used.
+The hours in operation of the mechanical ventilation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-mechanical-ventilation-fans'>HPXML Mechanical Ventilation Fans</a>) is used.
 
 - **Name:** ``mech_vent_hours_in_operation``
 - **Type:** ``Double``
@@ -3318,7 +3318,7 @@ The Unadjusted or Adjusted sensible recovery efficiency of the mechanical ventil
 
 **Mechanical Ventilation: Fan Power**
 
-The fan power of the mechanical ventilation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-mechanical-ventilation-fans'>HPXML Mechanical Ventilation Fans</a>) is used.
+The fan power of the mechanical ventilation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-mechanical-ventilation-fans'>HPXML Mechanical Ventilation Fans</a>) is used.
 
 - **Name:** ``mech_vent_fan_power``
 - **Type:** ``Double``
@@ -3526,7 +3526,7 @@ The fan power of the second mechanical ventilation.
 
 **Kitchen Fans: Quantity**
 
-The quantity of the kitchen fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The quantity of the kitchen fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``kitchen_fans_quantity``
 - **Type:** ``Integer``
@@ -3539,7 +3539,7 @@ The quantity of the kitchen fans. If not provided, the OS-HPXML default (see <a 
 
 **Kitchen Fans: Flow Rate**
 
-The flow rate of the kitchen fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The flow rate of the kitchen fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``kitchen_fans_flow_rate``
 - **Type:** ``Double``
@@ -3552,7 +3552,7 @@ The flow rate of the kitchen fan. If not provided, the OS-HPXML default (see <a 
 
 **Kitchen Fans: Hours In Operation**
 
-The hours in operation of the kitchen fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The hours in operation of the kitchen fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``kitchen_fans_hours_in_operation``
 - **Type:** ``Double``
@@ -3565,7 +3565,7 @@ The hours in operation of the kitchen fan. If not provided, the OS-HPXML default
 
 **Kitchen Fans: Fan Power**
 
-The fan power of the kitchen fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The fan power of the kitchen fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``kitchen_fans_power``
 - **Type:** ``Double``
@@ -3578,7 +3578,7 @@ The fan power of the kitchen fan. If not provided, the OS-HPXML default (see <a 
 
 **Kitchen Fans: Start Hour**
 
-The start hour of the kitchen fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The start hour of the kitchen fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``kitchen_fans_start_hour``
 - **Type:** ``Integer``
@@ -3591,7 +3591,7 @@ The start hour of the kitchen fan. If not provided, the OS-HPXML default (see <a
 
 **Bathroom Fans: Quantity**
 
-The quantity of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The quantity of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``bathroom_fans_quantity``
 - **Type:** ``Integer``
@@ -3604,7 +3604,7 @@ The quantity of the bathroom fans. If not provided, the OS-HPXML default (see <a
 
 **Bathroom Fans: Flow Rate**
 
-The flow rate of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The flow rate of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``bathroom_fans_flow_rate``
 - **Type:** ``Double``
@@ -3617,7 +3617,7 @@ The flow rate of the bathroom fans. If not provided, the OS-HPXML default (see <
 
 **Bathroom Fans: Hours In Operation**
 
-The hours in operation of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The hours in operation of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``bathroom_fans_hours_in_operation``
 - **Type:** ``Double``
@@ -3630,7 +3630,7 @@ The hours in operation of the bathroom fans. If not provided, the OS-HPXML defau
 
 **Bathroom Fans: Fan Power**
 
-The fan power of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The fan power of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``bathroom_fans_power``
 - **Type:** ``Double``
@@ -3643,7 +3643,7 @@ The fan power of the bathroom fans. If not provided, the OS-HPXML default (see <
 
 **Bathroom Fans: Start Hour**
 
-The start hour of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
+The start hour of the bathroom fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'>HPXML Local Ventilation Fans</a>) is used.
 
 - **Name:** ``bathroom_fans_start_hour``
 - **Type:** ``Integer``
@@ -3667,7 +3667,7 @@ Whether there is a whole house fan.
 
 **Whole House Fan: Flow Rate**
 
-The flow rate of the whole house fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-whole-house-fans'>HPXML Whole House Fans</a>) is used.
+The flow rate of the whole house fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-whole-house-fans'>HPXML Whole House Fans</a>) is used.
 
 - **Name:** ``whole_house_fan_flow_rate``
 - **Type:** ``Double``
@@ -3680,7 +3680,7 @@ The flow rate of the whole house fan. If not provided, the OS-HPXML default (see
 
 **Whole House Fan: Fan Power**
 
-The fan power of the whole house fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-whole-house-fans'>HPXML Whole House Fans</a>) is used.
+The fan power of the whole house fan. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-whole-house-fans'>HPXML Whole House Fans</a>) is used.
 
 - **Name:** ``whole_house_fan_power``
 - **Type:** ``Double``
@@ -3719,7 +3719,7 @@ The fuel type of water heater. Ignored for heat pump water heater.
 
 **Water Heater: Location**
 
-The location of water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-water-heating-systems'>HPXML Water Heating Systems</a>) is used.
+The location of water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-water-heating-systems'>HPXML Water Heating Systems</a>) is used.
 
 - **Name:** ``water_heater_location``
 - **Type:** ``Choice``
@@ -3732,7 +3732,7 @@ The location of water heater. If not provided, the OS-HPXML default (see <a href
 
 **Water Heater: Tank Volume**
 
-Nominal volume of water heater tank. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'>Conventional Storage</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'>Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#combi-boiler-w-storage'>Combi Boiler w/ Storage</a>) is used.
+Nominal volume of water heater tank. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'>Conventional Storage</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'>Heat Pump</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#combi-boiler-w-storage'>Combi Boiler w/ Storage</a>) is used.
 
 - **Name:** ``water_heater_tank_volume``
 - **Type:** ``Double``
@@ -3769,7 +3769,7 @@ Rated Energy Factor or Uniform Energy Factor. Does not apply to space-heating bo
 
 **Water Heater: Usage Bin**
 
-The usage of the water heater. Only applies if Efficiency Type is UniformEnergyFactor and Type is not instantaneous water heater. Does not apply to space-heating boilers. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'>Conventional Storage</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'>Heat Pump</a>) is used.
+The usage of the water heater. Only applies if Efficiency Type is UniformEnergyFactor and Type is not instantaneous water heater. Does not apply to space-heating boilers. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'>Conventional Storage</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'>Heat Pump</a>) is used.
 
 - **Name:** ``water_heater_usage_bin``
 - **Type:** ``Choice``
@@ -3782,7 +3782,7 @@ The usage of the water heater. Only applies if Efficiency Type is UniformEnergyF
 
 **Water Heater: Recovery Efficiency**
 
-Ratio of energy delivered to water heater to the energy content of the fuel consumed by the water heater. Only used for non-electric storage water heaters. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'>Conventional Storage</a>) is used.
+Ratio of energy delivered to water heater to the energy content of the fuel consumed by the water heater. Only used for non-electric storage water heaters. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'>Conventional Storage</a>) is used.
 
 - **Name:** ``water_heater_recovery_efficiency``
 - **Type:** ``Double``
@@ -3795,7 +3795,7 @@ Ratio of energy delivered to water heater to the energy content of the fuel cons
 
 **Water Heater: Heating Capacity**
 
-Heating capacity. Only applies to storage water heater and heat pump water heater (compressor). If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'>Conventional Storage</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'>Heat Pump</a>) is used.
+Heating capacity. Only applies to storage water heater and heat pump water heater (compressor). If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'>Conventional Storage</a>, <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'>Heat Pump</a>) is used.
 
 - **Name:** ``water_heater_heating_capacity``
 - **Type:** ``Double``
@@ -3808,7 +3808,7 @@ Heating capacity. Only applies to storage water heater and heat pump water heate
 
 **Water Heater: Backup Heating Capacity**
 
-Backup heating capacity for a heat pump water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'>Heat Pump</a>) is used.
+Backup heating capacity for a heat pump water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'>Heat Pump</a>) is used.
 
 - **Name:** ``water_heater_backup_heating_capacity``
 - **Type:** ``Double``
@@ -3821,7 +3821,7 @@ Backup heating capacity for a heat pump water heater. If not provided, the OS-HP
 
 **Water Heater: Standby Loss**
 
-The standby loss of water heater. Only applies to space-heating boilers. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#combi-boiler-w-storage'>Combi Boiler w/ Storage</a>) is used.
+The standby loss of water heater. Only applies to space-heating boilers. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#combi-boiler-w-storage'>Combi Boiler w/ Storage</a>) is used.
 
 - **Name:** ``water_heater_standby_loss``
 - **Type:** ``Double``
@@ -3847,7 +3847,7 @@ The jacket R-value of water heater. Doesn't apply to instantaneous water heater 
 
 **Water Heater: Setpoint Temperature**
 
-The setpoint temperature of water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-water-heating-systems'>HPXML Water Heating Systems</a>) is used.
+The setpoint temperature of water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-water-heating-systems'>HPXML Water Heating Systems</a>) is used.
 
 - **Name:** ``water_heater_setpoint_temperature``
 - **Type:** ``Double``
@@ -3884,7 +3884,7 @@ Requires that the dwelling unit has a air-to-air, mini-split, or ground-to-air h
 
 **Water Heater: Tank Type**
 
-Type of tank model to use. The 'stratified' tank generally provide more accurate results, but may significantly increase run time. Applies only to storage water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'>Conventional Storage</a>) is used.
+Type of tank model to use. The 'stratified' tank generally provide more accurate results, but may significantly increase run time. Applies only to storage water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'>Conventional Storage</a>) is used.
 
 - **Name:** ``water_heater_tank_model_type``
 - **Type:** ``Choice``
@@ -3897,7 +3897,7 @@ Type of tank model to use. The 'stratified' tank generally provide more accurate
 
 **Water Heater: Operating Mode**
 
-The water heater operating mode. The 'heat pump only' option only uses the heat pump, while 'hybrid/auto' allows the backup electric resistance to come on in high demand situations. This is ignored if a scheduled operating mode type is selected. Applies only to heat pump water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'>Heat Pump</a>) is used.
+The water heater operating mode. The 'heat pump only' option only uses the heat pump, while 'hybrid/auto' allows the backup electric resistance to come on in high demand situations. This is ignored if a scheduled operating mode type is selected. Applies only to heat pump water heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'>Heat Pump</a>) is used.
 
 - **Name:** ``water_heater_operating_mode``
 - **Type:** ``Choice``
@@ -3923,7 +3923,7 @@ The type of the hot water distribution system.
 
 **Hot Water Distribution: Standard Piping Length**
 
-If the distribution system is Standard, the length of the piping. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#standard'>Standard</a>) is used.
+If the distribution system is Standard, the length of the piping. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#standard'>Standard</a>) is used.
 
 - **Name:** ``hot_water_distribution_standard_piping_length``
 - **Type:** ``Double``
@@ -3949,7 +3949,7 @@ If the distribution system is Recirculation, the type of hot water recirculation
 
 **Hot Water Distribution: Recirculation Piping Length**
 
-If the distribution system is Recirculation, the length of the recirculation piping. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#recirculation-in-unit'>Recirculation (In-Unit)</a>) is used.
+If the distribution system is Recirculation, the length of the recirculation piping. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#recirculation-in-unit'>Recirculation (In-Unit)</a>) is used.
 
 - **Name:** ``hot_water_distribution_recirc_piping_length``
 - **Type:** ``Double``
@@ -3962,7 +3962,7 @@ If the distribution system is Recirculation, the length of the recirculation pip
 
 **Hot Water Distribution: Recirculation Branch Piping Length**
 
-If the distribution system is Recirculation, the length of the recirculation branch piping. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#recirculation-in-unit'>Recirculation (In-Unit)</a>) is used.
+If the distribution system is Recirculation, the length of the recirculation branch piping. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#recirculation-in-unit'>Recirculation (In-Unit)</a>) is used.
 
 - **Name:** ``hot_water_distribution_recirc_branch_piping_length``
 - **Type:** ``Double``
@@ -3975,7 +3975,7 @@ If the distribution system is Recirculation, the length of the recirculation bra
 
 **Hot Water Distribution: Recirculation Pump Power**
 
-If the distribution system is Recirculation, the recirculation pump power. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#recirculation-in-unit'>Recirculation (In-Unit)</a>) is used.
+If the distribution system is Recirculation, the recirculation pump power. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#recirculation-in-unit'>Recirculation (In-Unit)</a>) is used.
 
 - **Name:** ``hot_water_distribution_recirc_pump_power``
 - **Type:** ``Double``
@@ -3988,7 +3988,7 @@ If the distribution system is Recirculation, the recirculation pump power. If no
 
 **Hot Water Distribution: Pipe Insulation Nominal R-Value**
 
-Nominal R-value of the pipe insulation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hot-water-distribution'>HPXML Hot Water Distribution</a>) is used.
+Nominal R-value of the pipe insulation. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hot-water-distribution'>HPXML Hot Water Distribution</a>) is used.
 
 - **Name:** ``hot_water_distribution_pipe_r``
 - **Type:** ``Double``
@@ -4060,7 +4060,7 @@ Whether the sink fixture is low flow.
 
 **Hot Water Fixtures: Usage Multiplier**
 
-Multiplier on the hot water usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-water-fixtures'>HPXML Water Fixtures</a>) is used.
+Multiplier on the hot water usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-water-fixtures'>HPXML Water Fixtures</a>) is used.
 
 - **Name:** ``water_fixtures_usage_multiplier``
 - **Type:** ``Double``
@@ -4071,7 +4071,7 @@ Multiplier on the hot water usage that can reflect, e.g., high/low usage occupan
 
 **General Water Use: Usage Multiplier**
 
-Multiplier on internal gains from general water use (floor mopping, shower evaporation, water films on showers, tubs & sinks surfaces, plant watering, etc.) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-occupancy'>HPXML Building Occupancy</a>) is used.
+Multiplier on internal gains from general water use (floor mopping, shower evaporation, water films on showers, tubs & sinks surfaces, plant watering, etc.) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-occupancy'>HPXML Building Occupancy</a>) is used.
 
 - **Name:** ``general_water_use_usage_multiplier``
 - **Type:** ``Double``
@@ -4184,7 +4184,7 @@ The collector rated thermal losses of the solar thermal system.
 
 **Solar Thermal: Storage Volume**
 
-The storage volume of the solar thermal system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#detailed-inputs'>Detailed Inputs</a>) is used.
+The storage volume of the solar thermal system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#detailed-inputs'>Detailed Inputs</a>) is used.
 
 - **Name:** ``solar_thermal_storage_volume``
 - **Type:** ``Double``
@@ -4221,7 +4221,7 @@ Whether there is a PV system present.
 
 **PV System: Module Type**
 
-Module type of the PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
+Module type of the PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
 
 - **Name:** ``pv_system_module_type``
 - **Type:** ``Choice``
@@ -4234,7 +4234,7 @@ Module type of the PV system. If not provided, the OS-HPXML default (see <a href
 
 **PV System: Location**
 
-Location of the PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
+Location of the PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
 
 - **Name:** ``pv_system_location``
 - **Type:** ``Choice``
@@ -4247,7 +4247,7 @@ Location of the PV system. If not provided, the OS-HPXML default (see <a href='h
 
 **PV System: Tracking**
 
-Type of tracking for the PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
+Type of tracking for the PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
 
 - **Name:** ``pv_system_tracking``
 - **Type:** ``Choice``
@@ -4297,7 +4297,7 @@ Maximum power output of the PV system. For a shared system, this is the total bu
 
 **PV System: Inverter Efficiency**
 
-Inverter efficiency of the PV system. If there are two PV systems, this will apply to both. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
+Inverter efficiency of the PV system. If there are two PV systems, this will apply to both. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
 
 - **Name:** ``pv_system_inverter_efficiency``
 - **Type:** ``Double``
@@ -4310,7 +4310,7 @@ Inverter efficiency of the PV system. If there are two PV systems, this will app
 
 **PV System: System Losses Fraction**
 
-System losses fraction of the PV system. If there are two PV systems, this will apply to both. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
+System losses fraction of the PV system. If there are two PV systems, this will apply to both. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
 
 - **Name:** ``pv_system_system_losses_fraction``
 - **Type:** ``Double``
@@ -4347,7 +4347,7 @@ Whether there is a second PV system present.
 
 **PV System 2: Module Type**
 
-Module type of the second PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
+Module type of the second PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
 
 - **Name:** ``pv_system_2_module_type``
 - **Type:** ``Choice``
@@ -4360,7 +4360,7 @@ Module type of the second PV system. If not provided, the OS-HPXML default (see 
 
 **PV System 2: Location**
 
-Location of the second PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
+Location of the second PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
 
 - **Name:** ``pv_system_2_location``
 - **Type:** ``Choice``
@@ -4373,7 +4373,7 @@ Location of the second PV system. If not provided, the OS-HPXML default (see <a 
 
 **PV System 2: Tracking**
 
-Type of tracking for the second PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
+Type of tracking for the second PV system. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'>HPXML Photovoltaics</a>) is used.
 
 - **Name:** ``pv_system_2_tracking``
 - **Type:** ``Choice``
@@ -4434,7 +4434,7 @@ Whether there is a lithium ion battery present.
 
 **Battery: Location**
 
-The space type for the lithium ion battery location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
+The space type for the lithium ion battery location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
 
 - **Name:** ``battery_location``
 - **Type:** ``Choice``
@@ -4447,7 +4447,7 @@ The space type for the lithium ion battery location. If not provided, the OS-HPX
 
 **Battery: Rated Power Output**
 
-The rated power output of the lithium ion battery. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
+The rated power output of the lithium ion battery. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
 
 - **Name:** ``battery_power``
 - **Type:** ``Double``
@@ -4460,7 +4460,7 @@ The rated power output of the lithium ion battery. If not provided, the OS-HPXML
 
 **Battery: Nominal Capacity**
 
-The nominal capacity of the lithium ion battery. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
+The nominal capacity of the lithium ion battery. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
 
 - **Name:** ``battery_capacity``
 - **Type:** ``Double``
@@ -4473,7 +4473,7 @@ The nominal capacity of the lithium ion battery. If not provided, the OS-HPXML d
 
 **Battery: Usable Capacity**
 
-The usable capacity of the lithium ion battery. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
+The usable capacity of the lithium ion battery. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
 
 - **Name:** ``battery_usable_capacity``
 - **Type:** ``Double``
@@ -4486,7 +4486,7 @@ The usable capacity of the lithium ion battery. If not provided, the OS-HPXML de
 
 **Battery: Round Trip Efficiency**
 
-The round trip efficiency of the lithium ion battery. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
+The round trip efficiency of the lithium ion battery. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'>HPXML Batteries</a>) is used.
 
 - **Name:** ``battery_round_trip_efficiency``
 - **Type:** ``Double``
@@ -4556,7 +4556,7 @@ Fraction of all lamps (interior) that are light emitting diodes. Lighting not sp
 
 **Lighting: Interior Usage Multiplier**
 
-Multiplier on the lighting energy usage (interior) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
+Multiplier on the lighting energy usage (interior) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
 
 - **Name:** ``lighting_interior_usage_multiplier``
 - **Type:** ``Double``
@@ -4600,7 +4600,7 @@ Fraction of all lamps (exterior) that are light emitting diodes. Lighting not sp
 
 **Lighting: Exterior Usage Multiplier**
 
-Multiplier on the lighting energy usage (exterior) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
+Multiplier on the lighting energy usage (exterior) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
 
 - **Name:** ``lighting_exterior_usage_multiplier``
 - **Type:** ``Double``
@@ -4644,7 +4644,7 @@ Fraction of all lamps (garage) that are light emitting diodes. Lighting not spec
 
 **Lighting: Garage Usage Multiplier**
 
-Multiplier on the lighting energy usage (garage) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
+Multiplier on the lighting energy usage (garage) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
 
 - **Name:** ``lighting_garage_usage_multiplier``
 - **Type:** ``Double``
@@ -4666,7 +4666,7 @@ Whether there is holiday lighting.
 
 **Holiday Lighting: Daily Consumption**
 
-The daily energy consumption for holiday lighting (exterior). If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
+The daily energy consumption for holiday lighting (exterior). If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
 
 - **Name:** ``holiday_lighting_daily_kwh``
 - **Type:** ``Double``
@@ -4679,7 +4679,7 @@ The daily energy consumption for holiday lighting (exterior). If not provided, t
 
 **Holiday Lighting: Period**
 
-Enter a date range like 'Nov 25 - Jan 5'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
+Enter a date range like 'Nov 25 - Jan 5'. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'>HPXML Lighting</a>) is used.
 
 - **Name:** ``holiday_lighting_period``
 - **Type:** ``String``
@@ -4779,7 +4779,7 @@ Whether there is a clothes washer present.
 
 **Clothes Washer: Location**
 
-The space type for the clothes washer location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+The space type for the clothes washer location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_location``
 - **Type:** ``Choice``
@@ -4805,7 +4805,7 @@ The efficiency type of the clothes washer.
 
 **Clothes Washer: Efficiency**
 
-The efficiency of the clothes washer. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+The efficiency of the clothes washer. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_efficiency``
 - **Type:** ``Double``
@@ -4818,7 +4818,7 @@ The efficiency of the clothes washer. If not provided, the OS-HPXML default (see
 
 **Clothes Washer: Rated Annual Consumption**
 
-The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_rated_annual_kwh``
 - **Type:** ``Double``
@@ -4831,7 +4831,7 @@ The annual energy consumed by the clothes washer, as rated, obtained from the En
 
 **Clothes Washer: Label Electric Rate**
 
-The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_label_electric_rate``
 - **Type:** ``Double``
@@ -4844,7 +4844,7 @@ The annual energy consumed by the clothes washer, as rated, obtained from the En
 
 **Clothes Washer: Label Gas Rate**
 
-The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_label_gas_rate``
 - **Type:** ``Double``
@@ -4857,7 +4857,7 @@ The annual energy consumed by the clothes washer, as rated, obtained from the En
 
 **Clothes Washer: Label Annual Cost with Gas DHW**
 
-The annual cost of using the system under test conditions. Input is obtained from the EnergyGuide label. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+The annual cost of using the system under test conditions. Input is obtained from the EnergyGuide label. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_label_annual_gas_cost``
 - **Type:** ``Double``
@@ -4870,7 +4870,7 @@ The annual cost of using the system under test conditions. Input is obtained fro
 
 **Clothes Washer: Label Usage**
 
-The clothes washer loads per week. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+The clothes washer loads per week. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_label_usage``
 - **Type:** ``Double``
@@ -4883,7 +4883,7 @@ The clothes washer loads per week. If not provided, the OS-HPXML default (see <a
 
 **Clothes Washer: Drum Volume**
 
-Volume of the washer drum. Obtained from the EnergyStar website or the manufacturer's literature. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+Volume of the washer drum. Obtained from the EnergyStar website or the manufacturer's literature. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_capacity``
 - **Type:** ``Double``
@@ -4896,7 +4896,7 @@ Volume of the washer drum. Obtained from the EnergyStar website or the manufactu
 
 **Clothes Washer: Usage Multiplier**
 
-Multiplier on the clothes washer energy and hot water usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
+Multiplier on the clothes washer energy and hot water usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'>HPXML Clothes Washer</a>) is used.
 
 - **Name:** ``clothes_washer_usage_multiplier``
 - **Type:** ``Double``
@@ -4918,7 +4918,7 @@ Whether there is a clothes dryer present.
 
 **Clothes Dryer: Location**
 
-The space type for the clothes dryer location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-dryer'>HPXML Clothes Dryer</a>) is used.
+The space type for the clothes dryer location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-dryer'>HPXML Clothes Dryer</a>) is used.
 
 - **Name:** ``clothes_dryer_location``
 - **Type:** ``Choice``
@@ -4957,7 +4957,7 @@ The efficiency type of the clothes dryer.
 
 **Clothes Dryer: Efficiency**
 
-The efficiency of the clothes dryer. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-dryer'>HPXML Clothes Dryer</a>) is used.
+The efficiency of the clothes dryer. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-dryer'>HPXML Clothes Dryer</a>) is used.
 
 - **Name:** ``clothes_dryer_efficiency``
 - **Type:** ``Double``
@@ -4970,7 +4970,7 @@ The efficiency of the clothes dryer. If not provided, the OS-HPXML default (see 
 
 **Clothes Dryer: Vented Flow Rate**
 
-The exhaust flow rate of the vented clothes dryer. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-dryer'>HPXML Clothes Dryer</a>) is used.
+The exhaust flow rate of the vented clothes dryer. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-dryer'>HPXML Clothes Dryer</a>) is used.
 
 - **Name:** ``clothes_dryer_vented_flow_rate``
 - **Type:** ``Double``
@@ -4983,7 +4983,7 @@ The exhaust flow rate of the vented clothes dryer. If not provided, the OS-HPXML
 
 **Clothes Dryer: Usage Multiplier**
 
-Multiplier on the clothes dryer energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-dryer'>HPXML Clothes Dryer</a>) is used.
+Multiplier on the clothes dryer energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-dryer'>HPXML Clothes Dryer</a>) is used.
 
 - **Name:** ``clothes_dryer_usage_multiplier``
 - **Type:** ``Double``
@@ -5005,7 +5005,7 @@ Whether there is a dishwasher present.
 
 **Dishwasher: Location**
 
-The space type for the dishwasher location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
+The space type for the dishwasher location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
 
 - **Name:** ``dishwasher_location``
 - **Type:** ``Choice``
@@ -5031,7 +5031,7 @@ The efficiency type of dishwasher.
 
 **Dishwasher: Efficiency**
 
-The efficiency of the dishwasher. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
+The efficiency of the dishwasher. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
 
 - **Name:** ``dishwasher_efficiency``
 - **Type:** ``Double``
@@ -5044,7 +5044,7 @@ The efficiency of the dishwasher. If not provided, the OS-HPXML default (see <a 
 
 **Dishwasher: Label Electric Rate**
 
-The label electric rate of the dishwasher. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
+The label electric rate of the dishwasher. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
 
 - **Name:** ``dishwasher_label_electric_rate``
 - **Type:** ``Double``
@@ -5057,7 +5057,7 @@ The label electric rate of the dishwasher. If not provided, the OS-HPXML default
 
 **Dishwasher: Label Gas Rate**
 
-The label gas rate of the dishwasher. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
+The label gas rate of the dishwasher. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
 
 - **Name:** ``dishwasher_label_gas_rate``
 - **Type:** ``Double``
@@ -5070,7 +5070,7 @@ The label gas rate of the dishwasher. If not provided, the OS-HPXML default (see
 
 **Dishwasher: Label Annual Gas Cost**
 
-The label annual gas cost of the dishwasher. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
+The label annual gas cost of the dishwasher. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
 
 - **Name:** ``dishwasher_label_annual_gas_cost``
 - **Type:** ``Double``
@@ -5083,7 +5083,7 @@ The label annual gas cost of the dishwasher. If not provided, the OS-HPXML defau
 
 **Dishwasher: Label Usage**
 
-The dishwasher loads per week. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
+The dishwasher loads per week. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
 
 - **Name:** ``dishwasher_label_usage``
 - **Type:** ``Double``
@@ -5096,7 +5096,7 @@ The dishwasher loads per week. If not provided, the OS-HPXML default (see <a hre
 
 **Dishwasher: Number of Place Settings**
 
-The number of place settings for the unit. Data obtained from manufacturer's literature. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
+The number of place settings for the unit. Data obtained from manufacturer's literature. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
 
 - **Name:** ``dishwasher_place_setting_capacity``
 - **Type:** ``Integer``
@@ -5109,7 +5109,7 @@ The number of place settings for the unit. Data obtained from manufacturer's lit
 
 **Dishwasher: Usage Multiplier**
 
-Multiplier on the dishwasher energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
+Multiplier on the dishwasher energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'>HPXML Dishwasher</a>) is used.
 
 - **Name:** ``dishwasher_usage_multiplier``
 - **Type:** ``Double``
@@ -5131,7 +5131,7 @@ Whether there is a refrigerator present.
 
 **Refrigerator: Location**
 
-The space type for the refrigerator location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
+The space type for the refrigerator location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
 
 - **Name:** ``refrigerator_location``
 - **Type:** ``Choice``
@@ -5144,7 +5144,7 @@ The space type for the refrigerator location. If not provided, the OS-HPXML defa
 
 **Refrigerator: Rated Annual Consumption**
 
-The EnergyGuide rated annual energy consumption for a refrigerator. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
+The EnergyGuide rated annual energy consumption for a refrigerator. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
 
 - **Name:** ``refrigerator_rated_annual_kwh``
 - **Type:** ``Double``
@@ -5157,7 +5157,7 @@ The EnergyGuide rated annual energy consumption for a refrigerator. If not provi
 
 **Refrigerator: Usage Multiplier**
 
-Multiplier on the refrigerator energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
+Multiplier on the refrigerator energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
 
 - **Name:** ``refrigerator_usage_multiplier``
 - **Type:** ``Double``
@@ -5179,7 +5179,7 @@ Whether there is an extra refrigerator present.
 
 **Extra Refrigerator: Location**
 
-The space type for the extra refrigerator location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
+The space type for the extra refrigerator location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
 
 - **Name:** ``extra_refrigerator_location``
 - **Type:** ``Choice``
@@ -5192,7 +5192,7 @@ The space type for the extra refrigerator location. If not provided, the OS-HPXM
 
 **Extra Refrigerator: Rated Annual Consumption**
 
-The EnergyGuide rated annual energy consumption for an extra refrigerator. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
+The EnergyGuide rated annual energy consumption for an extra refrigerator. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
 
 - **Name:** ``extra_refrigerator_rated_annual_kwh``
 - **Type:** ``Double``
@@ -5205,7 +5205,7 @@ The EnergyGuide rated annual energy consumption for an extra refrigerator. If no
 
 **Extra Refrigerator: Usage Multiplier**
 
-Multiplier on the extra refrigerator energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
+Multiplier on the extra refrigerator energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'>HPXML Refrigerators</a>) is used.
 
 - **Name:** ``extra_refrigerator_usage_multiplier``
 - **Type:** ``Double``
@@ -5227,7 +5227,7 @@ Whether there is a freezer present.
 
 **Freezer: Location**
 
-The space type for the freezer location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-freezers'>HPXML Freezers</a>) is used.
+The space type for the freezer location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-freezers'>HPXML Freezers</a>) is used.
 
 - **Name:** ``freezer_location``
 - **Type:** ``Choice``
@@ -5240,7 +5240,7 @@ The space type for the freezer location. If not provided, the OS-HPXML default (
 
 **Freezer: Rated Annual Consumption**
 
-The EnergyGuide rated annual energy consumption for a freezer. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-freezers'>HPXML Freezers</a>) is used.
+The EnergyGuide rated annual energy consumption for a freezer. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-freezers'>HPXML Freezers</a>) is used.
 
 - **Name:** ``freezer_rated_annual_kwh``
 - **Type:** ``Double``
@@ -5253,7 +5253,7 @@ The EnergyGuide rated annual energy consumption for a freezer. If not provided, 
 
 **Freezer: Usage Multiplier**
 
-Multiplier on the freezer energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-freezers'>HPXML Freezers</a>) is used.
+Multiplier on the freezer energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-freezers'>HPXML Freezers</a>) is used.
 
 - **Name:** ``freezer_usage_multiplier``
 - **Type:** ``Double``
@@ -5275,7 +5275,7 @@ Whether there is a cooking range/oven present.
 
 **Cooking Range/Oven: Location**
 
-The space type for the cooking range/oven location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooking-range-oven'>HPXML Cooking Range/Oven</a>) is used.
+The space type for the cooking range/oven location. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooking-range-oven'>HPXML Cooking Range/Oven</a>) is used.
 
 - **Name:** ``cooking_range_oven_location``
 - **Type:** ``Choice``
@@ -5301,7 +5301,7 @@ Type of fuel used by the cooking range/oven.
 
 **Cooking Range/Oven: Is Induction**
 
-Whether the cooking range is induction. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooking-range-oven'>HPXML Cooking Range/Oven</a>) is used.
+Whether the cooking range is induction. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooking-range-oven'>HPXML Cooking Range/Oven</a>) is used.
 
 - **Name:** ``cooking_range_oven_is_induction``
 - **Type:** ``Boolean``
@@ -5312,7 +5312,7 @@ Whether the cooking range is induction. If not provided, the OS-HPXML default (s
 
 **Cooking Range/Oven: Is Convection**
 
-Whether the oven is convection. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooking-range-oven'>HPXML Cooking Range/Oven</a>) is used.
+Whether the oven is convection. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooking-range-oven'>HPXML Cooking Range/Oven</a>) is used.
 
 - **Name:** ``cooking_range_oven_is_convection``
 - **Type:** ``Boolean``
@@ -5323,7 +5323,7 @@ Whether the oven is convection. If not provided, the OS-HPXML default (see <a hr
 
 **Cooking Range/Oven: Usage Multiplier**
 
-Multiplier on the cooking range/oven energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooking-range-oven'>HPXML Cooking Range/Oven</a>) is used.
+Multiplier on the cooking range/oven energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooking-range-oven'>HPXML Cooking Range/Oven</a>) is used.
 
 - **Name:** ``cooking_range_oven_usage_multiplier``
 - **Type:** ``Double``
@@ -5345,7 +5345,7 @@ Whether there are any ceiling fans.
 
 **Ceiling Fan: Label Energy Use**
 
-The label average energy use of the ceiling fan(s). If neither Efficiency nor Label Energy Use provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-ceiling-fans'>HPXML Ceiling Fans</a>) is used.
+The label average energy use of the ceiling fan(s). If neither Efficiency nor Label Energy Use provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-ceiling-fans'>HPXML Ceiling Fans</a>) is used.
 
 - **Name:** ``ceiling_fan_label_energy_use``
 - **Type:** ``Double``
@@ -5358,7 +5358,7 @@ The label average energy use of the ceiling fan(s). If neither Efficiency nor La
 
 **Ceiling Fan: Efficiency**
 
-The efficiency rating of the ceiling fan(s) at medium speed. Only used if Label Energy Use not provided. If neither Efficiency nor Label Energy Use provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-ceiling-fans'>HPXML Ceiling Fans</a>) is used.
+The efficiency rating of the ceiling fan(s) at medium speed. Only used if Label Energy Use not provided. If neither Efficiency nor Label Energy Use provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-ceiling-fans'>HPXML Ceiling Fans</a>) is used.
 
 - **Name:** ``ceiling_fan_efficiency``
 - **Type:** ``Double``
@@ -5371,7 +5371,7 @@ The efficiency rating of the ceiling fan(s) at medium speed. Only used if Label 
 
 **Ceiling Fan: Quantity**
 
-Total number of ceiling fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-ceiling-fans'>HPXML Ceiling Fans</a>) is used.
+Total number of ceiling fans. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-ceiling-fans'>HPXML Ceiling Fans</a>) is used.
 
 - **Name:** ``ceiling_fan_quantity``
 - **Type:** ``Integer``
@@ -5384,7 +5384,7 @@ Total number of ceiling fans. If not provided, the OS-HPXML default (see <a href
 
 **Ceiling Fan: Cooling Setpoint Temperature Offset**
 
-The cooling setpoint temperature offset during months when the ceiling fans are operating. Only applies if ceiling fan quantity is greater than zero. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-ceiling-fans'>HPXML Ceiling Fans</a>) is used.
+The cooling setpoint temperature offset during months when the ceiling fans are operating. Only applies if ceiling fan quantity is greater than zero. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-ceiling-fans'>HPXML Ceiling Fans</a>) is used.
 
 - **Name:** ``ceiling_fan_cooling_setpoint_temp_offset``
 - **Type:** ``Double``
@@ -5408,7 +5408,7 @@ Whether there are televisions.
 
 **Misc Plug Loads: Television Annual kWh**
 
-The annual energy consumption of the television plug loads. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+The annual energy consumption of the television plug loads. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_television_annual_kwh``
 - **Type:** ``Double``
@@ -5421,7 +5421,7 @@ The annual energy consumption of the television plug loads. If not provided, the
 
 **Misc Plug Loads: Television Usage Multiplier**
 
-Multiplier on the television energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+Multiplier on the television energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_television_usage_multiplier``
 - **Type:** ``Double``
@@ -5432,7 +5432,7 @@ Multiplier on the television energy usage that can reflect, e.g., high/low usage
 
 **Misc Plug Loads: Other Annual kWh**
 
-The annual energy consumption of the other residual plug loads. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+The annual energy consumption of the other residual plug loads. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_other_annual_kwh``
 - **Type:** ``Double``
@@ -5445,7 +5445,7 @@ The annual energy consumption of the other residual plug loads. If not provided,
 
 **Misc Plug Loads: Other Sensible Fraction**
 
-Fraction of other residual plug loads' internal gains that are sensible. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+Fraction of other residual plug loads' internal gains that are sensible. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_other_frac_sensible``
 - **Type:** ``Double``
@@ -5458,7 +5458,7 @@ Fraction of other residual plug loads' internal gains that are sensible. If not 
 
 **Misc Plug Loads: Other Latent Fraction**
 
-Fraction of other residual plug loads' internal gains that are latent. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+Fraction of other residual plug loads' internal gains that are latent. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_other_frac_latent``
 - **Type:** ``Double``
@@ -5471,7 +5471,7 @@ Fraction of other residual plug loads' internal gains that are latent. If not pr
 
 **Misc Plug Loads: Other Usage Multiplier**
 
-Multiplier on the other energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+Multiplier on the other energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_other_usage_multiplier``
 - **Type:** ``Double``
@@ -5493,7 +5493,7 @@ Whether there is a well pump.
 
 **Misc Plug Loads: Well Pump Annual kWh**
 
-The annual energy consumption of the well pump plug loads. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+The annual energy consumption of the well pump plug loads. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_well_pump_annual_kwh``
 - **Type:** ``Double``
@@ -5506,7 +5506,7 @@ The annual energy consumption of the well pump plug loads. If not provided, the 
 
 **Misc Plug Loads: Well Pump Usage Multiplier**
 
-Multiplier on the well pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+Multiplier on the well pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_well_pump_usage_multiplier``
 - **Type:** ``Double``
@@ -5528,7 +5528,7 @@ Whether there is an electric vehicle.
 
 **Misc Plug Loads: Vehicle Annual kWh**
 
-The annual energy consumption of the electric vehicle plug loads. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+The annual energy consumption of the electric vehicle plug loads. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_vehicle_annual_kwh``
 - **Type:** ``Double``
@@ -5541,7 +5541,7 @@ The annual energy consumption of the electric vehicle plug loads. If not provide
 
 **Misc Plug Loads: Vehicle Usage Multiplier**
 
-Multiplier on the electric vehicle energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
+Multiplier on the electric vehicle energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'>HPXML Plug Loads</a>) is used.
 
 - **Name:** ``misc_plug_loads_vehicle_usage_multiplier``
 - **Type:** ``Double``
@@ -5576,7 +5576,7 @@ The fuel type of the fuel loads grill.
 
 **Misc Fuel Loads: Grill Annual therm**
 
-The annual energy consumption of the fuel loads grill. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
+The annual energy consumption of the fuel loads grill. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
 
 - **Name:** ``misc_fuel_loads_grill_annual_therm``
 - **Type:** ``Double``
@@ -5589,7 +5589,7 @@ The annual energy consumption of the fuel loads grill. If not provided, the OS-H
 
 **Misc Fuel Loads: Grill Usage Multiplier**
 
-Multiplier on the fuel loads grill energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
+Multiplier on the fuel loads grill energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
 
 - **Name:** ``misc_fuel_loads_grill_usage_multiplier``
 - **Type:** ``Double``
@@ -5624,7 +5624,7 @@ The fuel type of the fuel loads lighting.
 
 **Misc Fuel Loads: Lighting Annual therm**
 
-The annual energy consumption of the fuel loads lighting. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>)is used.
+The annual energy consumption of the fuel loads lighting. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>)is used.
 
 - **Name:** ``misc_fuel_loads_lighting_annual_therm``
 - **Type:** ``Double``
@@ -5637,7 +5637,7 @@ The annual energy consumption of the fuel loads lighting. If not provided, the O
 
 **Misc Fuel Loads: Lighting Usage Multiplier**
 
-Multiplier on the fuel loads lighting energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
+Multiplier on the fuel loads lighting energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
 
 - **Name:** ``misc_fuel_loads_lighting_usage_multiplier``
 - **Type:** ``Double``
@@ -5672,7 +5672,7 @@ The fuel type of the fuel loads fireplace.
 
 **Misc Fuel Loads: Fireplace Annual therm**
 
-The annual energy consumption of the fuel loads fireplace. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
+The annual energy consumption of the fuel loads fireplace. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
 
 - **Name:** ``misc_fuel_loads_fireplace_annual_therm``
 - **Type:** ``Double``
@@ -5685,7 +5685,7 @@ The annual energy consumption of the fuel loads fireplace. If not provided, the 
 
 **Misc Fuel Loads: Fireplace Sensible Fraction**
 
-Fraction of fireplace residual fuel loads' internal gains that are sensible. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
+Fraction of fireplace residual fuel loads' internal gains that are sensible. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
 
 - **Name:** ``misc_fuel_loads_fireplace_frac_sensible``
 - **Type:** ``Double``
@@ -5698,7 +5698,7 @@ Fraction of fireplace residual fuel loads' internal gains that are sensible. If 
 
 **Misc Fuel Loads: Fireplace Latent Fraction**
 
-Fraction of fireplace residual fuel loads' internal gains that are latent. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
+Fraction of fireplace residual fuel loads' internal gains that are latent. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
 
 - **Name:** ``misc_fuel_loads_fireplace_frac_latent``
 - **Type:** ``Double``
@@ -5711,7 +5711,7 @@ Fraction of fireplace residual fuel loads' internal gains that are latent. If no
 
 **Misc Fuel Loads: Fireplace Usage Multiplier**
 
-Multiplier on the fuel loads fireplace energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
+Multiplier on the fuel loads fireplace energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'>HPXML Fuel Loads</a>) is used.
 
 - **Name:** ``misc_fuel_loads_fireplace_usage_multiplier``
 - **Type:** ``Double``
@@ -5733,7 +5733,7 @@ Whether there is a pool.
 
 **Pool: Pump Annual kWh**
 
-The annual energy consumption of the pool pump. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-pump'>Pool Pump</a>) is used.
+The annual energy consumption of the pool pump. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-pump'>Pool Pump</a>) is used.
 
 - **Name:** ``pool_pump_annual_kwh``
 - **Type:** ``Double``
@@ -5746,7 +5746,7 @@ The annual energy consumption of the pool pump. If not provided, the OS-HPXML de
 
 **Pool: Pump Usage Multiplier**
 
-Multiplier on the pool pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-pump'>Pool Pump</a>) is used.
+Multiplier on the pool pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-pump'>Pool Pump</a>) is used.
 
 - **Name:** ``pool_pump_usage_multiplier``
 - **Type:** ``Double``
@@ -5770,7 +5770,7 @@ The type of pool heater. Use 'none' if there is no pool heater.
 
 **Pool: Heater Annual kWh**
 
-The annual energy consumption of the electric resistance pool heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-heater'>Pool Heater</a>) is used.
+The annual energy consumption of the electric resistance pool heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-heater'>Pool Heater</a>) is used.
 
 - **Name:** ``pool_heater_annual_kwh``
 - **Type:** ``Double``
@@ -5783,7 +5783,7 @@ The annual energy consumption of the electric resistance pool heater. If not pro
 
 **Pool: Heater Annual therm**
 
-The annual energy consumption of the gas fired pool heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-heater'>Pool Heater</a>) is used.
+The annual energy consumption of the gas fired pool heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-heater'>Pool Heater</a>) is used.
 
 - **Name:** ``pool_heater_annual_therm``
 - **Type:** ``Double``
@@ -5796,7 +5796,7 @@ The annual energy consumption of the gas fired pool heater. If not provided, the
 
 **Pool: Heater Usage Multiplier**
 
-Multiplier on the pool heater energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-heater'>Pool Heater</a>) is used.
+Multiplier on the pool heater energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-heater'>Pool Heater</a>) is used.
 
 - **Name:** ``pool_heater_usage_multiplier``
 - **Type:** ``Double``
@@ -5818,7 +5818,7 @@ Whether there is a permanent spa.
 
 **Permanent Spa: Pump Annual kWh**
 
-The annual energy consumption of the permanent spa pump. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-pump'>Permanent Spa Pump</a>) is used.
+The annual energy consumption of the permanent spa pump. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-pump'>Permanent Spa Pump</a>) is used.
 
 - **Name:** ``permanent_spa_pump_annual_kwh``
 - **Type:** ``Double``
@@ -5831,7 +5831,7 @@ The annual energy consumption of the permanent spa pump. If not provided, the OS
 
 **Permanent Spa: Pump Usage Multiplier**
 
-Multiplier on the permanent spa pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-pump'>Permanent Spa Pump</a>) is used.
+Multiplier on the permanent spa pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-pump'>Permanent Spa Pump</a>) is used.
 
 - **Name:** ``permanent_spa_pump_usage_multiplier``
 - **Type:** ``Double``
@@ -5855,7 +5855,7 @@ The type of permanent spa heater. Use 'none' if there is no permanent spa heater
 
 **Permanent Spa: Heater Annual kWh**
 
-The annual energy consumption of the electric resistance permanent spa heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-heater'>Permanent Spa Heater</a>) is used.
+The annual energy consumption of the electric resistance permanent spa heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-heater'>Permanent Spa Heater</a>) is used.
 
 - **Name:** ``permanent_spa_heater_annual_kwh``
 - **Type:** ``Double``
@@ -5868,7 +5868,7 @@ The annual energy consumption of the electric resistance permanent spa heater. I
 
 **Permanent Spa: Heater Annual therm**
 
-The annual energy consumption of the gas fired permanent spa heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-heater'>Permanent Spa Heater</a>) is used.
+The annual energy consumption of the gas fired permanent spa heater. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-heater'>Permanent Spa Heater</a>) is used.
 
 - **Name:** ``permanent_spa_heater_annual_therm``
 - **Type:** ``Double``
@@ -5881,7 +5881,7 @@ The annual energy consumption of the gas fired permanent spa heater. If not prov
 
 **Permanent Spa: Heater Usage Multiplier**
 
-Multiplier on the permanent spa heater energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-heater'>Permanent Spa Heater</a>) is used.
+Multiplier on the permanent spa heater energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-heater'>Permanent Spa Heater</a>) is used.
 
 - **Name:** ``permanent_spa_heater_usage_multiplier``
 - **Type:** ``Double``

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>6024806a-1640-4c75-86e4-d00329c89e3a</version_id>
-  <version_modified>2024-10-31T22:43:54Z</version_modified>
+  <version_id>c71892c3-d59c-410c-8256-e328fd579975</version_id>
+  <version_modified>2024-11-25T23:03:23Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -88,7 +88,7 @@
     <argument>
       <name>schedules_unavailable_period_window_natvent_availabilities</name>
       <display_name>Schedules: Unavailable Period Window Natural Ventilation Availabilities</display_name>
-      <description>The availability of the natural ventilation schedule during unavailable periods. Valid choices are: regular schedule, always available, always unavailable. If multiple periods, use a comma-separated list. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-unavailable-periods'&gt;HPXML Unavailable Periods&lt;/a&gt;) is used.</description>
+      <description>The availability of the natural ventilation schedule during unavailable periods. Valid choices are: regular schedule, always available, always unavailable. If multiple periods, use a comma-separated list. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-unavailable-periods'&gt;HPXML Unavailable Periods&lt;/a&gt;) is used.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -96,7 +96,7 @@
     <argument>
       <name>simulation_control_timestep</name>
       <display_name>Simulation Control: Timestep</display_name>
-      <description>Value must be a divisor of 60. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
+      <description>Value must be a divisor of 60. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>min</units>
       <required>false</required>
@@ -105,7 +105,7 @@
     <argument>
       <name>simulation_control_run_period</name>
       <display_name>Simulation Control: Run Period</display_name>
-      <description>Enter a date range like 'Jan 1 - Dec 31'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
+      <description>Enter a date range like 'Jan 1 - Dec 31'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -113,7 +113,7 @@
     <argument>
       <name>simulation_control_run_period_calendar_year</name>
       <display_name>Simulation Control: Run Period Calendar Year</display_name>
-      <description>This numeric field should contain the calendar year that determines the start day of week. If you are running simulations using AMY weather files, the value entered for calendar year will not be used; it will be overridden by the actual year found in the AMY weather file. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
+      <description>This numeric field should contain the calendar year that determines the start day of week. If you are running simulations using AMY weather files, the value entered for calendar year will not be used; it will be overridden by the actual year found in the AMY weather file. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>year</units>
       <required>false</required>
@@ -122,7 +122,7 @@
     <argument>
       <name>simulation_control_daylight_saving_enabled</name>
       <display_name>Simulation Control: Daylight Saving Enabled</display_name>
-      <description>Whether to use daylight saving. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-site'&gt;HPXML Building Site&lt;/a&gt;) is used.</description>
+      <description>Whether to use daylight saving. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-site'&gt;HPXML Building Site&lt;/a&gt;) is used.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -140,7 +140,7 @@
     <argument>
       <name>simulation_control_daylight_saving_period</name>
       <display_name>Simulation Control: Daylight Saving Period</display_name>
-      <description>Enter a date range like 'Mar 15 - Dec 15'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-site'&gt;HPXML Building Site&lt;/a&gt;) is used.</description>
+      <description>Enter a date range like 'Mar 15 - Dec 15'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-site'&gt;HPXML Building Site&lt;/a&gt;) is used.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -148,7 +148,7 @@
     <argument>
       <name>simulation_control_temperature_capacitance_multiplier</name>
       <display_name>Simulation Control: Temperature Capacitance Multiplier</display_name>
-      <description>Affects the transient calculation of indoor air temperatures. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
+      <description>Affects the transient calculation of indoor air temperatures. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -156,7 +156,7 @@
     <argument>
       <name>simulation_control_defrost_model_type</name>
       <display_name>Simulation Control: Defrost Model Type</display_name>
-      <description>Research feature to select the type of defrost model. Use standard for default E+ defrost setting. Use advanced for an improved model that better accounts for load and energy use during defrost; using advanced may impact simulation runtime. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
+      <description>Research feature to select the type of defrost model. Use standard for default E+ defrost setting. Use advanced for an improved model that better accounts for load and energy use during defrost; using advanced may impact simulation runtime. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -192,7 +192,7 @@
     <argument>
       <name>site_type</name>
       <display_name>Site: Type</display_name>
-      <description>The type of site. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
+      <description>The type of site. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -214,7 +214,7 @@
     <argument>
       <name>site_shielding_of_home</name>
       <display_name>Site: Shielding of Home</display_name>
-      <description>Presence of nearby buildings, trees, obstructions for infiltration model. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
+      <description>Presence of nearby buildings, trees, obstructions for infiltration model. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -236,7 +236,7 @@
     <argument>
       <name>site_soil_and_moisture_type</name>
       <display_name>Site: Soil and Moisture Type</display_name>
-      <description>Type of soil and moisture. This is used to inform ground conductivity and diffusivity. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
+      <description>Type of soil and moisture. This is used to inform ground conductivity and diffusivity. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -434,7 +434,7 @@
     <argument>
       <name>site_state_code</name>
       <display_name>Site: State Code</display_name>
-      <description>State code of the home address. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
+      <description>State code of the home address. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -656,7 +656,7 @@
     <argument>
       <name>site_time_zone_utc_offset</name>
       <display_name>Site: Time Zone UTC Offset</display_name>
-      <description>Time zone UTC offset of the home address. Must be between -12 and 14. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
+      <description>Time zone UTC offset of the home address. Must be between -12 and 14. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>hr</units>
       <required>false</required>
@@ -665,7 +665,7 @@
     <argument>
       <name>site_elevation</name>
       <display_name>Site: Elevation</display_name>
-      <description>Elevation of the home address. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
+      <description>Elevation of the home address. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -674,7 +674,7 @@
     <argument>
       <name>site_latitude</name>
       <display_name>Site: Latitude</display_name>
-      <description>Latitude of the home address. Must be between -90 and 90. Use negative values for southern hemisphere. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
+      <description>Latitude of the home address. Must be between -90 and 90. Use negative values for southern hemisphere. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>deg</units>
       <required>false</required>
@@ -683,7 +683,7 @@
     <argument>
       <name>site_longitude</name>
       <display_name>Site: Longitude</display_name>
-      <description>Longitude of the home address. Must be between -180 and 180. Use negative values for the western hemisphere. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
+      <description>Longitude of the home address. Must be between -180 and 180. Use negative values for the western hemisphere. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-site'&gt;HPXML Site&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>deg</units>
       <required>false</required>
@@ -869,7 +869,7 @@
     <argument>
       <name>geometry_unit_num_bathrooms</name>
       <display_name>Geometry: Unit Number of Bathrooms</display_name>
-      <description>The number of bathrooms in the unit. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-construction'&gt;HPXML Building Construction&lt;/a&gt;) is used.</description>
+      <description>The number of bathrooms in the unit. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-construction'&gt;HPXML Building Construction&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>#</units>
       <required>false</required>
@@ -906,7 +906,7 @@
     <argument>
       <name>geometry_unit_height_above_grade</name>
       <display_name>Geometry: Unit Height Above Grade</display_name>
-      <description>Describes the above-grade height of apartment units on upper floors or homes above ambient or belly-and-wing foundations. It is defined as the height of the lowest conditioned floor above grade and is used to calculate the wind speed for the infiltration model. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-construction'&gt;HPXML Building Construction&lt;/a&gt;) is used.</description>
+      <description>Describes the above-grade height of apartment units on upper floors or homes above ambient or belly-and-wing foundations. It is defined as the height of the lowest conditioned floor above grade and is used to calculate the wind speed for the infiltration model. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-construction'&gt;HPXML Building Construction&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -1203,7 +1203,7 @@
     <argument>
       <name>neighbor_front_height</name>
       <display_name>Neighbor: Front Height</display_name>
-      <description>The height of the neighboring building to the front. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-neighbor-buildings'&gt;HPXML Neighbor Building&lt;/a&gt;) is used.</description>
+      <description>The height of the neighboring building to the front. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-neighbor-buildings'&gt;HPXML Neighbor Building&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -1212,7 +1212,7 @@
     <argument>
       <name>neighbor_back_height</name>
       <display_name>Neighbor: Back Height</display_name>
-      <description>The height of the neighboring building to the back. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-neighbor-buildings'&gt;HPXML Neighbor Building&lt;/a&gt;) is used.</description>
+      <description>The height of the neighboring building to the back. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-neighbor-buildings'&gt;HPXML Neighbor Building&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -1221,7 +1221,7 @@
     <argument>
       <name>neighbor_left_height</name>
       <display_name>Neighbor: Left Height</display_name>
-      <description>The height of the neighboring building to the left. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-neighbor-buildings'&gt;HPXML Neighbor Building&lt;/a&gt;) is used.</description>
+      <description>The height of the neighboring building to the left. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-neighbor-buildings'&gt;HPXML Neighbor Building&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -1230,7 +1230,7 @@
     <argument>
       <name>neighbor_right_height</name>
       <display_name>Neighbor: Right Height</display_name>
-      <description>The height of the neighboring building to the right. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-neighbor-buildings'&gt;HPXML Neighbor Building&lt;/a&gt;) is used.</description>
+      <description>The height of the neighboring building to the right. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-neighbor-buildings'&gt;HPXML Neighbor Building&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -1286,7 +1286,7 @@
     <argument>
       <name>foundation_wall_type</name>
       <display_name>Foundation Wall: Type</display_name>
-      <description>The material type of the foundation wall. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-foundation-walls'&gt;HPXML Foundation Walls&lt;/a&gt;) is used.</description>
+      <description>The material type of the foundation wall. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-foundation-walls'&gt;HPXML Foundation Walls&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -1328,7 +1328,7 @@
     <argument>
       <name>foundation_wall_thickness</name>
       <display_name>Foundation Wall: Thickness</display_name>
-      <description>The thickness of the foundation wall. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-foundation-walls'&gt;HPXML Foundation Walls&lt;/a&gt;) is used.</description>
+      <description>The thickness of the foundation wall. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-foundation-walls'&gt;HPXML Foundation Walls&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>in</units>
       <required>false</required>
@@ -1367,7 +1367,7 @@
     <argument>
       <name>foundation_wall_insulation_distance_to_top</name>
       <display_name>Foundation Wall: Insulation Distance To Top</display_name>
-      <description>The distance from the top of the foundation wall to the top of the foundation wall insulation. Only applies to basements/crawlspaces. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-foundation-walls'&gt;HPXML Foundation Walls&lt;/a&gt;) is used.</description>
+      <description>The distance from the top of the foundation wall to the top of the foundation wall insulation. Only applies to basements/crawlspaces. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-foundation-walls'&gt;HPXML Foundation Walls&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -1376,7 +1376,7 @@
     <argument>
       <name>foundation_wall_insulation_distance_to_bottom</name>
       <display_name>Foundation Wall: Insulation Distance To Bottom</display_name>
-      <description>The distance from the top of the foundation wall to the bottom of the foundation wall insulation. Only applies to basements/crawlspaces. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-foundation-walls'&gt;HPXML Foundation Walls&lt;/a&gt;) is used.</description>
+      <description>The distance from the top of the foundation wall to the bottom of the foundation wall insulation. Only applies to basements/crawlspaces. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-foundation-walls'&gt;HPXML Foundation Walls&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -1470,7 +1470,7 @@
     <argument>
       <name>slab_thickness</name>
       <display_name>Slab: Thickness</display_name>
-      <description>The thickness of the slab. Zero can be entered if there is a dirt floor instead of a slab. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-slabs'&gt;HPXML Slabs&lt;/a&gt;) is used.</description>
+      <description>The thickness of the slab. Zero can be entered if there is a dirt floor instead of a slab. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-slabs'&gt;HPXML Slabs&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>in</units>
       <required>false</required>
@@ -1479,7 +1479,7 @@
     <argument>
       <name>slab_carpet_fraction</name>
       <display_name>Slab: Carpet Fraction</display_name>
-      <description>Fraction of the slab floor area that is carpeted. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-slabs'&gt;HPXML Slabs&lt;/a&gt;) is used.</description>
+      <description>Fraction of the slab floor area that is carpeted. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-slabs'&gt;HPXML Slabs&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -1488,7 +1488,7 @@
     <argument>
       <name>slab_carpet_r</name>
       <display_name>Slab: Carpet R-value</display_name>
-      <description>R-value of the slab carpet. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-slabs'&gt;HPXML Slabs&lt;/a&gt;) is used.</description>
+      <description>R-value of the slab carpet. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-slabs'&gt;HPXML Slabs&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>h-ft^2-R/Btu</units>
       <required>false</required>
@@ -1507,7 +1507,7 @@
     <argument>
       <name>roof_material_type</name>
       <display_name>Roof: Material Type</display_name>
-      <description>The material type of the roof. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-roofs'&gt;HPXML Roofs&lt;/a&gt;) is used.</description>
+      <description>The material type of the roof. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-roofs'&gt;HPXML Roofs&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -1553,7 +1553,7 @@
     <argument>
       <name>roof_color</name>
       <display_name>Roof: Color</display_name>
-      <description>The color of the roof. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-roofs'&gt;HPXML Roofs&lt;/a&gt;) is used.</description>
+      <description>The color of the roof. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-roofs'&gt;HPXML Roofs&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -1619,7 +1619,7 @@
     <argument>
       <name>radiant_barrier_grade</name>
       <display_name>Attic: Radiant Barrier Grade</display_name>
-      <description>The grade of the radiant barrier in the attic. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-roofs'&gt;HPXML Roofs&lt;/a&gt;) is used.</description>
+      <description>The grade of the radiant barrier in the attic. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-roofs'&gt;HPXML Roofs&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -1696,7 +1696,7 @@
     <argument>
       <name>wall_siding_type</name>
       <display_name>Wall: Siding Type</display_name>
-      <description>The siding type of the walls. Also applies to rim joists. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-walls'&gt;HPXML Walls&lt;/a&gt;) is used.</description>
+      <description>The siding type of the walls. Also applies to rim joists. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-walls'&gt;HPXML Walls&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -1750,7 +1750,7 @@
     <argument>
       <name>wall_color</name>
       <display_name>Wall: Color</display_name>
-      <description>The color of the walls. Also applies to rim joists. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-walls'&gt;HPXML Walls&lt;/a&gt;) is used.</description>
+      <description>The color of the walls. Also applies to rim joists. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-walls'&gt;HPXML Walls&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -1880,7 +1880,7 @@
     <argument>
       <name>window_fraction_operable</name>
       <display_name>Windows: Fraction Operable</display_name>
-      <description>Fraction of windows that are operable. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-windows'&gt;HPXML Windows&lt;/a&gt;) is used.</description>
+      <description>Fraction of windows that are operable. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-windows'&gt;HPXML Windows&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -1889,7 +1889,7 @@
     <argument>
       <name>window_natvent_availability</name>
       <display_name>Windows: Natural Ventilation Availability</display_name>
-      <description>For operable windows, the number of days/week that windows can be opened by occupants for natural ventilation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-windows'&gt;HPXML Windows&lt;/a&gt;) is used.</description>
+      <description>For operable windows, the number of days/week that windows can be opened by occupants for natural ventilation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-windows'&gt;HPXML Windows&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>Days/week</units>
       <required>false</required>
@@ -1917,7 +1917,7 @@
     <argument>
       <name>window_interior_shading_type</name>
       <display_name>Windows: Interior Shading Type</display_name>
-      <description>Type of window interior shading. Summer/winter shading coefficients can be provided below instead. If neither is provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-interior-shading'&gt;HPXML Interior Shading&lt;/a&gt;) is used.</description>
+      <description>Type of window interior shading. Summer/winter shading coefficients can be provided below instead. If neither is provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-interior-shading'&gt;HPXML Interior Shading&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -1967,7 +1967,7 @@
     <argument>
       <name>window_interior_shading_winter</name>
       <display_name>Windows: Winter Interior Shading Coefficient</display_name>
-      <description>Interior shading coefficient for the winter season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-interior-shading'&gt;HPXML Interior Shading&lt;/a&gt;) is used.</description>
+      <description>Interior shading coefficient for the winter season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-interior-shading'&gt;HPXML Interior Shading&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -1976,7 +1976,7 @@
     <argument>
       <name>window_interior_shading_summer</name>
       <display_name>Windows: Summer Interior Shading Coefficient</display_name>
-      <description>Interior shading coefficient for the summer season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-interior-shading'&gt;HPXML Interior Shading&lt;/a&gt;) is used.</description>
+      <description>Interior shading coefficient for the summer season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-interior-shading'&gt;HPXML Interior Shading&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -1985,7 +1985,7 @@
     <argument>
       <name>window_exterior_shading_type</name>
       <display_name>Windows: Exterior Shading Type</display_name>
-      <description>Type of window exterior shading. Summer/winter shading coefficients can be provided below instead. If neither is provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-exterior-shading'&gt;HPXML Exterior Shading&lt;/a&gt;) is used.</description>
+      <description>Type of window exterior shading. Summer/winter shading coefficients can be provided below instead. If neither is provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-exterior-shading'&gt;HPXML Exterior Shading&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -2007,7 +2007,7 @@
     <argument>
       <name>window_exterior_shading_winter</name>
       <display_name>Windows: Winter Exterior Shading Coefficient</display_name>
-      <description>Exterior shading coefficient for the winter season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-exterior-shading'&gt;HPXML Exterior Shading&lt;/a&gt;) is used.</description>
+      <description>Exterior shading coefficient for the winter season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-exterior-shading'&gt;HPXML Exterior Shading&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -2016,7 +2016,7 @@
     <argument>
       <name>window_exterior_shading_summer</name>
       <display_name>Windows: Summer Exterior Shading Coefficient</display_name>
-      <description>Exterior shading coefficient for the summer season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-exterior-shading'&gt;HPXML Exterior Shading&lt;/a&gt;) is used.</description>
+      <description>Exterior shading coefficient for the summer season, which if provided overrides the shading type input. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-exterior-shading'&gt;HPXML Exterior Shading&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -2025,7 +2025,7 @@
     <argument>
       <name>window_shading_summer_season</name>
       <display_name>Windows: Shading Summer Season</display_name>
-      <description>Enter a date range like 'May 1 - Sep 30'. Defines the summer season for purposes of shading coefficients; the rest of the year is assumed to be winter. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-windows'&gt;HPXML Windows&lt;/a&gt;) is used.</description>
+      <description>Enter a date range like 'May 1 - Sep 30'. Defines the summer season for purposes of shading coefficients; the rest of the year is assumed to be winter. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-windows'&gt;HPXML Windows&lt;/a&gt;) is used.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -2386,7 +2386,7 @@
     <argument>
       <name>air_leakage_has_flue_or_chimney_in_conditioned_space</name>
       <display_name>Air Leakage: Has Flue or Chimney in Conditioned Space</display_name>
-      <description>Presence of flue or chimney with combustion air from conditioned space; used for infiltration model. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#flue-or-chimney'&gt;Flue or Chimney&lt;/a&gt;) is used.</description>
+      <description>Presence of flue or chimney with combustion air from conditioned space; used for infiltration model. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#flue-or-chimney'&gt;Flue or Chimney&lt;/a&gt;) is used.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -2508,7 +2508,7 @@
     <argument>
       <name>heating_system_heating_capacity</name>
       <display_name>Heating System: Heating Capacity</display_name>
-      <description>The output heating capacity of the heating system. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-heating-systems'&gt;HPXML Heating Systems&lt;/a&gt;) is used.</description>
+      <description>The output heating capacity of the heating system. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-heating-systems'&gt;HPXML Heating Systems&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -2633,7 +2633,7 @@
     <argument>
       <name>cooling_system_cooling_compressor_type</name>
       <display_name>Cooling System: Cooling Compressor Type</display_name>
-      <description>The compressor type of the cooling system. Only applies to central air conditioner and mini-split. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#central-air-conditioner'&gt;Central Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-air-conditioner'&gt;Mini-Split Air Conditioner&lt;/a&gt;) is used.</description>
+      <description>The compressor type of the cooling system. Only applies to central air conditioner and mini-split. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#central-air-conditioner'&gt;Central Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-air-conditioner'&gt;Mini-Split Air Conditioner&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -2655,7 +2655,7 @@
     <argument>
       <name>cooling_system_cooling_sensible_heat_fraction</name>
       <display_name>Cooling System: Cooling Sensible Heat Fraction</display_name>
-      <description>The sensible heat fraction of the cooling system. Ignored for evaporative cooler. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#central-air-conditioner'&gt;Central Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner'&gt;Room Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-air-conditioner'&gt;Packaged Terminal Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-air-conditioner'&gt;Mini-Split Air Conditioner&lt;/a&gt;) is used.</description>
+      <description>The sensible heat fraction of the cooling system. Ignored for evaporative cooler. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#central-air-conditioner'&gt;Central Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner'&gt;Room Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-air-conditioner'&gt;Packaged Terminal Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-air-conditioner'&gt;Mini-Split Air Conditioner&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -2664,7 +2664,7 @@
     <argument>
       <name>cooling_system_cooling_capacity</name>
       <display_name>Cooling System: Cooling Capacity</display_name>
-      <description>The output cooling capacity of the cooling system. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#central-air-conditioner'&gt;Central Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner'&gt;Room Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-air-conditioner'&gt;Packaged Terminal Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#evaporative-cooler'&gt;Evaporative Cooler&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-air-conditioner'&gt;Mini-Split Air Conditioner&lt;/a&gt;) is used.</description>
+      <description>The output cooling capacity of the cooling system. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#central-air-conditioner'&gt;Central Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner'&gt;Room Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-air-conditioner'&gt;Packaged Terminal Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#evaporative-cooler'&gt;Evaporative Cooler&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-air-conditioner'&gt;Mini-Split Air Conditioner&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -2737,7 +2737,7 @@
     <argument>
       <name>cooling_system_crankcase_heater_watts</name>
       <display_name>Cooling System: Crankcase Heater Power Watts</display_name>
-      <description>Cooling system crankcase heater power consumption in Watts. Applies only to central air conditioner, room air conditioner, packaged terminal air conditioner and mini-split. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#central-air-conditioner'&gt;Central Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner'&gt;Room Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-air-conditioner'&gt;Packaged Terminal Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-air-conditioner'&gt;Mini-Split Air Conditioner&lt;/a&gt;) is used.</description>
+      <description>Cooling system crankcase heater power consumption in Watts. Applies only to central air conditioner, room air conditioner, packaged terminal air conditioner and mini-split. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#central-air-conditioner'&gt;Central Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner'&gt;Room Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-air-conditioner'&gt;Packaged Terminal Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-air-conditioner'&gt;Mini-Split Air Conditioner&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -2793,7 +2793,7 @@
     <argument>
       <name>cooling_system_integrated_heating_system_capacity</name>
       <display_name>Cooling System: Integrated Heating System Heating Capacity</display_name>
-      <description>The output heating capacity of the heating system integrated into cooling system. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner'&gt;Room Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-air-conditioner'&gt;Packaged Terminal Air Conditioner&lt;/a&gt;) is used. Only used for room air conditioner and packaged terminal air conditioner.</description>
+      <description>The output heating capacity of the heating system integrated into cooling system. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner'&gt;Room Air Conditioner&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-air-conditioner'&gt;Packaged Terminal Air Conditioner&lt;/a&gt;) is used. Only used for room air conditioner and packaged terminal air conditioner.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -2914,7 +2914,7 @@
     <argument>
       <name>heat_pump_cooling_compressor_type</name>
       <display_name>Heat Pump: Cooling Compressor Type</display_name>
-      <description>The compressor type of the heat pump. Only applies to air-to-air and mini-split. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;) is used.</description>
+      <description>The compressor type of the heat pump. Only applies to air-to-air and mini-split. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -2936,7 +2936,7 @@
     <argument>
       <name>heat_pump_cooling_sensible_heat_fraction</name>
       <display_name>Heat Pump: Cooling Sensible Heat Fraction</display_name>
-      <description>The sensible heat fraction of the heat pump. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#ground-to-air-heat-pump'&gt;Ground-to-Air Heat Pump&lt;/a&gt;) is used.</description>
+      <description>The sensible heat fraction of the heat pump. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#ground-to-air-heat-pump'&gt;Ground-to-Air Heat Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -2945,7 +2945,7 @@
     <argument>
       <name>heat_pump_heating_capacity</name>
       <display_name>Heat Pump: Heating Capacity</display_name>
-      <description>The output heating capacity of the heat pump. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#ground-to-air-heat-pump'&gt;Ground-to-Air Heat Pump&lt;/a&gt;) is used.</description>
+      <description>The output heating capacity of the heat pump. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#ground-to-air-heat-pump'&gt;Ground-to-Air Heat Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -2971,7 +2971,7 @@
     <argument>
       <name>heat_pump_heating_capacity_retention_fraction</name>
       <display_name>Heat Pump: Heating Capacity Retention Fraction</display_name>
-      <description>The output heating capacity of the heat pump at a user-specified temperature (e.g., 17F or 5F) divided by the above nominal heating capacity. Applies to all heat pump types except ground-to-air. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;) is used.</description>
+      <description>The output heating capacity of the heat pump at a user-specified temperature (e.g., 17F or 5F) divided by the above nominal heating capacity. Applies to all heat pump types except ground-to-air. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -2989,7 +2989,7 @@
     <argument>
       <name>heat_pump_cooling_capacity</name>
       <display_name>Heat Pump: Cooling Capacity</display_name>
-      <description>The output cooling capacity of the heat pump. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#ground-to-air-heat-pump'&gt;Ground-to-Air Heat Pump&lt;/a&gt;) is used.</description>
+      <description>The output cooling capacity of the heat pump. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#ground-to-air-heat-pump'&gt;Ground-to-Air Heat Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -3035,7 +3035,7 @@
     <argument>
       <name>heat_pump_compressor_lockout_temp</name>
       <display_name>Heat Pump: Compressor Lockout Temperature</display_name>
-      <description>The temperature below which the heat pump compressor is disabled. If both this and Backup Heating Lockout Temperature are provided and use the same value, it essentially defines a switchover temperature (for, e.g., a dual-fuel heat pump). Applies to all heat pump types other than ground-to-air. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;) is used.</description>
+      <description>The temperature below which the heat pump compressor is disabled. If both this and Backup Heating Lockout Temperature are provided and use the same value, it essentially defines a switchover temperature (for, e.g., a dual-fuel heat pump). Applies to all heat pump types other than ground-to-air. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>F</units>
       <required>false</required>
@@ -3120,7 +3120,7 @@
     <argument>
       <name>heat_pump_backup_heating_capacity</name>
       <display_name>Heat Pump: Backup Heating Capacity</display_name>
-      <description>The backup output heating capacity of the heat pump. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#backup'&gt;Backup&lt;/a&gt;) is used. Only applies if Backup Type is 'integrated'.</description>
+      <description>The backup output heating capacity of the heat pump. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#backup'&gt;Backup&lt;/a&gt;) is used. Only applies if Backup Type is 'integrated'.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -3129,7 +3129,7 @@
     <argument>
       <name>heat_pump_backup_heating_lockout_temp</name>
       <display_name>Heat Pump: Backup Heating Lockout Temperature</display_name>
-      <description>The temperature above which the heat pump backup system is disabled. If both this and Compressor Lockout Temperature are provided and use the same value, it essentially defines a switchover temperature (for, e.g., a dual-fuel heat pump). Applies for both Backup Type of 'integrated' and 'separate'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#backup'&gt;Backup&lt;/a&gt;) is used.</description>
+      <description>The temperature above which the heat pump backup system is disabled. If both this and Compressor Lockout Temperature are provided and use the same value, it essentially defines a switchover temperature (for, e.g., a dual-fuel heat pump). Applies for both Backup Type of 'integrated' and 'separate'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#backup'&gt;Backup&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>F</units>
       <required>false</required>
@@ -3138,7 +3138,7 @@
     <argument>
       <name>heat_pump_sizing_methodology</name>
       <display_name>Heat Pump: Sizing Methodology</display_name>
-      <description>The auto-sizing methodology to use when the heat pump capacity is not provided. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hvac-sizing-control'&gt;HPXML HVAC Sizing Control&lt;/a&gt;) is used.</description>
+      <description>The auto-sizing methodology to use when the heat pump capacity is not provided. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hvac-sizing-control'&gt;HPXML HVAC Sizing Control&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3160,7 +3160,7 @@
     <argument>
       <name>heat_pump_backup_sizing_methodology</name>
       <display_name>Heat Pump: Backup Sizing Methodology</display_name>
-      <description>The auto-sizing methodology to use when the heat pump backup capacity is not provided. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hvac-sizing-control'&gt;HPXML HVAC Sizing Control&lt;/a&gt;) is used.</description>
+      <description>The auto-sizing methodology to use when the heat pump backup capacity is not provided. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hvac-sizing-control'&gt;HPXML HVAC Sizing Control&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3214,7 +3214,7 @@
     <argument>
       <name>heat_pump_crankcase_heater_watts</name>
       <display_name>Heat Pump: Crankcase Heater Power Watts</display_name>
-      <description>Heat Pump crankcase heater power consumption in Watts. Applies only to air-to-air, mini-split, packaged terminal heat pump and room air conditioner with reverse cycle. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;) is used.</description>
+      <description>Heat Pump crankcase heater power consumption in Watts. Applies only to air-to-air, mini-split, packaged terminal heat pump and room air conditioner with reverse cycle. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-to-air-heat-pump'&gt;Air-to-Air Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#mini-split-heat-pump'&gt;Mini-Split Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#packaged-terminal-heat-pump'&gt;Packaged Terminal Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#room-air-conditioner-w-reverse-cycle'&gt;Room Air Conditioner w/ Reverse Cycle&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -3332,7 +3332,7 @@
     <argument>
       <name>geothermal_loop_configuration</name>
       <display_name>Geothermal Loop: Configuration</display_name>
-      <description>Configuration of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#ground-to-air-heat-pump'&gt;Ground-to-Air Heat Pump&lt;/a&gt;) is used.</description>
+      <description>Configuration of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#ground-to-air-heat-pump'&gt;Ground-to-Air Heat Pump&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3350,7 +3350,7 @@
     <argument>
       <name>geothermal_loop_borefield_configuration</name>
       <display_name>Geothermal Loop: Borefield Configuration</display_name>
-      <description>Borefield configuration of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Borefield configuration of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3384,7 +3384,7 @@
     <argument>
       <name>geothermal_loop_loop_flow</name>
       <display_name>Geothermal Loop: Loop Flow</display_name>
-      <description>Water flow rate through the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Water flow rate through the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>gpm</units>
       <required>false</required>
@@ -3393,7 +3393,7 @@
     <argument>
       <name>geothermal_loop_boreholes_count</name>
       <display_name>Geothermal Loop: Boreholes Count</display_name>
-      <description>Number of boreholes. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Number of boreholes. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>#</units>
       <required>false</required>
@@ -3402,7 +3402,7 @@
     <argument>
       <name>geothermal_loop_boreholes_length</name>
       <display_name>Geothermal Loop: Boreholes Length</display_name>
-      <description>Average length of each borehole (vertical). Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Average length of each borehole (vertical). Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -3411,7 +3411,7 @@
     <argument>
       <name>geothermal_loop_boreholes_spacing</name>
       <display_name>Geothermal Loop: Boreholes Spacing</display_name>
-      <description>Distance between bores. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Distance between bores. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -3420,7 +3420,7 @@
     <argument>
       <name>geothermal_loop_boreholes_diameter</name>
       <display_name>Geothermal Loop: Boreholes Diameter</display_name>
-      <description>Diameter of bores. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Diameter of bores. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>in</units>
       <required>false</required>
@@ -3429,7 +3429,7 @@
     <argument>
       <name>geothermal_loop_grout_type</name>
       <display_name>Geothermal Loop: Grout Type</display_name>
-      <description>Grout type of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Grout type of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3447,7 +3447,7 @@
     <argument>
       <name>geothermal_loop_pipe_type</name>
       <display_name>Geothermal Loop: Pipe Type</display_name>
-      <description>Pipe type of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Pipe type of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3465,7 +3465,7 @@
     <argument>
       <name>geothermal_loop_pipe_diameter</name>
       <display_name>Geothermal Loop: Pipe Diameter</display_name>
-      <description>Pipe diameter of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
+      <description>Pipe diameter of the geothermal loop. Only applies to ground-to-air heat pump type. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-geothermal-loops'&gt;HPXML Geothermal Loops&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <units>in</units>
       <required>false</required>
@@ -3584,7 +3584,7 @@
     <argument>
       <name>heating_system_2_heating_capacity</name>
       <display_name>Heating System 2: Heating Capacity</display_name>
-      <description>The output heating capacity of the second heating system. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-heating-systems'&gt;HPXML Heating Systems&lt;/a&gt;) is used.</description>
+      <description>The output heating capacity of the second heating system. If not provided, the OS-HPXML autosized default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-heating-systems'&gt;HPXML Heating Systems&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -3656,7 +3656,7 @@
     <argument>
       <name>hvac_control_heating_season_period</name>
       <display_name>HVAC Control: Heating Season Period</display_name>
-      <description>Enter a date range like 'Nov 1 - Jun 30'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hvac-control'&gt;HPXML HVAC Control&lt;/a&gt;) is used. Can also provide 'BuildingAmerica' to use automatic seasons from the Building America House Simulation Protocols.</description>
+      <description>Enter a date range like 'Nov 1 - Jun 30'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hvac-control'&gt;HPXML HVAC Control&lt;/a&gt;) is used. Can also provide 'BuildingAmerica' to use automatic seasons from the Building America House Simulation Protocols.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3664,7 +3664,7 @@
     <argument>
       <name>hvac_control_cooling_season_period</name>
       <display_name>HVAC Control: Cooling Season Period</display_name>
-      <description>Enter a date range like 'Jun 1 - Oct 31'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hvac-control'&gt;HPXML HVAC Control&lt;/a&gt;) is used. Can also provide 'BuildingAmerica' to use automatic seasons from the Building America House Simulation Protocols.</description>
+      <description>Enter a date range like 'Jun 1 - Oct 31'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hvac-control'&gt;HPXML HVAC Control&lt;/a&gt;) is used. Can also provide 'BuildingAmerica' to use automatic seasons from the Building America House Simulation Protocols.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3672,7 +3672,7 @@
     <argument>
       <name>hvac_blower_fan_watts_per_cfm</name>
       <display_name>HVAC Blower: Fan Efficiency</display_name>
-      <description>The blower fan efficiency at maximum fan speed. Applies only to split (not packaged) systems (i.e., applies to ducted systems as well as ductless mini-split systems). If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-heating-systems'&gt;HPXML Heating Systems&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooling-systems'&gt;HPXML Cooling Systems&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-heat-pumps'&gt;HPXML Heat Pumps&lt;/a&gt;) is used.</description>
+      <description>The blower fan efficiency at maximum fan speed. Applies only to split (not packaged) systems (i.e., applies to ducted systems as well as ductless mini-split systems). If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-heating-systems'&gt;HPXML Heating Systems&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooling-systems'&gt;HPXML Cooling Systems&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-heat-pumps'&gt;HPXML Heat Pumps&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W/CFM</units>
       <required>false</required>
@@ -3713,7 +3713,7 @@
     <argument>
       <name>ducts_supply_location</name>
       <display_name>Ducts: Supply Location</display_name>
-      <description>The location of the supply ducts. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The location of the supply ducts. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -3839,7 +3839,7 @@
     <argument>
       <name>ducts_supply_surface_area</name>
       <display_name>Ducts: Supply Surface Area</display_name>
-      <description>The supply ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The supply ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft^2</units>
       <required>false</required>
@@ -3848,7 +3848,7 @@
     <argument>
       <name>ducts_supply_surface_area_fraction</name>
       <display_name>Ducts: Supply Area Fraction</display_name>
-      <description>The fraction of supply ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The fraction of supply ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>frac</units>
       <required>false</required>
@@ -3857,7 +3857,7 @@
     <argument>
       <name>ducts_supply_fraction_rectangular</name>
       <display_name>Ducts: Supply Fraction Rectangular</display_name>
-      <description>The fraction of supply ducts that are rectangular (as opposed to round); this affects the duct effective R-value used for modeling. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The fraction of supply ducts that are rectangular (as opposed to round); this affects the duct effective R-value used for modeling. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>frac</units>
       <required>false</required>
@@ -3875,7 +3875,7 @@
     <argument>
       <name>ducts_return_location</name>
       <display_name>Ducts: Return Location</display_name>
-      <description>The location of the return ducts. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The location of the return ducts. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -4001,7 +4001,7 @@
     <argument>
       <name>ducts_return_surface_area</name>
       <display_name>Ducts: Return Surface Area</display_name>
-      <description>The return ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The return ducts surface area in the given location. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft^2</units>
       <required>false</required>
@@ -4010,7 +4010,7 @@
     <argument>
       <name>ducts_return_surface_area_fraction</name>
       <display_name>Ducts: Return Area Fraction</display_name>
-      <description>The fraction of return ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The fraction of return ducts surface area in the given location. Only used if Surface Area is not provided. If the fraction is less than 1, the remaining duct area is assumed to be in conditioned space. If neither Surface Area nor Area Fraction provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>frac</units>
       <required>false</required>
@@ -4019,7 +4019,7 @@
     <argument>
       <name>ducts_number_of_return_registers</name>
       <display_name>Ducts: Number of Return Registers</display_name>
-      <description>The number of return registers of the ducts. Only used to calculate default return duct surface area. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The number of return registers of the ducts. Only used to calculate default return duct surface area. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>#</units>
       <required>false</required>
@@ -4028,7 +4028,7 @@
     <argument>
       <name>ducts_return_fraction_rectangular</name>
       <display_name>Ducts: Return Fraction Rectangular</display_name>
-      <description>The fraction of return ducts that are rectangular (as opposed to round); this affects the duct effective R-value used for modeling. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
+      <description>The fraction of return ducts that are rectangular (as opposed to round); this affects the duct effective R-value used for modeling. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#air-distribution'&gt;Air Distribution&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>frac</units>
       <required>false</required>
@@ -4076,7 +4076,7 @@
     <argument>
       <name>mech_vent_flow_rate</name>
       <display_name>Mechanical Ventilation: Flow Rate</display_name>
-      <description>The flow rate of the mechanical ventilation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-mechanical-ventilation-fans'&gt;HPXML Mechanical Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The flow rate of the mechanical ventilation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-mechanical-ventilation-fans'&gt;HPXML Mechanical Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>CFM</units>
       <required>false</required>
@@ -4085,7 +4085,7 @@
     <argument>
       <name>mech_vent_hours_in_operation</name>
       <display_name>Mechanical Ventilation: Hours In Operation</display_name>
-      <description>The hours in operation of the mechanical ventilation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-mechanical-ventilation-fans'&gt;HPXML Mechanical Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The hours in operation of the mechanical ventilation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-mechanical-ventilation-fans'&gt;HPXML Mechanical Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>hrs/day</units>
       <required>false</required>
@@ -4133,7 +4133,7 @@
     <argument>
       <name>mech_vent_fan_power</name>
       <display_name>Mechanical Ventilation: Fan Power</display_name>
-      <description>The fan power of the mechanical ventilation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-mechanical-ventilation-fans'&gt;HPXML Mechanical Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The fan power of the mechanical ventilation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-mechanical-ventilation-fans'&gt;HPXML Mechanical Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -4353,7 +4353,7 @@
     <argument>
       <name>kitchen_fans_quantity</name>
       <display_name>Kitchen Fans: Quantity</display_name>
-      <description>The quantity of the kitchen fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The quantity of the kitchen fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>#</units>
       <required>false</required>
@@ -4362,7 +4362,7 @@
     <argument>
       <name>kitchen_fans_flow_rate</name>
       <display_name>Kitchen Fans: Flow Rate</display_name>
-      <description>The flow rate of the kitchen fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The flow rate of the kitchen fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>CFM</units>
       <required>false</required>
@@ -4371,7 +4371,7 @@
     <argument>
       <name>kitchen_fans_hours_in_operation</name>
       <display_name>Kitchen Fans: Hours In Operation</display_name>
-      <description>The hours in operation of the kitchen fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The hours in operation of the kitchen fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>hrs/day</units>
       <required>false</required>
@@ -4380,7 +4380,7 @@
     <argument>
       <name>kitchen_fans_power</name>
       <display_name>Kitchen Fans: Fan Power</display_name>
-      <description>The fan power of the kitchen fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The fan power of the kitchen fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -4389,7 +4389,7 @@
     <argument>
       <name>kitchen_fans_start_hour</name>
       <display_name>Kitchen Fans: Start Hour</display_name>
-      <description>The start hour of the kitchen fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The start hour of the kitchen fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>hr</units>
       <required>false</required>
@@ -4398,7 +4398,7 @@
     <argument>
       <name>bathroom_fans_quantity</name>
       <display_name>Bathroom Fans: Quantity</display_name>
-      <description>The quantity of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The quantity of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>#</units>
       <required>false</required>
@@ -4407,7 +4407,7 @@
     <argument>
       <name>bathroom_fans_flow_rate</name>
       <display_name>Bathroom Fans: Flow Rate</display_name>
-      <description>The flow rate of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The flow rate of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>CFM</units>
       <required>false</required>
@@ -4416,7 +4416,7 @@
     <argument>
       <name>bathroom_fans_hours_in_operation</name>
       <display_name>Bathroom Fans: Hours In Operation</display_name>
-      <description>The hours in operation of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The hours in operation of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>hrs/day</units>
       <required>false</required>
@@ -4425,7 +4425,7 @@
     <argument>
       <name>bathroom_fans_power</name>
       <display_name>Bathroom Fans: Fan Power</display_name>
-      <description>The fan power of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The fan power of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -4434,7 +4434,7 @@
     <argument>
       <name>bathroom_fans_start_hour</name>
       <display_name>Bathroom Fans: Start Hour</display_name>
-      <description>The start hour of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
+      <description>The start hour of the bathroom fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-local-ventilation-fans'&gt;HPXML Local Ventilation Fans&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>hr</units>
       <required>false</required>
@@ -4462,7 +4462,7 @@
     <argument>
       <name>whole_house_fan_flow_rate</name>
       <display_name>Whole House Fan: Flow Rate</display_name>
-      <description>The flow rate of the whole house fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-whole-house-fans'&gt;HPXML Whole House Fans&lt;/a&gt;) is used.</description>
+      <description>The flow rate of the whole house fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-whole-house-fans'&gt;HPXML Whole House Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>CFM</units>
       <required>false</required>
@@ -4471,7 +4471,7 @@
     <argument>
       <name>whole_house_fan_power</name>
       <display_name>Whole House Fan: Fan Power</display_name>
-      <description>The fan power of the whole house fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-whole-house-fans'&gt;HPXML Whole House Fans&lt;/a&gt;) is used.</description>
+      <description>The fan power of the whole house fan. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-whole-house-fans'&gt;HPXML Whole House Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -4550,7 +4550,7 @@
     <argument>
       <name>water_heater_location</name>
       <display_name>Water Heater: Location</display_name>
-      <description>The location of water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-water-heating-systems'&gt;HPXML Water Heating Systems&lt;/a&gt;) is used.</description>
+      <description>The location of water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-water-heating-systems'&gt;HPXML Water Heating Systems&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -4624,7 +4624,7 @@
     <argument>
       <name>water_heater_tank_volume</name>
       <display_name>Water Heater: Tank Volume</display_name>
-      <description>Nominal volume of water heater tank. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#combi-boiler-w-storage'&gt;Combi Boiler w/ Storage&lt;/a&gt;) is used.</description>
+      <description>Nominal volume of water heater tank. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#combi-boiler-w-storage'&gt;Combi Boiler w/ Storage&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>gal</units>
       <required>false</required>
@@ -4661,7 +4661,7 @@
     <argument>
       <name>water_heater_usage_bin</name>
       <display_name>Water Heater: Usage Bin</display_name>
-      <description>The usage of the water heater. Only applies if Efficiency Type is UniformEnergyFactor and Type is not instantaneous water heater. Does not apply to space-heating boilers. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;) is used.</description>
+      <description>The usage of the water heater. Only applies if Efficiency Type is UniformEnergyFactor and Type is not instantaneous water heater. Does not apply to space-heating boilers. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -4687,7 +4687,7 @@
     <argument>
       <name>water_heater_recovery_efficiency</name>
       <display_name>Water Heater: Recovery Efficiency</display_name>
-      <description>Ratio of energy delivered to water heater to the energy content of the fuel consumed by the water heater. Only used for non-electric storage water heaters. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;) is used.</description>
+      <description>Ratio of energy delivered to water heater to the energy content of the fuel consumed by the water heater. Only used for non-electric storage water heaters. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -4696,7 +4696,7 @@
     <argument>
       <name>water_heater_heating_capacity</name>
       <display_name>Water Heater: Heating Capacity</display_name>
-      <description>Heating capacity. Only applies to storage water heater and heat pump water heater (compressor). If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;) is used.</description>
+      <description>Heating capacity. Only applies to storage water heater and heat pump water heater (compressor). If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;, &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -4705,7 +4705,7 @@
     <argument>
       <name>water_heater_backup_heating_capacity</name>
       <display_name>Water Heater: Backup Heating Capacity</display_name>
-      <description>Backup heating capacity for a heat pump water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;) is used.</description>
+      <description>Backup heating capacity for a heat pump water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Btu/hr</units>
       <required>false</required>
@@ -4714,7 +4714,7 @@
     <argument>
       <name>water_heater_standby_loss</name>
       <display_name>Water Heater: Standby Loss</display_name>
-      <description>The standby loss of water heater. Only applies to space-heating boilers. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#combi-boiler-w-storage'&gt;Combi Boiler w/ Storage&lt;/a&gt;) is used.</description>
+      <description>The standby loss of water heater. Only applies to space-heating boilers. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#combi-boiler-w-storage'&gt;Combi Boiler w/ Storage&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>F/hr</units>
       <required>false</required>
@@ -4732,7 +4732,7 @@
     <argument>
       <name>water_heater_setpoint_temperature</name>
       <display_name>Water Heater: Setpoint Temperature</display_name>
-      <description>The setpoint temperature of water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-water-heating-systems'&gt;HPXML Water Heating Systems&lt;/a&gt;) is used.</description>
+      <description>The setpoint temperature of water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-water-heating-systems'&gt;HPXML Water Heating Systems&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>F</units>
       <required>false</required>
@@ -4768,7 +4768,7 @@
     <argument>
       <name>water_heater_tank_model_type</name>
       <display_name>Water Heater: Tank Type</display_name>
-      <description>Type of tank model to use. The 'stratified' tank generally provide more accurate results, but may significantly increase run time. Applies only to storage water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;) is used.</description>
+      <description>Type of tank model to use. The 'stratified' tank generally provide more accurate results, but may significantly increase run time. Applies only to storage water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#conventional-storage'&gt;Conventional Storage&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -4786,7 +4786,7 @@
     <argument>
       <name>water_heater_operating_mode</name>
       <display_name>Water Heater: Operating Mode</display_name>
-      <description>The water heater operating mode. The 'heat pump only' option only uses the heat pump, while 'hybrid/auto' allows the backup electric resistance to come on in high demand situations. This is ignored if a scheduled operating mode type is selected. Applies only to heat pump water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;) is used.</description>
+      <description>The water heater operating mode. The 'heat pump only' option only uses the heat pump, while 'hybrid/auto' allows the backup electric resistance to come on in high demand situations. This is ignored if a scheduled operating mode type is selected. Applies only to heat pump water heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#heat-pump'&gt;Heat Pump&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -4823,7 +4823,7 @@
     <argument>
       <name>hot_water_distribution_standard_piping_length</name>
       <display_name>Hot Water Distribution: Standard Piping Length</display_name>
-      <description>If the distribution system is Standard, the length of the piping. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#standard'&gt;Standard&lt;/a&gt;) is used.</description>
+      <description>If the distribution system is Standard, the length of the piping. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#standard'&gt;Standard&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -4863,7 +4863,7 @@
     <argument>
       <name>hot_water_distribution_recirc_piping_length</name>
       <display_name>Hot Water Distribution: Recirculation Piping Length</display_name>
-      <description>If the distribution system is Recirculation, the length of the recirculation piping. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#recirculation-in-unit'&gt;Recirculation (In-Unit)&lt;/a&gt;) is used.</description>
+      <description>If the distribution system is Recirculation, the length of the recirculation piping. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#recirculation-in-unit'&gt;Recirculation (In-Unit)&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -4872,7 +4872,7 @@
     <argument>
       <name>hot_water_distribution_recirc_branch_piping_length</name>
       <display_name>Hot Water Distribution: Recirculation Branch Piping Length</display_name>
-      <description>If the distribution system is Recirculation, the length of the recirculation branch piping. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#recirculation-in-unit'&gt;Recirculation (In-Unit)&lt;/a&gt;) is used.</description>
+      <description>If the distribution system is Recirculation, the length of the recirculation branch piping. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#recirculation-in-unit'&gt;Recirculation (In-Unit)&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft</units>
       <required>false</required>
@@ -4881,7 +4881,7 @@
     <argument>
       <name>hot_water_distribution_recirc_pump_power</name>
       <display_name>Hot Water Distribution: Recirculation Pump Power</display_name>
-      <description>If the distribution system is Recirculation, the recirculation pump power. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#recirculation-in-unit'&gt;Recirculation (In-Unit)&lt;/a&gt;) is used.</description>
+      <description>If the distribution system is Recirculation, the recirculation pump power. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#recirculation-in-unit'&gt;Recirculation (In-Unit)&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -4890,7 +4890,7 @@
     <argument>
       <name>hot_water_distribution_pipe_r</name>
       <display_name>Hot Water Distribution: Pipe Insulation Nominal R-Value</display_name>
-      <description>Nominal R-value of the pipe insulation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-hot-water-distribution'&gt;HPXML Hot Water Distribution&lt;/a&gt;) is used.</description>
+      <description>Nominal R-value of the pipe insulation. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-hot-water-distribution'&gt;HPXML Hot Water Distribution&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>h-ft^2-R/Btu</units>
       <required>false</required>
@@ -4989,7 +4989,7 @@
     <argument>
       <name>water_fixtures_usage_multiplier</name>
       <display_name>Hot Water Fixtures: Usage Multiplier</display_name>
-      <description>Multiplier on the hot water usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-water-fixtures'&gt;HPXML Water Fixtures&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the hot water usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-water-fixtures'&gt;HPXML Water Fixtures&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -4997,7 +4997,7 @@
     <argument>
       <name>general_water_use_usage_multiplier</name>
       <display_name>General Water Use: Usage Multiplier</display_name>
-      <description>Multiplier on internal gains from general water use (floor mopping, shower evaporation, water films on showers, tubs &amp; sinks surfaces, plant watering, etc.) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-building-occupancy'&gt;HPXML Building Occupancy&lt;/a&gt;) is used.</description>
+      <description>Multiplier on internal gains from general water use (floor mopping, shower evaporation, water films on showers, tubs &amp; sinks surfaces, plant watering, etc.) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-building-occupancy'&gt;HPXML Building Occupancy&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5124,7 +5124,7 @@
     <argument>
       <name>solar_thermal_storage_volume</name>
       <display_name>Solar Thermal: Storage Volume</display_name>
-      <description>The storage volume of the solar thermal system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#detailed-inputs'&gt;Detailed Inputs&lt;/a&gt;) is used.</description>
+      <description>The storage volume of the solar thermal system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#detailed-inputs'&gt;Detailed Inputs&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>gal</units>
       <required>false</required>
@@ -5162,7 +5162,7 @@
     <argument>
       <name>pv_system_module_type</name>
       <display_name>PV System: Module Type</display_name>
-      <description>Module type of the PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
+      <description>Module type of the PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5184,7 +5184,7 @@
     <argument>
       <name>pv_system_location</name>
       <display_name>PV System: Location</display_name>
-      <description>Location of the PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
+      <description>Location of the PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5202,7 +5202,7 @@
     <argument>
       <name>pv_system_tracking</name>
       <display_name>PV System: Tracking</display_name>
-      <description>Type of tracking for the PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
+      <description>Type of tracking for the PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5258,7 +5258,7 @@
     <argument>
       <name>pv_system_inverter_efficiency</name>
       <display_name>PV System: Inverter Efficiency</display_name>
-      <description>Inverter efficiency of the PV system. If there are two PV systems, this will apply to both. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
+      <description>Inverter efficiency of the PV system. If there are two PV systems, this will apply to both. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -5267,7 +5267,7 @@
     <argument>
       <name>pv_system_system_losses_fraction</name>
       <display_name>PV System: System Losses Fraction</display_name>
-      <description>System losses fraction of the PV system. If there are two PV systems, this will apply to both. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
+      <description>System losses fraction of the PV system. If there are two PV systems, this will apply to both. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -5304,7 +5304,7 @@
     <argument>
       <name>pv_system_2_module_type</name>
       <display_name>PV System 2: Module Type</display_name>
-      <description>Module type of the second PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
+      <description>Module type of the second PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5326,7 +5326,7 @@
     <argument>
       <name>pv_system_2_location</name>
       <display_name>PV System 2: Location</display_name>
-      <description>Location of the second PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
+      <description>Location of the second PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5344,7 +5344,7 @@
     <argument>
       <name>pv_system_2_tracking</name>
       <display_name>PV System 2: Tracking</display_name>
-      <description>Type of tracking for the second PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
+      <description>Type of tracking for the second PV system. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-photovoltaics'&gt;HPXML Photovoltaics&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5419,7 +5419,7 @@
     <argument>
       <name>battery_location</name>
       <display_name>Battery: Location</display_name>
-      <description>The space type for the lithium ion battery location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
+      <description>The space type for the lithium ion battery location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5477,7 +5477,7 @@
     <argument>
       <name>battery_power</name>
       <display_name>Battery: Rated Power Output</display_name>
-      <description>The rated power output of the lithium ion battery. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
+      <description>The rated power output of the lithium ion battery. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -5486,7 +5486,7 @@
     <argument>
       <name>battery_capacity</name>
       <display_name>Battery: Nominal Capacity</display_name>
-      <description>The nominal capacity of the lithium ion battery. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
+      <description>The nominal capacity of the lithium ion battery. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh</units>
       <required>false</required>
@@ -5495,7 +5495,7 @@
     <argument>
       <name>battery_usable_capacity</name>
       <display_name>Battery: Usable Capacity</display_name>
-      <description>The usable capacity of the lithium ion battery. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
+      <description>The usable capacity of the lithium ion battery. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh</units>
       <required>false</required>
@@ -5504,7 +5504,7 @@
     <argument>
       <name>battery_round_trip_efficiency</name>
       <display_name>Battery: Round Trip Efficiency</display_name>
-      <description>The round trip efficiency of the lithium ion battery. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
+      <description>The round trip efficiency of the lithium ion battery. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-batteries'&gt;HPXML Batteries&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -5568,7 +5568,7 @@
     <argument>
       <name>lighting_interior_usage_multiplier</name>
       <display_name>Lighting: Interior Usage Multiplier</display_name>
-      <description>Multiplier on the lighting energy usage (interior) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the lighting energy usage (interior) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5603,7 +5603,7 @@
     <argument>
       <name>lighting_exterior_usage_multiplier</name>
       <display_name>Lighting: Exterior Usage Multiplier</display_name>
-      <description>Multiplier on the lighting energy usage (exterior) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the lighting energy usage (exterior) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5638,7 +5638,7 @@
     <argument>
       <name>lighting_garage_usage_multiplier</name>
       <display_name>Lighting: Garage Usage Multiplier</display_name>
-      <description>Multiplier on the lighting energy usage (garage) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the lighting energy usage (garage) that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5665,7 +5665,7 @@
     <argument>
       <name>holiday_lighting_daily_kwh</name>
       <display_name>Holiday Lighting: Daily Consumption</display_name>
-      <description>The daily energy consumption for holiday lighting (exterior). If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
+      <description>The daily energy consumption for holiday lighting (exterior). If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/day</units>
       <required>false</required>
@@ -5674,7 +5674,7 @@
     <argument>
       <name>holiday_lighting_period</name>
       <display_name>Holiday Lighting: Period</display_name>
-      <description>Enter a date range like 'Nov 25 - Jan 5'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
+      <description>Enter a date range like 'Nov 25 - Jan 5'. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-lighting'&gt;HPXML Lighting&lt;/a&gt;) is used.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5783,7 +5783,7 @@
     <argument>
       <name>clothes_washer_location</name>
       <display_name>Clothes Washer: Location</display_name>
-      <description>The space type for the clothes washer location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>The space type for the clothes washer location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5844,7 +5844,7 @@
     <argument>
       <name>clothes_washer_efficiency</name>
       <display_name>Clothes Washer: Efficiency</display_name>
-      <description>The efficiency of the clothes washer. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>The efficiency of the clothes washer. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft^3/kWh-cyc</units>
       <required>false</required>
@@ -5853,7 +5853,7 @@
     <argument>
       <name>clothes_washer_rated_annual_kwh</name>
       <display_name>Clothes Washer: Rated Annual Consumption</display_name>
-      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -5862,7 +5862,7 @@
     <argument>
       <name>clothes_washer_label_electric_rate</name>
       <display_name>Clothes Washer: Label Electric Rate</display_name>
-      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>$/kWh</units>
       <required>false</required>
@@ -5871,7 +5871,7 @@
     <argument>
       <name>clothes_washer_label_gas_rate</name>
       <display_name>Clothes Washer: Label Gas Rate</display_name>
-      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>$/therm</units>
       <required>false</required>
@@ -5880,7 +5880,7 @@
     <argument>
       <name>clothes_washer_label_annual_gas_cost</name>
       <display_name>Clothes Washer: Label Annual Cost with Gas DHW</display_name>
-      <description>The annual cost of using the system under test conditions. Input is obtained from the EnergyGuide label. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>The annual cost of using the system under test conditions. Input is obtained from the EnergyGuide label. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>$</units>
       <required>false</required>
@@ -5889,7 +5889,7 @@
     <argument>
       <name>clothes_washer_label_usage</name>
       <display_name>Clothes Washer: Label Usage</display_name>
-      <description>The clothes washer loads per week. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>The clothes washer loads per week. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>cyc/wk</units>
       <required>false</required>
@@ -5898,7 +5898,7 @@
     <argument>
       <name>clothes_washer_capacity</name>
       <display_name>Clothes Washer: Drum Volume</display_name>
-      <description>Volume of the washer drum. Obtained from the EnergyStar website or the manufacturer's literature. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>Volume of the washer drum. Obtained from the EnergyStar website or the manufacturer's literature. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>ft^3</units>
       <required>false</required>
@@ -5907,7 +5907,7 @@
     <argument>
       <name>clothes_washer_usage_multiplier</name>
       <display_name>Clothes Washer: Usage Multiplier</display_name>
-      <description>Multiplier on the clothes washer energy and hot water usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the clothes washer energy and hot water usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-washer'&gt;HPXML Clothes Washer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5934,7 +5934,7 @@
     <argument>
       <name>clothes_dryer_location</name>
       <display_name>Clothes Dryer: Location</display_name>
-      <description>The space type for the clothes dryer location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-dryer'&gt;HPXML Clothes Dryer&lt;/a&gt;) is used.</description>
+      <description>The space type for the clothes dryer location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-dryer'&gt;HPXML Clothes Dryer&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6030,7 +6030,7 @@
     <argument>
       <name>clothes_dryer_efficiency</name>
       <display_name>Clothes Dryer: Efficiency</display_name>
-      <description>The efficiency of the clothes dryer. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-dryer'&gt;HPXML Clothes Dryer&lt;/a&gt;) is used.</description>
+      <description>The efficiency of the clothes dryer. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-dryer'&gt;HPXML Clothes Dryer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>lb/kWh</units>
       <required>false</required>
@@ -6039,7 +6039,7 @@
     <argument>
       <name>clothes_dryer_vented_flow_rate</name>
       <display_name>Clothes Dryer: Vented Flow Rate</display_name>
-      <description>The exhaust flow rate of the vented clothes dryer. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-dryer'&gt;HPXML Clothes Dryer&lt;/a&gt;) is used.</description>
+      <description>The exhaust flow rate of the vented clothes dryer. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-dryer'&gt;HPXML Clothes Dryer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>CFM</units>
       <required>false</required>
@@ -6048,7 +6048,7 @@
     <argument>
       <name>clothes_dryer_usage_multiplier</name>
       <display_name>Clothes Dryer: Usage Multiplier</display_name>
-      <description>Multiplier on the clothes dryer energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-clothes-dryer'&gt;HPXML Clothes Dryer&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the clothes dryer energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-clothes-dryer'&gt;HPXML Clothes Dryer&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6075,7 +6075,7 @@
     <argument>
       <name>dishwasher_location</name>
       <display_name>Dishwasher: Location</display_name>
-      <description>The space type for the dishwasher location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
+      <description>The space type for the dishwasher location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6136,7 +6136,7 @@
     <argument>
       <name>dishwasher_efficiency</name>
       <display_name>Dishwasher: Efficiency</display_name>
-      <description>The efficiency of the dishwasher. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
+      <description>The efficiency of the dishwasher. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>RatedAnnualkWh or EnergyFactor</units>
       <required>false</required>
@@ -6145,7 +6145,7 @@
     <argument>
       <name>dishwasher_label_electric_rate</name>
       <display_name>Dishwasher: Label Electric Rate</display_name>
-      <description>The label electric rate of the dishwasher. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
+      <description>The label electric rate of the dishwasher. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>$/kWh</units>
       <required>false</required>
@@ -6154,7 +6154,7 @@
     <argument>
       <name>dishwasher_label_gas_rate</name>
       <display_name>Dishwasher: Label Gas Rate</display_name>
-      <description>The label gas rate of the dishwasher. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
+      <description>The label gas rate of the dishwasher. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>$/therm</units>
       <required>false</required>
@@ -6163,7 +6163,7 @@
     <argument>
       <name>dishwasher_label_annual_gas_cost</name>
       <display_name>Dishwasher: Label Annual Gas Cost</display_name>
-      <description>The label annual gas cost of the dishwasher. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
+      <description>The label annual gas cost of the dishwasher. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>$</units>
       <required>false</required>
@@ -6172,7 +6172,7 @@
     <argument>
       <name>dishwasher_label_usage</name>
       <display_name>Dishwasher: Label Usage</display_name>
-      <description>The dishwasher loads per week. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
+      <description>The dishwasher loads per week. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>cyc/wk</units>
       <required>false</required>
@@ -6181,7 +6181,7 @@
     <argument>
       <name>dishwasher_place_setting_capacity</name>
       <display_name>Dishwasher: Number of Place Settings</display_name>
-      <description>The number of place settings for the unit. Data obtained from manufacturer's literature. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
+      <description>The number of place settings for the unit. Data obtained from manufacturer's literature. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>#</units>
       <required>false</required>
@@ -6190,7 +6190,7 @@
     <argument>
       <name>dishwasher_usage_multiplier</name>
       <display_name>Dishwasher: Usage Multiplier</display_name>
-      <description>Multiplier on the dishwasher energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the dishwasher energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-dishwasher'&gt;HPXML Dishwasher&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6217,7 +6217,7 @@
     <argument>
       <name>refrigerator_location</name>
       <display_name>Refrigerator: Location</display_name>
-      <description>The space type for the refrigerator location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
+      <description>The space type for the refrigerator location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6259,7 +6259,7 @@
     <argument>
       <name>refrigerator_rated_annual_kwh</name>
       <display_name>Refrigerator: Rated Annual Consumption</display_name>
-      <description>The EnergyGuide rated annual energy consumption for a refrigerator. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
+      <description>The EnergyGuide rated annual energy consumption for a refrigerator. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -6268,7 +6268,7 @@
     <argument>
       <name>refrigerator_usage_multiplier</name>
       <display_name>Refrigerator: Usage Multiplier</display_name>
-      <description>Multiplier on the refrigerator energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the refrigerator energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6295,7 +6295,7 @@
     <argument>
       <name>extra_refrigerator_location</name>
       <display_name>Extra Refrigerator: Location</display_name>
-      <description>The space type for the extra refrigerator location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
+      <description>The space type for the extra refrigerator location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6337,7 +6337,7 @@
     <argument>
       <name>extra_refrigerator_rated_annual_kwh</name>
       <display_name>Extra Refrigerator: Rated Annual Consumption</display_name>
-      <description>The EnergyGuide rated annual energy consumption for an extra refrigerator. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
+      <description>The EnergyGuide rated annual energy consumption for an extra refrigerator. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -6346,7 +6346,7 @@
     <argument>
       <name>extra_refrigerator_usage_multiplier</name>
       <display_name>Extra Refrigerator: Usage Multiplier</display_name>
-      <description>Multiplier on the extra refrigerator energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the extra refrigerator energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-refrigerators'&gt;HPXML Refrigerators&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6373,7 +6373,7 @@
     <argument>
       <name>freezer_location</name>
       <display_name>Freezer: Location</display_name>
-      <description>The space type for the freezer location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-freezers'&gt;HPXML Freezers&lt;/a&gt;) is used.</description>
+      <description>The space type for the freezer location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-freezers'&gt;HPXML Freezers&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6415,7 +6415,7 @@
     <argument>
       <name>freezer_rated_annual_kwh</name>
       <display_name>Freezer: Rated Annual Consumption</display_name>
-      <description>The EnergyGuide rated annual energy consumption for a freezer. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-freezers'&gt;HPXML Freezers&lt;/a&gt;) is used.</description>
+      <description>The EnergyGuide rated annual energy consumption for a freezer. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-freezers'&gt;HPXML Freezers&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -6424,7 +6424,7 @@
     <argument>
       <name>freezer_usage_multiplier</name>
       <display_name>Freezer: Usage Multiplier</display_name>
-      <description>Multiplier on the freezer energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-freezers'&gt;HPXML Freezers&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the freezer energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-freezers'&gt;HPXML Freezers&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6451,7 +6451,7 @@
     <argument>
       <name>cooking_range_oven_location</name>
       <display_name>Cooking Range/Oven: Location</display_name>
-      <description>The space type for the cooking range/oven location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooking-range-oven'&gt;HPXML Cooking Range/Oven&lt;/a&gt;) is used.</description>
+      <description>The space type for the cooking range/oven location. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooking-range-oven'&gt;HPXML Cooking Range/Oven&lt;/a&gt;) is used.</description>
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6528,7 +6528,7 @@
     <argument>
       <name>cooking_range_oven_is_induction</name>
       <display_name>Cooking Range/Oven: Is Induction</display_name>
-      <description>Whether the cooking range is induction. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooking-range-oven'&gt;HPXML Cooking Range/Oven&lt;/a&gt;) is used.</description>
+      <description>Whether the cooking range is induction. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooking-range-oven'&gt;HPXML Cooking Range/Oven&lt;/a&gt;) is used.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6546,7 +6546,7 @@
     <argument>
       <name>cooking_range_oven_is_convection</name>
       <display_name>Cooking Range/Oven: Is Convection</display_name>
-      <description>Whether the oven is convection. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooking-range-oven'&gt;HPXML Cooking Range/Oven&lt;/a&gt;) is used.</description>
+      <description>Whether the oven is convection. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooking-range-oven'&gt;HPXML Cooking Range/Oven&lt;/a&gt;) is used.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6564,7 +6564,7 @@
     <argument>
       <name>cooking_range_oven_usage_multiplier</name>
       <display_name>Cooking Range/Oven: Usage Multiplier</display_name>
-      <description>Multiplier on the cooking range/oven energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-cooking-range-oven'&gt;HPXML Cooking Range/Oven&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the cooking range/oven energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-cooking-range-oven'&gt;HPXML Cooking Range/Oven&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6591,7 +6591,7 @@
     <argument>
       <name>ceiling_fan_label_energy_use</name>
       <display_name>Ceiling Fan: Label Energy Use</display_name>
-      <description>The label average energy use of the ceiling fan(s). If neither Efficiency nor Label Energy Use provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-ceiling-fans'&gt;HPXML Ceiling Fans&lt;/a&gt;) is used.</description>
+      <description>The label average energy use of the ceiling fan(s). If neither Efficiency nor Label Energy Use provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-ceiling-fans'&gt;HPXML Ceiling Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>W</units>
       <required>false</required>
@@ -6600,7 +6600,7 @@
     <argument>
       <name>ceiling_fan_efficiency</name>
       <display_name>Ceiling Fan: Efficiency</display_name>
-      <description>The efficiency rating of the ceiling fan(s) at medium speed. Only used if Label Energy Use not provided. If neither Efficiency nor Label Energy Use provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-ceiling-fans'&gt;HPXML Ceiling Fans&lt;/a&gt;) is used.</description>
+      <description>The efficiency rating of the ceiling fan(s) at medium speed. Only used if Label Energy Use not provided. If neither Efficiency nor Label Energy Use provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-ceiling-fans'&gt;HPXML Ceiling Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>CFM/W</units>
       <required>false</required>
@@ -6609,7 +6609,7 @@
     <argument>
       <name>ceiling_fan_quantity</name>
       <display_name>Ceiling Fan: Quantity</display_name>
-      <description>Total number of ceiling fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-ceiling-fans'&gt;HPXML Ceiling Fans&lt;/a&gt;) is used.</description>
+      <description>Total number of ceiling fans. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-ceiling-fans'&gt;HPXML Ceiling Fans&lt;/a&gt;) is used.</description>
       <type>Integer</type>
       <units>#</units>
       <required>false</required>
@@ -6618,7 +6618,7 @@
     <argument>
       <name>ceiling_fan_cooling_setpoint_temp_offset</name>
       <display_name>Ceiling Fan: Cooling Setpoint Temperature Offset</display_name>
-      <description>The cooling setpoint temperature offset during months when the ceiling fans are operating. Only applies if ceiling fan quantity is greater than zero. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-ceiling-fans'&gt;HPXML Ceiling Fans&lt;/a&gt;) is used.</description>
+      <description>The cooling setpoint temperature offset during months when the ceiling fans are operating. Only applies if ceiling fan quantity is greater than zero. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-ceiling-fans'&gt;HPXML Ceiling Fans&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>F</units>
       <required>false</required>
@@ -6646,7 +6646,7 @@
     <argument>
       <name>misc_plug_loads_television_annual_kwh</name>
       <display_name>Misc Plug Loads: Television Annual kWh</display_name>
-      <description>The annual energy consumption of the television plug loads. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the television plug loads. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -6655,7 +6655,7 @@
     <argument>
       <name>misc_plug_loads_television_usage_multiplier</name>
       <display_name>Misc Plug Loads: Television Usage Multiplier</display_name>
-      <description>Multiplier on the television energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the television energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6663,7 +6663,7 @@
     <argument>
       <name>misc_plug_loads_other_annual_kwh</name>
       <display_name>Misc Plug Loads: Other Annual kWh</display_name>
-      <description>The annual energy consumption of the other residual plug loads. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the other residual plug loads. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -6672,7 +6672,7 @@
     <argument>
       <name>misc_plug_loads_other_frac_sensible</name>
       <display_name>Misc Plug Loads: Other Sensible Fraction</display_name>
-      <description>Fraction of other residual plug loads' internal gains that are sensible. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>Fraction of other residual plug loads' internal gains that are sensible. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -6681,7 +6681,7 @@
     <argument>
       <name>misc_plug_loads_other_frac_latent</name>
       <display_name>Misc Plug Loads: Other Latent Fraction</display_name>
-      <description>Fraction of other residual plug loads' internal gains that are latent. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>Fraction of other residual plug loads' internal gains that are latent. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -6690,7 +6690,7 @@
     <argument>
       <name>misc_plug_loads_other_usage_multiplier</name>
       <display_name>Misc Plug Loads: Other Usage Multiplier</display_name>
-      <description>Multiplier on the other energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the other energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6717,7 +6717,7 @@
     <argument>
       <name>misc_plug_loads_well_pump_annual_kwh</name>
       <display_name>Misc Plug Loads: Well Pump Annual kWh</display_name>
-      <description>The annual energy consumption of the well pump plug loads. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the well pump plug loads. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -6726,7 +6726,7 @@
     <argument>
       <name>misc_plug_loads_well_pump_usage_multiplier</name>
       <display_name>Misc Plug Loads: Well Pump Usage Multiplier</display_name>
-      <description>Multiplier on the well pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the well pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6753,7 +6753,7 @@
     <argument>
       <name>misc_plug_loads_vehicle_annual_kwh</name>
       <display_name>Misc Plug Loads: Vehicle Annual kWh</display_name>
-      <description>The annual energy consumption of the electric vehicle plug loads. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the electric vehicle plug loads. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -6762,7 +6762,7 @@
     <argument>
       <name>misc_plug_loads_vehicle_usage_multiplier</name>
       <display_name>Misc Plug Loads: Vehicle Usage Multiplier</display_name>
-      <description>Multiplier on the electric vehicle energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the electric vehicle energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-plug-loads'&gt;HPXML Plug Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6820,7 +6820,7 @@
     <argument>
       <name>misc_fuel_loads_grill_annual_therm</name>
       <display_name>Misc Fuel Loads: Grill Annual therm</display_name>
-      <description>The annual energy consumption of the fuel loads grill. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the fuel loads grill. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>therm/yr</units>
       <required>false</required>
@@ -6829,7 +6829,7 @@
     <argument>
       <name>misc_fuel_loads_grill_usage_multiplier</name>
       <display_name>Misc Fuel Loads: Grill Usage Multiplier</display_name>
-      <description>Multiplier on the fuel loads grill energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the fuel loads grill energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6887,7 +6887,7 @@
     <argument>
       <name>misc_fuel_loads_lighting_annual_therm</name>
       <display_name>Misc Fuel Loads: Lighting Annual therm</display_name>
-      <description>The annual energy consumption of the fuel loads lighting. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;)is used.</description>
+      <description>The annual energy consumption of the fuel loads lighting. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;)is used.</description>
       <type>Double</type>
       <units>therm/yr</units>
       <required>false</required>
@@ -6896,7 +6896,7 @@
     <argument>
       <name>misc_fuel_loads_lighting_usage_multiplier</name>
       <display_name>Misc Fuel Loads: Lighting Usage Multiplier</display_name>
-      <description>Multiplier on the fuel loads lighting energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the fuel loads lighting energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -6954,7 +6954,7 @@
     <argument>
       <name>misc_fuel_loads_fireplace_annual_therm</name>
       <display_name>Misc Fuel Loads: Fireplace Annual therm</display_name>
-      <description>The annual energy consumption of the fuel loads fireplace. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the fuel loads fireplace. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>therm/yr</units>
       <required>false</required>
@@ -6963,7 +6963,7 @@
     <argument>
       <name>misc_fuel_loads_fireplace_frac_sensible</name>
       <display_name>Misc Fuel Loads: Fireplace Sensible Fraction</display_name>
-      <description>Fraction of fireplace residual fuel loads' internal gains that are sensible. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
+      <description>Fraction of fireplace residual fuel loads' internal gains that are sensible. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -6972,7 +6972,7 @@
     <argument>
       <name>misc_fuel_loads_fireplace_frac_latent</name>
       <display_name>Misc Fuel Loads: Fireplace Latent Fraction</display_name>
-      <description>Fraction of fireplace residual fuel loads' internal gains that are latent. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
+      <description>Fraction of fireplace residual fuel loads' internal gains that are latent. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>Frac</units>
       <required>false</required>
@@ -6981,7 +6981,7 @@
     <argument>
       <name>misc_fuel_loads_fireplace_usage_multiplier</name>
       <display_name>Misc Fuel Loads: Fireplace Usage Multiplier</display_name>
-      <description>Multiplier on the fuel loads fireplace energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the fuel loads fireplace energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-fuel-loads'&gt;HPXML Fuel Loads&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -7008,7 +7008,7 @@
     <argument>
       <name>pool_pump_annual_kwh</name>
       <display_name>Pool: Pump Annual kWh</display_name>
-      <description>The annual energy consumption of the pool pump. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-pump'&gt;Pool Pump&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the pool pump. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-pump'&gt;Pool Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -7017,7 +7017,7 @@
     <argument>
       <name>pool_pump_usage_multiplier</name>
       <display_name>Pool: Pump Usage Multiplier</display_name>
-      <description>Multiplier on the pool pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-pump'&gt;Pool Pump&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the pool pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-pump'&gt;Pool Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -7052,7 +7052,7 @@
     <argument>
       <name>pool_heater_annual_kwh</name>
       <display_name>Pool: Heater Annual kWh</display_name>
-      <description>The annual energy consumption of the electric resistance pool heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-heater'&gt;Pool Heater&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the electric resistance pool heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-heater'&gt;Pool Heater&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -7061,7 +7061,7 @@
     <argument>
       <name>pool_heater_annual_therm</name>
       <display_name>Pool: Heater Annual therm</display_name>
-      <description>The annual energy consumption of the gas fired pool heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-heater'&gt;Pool Heater&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the gas fired pool heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-heater'&gt;Pool Heater&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>therm/yr</units>
       <required>false</required>
@@ -7070,7 +7070,7 @@
     <argument>
       <name>pool_heater_usage_multiplier</name>
       <display_name>Pool: Heater Usage Multiplier</display_name>
-      <description>Multiplier on the pool heater energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#pool-heater'&gt;Pool Heater&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the pool heater energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#pool-heater'&gt;Pool Heater&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -7097,7 +7097,7 @@
     <argument>
       <name>permanent_spa_pump_annual_kwh</name>
       <display_name>Permanent Spa: Pump Annual kWh</display_name>
-      <description>The annual energy consumption of the permanent spa pump. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-pump'&gt;Permanent Spa Pump&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the permanent spa pump. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-pump'&gt;Permanent Spa Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -7106,7 +7106,7 @@
     <argument>
       <name>permanent_spa_pump_usage_multiplier</name>
       <display_name>Permanent Spa: Pump Usage Multiplier</display_name>
-      <description>Multiplier on the permanent spa pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-pump'&gt;Permanent Spa Pump&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the permanent spa pump energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-pump'&gt;Permanent Spa Pump&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -7141,7 +7141,7 @@
     <argument>
       <name>permanent_spa_heater_annual_kwh</name>
       <display_name>Permanent Spa: Heater Annual kWh</display_name>
-      <description>The annual energy consumption of the electric resistance permanent spa heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-heater'&gt;Permanent Spa Heater&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the electric resistance permanent spa heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-heater'&gt;Permanent Spa Heater&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>kWh/yr</units>
       <required>false</required>
@@ -7150,7 +7150,7 @@
     <argument>
       <name>permanent_spa_heater_annual_therm</name>
       <display_name>Permanent Spa: Heater Annual therm</display_name>
-      <description>The annual energy consumption of the gas fired permanent spa heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-heater'&gt;Permanent Spa Heater&lt;/a&gt;) is used.</description>
+      <description>The annual energy consumption of the gas fired permanent spa heater. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-heater'&gt;Permanent Spa Heater&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <units>therm/yr</units>
       <required>false</required>
@@ -7159,7 +7159,7 @@
     <argument>
       <name>permanent_spa_heater_usage_multiplier</name>
       <display_name>Permanent Spa: Heater Usage Multiplier</display_name>
-      <description>Multiplier on the permanent spa heater energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.8.1/workflow_inputs.html#permanent-spa-heater'&gt;Permanent Spa Heater&lt;/a&gt;) is used.</description>
+      <description>Multiplier on the permanent spa heater energy usage that can reflect, e.g., high/low usage occupants. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#permanent-spa-heater'&gt;Permanent Spa Heater&lt;/a&gt;) is used.</description>
       <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -7527,7 +7527,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>25110074</checksum>
+      <checksum>B595D2F2</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -7562,7 +7562,7 @@
       <filename>test_build_residential_hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>04146810</checksum>
+      <checksum>8663589D</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/tests/test_build_residential_hpxml.rb
+++ b/BuildResidentialHPXML/tests/test_build_residential_hpxml.rb
@@ -386,6 +386,22 @@ class BuildResidentialHPXMLTest < Minitest::Test
     assert_equal(31, hvac_control.seasons_cooling_end_day)
   end
 
+  def test_version
+    found_match = false
+    measure_xml_path = File.join(File.dirname(__FILE__), '..', 'measure.xml')
+    File.readlines(measure_xml_path).each do |xml_line|
+      next unless xml_line.include? '<description>'
+      next unless xml_line.include? 'https://openstudio-hpxml.readthedocs.io'
+
+      found_match = true
+      if not xml_line.include? Version::OS_HPXML_Version
+        puts "ERROR: Found incorrect OS-HPXML version. Manually edit the BuildResidentialHPXML/measure.rb and run 'openstudio tasks.rb update_measures' to force the measure.xml to be regenerated."
+      end
+      assert(xml_line.include? Version::OS_HPXML_Version)
+    end
+    assert(found_match)
+  end
+
   private
 
   def _set_measure_argument_values(hpxml_file, args)


### PR DESCRIPTION
## Pull Request Description

Adds a test to ensure BuildResidentialHPXML measure docs links are updated when the OS-HPXML version is bumped.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
