### PR TITLE
Fix BuildResidentialHPXML docs links, take 3

### DIFF
--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>9020722b-d574-4332-96a0-10d947d437fc</version_id>
-  <version_modified>2025-01-02T23:48:53Z</version_modified>
+  <version_id>1fbc249e-108c-4567-82f0-a04bc6a3374c</version_id>
+  <version_modified>2025-01-15T22:36:22Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -7562,7 +7562,7 @@
       <filename>version.txt</filename>
       <filetype>txt</filetype>
       <usage_type>resource</usage_type>
-      <checksum>93016553</checksum>
+      <checksum>6D7D7910</checksum>
     </file>
     <file>
       <filename>test_build_residential_hpxml.rb</filename>

--- a/BuildResidentialHPXML/resources/version.txt
+++ b/BuildResidentialHPXML/resources/version.txt
@@ -1,1 +1,1 @@
-237a7a19483db8aae3195ccffb40336c
+e8edd0fdf30035cab93a927df4f12ebb

--- a/tasks.rb
+++ b/tasks.rb
@@ -2658,9 +2658,8 @@ if ARGV[0].to_sym == :update_measures
   # This will ensure that the BuildResidentialHPXML measure.xml is appropriately updated.
   # Without this, the BuildResidentialHPXML measure has no differences and so OpenStudio
   # would skip updating it.
-  version_rb_path = File.join(File.dirname(__FILE__), 'HPXMLtoOpenStudio/resources/version.rb')
   version_txt_path = File.join(File.dirname(__FILE__), 'BuildResidentialHPXML/resources/version.txt')
-  File.write(version_txt_path, Digest::MD5.file(version_rb_path).hexdigest)
+  File.write(version_txt_path, Digest::MD5.hexdigest(Version::OS_HPXML_Version))
 
   # Update measures XMLs
   puts 'Updating measure.xmls...'


### PR DESCRIPTION
## Pull Request Description

Now just generating an md5 hash from the OS-HPXML version string instead of the version.rb file, to prevent unnecessary updates (due to e.g. different line endings).

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
