### PR TITLE
Allow array of measures_dir in apply_measures function

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f3f5fd7f-d737-43fd-8f03-401b59a8e482</version_id>
-  <version_modified>2025-01-09T18:24:38Z</version_modified>
+  <version_id>393105db-65a4-4d82-a4f0-16774169d39a</version_id>
+  <version_modified>2025-01-10T00:36:12Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -429,7 +429,7 @@
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>377E6136</checksum>
+      <checksum>D11644B9</checksum>
     </file>
     <file>
       <filename>minitest_helper.rb</filename>

--- a/HPXMLtoOpenStudio/resources/meta_measure.rb
+++ b/HPXMLtoOpenStudio/resources/meta_measure.rb
@@ -13,7 +13,7 @@ require 'fileutils'
 #
 # @param rundir [String] The run directory containing all simulation output files
 # @param measures [Hash] Map of OpenStudio-HPXML measure directory name => List of measure argument hashes
-# @param measures_dir [String] Parent directory path of all OpenStudio-HPXML measures
+# @param measures_dir [String or Array<String>] Parent directory path(s) of all OpenStudio-HPXML measures
 # @param debug [Boolean] If true, reports info statements from the runner results
 # @param run_measures_only [Boolean] True applies only OpenStudio Model measures, skipping IDF generation and the simulation
 # @param skip_simulation [Boolean] True applies the OpenStudio Model measures and generates the IDF, but skips the simulation
@@ -177,7 +177,7 @@ end
 # Apply OpenStudio measures and arguments (i.e., "run" method) corresponding to a provided Hash.
 # Optionally, save an OpenStudio Workflow based on the provided Hash.
 #
-# @param measures_dir [String, Array<String>] Parent directory path of all OpenStudio-HPXML measures
+# @param measures_dir [String or Array<String>] Parent directory path(s) of all OpenStudio-HPXML measures
 # @param measures [Hash] Map of OpenStudio-HPXML measure directory name => List of measure argument hashes
 # @param runner [OpenStudio::Measure::OSRunner] Object typically used to display warnings
 # @param model [OpenStudio::Model::Model] OpenStudio Model object
@@ -232,7 +232,7 @@ end
 
 # Get the full path to a measure.rb file given the measure directory name(s).
 #
-# @param measures_dir [String, Array<String>] Parent directory path(s) of OpenStudio-HPXML measures
+# @param measures_dir [String or Array<String>] Parent directory path(s) of all OpenStudio-HPXML measures
 # @param measure_name [String] Name of the OpenStudio measure directory
 # @param runner [OpenStudio::Measure::OSRunner] Object typically used to display warnings
 # @return [String] Full path to the measure.rb file
@@ -247,7 +247,7 @@ end
 
 # Apply OpenStudio measures and arguments (i.e., "energyPlusOutputRequests" method) corresponding to a provided Hash.
 #
-# @param measures_dir [String] Parent directory path of all OpenStudio-HPXML measures
+# @param measures_dir [String or Array<String>] Parent directory path(s) of all OpenStudio-HPXML measures
 # @param measures [Hash] Map of OpenStudio-HPXML measure directory name => List of measure argument hashes
 # @param runner [OpenStudio::Measure::OSRunner] Object typically used to display warnings
 # @param model [OpenStudio::Model::Model] OpenStudio Model object
@@ -278,7 +278,7 @@ end
 # Register an info statement to the OpenStudio Runner about calling measures with arguments.
 #
 # @param measure_args [Hash] Map of provided measure arguments to values
-# @param measures_dir [String] Parent directory path of all OpenStudio-HPXML measures
+# @param measures_dir [String or Array<String>] Parent directory path(s) of all OpenStudio-HPXML measures
 # @param runner [OpenStudio::Measure::OSRunner] Object typically used to display warnings
 # @return [nil]
 def print_measure_call(measure_args, measure_dir, runner)


### PR DESCRIPTION
## Pull Request Description

Update apply_measures function to allow an array of measures_dir because [some OSW file](https://github.com/NREL/resstock/blob/a26117cfd63a6a66a12692639e342b260cf5b620/measures/ResStockArgumentsPostHPXML/tests/SFD_1story_FB_UA_GRG_MSHP_FuelTanklessWH_upgrade.osw#L4) needs multiple measures_dir.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
