### PR TITLE
Resolve relative path relative to osw file

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -3648,14 +3648,14 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
     # Create HPXML file
     hpxml_path = args[:hpxml_path]
     unless (Pathname.new hpxml_path).absolute?
-      hpxml_path = File.expand_path(hpxml_path)
+      hpxml_path = File.join(runner.workflow.absoluteRootDir.to_s, hpxml_path)
     end
 
     # Existing HPXML File
     if not args[:existing_hpxml_path].nil?
       existing_hpxml_path = args[:existing_hpxml_path]
       unless (Pathname.new existing_hpxml_path).absolute?
-        existing_hpxml_path = File.expand_path(existing_hpxml_path)
+        existing_hpxml_path = File.join(runner.workflow.absoluteRootDir.to_s, existing_hpxml_path)
       end
     end
 

--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -104,7 +104,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
 
     hpxml_path = args[:hpxml_path]
     unless (Pathname.new hpxml_path).absolute?
-      hpxml_path = File.expand_path(hpxml_path)
+      hpxml_path = File.join(runner.workflow.absoluteRootDir.to_s, hpxml_path)
     end
     unless File.exist?(hpxml_path) && hpxml_path.downcase.end_with?('.xml')
       fail "'#{hpxml_path}' does not exist or is not an .xml file."
@@ -112,7 +112,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
 
     hpxml_output_path = args[:hpxml_output_path]
     unless (Pathname.new hpxml_output_path).absolute?
-      hpxml_output_path = File.expand_path(hpxml_output_path)
+      hpxml_output_path = File.join(runner.workflow.absoluteRootDir.to_s, hpxml_output_path)
     end
     args[:hpxml_output_path] = hpxml_output_path
 

--- a/HPXMLtoOpenStudio/measure.rb
+++ b/HPXMLtoOpenStudio/measure.rb
@@ -112,7 +112,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     Model.reset(runner, model)
 
     args = runner.getArgumentValues(arguments(model), user_arguments)
-    set_file_paths(args)
+    set_file_paths(runner, args)
 
     begin
       hpxml = create_hpxml_object(runner, args)
@@ -177,16 +177,16 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
   #
   # @param args [Hash] Map of :argument_name => value
   # @return [nil]
-  def set_file_paths(args)
+  def set_file_paths(runner, args)
     if not (Pathname.new args[:hpxml_path]).absolute?
-      args[:hpxml_path] = File.expand_path(args[:hpxml_path])
+      args[:hpxml_path] = File.join(runner.workflow.absoluteRootDir.to_s, args[:hpxml_path])
     end
     if not File.exist?(args[:hpxml_path]) && args[:hpxml_path].downcase.end_with?('.xml')
       fail "'#{args[:hpxml_path]}' does not exist or is not an .xml file."
     end
 
     if not (Pathname.new args[:output_dir]).absolute?
-      args[:output_dir] = File.expand_path(args[:output_dir])
+      args[:output_dir] = File.join(runner.workflow.absoluteRootDir.to_s, args[:output_dir])
     end
 
     if File.extname(args[:annual_output_file_name]).length == 0

--- a/HPXMLtoOpenStudio/resources/meta_measure.rb
+++ b/HPXMLtoOpenStudio/resources/meta_measure.rb
@@ -189,7 +189,7 @@ def apply_measures(measures_dir, measures, runner, model, show_measure_calls = t
   if not osw_out.nil?
     # Create a workflow based on the measures we're going to call. Convenient for debugging.
     workflowJSON = OpenStudio::WorkflowJSON.new
-    workflowJSON.setOswPath(File.expand_path("../#{osw_out}"))
+    workflowJSON.setOswPath(File.expand_path(runner.workflow.absoluteRootDir.to_s + "/#{osw_out}"))
     workflowJSON.addMeasurePath('measures')
     workflowJSON.addMeasurePath('resources/hpxml-measures')
     steps = OpenStudio::WorkflowStepVector.new

--- a/workflow/template-build-and-run-hpxml-with-stochastic-occupancy.osw
+++ b/workflow/template-build-and-run-hpxml-with-stochastic-occupancy.osw
@@ -52,7 +52,7 @@
         "heating_system_heating_capacity": 36000.0,
         "heating_system_heating_efficiency": 0.92,
         "heating_system_type": "Furnace",
-        "hpxml_path": "../built.xml",
+        "hpxml_path": "run/built.xml",
         "hvac_control_cooling_weekday_setpoint": "78",
         "hvac_control_cooling_weekend_setpoint": "78",
         "hvac_control_heating_weekday_setpoint": "68",
@@ -82,16 +82,16 @@
     },
     {
       "arguments": {
-        "hpxml_path": "../built.xml",
+        "hpxml_path": "run/built.xml",
         "output_csv_path": "stochastic.csv",
-        "hpxml_output_path": "../built-stochastic-schedules.xml"
+        "hpxml_output_path": "run/built-stochastic-schedules.xml"
       },
       "measure_dir_name": "BuildResidentialScheduleFile"
     },
     {
       "arguments": {
-        "hpxml_path": "../built-stochastic-schedules.xml",
-        "output_dir": "..",
+        "hpxml_path": "run/built-stochastic-schedules.xml",
+        "output_dir": "run",
         "debug": false,
         "add_component_loads": false,
         "skip_validation": false

--- a/workflow/template-run-hpxml-with-stochastic-occupancy-subset.osw
+++ b/workflow/template-run-hpxml-with-stochastic-occupancy-subset.osw
@@ -6,17 +6,17 @@
   "steps": [
     {
       "arguments": {
-        "hpxml_path": "../../sample_files/base.xml",
+        "hpxml_path": "sample_files/base.xml",
         "output_csv_path": "stochastic.csv",
-        "hpxml_output_path": "../built-stochastic-schedules.xml",
+        "hpxml_output_path": "run/built-stochastic-schedules.xml",
         "schedules_column_names": "cooking_range, dishwasher, hot_water_dishwasher, clothes_washer, hot_water_clothes_washer, clothes_dryer, hot_water_fixtures"
       },
       "measure_dir_name": "BuildResidentialScheduleFile"
     },
     {
       "arguments": {
-        "hpxml_path": "../built-stochastic-schedules.xml",
-        "output_dir": "..",
+        "hpxml_path": "run/built-stochastic-schedules.xml",
+        "output_dir": "run",
         "debug": false,
         "add_component_loads": false,
         "skip_validation": false

--- a/workflow/template-run-hpxml-with-stochastic-occupancy.osw
+++ b/workflow/template-run-hpxml-with-stochastic-occupancy.osw
@@ -6,16 +6,16 @@
   "steps": [
     {
       "arguments": {
-        "hpxml_path": "../../sample_files/base.xml",
+        "hpxml_path": "sample_files/base.xml",
         "output_csv_path": "stochastic.csv",
-        "hpxml_output_path": "../built-stochastic-schedules.xml"
+        "hpxml_output_path": "run/built-stochastic-schedules.xml"
       },
       "measure_dir_name": "BuildResidentialScheduleFile"
     },
     {
       "arguments": {
-        "hpxml_path": "../built-stochastic-schedules.xml",
-        "output_dir": "..",
+        "hpxml_path": "run/built-stochastic-schedules.xml",
+        "output_dir": "run",
         "debug": false,
         "add_component_loads": false,
         "skip_validation": false

--- a/workflow/template-run-hpxml.osw
+++ b/workflow/template-run-hpxml.osw
@@ -6,8 +6,8 @@
   "steps": [
     {
       "arguments": {
-        "hpxml_path": "../../sample_files/base.xml",
-        "output_dir": "..",
+        "hpxml_path": "sample_files/base.xml",
+        "output_dir": "run",
         "debug": false,
         "add_component_loads": false,
         "skip_validation": false,


### PR DESCRIPTION
## Pull Request Description

Currently relative paths are resolved relative to the current working directory which is confusing and [something like './run/000_measure_class_name/'](https://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/#using-files-and-using-externalfile-in-a-measure). This PR resolves the relative paths in the OSW relative to the OSW file itself.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
