### PR TITLE
Fix handling user output requests with 'none' timeseries frequency

### DIFF
--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -330,6 +330,8 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
 
         args[key] = false
       end
+      args[:user_output_variables] = nil
+      args[:user_output_meters] = nil
     end
     return args
   end

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>8b5a1812-c7f9-4efd-b090-2fe0d74f0bcb</version_id>
-  <version_modified>2025-02-18T17:50:35Z</version_modified>
+  <version_id>d1632134-9a7c-4510-aed0-89a8fb1c852f</version_id>
+  <version_modified>2025-04-02T14:52:18Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1978,7 +1978,7 @@
       <filename>test_report_sim_output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>97D742B1</checksum>
+      <checksum>8A2EF398</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>d1632134-9a7c-4510-aed0-89a8fb1c852f</version_id>
-  <version_modified>2025-04-02T14:52:18Z</version_modified>
+  <version_id>f1ccfcfd-cc8c-4895-a217-94d80a76ad87</version_id>
+  <version_modified>2025-04-02T15:00:15Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1972,13 +1972,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>8BAA16E7</checksum>
+      <checksum>561D1A81</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>8A2EF398</checksum>
+      <checksum>66999A82</checksum>
     </file>
   </files>
 </measure>

--- a/ReportSimulationOutput/tests/test_report_sim_output.rb
+++ b/ReportSimulationOutput/tests/test_report_sim_output.rb
@@ -1355,7 +1355,10 @@ class ReportSimulationOutputTest < Minitest::Test
                   'add_component_loads' => true,
                   'timeseries_frequency' => 'none',
                   'user_output_variables' => 'Zone People Occupant Count, Zone People Total Heating Energy, Foo, Surface Construction Index' }
-    _annual_csv, _timeseries_csv, _run_log = _test_measure(args_hash)
+    annual_csv, timeseries_csv, run_log = _test_measure(args_hash)
+    assert(File.exist?(annual_csv))
+    assert(!File.exist?(timeseries_csv))
+    assert(!File.readlines(run_log).any? { |line| line.include?("Request for output variable 'Foo'") })
   end
 
   def test_timeseries_energyplus_output_meters

--- a/ReportSimulationOutput/tests/test_report_sim_output.rb
+++ b/ReportSimulationOutput/tests/test_report_sim_output.rb
@@ -1349,6 +1349,15 @@ class ReportSimulationOutputTest < Minitest::Test
     assert(File.readlines(run_log).any? { |line| line.include?("Request for output variable 'Foo'") })
   end
 
+  def test_timeseries_energyplus_output_variables_freq_none
+    args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
+                  'skip_validation' => true,
+                  'add_component_loads' => true,
+                  'timeseries_frequency' => 'none',
+                  'user_output_variables' => 'Zone People Occupant Count, Zone People Total Heating Energy, Foo, Surface Construction Index' }
+    _annual_csv, _timeseries_csv, _run_log = _test_measure(args_hash)
+  end
+
   def test_timeseries_energyplus_output_meters
     args_hash = { 'hpxml_path' => File.join(File.dirname(__FILE__), '../../workflow/sample_files/base.xml'),
                   'skip_validation' => true,


### PR DESCRIPTION
## Pull Request Description

For example, a resstock YML file with `output_variables` specified but `timeseries_frequency=none` leads to an IDF with:

```
Output:Variable,
  *,                                      !- Key Value
  Zone Mean Air Temperature,              !- Variable Name
  none;                                   !- Reporting Frequency
```

Which then leads to `   ** Severe  ** <root>[Output:Variable][Output:Variable 22][reporting_frequency] - "none" - Failed to match against any enum values.`.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
