### PR TITLE
Let through unknown columns with a warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ __New Features__
 - Output updates:
   - **Breaking change**: Adds generator electricity produced to *total* fuel/energy use; previously it was only included in *net* values.
   - Adds new outputs for *net* peak electricity (summer/winter/annual); same as *total* peak electricity outputs but subtracts power produced by PV.
+- Allows arbitrary columns to be present in the schedule file with warning.
 
 __Bugfixes__
 - Fixes zero occupants specified for one unit in a whole MF building from being treated like zero occupants for every unit.

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,7 @@ __New Features__
 - Output updates:
   - **Breaking change**: Adds generator electricity produced to *total* fuel/energy use; previously it was only included in *net* values.
   - Adds new outputs for *net* peak electricity (summer/winter/annual); same as *total* peak electricity outputs but subtracts power produced by PV.
-- Allows arbitrary columns to be present in the schedule file with warning.
+- Allows arbitrary columns to be present in a detailed schedule csv file with warning.
 
 __Bugfixes__
 - Fixes zero occupants specified for one unit in a whole MF building from being treated like zero occupants for every unit.

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>66547fd4-aed2-4018-b62c-b42f1be47c6f</version_id>
-  <version_modified>2025-03-12T01:36:17Z</version_modified>
+  <version_id>32de2cef-2381-4f59-83d6-68aa71e42a49</version_id>
+  <version_modified>2025-03-13T00:04:23Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -633,7 +633,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D2EF0FF6</checksum>
+      <checksum>BA4E17C6</checksum>
     </file>
     <file>
       <filename>simcontrols.rb</filename>
@@ -783,7 +783,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>06CA5017</checksum>
+      <checksum>F43A4E45</checksum>
     </file>
     <file>
       <filename>test_vehicle.rb</filename>

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1080,8 +1080,10 @@ class SchedulesFile
     return false
   end
 
-  # Assemble schedules from all detailed schedule CSVs into a hash.
+  # Assemble schedules from all detailed schedule CSVs into a hash and perform various
+  # error-checks and data validation.
   #
+  # @param runner [OpenStudio::Measure::OSRunner] Object typically used to display warnings
   # @param schedules_paths [Array<String>] array of file paths pointing to detailed schedule CSVs
   # @return [nil]
   def import(runner, schedules_paths)

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1045,7 +1045,7 @@ class SchedulesFile
     return if schedules_paths.empty?
 
     @year = year
-    import(schedules_paths)
+    import(runner, schedules_paths)
     create_battery_charging_discharging_schedules
     expand_schedules
     @tmp_schedules = Marshal.load(Marshal.dump(@schedules)) # make a deep copy because we use unmodified schedules downstream
@@ -1084,7 +1084,7 @@ class SchedulesFile
   #
   # @param schedules_paths [Array<String>] array of file paths pointing to detailed schedule CSVs
   # @return [nil]
-  def import(schedules_paths)
+  def import(runner, schedules_paths)
     num_hrs_in_year = Calendar.num_hours_in_year(@year)
     @schedules = {}
     schedules_paths.each do |schedules_path|
@@ -1093,7 +1093,11 @@ class SchedulesFile
       columns.each do |col|
         col_name = col[0]
         column = Columns.values.find { |c| c.name == col_name }
-
+        if column.nil?
+          @schedules[col_name] = col[1..-1]
+          runner.registerWarning("Unknown column found in schedule file: #{col_name}. [context: #{schedules_path}]")
+          next
+        end
         values = col[1..-1].reject { |v| v.nil? }
 
         begin

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -1864,7 +1864,8 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
                               'schedule-file-and-operating-mode' => ["Both 'water_heater_operating_mode' schedule file and operating mode provided; the latter will be ignored."],
                               'schedule-file-max-power-ratio-with-single-speed-system' => ['Maximum power ratio schedule is only supported for variable speed systems.'],
                               'schedule-file-max-power-ratio-with-two-speed-system' => ['Maximum power ratio schedule is only supported for variable speed systems.'],
-                              'schedule-file-max-power-ratio-with-separate-backup-system' => ['Maximum power ratio schedule is only supported for integrated backup system. Schedule is ignored for heating.'] }
+                              'schedule-file-max-power-ratio-with-separate-backup-system' => ['Maximum power ratio schedule is only supported for integrated backup system. Schedule is ignored for heating.'],
+                              'schedule-file-unknown-columns' => ['Unknown column found in schedule file: unknown_column'] }
 
     all_expected_warnings.each_with_index do |(warning_case, expected_warnings), i|
       puts "[#{i + 1}/#{all_expected_warnings.size}] Testing #{warning_case}..."
@@ -2016,6 +2017,12 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
       when 'schedule-file-max-power-ratio-with-separate-backup-system'
         hpxml, hpxml_bldg = _create_hpxml('base-hvac-air-to-air-heat-pump-var-speed-backup-boiler.xml')
         hpxml_bldg.header.schedules_filepaths << File.join(File.dirname(__FILE__), '../resources/schedule_files/hvac-variable-system-maximum-power-ratios-varied.csv')
+      when 'schedule-file-unknown-columns'
+        hpxml, hpxml_bldg = _create_hpxml('base-schedules-detailed-occupancy-stochastic.xml')
+        csv_data = CSV.read(File.join(File.dirname(hpxml.hpxml_path), hpxml_bldg.header.schedules_filepaths[0]))
+        csv_data[0][csv_data[0].find_index('lighting_interior')] = 'unknown_column'
+        File.write(@tmp_csv_path, csv_data.map(&:to_csv).join)
+        hpxml_bldg.header.schedules_filepaths = [@tmp_csv_path]
       else
         fail "Unhandled case: #{warning_case}."
       end


### PR DESCRIPTION
## Pull Request Description

Currently, when unknown (i.e. not defined [here](https://github.com/NREL/OpenStudio-HPXML/blob/eadf702d72546097e7a68f81552a1ed4617914c4/HPXMLtoOpenStudio/resources/schedules.rb#L981)) is present in schedule file, it throws `Error: undefined method 'type' for nil:NilClass` error. This is not a user friendly error. This PR lets the unknown column to pass through without validation by registering a warning. This functionality is required by the ResStock load flexibility measure being developed to add peak period and pre peak period schedule into the schedule file. 

Peak period and Pre peak period columns are now passing through.
![image](https://github.com/user-attachments/assets/04f9240a-c498-4c40-a5a0-5df7ec912d16)

With warning message in run.log:
```
18:24:02.313047 WARN] [openstudio.measure.OSRunner] Unknown column found in schedule file: peak_period. [context: /Users/radhikar/Documents/buildstock2025/resstock_loadflex/project_national/mar12_test_run5/simulation_output/up01/bldg0000002/run/detailed_schedules_1.csv]
[18:24:02.313103 WARN] [openstudio.measure.OSRunner] Unknown column found in schedule file: pre_peak_period. [context: /Users/radhikar/Documents/buildstock2025/resstock_loadflex/project_national/mar12_test_run5/simulation_output/up01/bldg0000002/run/detailed_schedules_1.csv]
```

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
