### PR TITLE
Preserve HP cfm/ton

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>2b1937bb-af01-4093-8b68-566893ecb620</version_id>
-  <version_modified>2025-04-10T22:10:22Z</version_modified>
+  <version_id>c930cb39-1d82-4153-9450-b702720e1290</version_id>
+  <version_modified>2025-04-11T16:49:59Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -333,7 +333,7 @@
       <filename>defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D5976D45</checksum>
+      <checksum>5402EFDC</checksum>
     </file>
     <file>
       <filename>energyplus.rb</filename>
@@ -393,13 +393,13 @@
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>CC07B619</checksum>
+      <checksum>F584C0F1</checksum>
     </file>
     <file>
       <filename>hvac_sizing.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>CFB5FA6B</checksum>
+      <checksum>1B2D5BEA</checksum>
     </file>
     <file>
       <filename>internal_gains.rb</filename>
@@ -711,7 +711,7 @@
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>12C5CCBB</checksum>
+      <checksum>F389F75B</checksum>
     </file>
     <file>
       <filename>test_enclosure.rb</filename>
@@ -735,7 +735,7 @@
       <filename>test_hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>CEDD52E5</checksum>
+      <checksum>59C7E8DD</checksum>
     </file>
     <file>
       <filename>test_hvac_sizing.rb</filename>
@@ -783,7 +783,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>CA12984B</checksum>
+      <checksum>A117C31C</checksum>
     </file>
     <file>
       <filename>test_vehicle.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -302,8 +302,8 @@ module HVAC
           else
             obj_name = Constants::ObjectTypeCentralAirConditionerAndFurnace
             # error checking for fan power
-            if (cooling_system.fan_watts_per_cfm.to_f != heating_system.fan_watts_per_cfm.to_f)
-              fail "Fan powers for heating system '#{heating_system.id}' and cooling system '#{cooling_system.id}' are attached to a single distribution system and therefore must be the same."
+            if (not cooling_system.fan_watts_per_cfm.nil?) && (not heating_system.fan_watts_per_cfm.nil?) && (cooling_system.fan_watts_per_cfm != heating_system.fan_watts_per_cfm)
+              fail "Fan powers for heating system '#{heating_system.id}' (#{heating_system.fan_watts_per_cfm} W/cfm) and cooling system '#{cooling_system.id}' (#{cooling_system.fan_watts_per_cfm} W/cfm) are attached to a single distribution system and therefore must be the same."
             end
           end
         when HPXML::HVACTypeRoomAirConditioner, HPXML::HVACTypePTAC

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -1589,8 +1589,21 @@ class HPXMLtoOpenStudioDefaultsTest < Minitest::Test
     _default_hpxml, default_hpxml_bldg = _test_measure()
     _test_default_central_air_conditioner_values(default_hpxml_bldg.cooling_systems[0], 0.66, HPXML::HVACFanMotorTypeBPM, nil, -0.11, -0.22, nil, 11.4, 11.0, 40.0, 1.2)
 
-    # Test watts/cfm based on fan model type
+    # Test watts/cfm based on attached heating system
     hpxml_bldg.cooling_systems[0].fan_watts_per_cfm = nil
+    hpxml_bldg.heating_systems.add(id: 'HeatingSystem1',
+                                   distribution_system_idref: hpxml_bldg.hvac_distributions[0].id,
+                                   heating_system_type: HPXML::HVACTypeFurnace,
+                                   heating_system_fuel: HPXML::FuelTypeElectricity,
+                                   heating_efficiency_afue: 1,
+                                   fraction_heat_load_served: 1.0,
+                                   fan_watts_per_cfm: 0.55)
+    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
+    _default_hpxml, default_hpxml_bldg = _test_measure()
+    _test_default_central_air_conditioner_values(default_hpxml_bldg.cooling_systems[0], 0.55, HPXML::HVACFanMotorTypeBPM, nil, -0.11, -0.22, nil, 11.4, 11.0, 40.0, 1.2)
+
+    # Test watts/cfm based on fan model type
+    hpxml_bldg.heating_systems[0].delete
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
     _default_hpxml, default_hpxml_bldg = _test_measure()
     _test_default_central_air_conditioner_values(default_hpxml_bldg.cooling_systems[0], 0.375, HPXML::HVACFanMotorTypeBPM, nil, -0.11, -0.22, nil, 11.4, 11.0, 40.0, 1.2)
@@ -1755,6 +1768,7 @@ class HPXMLtoOpenStudioDefaultsTest < Minitest::Test
   def test_furnaces
     # Test inputs not overridden by defaults
     hpxml, hpxml_bldg = _create_hpxml('base.xml')
+    hpxml_bldg.cooling_systems[0].fan_watts_per_cfm = 0.66
     hpxml_bldg.heating_systems[0].fan_watts_per_cfm = 0.66
     hpxml_bldg.heating_systems[0].fan_motor_type = HPXML::HVACFanMotorTypeBPM
     hpxml_bldg.heating_systems[0].airflow_defect_ratio = -0.22
@@ -1772,8 +1786,15 @@ class HPXMLtoOpenStudioDefaultsTest < Minitest::Test
     _default_hpxml, default_hpxml_bldg = _test_measure()
     _test_default_furnace_values(default_hpxml_bldg.heating_systems[0], 0.66, HPXML::HVACFanMotorTypeBPM, nil, -0.22, nil, true, 999, 1.2)
 
-    # Test watts/cfm based on fan model type
+    # Test watts/cfm based on attached cooling system
     hpxml_bldg.heating_systems[0].fan_watts_per_cfm = nil
+    hpxml_bldg.cooling_systems[0].fan_watts_per_cfm = 0.55
+    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
+    _default_hpxml, default_hpxml_bldg = _test_measure()
+    _test_default_furnace_values(default_hpxml_bldg.heating_systems[0], 0.55, HPXML::HVACFanMotorTypeBPM, nil, -0.22, nil, true, 999, 1.2)
+
+    # Test watts/cfm based on fan model type
+    hpxml_bldg.cooling_systems[0].fan_watts_per_cfm = nil
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
     _default_hpxml, default_hpxml_bldg = _test_measure()
     _test_default_furnace_values(default_hpxml_bldg.heating_systems[0], 0.375, HPXML::HVACFanMotorTypeBPM, nil, -0.22, nil, true, 999, 1.2)

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -1211,7 +1211,7 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
                             'hvac-research-features-num-unit-greater-than-one' => ['NumberofUnits greater than 1 is not supported for on-off thermostat deadband.',
                                                                                    'NumberofUnits greater than 1 is not supported for multi-staging backup coil.'],
                             'hvac-gshp-invalid-num-bore-holes' => ["Number of bore holes (5) with borefield configuration 'Lopsided U' not supported."],
-                            'hvac-inconsistent-fan-powers' => ["Fan powers for heating system 'HeatingSystem1' and cooling system 'CoolingSystem1' are attached to a single distribution system and therefore must be the same."],
+                            'hvac-inconsistent-fan-powers' => ["Fan powers for heating system 'HeatingSystem1' (0.45 W/cfm) and cooling system 'CoolingSystem1' (0.55 W/cfm) are attached to a single distribution system and therefore must be the same."],
                             'hvac-invalid-distribution-system-type' => ["Incorrect HVAC distribution system type for HVAC type: 'Furnace'. Should be one of: ["],
                             'hvac-shared-boiler-multiple' => ['More than one shared heating system found.'],
                             'hvac-shared-chiller-multiple' => ['More than one shared cooling system found.'],

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -2173,7 +2173,7 @@ Each central furnace is entered as a ``/HPXML/Building/BuildingDetails/Systems/H
          If there is a cooling system attached to the DistributionSystem, the heating and cooling systems cannot have different values for FanMotorType.
   .. [#] If FanMotorType is not provided and if there is a cooling system attached to the DistributionSystem, defaults to "PSC" if the attached cooling system CompressorType is "single stage", else "BPM"; If there's no cooling system attached, defaults to "PSC" if AFUE <= 0.9, else "BPM".
   .. [#] If there is a cooling system attached to the DistributionSystem, the heating and cooling systems cannot have different values for FanPowerWattsPerCFM.
-  .. [#] If FanPowerWattsPerCFM not provided, defaults to 0 W/cfm if gravity distribution system, else 0.5 W/cfm if FanMotorType is "PSC", else 0.375 W/cfm if FanMotorType is "BPM".
+  .. [#] If FanPowerWattsPerCFM not provided, defaults to using attached central air conditioner W/cfm if available, else 0 W/cfm if gravity distribution system, else 0.5 W/cfm if FanMotorType is "PSC", else 0.375 W/cfm if FanMotorType is "BPM".
   .. [#] AirflowDefectRatio is defined as (InstalledAirflow - DesignAirflow) / DesignAirflow; a value of zero means no airflow defect.
          See `ANSI/RESNET/ACCA 310-2020 <https://codes.iccsafe.org/content/ICC3102020P1>`_ for more information.
 
@@ -2805,8 +2805,8 @@ Each air-to-air heat pump is entered as a ``/HPXML/Building/BuildingDetails/Syst
   ``extension/HeatingCapacityFraction17F``                          double   frac      >= 0, < 1                 No        See [#]_        Heating output capacity at 17F divided by heating output capacity at 47F [#]_
   ``extension/FanMotorType``                                        string             See [#]_                  No        See [#]_        Blower fan model type
   ``extension/FanPowerWattsPerCFM``                                 double   W/cfm     >= 0                      No        See [#]_        Blower fan efficiency at maximum fan speed
-  ``extension/HeatingAirflowCFM``                                   double   cfm       >= 0                      No        360 cfm/ton     Blower fan heating design airflow rate
-  ``extension/CoolingAirflowCFM``                                   double   cfm       >= 0                      No        360 cfm/ton     Blower fan cooling design airflow rate
+  ``extension/HeatingAirflowCFM``                                   double   cfm       >= 0                      No        See [#]_        Blower fan heating design airflow rate
+  ``extension/CoolingAirflowCFM``                                   double   cfm       >= 0                      No        See [#]_        Blower fan cooling design airflow rate
   ``extension/AirflowDefectRatio``                                  double   frac      >= -0.9, <= 9             No        0.0             Deviation between design/installed airflow rates [#]_
   ``extension/ChargeDefectRatio``                                   double   frac      >= -0.9, <= 9             No        0.0             Deviation between design/installed refrigerant charges [#]_
   ``extension/CrankcaseHeaterPowerWatts``                           double   W         >= 0                      No        See [#]_        Crankcase heater power
@@ -2852,6 +2852,8 @@ Each air-to-air heat pump is entered as a ``/HPXML/Building/BuildingDetails/Syst
   .. [#] FanMotorType choices are "PSC" (Permanent Split Capacitor) and "BPM" (Brushless Permanent Magnet).
   .. [#] If FanMotorType is not provided, defaults to "PSC" if CompressorType is "single stage", else "BPM".
   .. [#] If FanPowerWattsPerCFM not provided, defaults to 0.5 W/cfm if FanMotorType is "PSC", else 0.375 W/cfm if FanMotorType is "BPM".
+  .. [#] If HeatingAirflowCFM not provided, defaults to cfm/ton based on CoolingAirflowCFM if provided, else 360 cfm/ton.
+  .. [#] If CoolingAirflowCFM not provided, defaults to cfm/ton based on HeatingAirflowCFM if provided, else 360 cfm/ton.
   .. [#] AirflowDefectRatio is defined as (InstalledAirflow - DesignAirflow) / DesignAirflow; a value of zero means no airflow defect.
          See `ANSI/RESNET/ACCA 310-2020 <https://codes.iccsafe.org/content/ICC3102020P1>`_ for more information.
   .. [#] ChargeDefectRatio is defined as (InstalledCharge - DesignCharge) / DesignCharge; a value of zero means no refrigerant charge defect.
@@ -2895,8 +2897,8 @@ Each ``HeatPump`` should represent a single outdoor unit, whether connected to o
   ``extension/HeatingCapacityFraction17F``                          double    frac      >= 0, < 1                 No        See [#]_        Heating output capacity at 17F divided by heating output capacity at 47F [#]_
   ``extension/FanMotorType``                                        string              See [#]_                  No        BPM             Blower fan model type
   ``extension/FanPowerWattsPerCFM``                                 double    W/cfm     >= 0                      No        See [#]_        Blower fan efficiency at maximum fan speed
-  ``extension/HeatingAirflowCFM``                                   double    cfm       >= 0                      No        360 cfm/ton     Blower fan heating design airflow rate
-  ``extension/CoolingAirflowCFM``                                   double    cfm       >= 0                      No        360 cfm/ton     Blower fan cooling design airflow rate
+  ``extension/HeatingAirflowCFM``                                   double    cfm       >= 0                      No        See [#]_        Blower fan heating design airflow rate
+  ``extension/CoolingAirflowCFM``                                   double    cfm       >= 0                      No        See [#]_        Blower fan cooling design airflow rate
   ``extension/AirflowDefectRatio``                                  double    frac      >= -0.9, <= 9             No        0.0             Deviation between design/installed airflow rates [#]_
   ``extension/ChargeDefectRatio``                                   double    frac      >= -0.9, <= 9             No        0.0             Deviation between design/installed refrigerant charges [#]_
   ``extension/CrankcaseHeaterPowerWatts``                           double    W         >= 0                      No        See [#]_        Crankcase heater power
@@ -2940,6 +2942,8 @@ Each ``HeatPump`` should represent a single outdoor unit, whether connected to o
          Either input approach can be used, but not both.
   .. [#] FanMotorType choices are "PSC" (Permanent Split Capacitor) and "BPM" (Brushless Permanent Magnet).
   .. [#] FanPowerWattsPerCFM defaults to 0.07 W/cfm for ductless systems and 0.18 W/cfm for ducted systems.
+  .. [#] If HeatingAirflowCFM not provided, defaults to cfm/ton based on CoolingAirflowCFM if provided, else 360 cfm/ton.
+  .. [#] If CoolingAirflowCFM not provided, defaults to cfm/ton based on HeatingAirflowCFM if provided, else 360 cfm/ton.
   .. [#] AirflowDefectRatio is defined as (InstalledAirflow - DesignAirflow) / DesignAirflow; a value of zero means no airflow defect.
          A non-zero airflow defect can only be applied for systems attached to a distribution system.
          See `ANSI/RESNET/ACCA 310-2020 <https://codes.iccsafe.org/content/ICC3102020P1>`_ for more information.
@@ -3081,8 +3085,8 @@ Each ground-to-air heat pump is entered as a ``/HPXML/Building/BuildingDetails/S
   ``extension/SharedLoopWatts``                    double    W       >= 0             See [#]_                  Shared pump power [#]_
   ``extension/FanMotorType``                       string            See [#]_         No        See [#]_        Blower fan model type
   ``extension/FanPowerWattsPerCFM``                double    W/cfm   >= 0             No        See [#]_        Blower fan efficiency at maximum fan speed
-  ``extension/HeatingAirflowCFM``                  double    cfm     >= 0             No        360 cfm/ton     Blower fan heating design airflow rate
-  ``extension/CoolingAirflowCFM``                  double    cfm     >= 0             No        360 cfm/ton     Blower fan cooling design airflow rate
+  ``extension/HeatingAirflowCFM``                  double    cfm     >= 0             No        See [#]_        Blower fan heating design airflow rate
+  ``extension/CoolingAirflowCFM``                  double    cfm     >= 0             No        See [#]_        Blower fan cooling design airflow rate
   ``extension/AirflowDefectRatio``                 double    frac    >= -0.9, <= 9    No        0.0             Deviation between design/installed airflow rates [#]_
   ``extension/ChargeDefectRatio``                  double    frac    >= -0.9, <= 9    No        0.0             Deviation between design/installed refrigerant charges [#]_
   ``extension/CoolingAutosizingFactor``            double    frac    > 0              No        1.0             Cooling autosizing capacity multiplier
@@ -3122,6 +3126,8 @@ Each ground-to-air heat pump is entered as a ``/HPXML/Building/BuildingDetails/S
   .. [#] FanMotorType choices are "PSC" (Permanent Split Capacitor) and "BPM" (Brushless Permanent Magnet).
   .. [#] If FanMotorType is not provided, defaults to "PSC" if COP <= 8.75/3.2, else "BPM".
   .. [#] If FanPowerWattsPerCFM not provided, defaults to 0.5 W/cfm if FanMotorType is "PSC", else 0.375 W/cfm if FanMotorType is "BPM".
+  .. [#] If HeatingAirflowCFM not provided, defaults to cfm/ton based on CoolingAirflowCFM if provided, else 360 cfm/ton.
+  .. [#] If CoolingAirflowCFM not provided, defaults to cfm/ton based on HeatingAirflowCFM if provided, else 360 cfm/ton.
   .. [#] AirflowDefectRatio is defined as (InstalledAirflow - DesignAirflow) / DesignAirflow; a value of zero means no airflow defect.
          See `ANSI/RESNET/ACCA 310-2020 <https://codes.iccsafe.org/content/ICC3102020P1>`_ for more information.
   .. [#] ChargeDefectRatio is defined as (InstalledCharge - DesignCharge) / DesignCharge; a value of zero means no refrigerant charge defect.


### PR DESCRIPTION
## Pull Request Description

Follow-up to https://github.com/NREL/OpenStudio-HPXML/pull/1979.

If only heating (or cooling) airflow provided for HPs, preserve the cfm/ton for the other mode.

(Unrelated but similar improvement: For AC/furnace systems, allow fan W/cfm to be only provided for one mode, in which case the other mode will use the same value.)

Added unit tests for both.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
