### PR TITLE
Make EV charging/discharging unavailable during vacancy periods

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@ __Bugfixes__
 - Fixes possible error if there's a surface w/ interior unconditioned space and exterior "other housing unit".
 - Fixes default shading coefficients for window solar screens and solar film.
 - Fixes `SolarFraction` documentation/error-checking for solar thermal systems; must now be <= 0.99.
+- Fixes whole house fans so that they are unavailable during vacancies.
 - BuildResidentialHPXML measure: Fixes error when specifying a combi boiler as the water heater type and a *shared* boiler as the heating system type.
 - BuildResidentialScheduleFile measure: Fixes out-of-sync shifting of occupancy and end use schedule resulting in activities even when there is no occupancy.
 - BuildResidentialScheduleFile measure: Fixes a small bug in sink schedule generation resulting in more concentrated schedule.

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7f2343b5-1c13-4f0f-baec-c6b000bb474d</version_id>
-  <version_modified>2025-03-20T19:38:43Z</version_modified>
+  <version_id>35354a31-2a67-4306-a5e7-59157923d8f1</version_id>
+  <version_modified>2025-03-26T22:01:33Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -321,7 +321,7 @@
       <filename>data/unavailable_periods.csv</filename>
       <filetype>csv</filetype>
       <usage_type>resource</usage_type>
-      <checksum>3FBE7B42</checksum>
+      <checksum>2DE72980</checksum>
     </file>
     <file>
       <filename>data/zipcode_weather_stations.csv</filename>

--- a/HPXMLtoOpenStudio/resources/data/unavailable_periods.csv
+++ b/HPXMLtoOpenStudio/resources/data/unavailable_periods.csv
@@ -36,5 +36,5 @@ bath_fan,1,1,0,0
 whole_house_fan,0,1,0,0
 battery_charging,0,1,0,0
 battery_discharging,0,1,0,0
-electric_vehicle_charging,0,1,0,0
-electric_vehicle_discharging,0,1,0,0
+electric_vehicle_charging,1,1,0,0
+electric_vehicle_discharging,1,1,0,0

--- a/HPXMLtoOpenStudio/resources/data/unavailable_periods.csv
+++ b/HPXMLtoOpenStudio/resources/data/unavailable_periods.csv
@@ -33,7 +33,7 @@ dehumidifier,0,1,0,0
 house_fan,0,1,0,0
 kitchen_fan,1,1,0,0
 bath_fan,1,1,0,0
-whole_house_fan,0,1,0,0
+whole_house_fan,1,1,0,0
 battery_charging,0,1,0,0
 battery_discharging,0,1,0,0
 electric_vehicle_charging,1,1,0,0


### PR DESCRIPTION
## Pull Request Description

I was looking at the unavailable period table and what end-uses are unavailable during a vacancy period. I think the EV charging and discharging end-uses should be unavailable during the vacancy period.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
