### PR TITLE
Update rubocop settings to match rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 AllCops:
   DisabledByDefault: true
 
+Layout:
+  Enabled: True
 Layout/EndOfLine:
   Enabled: false
 Layout/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,20 @@
 AllCops:
   DisabledByDefault: true
 
-Layout:
+Layout/EndOfLine:
+  Enabled: false
+Layout/LineLength:
+  AutoCorrect: false
+  Enabled: false
+Layout/RescueEnsureAlignment:
+  AutoCorrect: true
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: true
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: true
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
   Enabled: true
 Lint/DeprecatedClassMethods:
   Enabled: true
@@ -30,9 +43,15 @@ Lint/UselessAssignment:
 Style/AndOr:
   Enabled: true
 Style/Documentation:
-  Enabled: true
+  Exclude:
+    - '**/tests/*.rb'
+    - 'workflow/**/*.rb'
+    - 'tasks.rb'
 Style/DocumentationMethod:
-  Enabled: true
+  Exclude:
+    - '**/tests/*.rb'
+    - 'workflow/**/*.rb'
+    - 'tasks.rb'
 Style/FrozenStringLiteralComment:
   Enabled: true
 Style/HashSyntax:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,23 +1,14 @@
 AllCops:
   DisabledByDefault: true
+  NewCops: enable
 
 Layout:
-  Enabled: True
+  Enabled: true
 Layout/EndOfLine:
   Enabled: false
 Layout/LineLength:
   AutoCorrect: false
   Enabled: false
-Layout/RescueEnsureAlignment:
-  AutoCorrect: true
-Layout/SpaceBeforeBrackets:
-  Enabled: true
-Layout/LineContinuationLeadingSpace: # new in 1.31
-  Enabled: true
-Layout/LineContinuationSpacing: # new in 1.31
-  Enabled: true
-Layout/LineEndStringConcatenationIndentation: # new in 1.18
-  Enabled: true
 Lint/DeprecatedClassMethods:
   Enabled: true
 Lint/DuplicateElsifCondition:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,197 +1,55 @@
-Layout/EndOfLine:
-  Enabled: false
-Layout/LineLength:
-  AutoCorrect: false
-  Enabled: false
-Layout/RescueEnsureAlignment:
-  AutoCorrect: true
-Style/FrozenStringLiteralComment:
-  AutoCorrect: true
-Style/HashEachMethods:
+AllCops:
+  DisabledByDefault: true
+
+Layout:
   Enabled: true
-Style/HashTransformKeys:
+Lint/DeprecatedClassMethods:
   Enabled: true
-Style/HashTransformValues:
+Lint/DuplicateElsifCondition:
   Enabled: true
-Gemspec/DeprecatedAttributeAssignment:
+Lint/DuplicateHashKey:
   Enabled: true
-Layout/SpaceBeforeBrackets:
+Lint/DuplicateMethods:
   Enabled: true
-Lint/AmbiguousAssignment:
+Lint/InterpolationCheck:
   Enabled: true
-Lint/DeprecatedConstants:
+Lint/LiteralAsCondition:
   Enabled: true
-Lint/DuplicateBranch:
+Lint/RedundantStringCoercion:
   Enabled: true
-Lint/DuplicateRegexpCharacterClassElement:
+Lint/SelfAssignment:
   Enabled: true
-Lint/EmptyBlock:
+Lint/UnderscorePrefixedVariableName:
   Enabled: true
-Lint/EmptyClass:
+Lint/UnusedBlockArgument:
   Enabled: true
-Lint/LambdaWithoutLiteralBlock:
+Lint/UnusedMethodArgument:
   Enabled: true
-Lint/NoReturnInBeginEndBlocks:
+Lint/UselessAssignment:
   Enabled: true
-Lint/NumberedParameterAssignment:
-  Enabled: true
-Lint/OrAssignmentToConstant:
-  Enabled: true
-Lint/RedundantDirGlobSort:
-  Enabled: true
-Lint/SymbolConversion:
-  Enabled: true
-Lint/ToEnumArguments:
-  Enabled: true
-Lint/TripleQuotes:
-  Enabled: true
-Lint/UnexpectedBlockArity:
-  Enabled: true
-Lint/UnmodifiedReduceAccumulator:
-  Enabled: true
-Style/ArgumentsForwarding:
-  Enabled: true
-Style/CollectionCompact:
+Style/AndOr:
   Enabled: true
 Style/Documentation:
-  Exclude:
-    - '**/tests/*.rb'
-    - 'workflow/**/*.rb'
-    - 'tasks.rb'
+  Enabled: true
 Style/DocumentationMethod:
-  Exclude:
-    - '**/tests/*.rb'
-    - 'workflow/**/*.rb'
-    - 'tasks.rb'
-Style/DocumentDynamicEvalDefinition:
   Enabled: true
-Style/EndlessMethod:
+Style/FrozenStringLiteralComment:
   Enabled: true
-Style/HashConversion:
+Style/HashSyntax:
   Enabled: true
-Style/HashExcept:
+Style/Next:
   Enabled: true
-Style/IfWithBooleanLiteralBranches:
+Style/NilComparison:
   Enabled: true
-Style/NegatedIfElseCondition:
+Style/RedundantParentheses:
   Enabled: true
-Style/NilLambda:
+Style/RedundantSelf:
   Enabled: true
-Style/RedundantArgument:
+Style/ReturnNil:
   Enabled: true
-Style/StringChars:
+Style/SelfAssignment:
   Enabled: true
-Style/SwapValues:
+Style/StringLiterals:
   Enabled: true
-Gemspec/DevelopmentDependencies: # new in 1.44
-  Enabled: true
-Gemspec/RequireMFA: # new in 1.23
-  Enabled: true
-Layout/LineContinuationLeadingSpace: # new in 1.31
-  Enabled: true
-Layout/LineContinuationSpacing: # new in 1.31
-  Enabled: true
-Layout/LineEndStringConcatenationIndentation: # new in 1.18
-  Enabled: true
-Lint/AmbiguousOperatorPrecedence: # new in 1.21
-  Enabled: true
-Lint/AmbiguousRange: # new in 1.19
-  Enabled: true
-Lint/ConstantOverwrittenInRescue: # new in 1.31
-  Enabled: true
-Lint/DuplicateMagicComment: # new in 1.37
-  Enabled: true
-Lint/DuplicateMatchPattern: # new in 1.50
-  Enabled: true
-Lint/EmptyInPattern: # new in 1.16
-  Enabled: true
-Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
-  Enabled: true
-Lint/NonAtomicFileOperation: # new in 1.31
-  Enabled: true
-Lint/RefinementImportMethods: # new in 1.27
-  Enabled: true
-Lint/RequireRangeParentheses: # new in 1.32
-  Enabled: true
-Lint/RequireRelativeSelfPath: # new in 1.22
-  Enabled: true
-Lint/UselessRescue: # new in 1.43
-  Enabled: true
-Lint/UselessRuby2Keywords: # new in 1.23
-  Enabled: true
-Metrics/CollectionLiteralLength: # new in 1.47
-  Enabled: true
-Naming/BlockForwarding: # new in 1.24
-  Enabled: true
-Security/CompoundHash: # new in 1.28
-  Enabled: true
-Security/IoMethods: # new in 1.22
-  Enabled: true
-Style/ArrayIntersect: # new in 1.40
-  Enabled: true
-Style/ComparableClamp: # new in 1.44
-  Enabled: true
-Style/ConcatArrayLiterals: # new in 1.41
-  Enabled: true
-Style/DataInheritance: # new in 1.49
-  Enabled: true
-Style/DirEmpty: # new in 1.48
-  Enabled: true
-Style/EmptyHeredoc: # new in 1.32
-  Enabled: true
-Style/EnvHome: # new in 1.29
-  Enabled: true
-Style/FetchEnvVar: # new in 1.28
-  Enabled: true
-Style/FileEmpty: # new in 1.48
-  Enabled: true
-Style/FileRead: # new in 1.24
-  Enabled: true
-Style/FileWrite: # new in 1.24
-  Enabled: true
-Style/InPatternThen: # new in 1.16
-  Enabled: true
-Style/MagicCommentFormat: # new in 1.35
-  Enabled: true
-Style/MapCompactWithConditionalBlock: # new in 1.30
-  Enabled: true
-Style/MapToHash: # new in 1.24
-  Enabled: true
-Style/MapToSet: # new in 1.42
-  Enabled: true
-Style/MinMaxComparison: # new in 1.42
-  Enabled: true
-Style/MultilineInPatternThen: # new in 1.16
-  Enabled: true
-Style/NestedFileDirname: # new in 1.26
-  Enabled: true
-Style/NumberedParameters: # new in 1.22
-  Enabled: true
-Style/NumberedParametersLimit: # new in 1.22
-  Enabled: true
-Style/ObjectThen: # new in 1.28
-  Enabled: true
-Style/OpenStructUse: # new in 1.23
-  Enabled: true
-Style/OperatorMethodCall: # new in 1.37
-  Enabled: true
-Style/QuotedSymbols: # new in 1.16
-  Enabled: true
-Style/RedundantConstantBase: # new in 1.40
-  Enabled: true
-Style/RedundantDoubleSplatHashBraces: # new in 1.41
-  Enabled: true
-Style/RedundantEach: # new in 1.38
-  Enabled: true
-Style/RedundantHeredocDelimiterQuotes: # new in 1.45
-  Enabled: true
-Style/RedundantInitialize: # new in 1.27
-  Enabled: true
-Style/RedundantLineContinuation: # new in 1.49
-  Enabled: true
-Style/RedundantSelfAssignmentBranch: # new in 1.19
-  Enabled: true
-Style/RedundantStringEscape: # new in 1.37
-  Enabled: true
-Style/SelectByRegexp: # new in 1.22
+Style/StringLiteralsInInterpolation:
   Enabled: true

--- a/tasks.rb
+++ b/tasks.rb
@@ -2637,7 +2637,7 @@ if ARGV[0].to_sym == :update_measures
   # Apply rubocop (uses .rubocop.yml)
   commands = ["\"require 'rubocop/rake_task' \"",
               "\"require 'stringio' \"",
-              "\"RuboCop::RakeTask.new(:rubocop) do |t| t.options = ['--autocorrect', '--format', 'simple'] end\"",
+              "\"RuboCop::RakeTask.new(:rubocop) do |t| t.options = ['--autocorrect-all', '--format', 'simple'] end\"",
               '"Rake.application[:rubocop].invoke"']
   command = "#{OpenStudio.getOpenStudioCLI} -e #{commands.join(' -e ')}"
   puts 'Applying rubocop auto-correct to measures...'

--- a/tasks.rb
+++ b/tasks.rb
@@ -2634,36 +2634,10 @@ if ARGV[0].to_sym == :update_measures
   ENV['HOME'] = 'C:' if !ENV['HOME'].nil? && ENV['HOME'].start_with?('U:')
   ENV['HOMEDRIVE'] = 'C:\\' if !ENV['HOMEDRIVE'].nil? && ENV['HOMEDRIVE'].start_with?('U:')
 
-  # Apply rubocop
-  cops = ['Layout',
-          'Lint/DeprecatedClassMethods',
-          'Lint/DuplicateElsifCondition',
-          'Lint/DuplicateHashKey',
-          'Lint/DuplicateMethods',
-          'Lint/InterpolationCheck',
-          'Lint/LiteralAsCondition',
-          'Lint/RedundantStringCoercion',
-          'Lint/SelfAssignment',
-          'Lint/UnderscorePrefixedVariableName',
-          'Lint/UnusedBlockArgument',
-          'Lint/UnusedMethodArgument',
-          'Lint/UselessAssignment',
-          'Style/AndOr',
-          'Style/Documentation',
-          'Style/DocumentationMethod',
-          'Style/FrozenStringLiteralComment',
-          'Style/HashSyntax',
-          'Style/Next',
-          'Style/NilComparison',
-          'Style/RedundantParentheses',
-          'Style/RedundantSelf',
-          'Style/ReturnNil',
-          'Style/SelfAssignment',
-          'Style/StringLiterals',
-          'Style/StringLiteralsInInterpolation']
+  # Apply rubocop (uses .rubocop.yml)
   commands = ["\"require 'rubocop/rake_task' \"",
               "\"require 'stringio' \"",
-              "\"RuboCop::RakeTask.new(:rubocop) do |t| t.options = ['--autocorrect', '--format', 'simple', '--only', '#{cops.join(',')}'] end\"",
+              "\"RuboCop::RakeTask.new(:rubocop) do |t| t.options = ['--autocorrect', '--format', 'simple'] end\"",
               '"Rake.application[:rubocop].invoke"']
   command = "#{OpenStudio.getOpenStudioCLI} -e #{commands.join(' -e ')}"
   puts 'Applying rubocop auto-correct to measures...'


### PR DESCRIPTION
## Pull Request Description

There was a discrepancy between the settings in .rubocop.yml and the set of cops we were using [in the rake task](https://github.com/NREL/OpenStudio-HPXML/blob/12518133072823a3ce29e53505b8c5206864b145/tasks.rb#L2666). This PR updates the .rubocop.yml to use the same set of cops being used in rake task and removes hardcoded list.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
