### PR TITLE
Change temperature capacitance multiplier argument from string to double

### DIFF
--- a/BuildResidentialHPXML/README.md
+++ b/BuildResidentialHPXML/README.md
@@ -174,7 +174,7 @@ Enter a date range like 'Mar 15 - Dec 15'. If not provided, the OS-HPXML default
 Affects the transient calculation of indoor air temperatures. If not provided, the OS-HPXML default (see <a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.
 
 - **Name:** ``simulation_control_temperature_capacitance_multiplier``
-- **Type:** ``String``
+- **Type:** ``Double``
 
 - **Required:** ``false``
 

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -114,7 +114,7 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     arg.setDescription("Enter a date range like 'Mar 15 - Dec 15'. If not provided, the OS-HPXML default (see <a href='#{docs_base_url}#hpxml-building-site'>HPXML Building Site</a>) is used.")
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument::makeStringArgument('simulation_control_temperature_capacitance_multiplier', false)
+    arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('simulation_control_temperature_capacitance_multiplier', false)
     arg.setDisplayName('Simulation Control: Temperature Capacitance Multiplier')
     arg.setDescription("Affects the transient calculation of indoor air temperatures. If not provided, the OS-HPXML default (see <a href='#{docs_base_url}#hpxml-simulation-control'>HPXML Simulation Control</a>) is used.")
     args << arg

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>1fbc249e-108c-4567-82f0-a04bc6a3374c</version_id>
-  <version_modified>2025-01-15T22:36:22Z</version_modified>
+  <version_id>48a9fb98-bc96-4ccc-97a5-c7aaac3f2199</version_id>
+  <version_modified>2025-02-06T21:09:42Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -149,7 +149,7 @@
       <name>simulation_control_temperature_capacitance_multiplier</name>
       <display_name>Simulation Control: Temperature Capacitance Multiplier</display_name>
       <description>Affects the transient calculation of indoor air temperatures. If not provided, the OS-HPXML default (see &lt;a href='https://openstudio-hpxml.readthedocs.io/en/v1.10.0/workflow_inputs.html#hpxml-simulation-control'&gt;HPXML Simulation Control&lt;/a&gt;) is used.</description>
-      <type>String</type>
+      <type>Double</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
     </argument>
@@ -7527,7 +7527,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>ECAEDA1E</checksum>
+      <checksum>47F34ABF</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -7544,7 +7544,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>DF604C07</checksum>
+      <checksum>ACBA8A93</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>


### PR DESCRIPTION
## Pull Request Description

Related to:
* a user trying to set TCM as a discrete integer with variables in PAT
* #1148

## Checklist

Not all may apply:

- [ ] ~Schematron validator (`EPvalidator.xml`) has been updated~
- [ ] ~Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)~
- [ ] ~Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)~
- [ ] ~Documentation has been updated~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
