### PR TITLE
Timeseries EnergyPlus output meters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 ## OpenStudio-HPXML v1.10.0
 
 __New Features__
-- Allows requesting timeseries EnergyPlus output meters (e.g., `"--hourly MainsWater:Facility"`), similar to requesting EnergyPlus output variables.
+- Allows requesting timeseries EnergyPlus output meters (e.g., `--hourly "MainsWater:Facility"`), similar to requesting EnergyPlus output variables.
 
 __Bugfixes__
 - Fixes zero occupants specified for one unit in a whole MF building from being treated like zero occupants for every unit.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## OpenStudio-HPXML v1.10.0
 
 __New Features__
+- Allows requesting timeseries EnergyPlus output meters (e.g., `"--hourly MainsWater:Facility"`), similar to requesting EnergyPlus output variables.
 
 __Bugfixes__
 - Fixes zero occupants specified for one unit in a whole MF building from being treated like zero occupants for every unit.

--- a/ReportSimulationOutput/README.md
+++ b/ReportSimulationOutput/README.md
@@ -424,6 +424,17 @@ Optionally generates timeseries EnergyPlus output variables. If multiple output 
 
 <br/>
 
+**Generate Timeseries Output: EnergyPlus Output Meters**
+
+Optionally generates timeseries EnergyPlus output meters. If multiple output meters are desired, use a comma-separated list. Example: "Electricity:Facility, HeatingCoils:EnergyTransfer"
+
+- **Name:** ``user_output_meters``
+- **Type:** ``String``
+
+- **Required:** ``false``
+
+<br/>
+
 **Annual Output File Name**
 
 If not provided, defaults to 'results_annual.csv' (or 'results_annual.json' or 'results_annual.msgpack').

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>5e609cb1-8e83-479b-afda-c1de10cd62ea</version_id>
-  <version_modified>2024-11-27T02:33:41Z</version_modified>
+  <version_id>ca741975-505b-4e74-a17b-b96671720b39</version_id>
+  <version_modified>2025-01-25T08:36:10Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -708,6 +708,14 @@
       <name>user_output_variables</name>
       <display_name>Generate Timeseries Output: EnergyPlus Output Variables</display_name>
       <description>Optionally generates timeseries EnergyPlus output variables. If multiple output variables are desired, use a comma-separated list. Do not include key values; by default all key values will be requested. Example: "Zone People Occupant Count, Zone People Total Heating Energy"</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>user_output_meters</name>
+      <display_name>Generate Timeseries Output: EnergyPlus Output Meters</display_name>
+      <description>Optionally generates timeseries EnergyPlus output meters. If multiple output meters are desired, use a comma-separated list. Example: "Electricity:Facility, HeatingCoils:EnergyTransfer"</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -1912,7 +1920,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>CDB2D617</checksum>
+      <checksum>E1D3B16D</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -1929,13 +1937,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4C7478A8</checksum>
+      <checksum>2D3EC7C0</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>8552F493</checksum>
+      <checksum>F630E4A7</checksum>
     </file>
   </files>
 </measure>

--- a/docs/source/usage_instructions.rst
+++ b/docs/source/usage_instructions.rst
@@ -38,6 +38,7 @@ Basic Run
 | ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --hourly ALL``
 | ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --monthly fuels --monthly temperatures --output-format json``
 | ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --monthly fuels --hourly temperatures --hourly 'Zone People Occupant Count'``
+| ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --monthly fuels --hourly temperatures --hourly 'MainsWater:Facility'``
 | ``openstudio workflow/run_simulation.rb -x workflow/sample_files/base.xml --hourly ALL --output-format csv_dview``
 | The last command will create a timeseries CSV output file that can be visualized by `DView <https://github.com/NREL/wex/wiki/DView>`_ (available for download `here <https://beopt.nrel.gov>`_).
 

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -619,26 +619,26 @@ If multiple timeseries frequencies are requested (e.g., hourly and daily), the t
 
 Depending on the outputs requested, the file may include:
 
-  ===========================  ===================  ==================================================================================================================================
-  Type                         Argument [#]_        Notes
-  ===========================  ===================  ==================================================================================================================================
-  Total Consumptions           ``total``            Energy use for building total and net (i.e., subtracts any power produced by PV or generators).
-  Fuel Consumptions            ``fuels``            Energy use for each fuel type (in kBtu for fossil fuels and kWh for electricity).
-  End Use Consumptions         ``enduses``          Energy use for each end use type (in kBtu for fossil fuels and kWh for electricity).
-  System Use Consumptions      ``systemuses``       Energy use for each HVAC and water heating system (in kBtu).
-  Emissions                    ``emissions``        Emissions (e.g., CO2) for each scenario defined in the HPXML file.
-  Emission Fuels               ``emissionfuels``    Emissions (e.g., CO2) disaggregated by fuel type for each scenario defined in the HPXML file.
-  Emission End Uses            ``emissionenduses``  Emissions (e.g., CO2) disaggregated by end use for each scenario defined in the HPXML file.
-  Hot Water Uses               ``hotwater``         Water use for each end use type (in gallons).
-  Total Loads                  ``loads``            Heating, cooling, and hot water loads (in kBtu).
-  Component Loads              ``componentloads``   Heating and cooling loads (in kBtu) disaggregated by component (e.g., Walls, Windows, Infiltration, Ducts, etc.).
-  Unmet Hours                  ``unmethours``       Heating and cooling unmet hours.
-  Zone Temperatures            ``temperatures``     Zone temperatures (in deg-F) for each space (e.g., conditioned space, attic, garage, basement, crawlspace, etc.) plus heating/cooling setpoints.
-  Airflows                     ``airflows``         Airflow rates (in cfm) for infiltration, mechanical ventilation (including clothes dryer exhaust), natural ventilation, whole house fans.
-  Weather                      ``weather``          Weather file data including outdoor temperatures, relative humidity, wind speed, and solar.
-  Resilience                   ``resilience``       Resilience outputs (currently only average resilience hours for battery storage).
-  EnergyPlus Output Variables                       Any user-specified EnergyPlus output variables (e.g., 'Zone People Occupant Count').
-  ===========================  ===================  ==================================================================================================================================
+  ==================================  ===================  ==================================================================================================================================
+  Type                                Argument [#]_        Notes
+  ==================================  ===================  ==================================================================================================================================
+  Total Consumptions                  ``total``            Energy use for building total and net (i.e., subtracts any power produced by PV or generators).
+  Fuel Consumptions                   ``fuels``            Energy use for each fuel type (in kBtu for fossil fuels and kWh for electricity).
+  End Use Consumptions                ``enduses``          Energy use for each end use type (in kBtu for fossil fuels and kWh for electricity).
+  System Use Consumptions             ``systemuses``       Energy use for each HVAC and water heating system (in kBtu).
+  Emissions                           ``emissions``        Emissions (e.g., CO2) for each scenario defined in the HPXML file.
+  Emission Fuels                      ``emissionfuels``    Emissions (e.g., CO2) disaggregated by fuel type for each scenario defined in the HPXML file.
+  Emission End Uses                   ``emissionenduses``  Emissions (e.g., CO2) disaggregated by end use for each scenario defined in the HPXML file.
+  Hot Water Uses                      ``hotwater``         Water use for each end use type (in gallons).
+  Total Loads                         ``loads``            Heating, cooling, and hot water loads (in kBtu).
+  Component Loads                     ``componentloads``   Heating and cooling loads (in kBtu) disaggregated by component (e.g., Walls, Windows, Infiltration, Ducts, etc.).
+  Unmet Hours                         ``unmethours``       Heating and cooling unmet hours.
+  Zone Temperatures                   ``temperatures``     Zone temperatures (in deg-F) for each space (e.g., conditioned space, attic, garage, basement, crawlspace, etc.) plus heating/cooling setpoints.
+  Airflows                            ``airflows``         Airflow rates (in cfm) for infiltration, mechanical ventilation (including clothes dryer exhaust), natural ventilation, whole house fans.
+  Weather                             ``weather``          Weather file data including outdoor temperatures, relative humidity, wind speed, and solar.
+  Resilience                          ``resilience``       Resilience outputs (currently only average resilience hours for battery storage).
+  EnergyPlus Output Variables/Meters                       Any user-specified EnergyPlus output variables/meters (e.g., 'Zone People Occupant Count', 'MainsWater:Facility').
+  ==================================  ===================  ==================================================================================================================================
 
   .. [#] This is the argument provided to ``run_simulation.rb`` as described in the :ref:`basic_run` usage instructions.
 

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -57,6 +57,11 @@ def run_workflow(basedir, rundir, hpxml, debug, skip_validation, add_comp_loads,
       'timestep' => timestep_outputs }.each do |timeseries_output_freq, timeseries_outputs|
       next if (timeseries_outputs.empty? && timeseries_output_freq != 'none')
 
+      comma_output = timeseries_outputs.find { |o| o.include? ',' }
+      if not comma_output.nil?
+        fail "Timeseries output request '#{comma_output}' cannot include a comma."
+      end
+
       if timeseries_outputs.include? 'ALL'
         # Replace 'ALL' with all individual timeseries types
         timeseries_outputs.delete('ALL')

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -85,8 +85,11 @@ def run_workflow(basedir, rundir, hpxml, debug, skip_validation, add_comp_loads,
       args['include_timeseries_airflows'] = timeseries_outputs.include? 'airflows'
       args['include_timeseries_weather'] = timeseries_outputs.include? 'weather'
       args['include_timeseries_resilience'] = timeseries_outputs.include? 'resilience'
-      user_output_variables = timeseries_outputs - $timeseries_types
-      args['user_output_variables'] = user_output_variables.join(', ') unless user_output_variables.empty?
+      remaining_outputs = timeseries_outputs - $timeseries_types
+      output_variables = remaining_outputs.select { |o| !o.include?(':') }
+      output_meters = remaining_outputs.select { |o| o.include?(':') }
+      args['user_output_variables'] = output_variables.join(', ') unless output_variables.empty?
+      args['user_output_meters'] = output_meters.join(', ') unless output_meters.empty?
       if n_timeseries_freqs > 1
         # Need to use different timeseries filenames
         args['timeseries_output_file_name'] = "results_timeseries_#{timeseries_output_freq}.#{output_format}"
@@ -125,22 +128,22 @@ OptionParser.new do |opts|
   end
 
   options[:hourly_outputs] = []
-  opts.on('--hourly NAME', 'Request hourly output category* or EnergyPlus output variable; can be called multiple times') do |t|
+  opts.on('--hourly NAME', 'Request hourly output category* or EnergyPlus output variable/meter; can be called multiple times') do |t|
     options[:hourly_outputs] << t
   end
 
   options[:daily_outputs] = []
-  opts.on('--daily NAME', 'Request daily output category* or EnergyPlus output variable; can be called multiple times') do |t|
+  opts.on('--daily NAME', 'Request daily output category* or EnergyPlus output variable/meter; can be called multiple times') do |t|
     options[:daily_outputs] << t
   end
 
   options[:monthly_outputs] = []
-  opts.on('--monthly NAME', 'Request monthly output category* or EnergyPlus output variable; can be called multiple times') do |t|
+  opts.on('--monthly NAME', 'Request monthly output category* or EnergyPlus output variable/meter; can be called multiple times') do |t|
     options[:monthly_outputs] << t
   end
 
   options[:timestep_outputs] = []
-  opts.on('--timestep NAME', 'Request timestep output category* or EnergyPlus output variable; can be called multiple times') do |t|
+  opts.on('--timestep NAME', 'Request timestep output category* or EnergyPlus output variable/meter; can be called multiple times') do |t|
     options[:timestep_outputs] << t
   end
 

--- a/workflow/template-build-and-run-hpxml-with-stochastic-occupancy.osw
+++ b/workflow/template-build-and-run-hpxml-with-stochastic-occupancy.osw
@@ -135,7 +135,8 @@
         "timeseries_timestamp_convention": "start",
         "add_timeseries_dst_column": false,
         "add_timeseries_utc_column": false,
-        "user_output_variables": ""
+        "user_output_variables": "",
+        "user_output_meters": ""
       },
       "measure_dir_name": "ReportSimulationOutput"
     },

--- a/workflow/template-run-hpxml-with-stochastic-occupancy-subset.osw
+++ b/workflow/template-run-hpxml-with-stochastic-occupancy-subset.osw
@@ -60,7 +60,8 @@
         "timeseries_timestamp_convention": "start",
         "add_timeseries_dst_column": false,
         "add_timeseries_utc_column": false,
-        "user_output_variables": ""
+        "user_output_variables": "",
+        "user_output_meters": ""
       },
       "measure_dir_name": "ReportSimulationOutput"
     },

--- a/workflow/template-run-hpxml-with-stochastic-occupancy.osw
+++ b/workflow/template-run-hpxml-with-stochastic-occupancy.osw
@@ -59,7 +59,8 @@
         "timeseries_timestamp_convention": "start",
         "add_timeseries_dst_column": false,
         "add_timeseries_utc_column": false,
-        "user_output_variables": ""
+        "user_output_variables": "",
+        "user_output_meters": ""
       },
       "measure_dir_name": "ReportSimulationOutput"
     },

--- a/workflow/template-run-hpxml.osw
+++ b/workflow/template-run-hpxml.osw
@@ -52,7 +52,8 @@
         "timeseries_timestamp_convention": "start",
         "add_timeseries_dst_column": false,
         "add_timeseries_utc_column": false,
-        "user_output_variables": ""
+        "user_output_variables": "",
+        "user_output_meters": ""
       },
       "measure_dir_name": "ReportSimulationOutput"
     },

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -166,6 +166,16 @@ class WorkflowOtherTest < Minitest::Test
     end
   end
 
+  def test_run_simulation_timeseries_outputs_comma
+    # Check that the simulation produces timeseries with requested outputs
+    rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
+    xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
+    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --hourly 'Zone People Occupant Count,MainsWater:Facility'"
+    success = system(command, err: File::NULL)
+
+    refute(success)
+  end
+
   def test_run_simulation_mixed_timeseries_frequencies
     # Check that we can correctly skip the EnergyPlus simulation and reporting measures
     rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -135,8 +135,10 @@ class WorkflowOtherTest < Minitest::Test
         command += ' --hourly ALL'
         command += " --hourly 'Zone People Occupant Count'"
         command += " --hourly 'Zone People Total Heating Energy'"
+        command += " --hourly 'MainsWater:Facility'"
       end
       command += " --hourly 'Foobar Variable'" # Test invalid output variable request
+      command += " --hourly 'Foobar:Meter'" # Test invalid output variable request
       system(command, err: File::NULL)
 
       # Check for output files
@@ -151,14 +153,16 @@ class WorkflowOtherTest < Minitest::Test
         assert_equal(1, timeseries_rows[0].count { |r| r == 'Time' })
         assert_equal(1, timeseries_rows[0].count { |r| r == 'Zone People Occupant Count: Conditioned Space' })
         assert_equal(1, timeseries_rows[0].count { |r| r == 'Zone People Total Heating Energy: Conditioned Space' })
+        assert_equal(1, timeseries_rows[0].count { |r| r == 'MainsWater:Facility' })
       else
         refute(File.exist? timeseries_output_path)
       end
 
-      # Check run.log has warning about missing Foobar Variable
+      # Check run.log has warning about missing Foobar Variable & Meter
       assert(File.exist? File.join(File.dirname(xml), 'run', 'run.log'))
       log_lines = File.readlines(File.join(File.dirname(xml), 'run', 'run.log')).map(&:strip)
-      assert(log_lines.include? "Warning: Request for output variable 'Foobar Variable' returned no key values.")
+      assert(log_lines.include? "Warning: Request for output variable 'Foobar Variable' returned no results.")
+      assert(log_lines.include? "Warning: Request for output meter 'Foobar:Meter' returned no results.")
     end
   end
 
@@ -166,7 +170,7 @@ class WorkflowOtherTest < Minitest::Test
     # Check that we can correctly skip the EnergyPlus simulation and reporting measures
     rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
     xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')
-    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --timestep weather --hourly enduses --daily temperatures --monthly ALL --monthly 'Zone People Total Heating Energy'"
+    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --timestep weather --hourly enduses --daily temperatures --monthly ALL --monthly 'Zone People Total Heating Energy' --daily 'MainsWater:Facility'"
     system(command, err: File::NULL)
 
     # Check for output files
@@ -180,7 +184,7 @@ class WorkflowOtherTest < Minitest::Test
     # Check timeseries columns exist
     { 'timestep' => ['Weather:'],
       'hourly' => ['End Use:'],
-      'daily' => ['Temperature:'],
+      'daily' => ['Temperature:', 'MainsWater:Facility'],
       'monthly' => ['End Use:', 'Fuel Use:', 'Zone People Total Heating Energy:'] }.each do |freq, col_names|
       timeseries_rows = CSV.read(File.join(File.dirname(xml), 'run', "results_timeseries_#{freq}.csv"))
       assert_equal(1, timeseries_rows[0].count { |r| r == 'Time' })


### PR DESCRIPTION
## Pull Request Description

Allows requesting timeseries EnergyPlus output meters (e.g., `--hourly "MainsWater:Facility"`), similar to requesting EnergyPlus output variables.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
