### PR TITLE
Add concurrency to stop previous CI job

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,6 +7,12 @@ on:
     types: [ synchronize, opened ]
   workflow_dispatch:
 
+# Cancel in-progress jobs when a new commit is pushed to the PR
+# This avoids CI jobs "stacking up" for the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-unit-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -9,6 +9,7 @@ on:
 
 # Cancel in-progress jobs when a new commit is pushed to the PR
 # This avoids CI jobs "stacking up" for the same PR
+# This won't stop existing job if new commit is pushed with [ci skip].
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Pull Request Description

Stops existing CI job when new commits are pushed. Verified to work in ResStock: https://github.com/NREL/resstock/pull/1363#issuecomment-2722092210

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
