### PR TITLE
Reduce outputs by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ __New Features__
 - Output updates:
   - **Breaking change**: Adds generator electricity produced to *total* fuel/energy use; previously it was only included in *net* values.
   - Adds new outputs for *net* peak electricity (summer/winter/annual); same as *total* peak electricity outputs but subtracts power produced by PV.
+  - Avoids writing the E+ eplustbl.htm by default; use the debug flag to get it.
+  - Deletes the eplusout\*.msgpack files by default (run_simulation.rb only); use the debug flag to preserve them.
 - Allows arbitrary columns to be present in a detailed schedule csv file with warning.
 
 __Bugfixes__

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3fee514e-82e1-4c56-a9b8-165b08a34988</version_id>
-  <version_modified>2025-04-11T17:17:29Z</version_modified>
+  <version_id>c494c200-2f2f-4212-859d-6a488d2ba056</version_id>
+  <version_modified>2025-04-18T23:03:04Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -435,7 +435,7 @@
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D11644B9</checksum>
+      <checksum>C2D403E7</checksum>
     </file>
     <file>
       <filename>minitest_helper.rb</filename>
@@ -459,7 +459,7 @@
       <filename>output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>F1DAFE41</checksum>
+      <checksum>1466F155</checksum>
     </file>
     <file>
       <filename>psychrometrics.rb</filename>

--- a/HPXMLtoOpenStudio/resources/meta_measure.rb
+++ b/HPXMLtoOpenStudio/resources/meta_measure.rb
@@ -171,6 +171,11 @@ def run_hpxml_workflow(rundir, measures, measures_dir, debug: false, run_measure
 
   print "Done.\n" unless suppress_print
 
+  # Clean up EnergyPlus output files
+  if not debug
+    FileUtils.rm Dir.glob(File.join(rundir, 'eplusout*.msgpack'))
+  end
+
   return { success: true, runner: runner, sim_time: sim_time }
 end
 

--- a/HPXMLtoOpenStudio/resources/output.rb
+++ b/HPXMLtoOpenStudio/resources/output.rb
@@ -901,6 +901,7 @@ module Outputs
     ocf.setOutputCSV(debug)
     ocf.setOutputSQLite(debug)
     ocf.setOutputPerfLog(debug)
+    ocf.setOutputTabular(debug)
   end
 
   # Store some data for use in reporting measure.

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -53,6 +53,9 @@ class WorkflowOtherTest < Minitest::Test
 
     # Check for output files
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+
+    # Check for no E+ msgpack files
+    refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
   end
 
   def test_run_simulation_idf_input
@@ -67,6 +70,9 @@ class WorkflowOtherTest < Minitest::Test
 
     # Check for output files
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+
+    # Check for no E+ msgpack files
+    refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
   end
 
   def test_run_simulation_faster_performance
@@ -78,6 +84,9 @@ class WorkflowOtherTest < Minitest::Test
 
     # Check for output files
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+
+    # Check for no E+ msgpack files
+    refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
 
     # Check component loads don't exist
     component_loads = {}
@@ -107,6 +116,13 @@ class WorkflowOtherTest < Minitest::Test
       assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
       assert(File.exist? File.join(File.dirname(xml), 'run', 'in.schedules.csv'))
       assert(File.exist? File.join(File.dirname(xml), 'run', 'stochastic.csv'))
+
+      # Check for E+ msgpack files
+      if debug
+        assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+      else
+        refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+      end
 
       # Check stochastic.csv headers
       schedules = CSV.read(File.join(File.dirname(xml), 'run', 'stochastic.csv'), headers: true)
@@ -139,6 +155,9 @@ class WorkflowOtherTest < Minitest::Test
 
       # Check for output files
       assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+
+      # Check for no E+ msgpack files
+      refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
 
       timeseries_output_path = File.join(File.dirname(xml), 'run', 'results_timeseries.csv')
       if not invalid_variable_only
@@ -185,6 +204,9 @@ class WorkflowOtherTest < Minitest::Test
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries_daily.csv'))
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries_monthly.csv'))
 
+    # Check for no E+ msgpack files
+    refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+
     # Check timeseries columns exist
     { 'timestep' => ['Weather:'],
       'hourly' => ['End Use:'],
@@ -211,8 +233,9 @@ class WorkflowOtherTest < Minitest::Test
     # Check for annual results (design load/capacities only)
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
 
-    # Check for no idf
+    # Check for no idf or output file
     refute(File.exist? File.join(File.dirname(xml), 'run', 'in.idf'))
+    refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
   end
 
   def test_run_defaulted_in_xml
@@ -280,6 +303,7 @@ class WorkflowOtherTest < Minitest::Test
       system(command, err: File::NULL)
 
       # Check for output files
+      assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'eplusout.msgpack')) unless skip_simulation
       assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'results_annual.csv')) unless skip_simulation
 
       # Check for debug files

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -19,7 +19,7 @@ class WorkflowOtherTest < Minitest::Test
       output_format = 'csv' if output_format == 'csv_dview'
 
       # Check for output files
-      assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+      assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack')) # Produced because --debug flag if used
       assert(File.exist? File.join(File.dirname(xml), 'run', "results_annual.#{output_format}"))
       assert(File.exist? File.join(File.dirname(xml), 'run', "results_timeseries.#{output_format}"))
       assert(File.exist?(File.join(File.dirname(xml), 'run', "results_bills.#{output_format}")))
@@ -52,7 +52,6 @@ class WorkflowOtherTest < Minitest::Test
     assert(File.exist? File.join(File.dirname(xml), 'run', 'in.epJSON'))
 
     # Check for output files
-    assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
   end
 
@@ -67,7 +66,6 @@ class WorkflowOtherTest < Minitest::Test
     assert(File.exist? File.join(File.dirname(xml), 'run', 'in.idf'))
 
     # Check for output files
-    assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
   end
 
@@ -79,7 +77,6 @@ class WorkflowOtherTest < Minitest::Test
     system(command, err: File::NULL)
 
     # Check for output files
-    assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
 
     # Check component loads don't exist
@@ -107,7 +104,6 @@ class WorkflowOtherTest < Minitest::Test
       system(command, err: File::NULL)
 
       # Check for output files
-      assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
       assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
       assert(File.exist? File.join(File.dirname(xml), 'run', 'in.schedules.csv'))
       assert(File.exist? File.join(File.dirname(xml), 'run', 'stochastic.csv'))
@@ -142,7 +138,6 @@ class WorkflowOtherTest < Minitest::Test
       system(command, err: File::NULL)
 
       # Check for output files
-      assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
       assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
 
       timeseries_output_path = File.join(File.dirname(xml), 'run', 'results_timeseries.csv')
@@ -184,7 +179,6 @@ class WorkflowOtherTest < Minitest::Test
     system(command, err: File::NULL)
 
     # Check for output files
-    assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries_timestep.csv'))
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_timeseries_hourly.csv'))
@@ -217,9 +211,8 @@ class WorkflowOtherTest < Minitest::Test
     # Check for annual results (design load/capacities only)
     assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
 
-    # Check for no idf or output file
+    # Check for no idf
     refute(File.exist? File.join(File.dirname(xml), 'run', 'in.idf'))
-    refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
   end
 
   def test_run_defaulted_in_xml
@@ -287,7 +280,6 @@ class WorkflowOtherTest < Minitest::Test
       system(command, err: File::NULL)
 
       # Check for output files
-      assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'eplusout.msgpack')) unless skip_simulation
       assert(File.exist? File.join(File.dirname(osw_path_test), 'run', 'results_annual.csv')) unless skip_simulation
 
       # Check for debug files


### PR DESCRIPTION
## Pull Request Description

Prompted by @rajeee, we now:
1. Avoid writing the E+ eplustbl.htm by default; use the debug flag to get it. (This was always the desired behavior but an [E+ bug](https://github.com/NREL/EnergyPlus/issues/9393) prevented us from doing so.)
2. Delete the eplusout*.msgpack files by default (run_simulation.rb only); use the debug flag to preserve them.

Master (top) vs this branch (bottom) when running `openstudio run_simulation.rb -x sample_files/base.xml --hourly ALL`:

![image](https://github.com/user-attachments/assets/155759ee-c467-42d3-88a3-6cb70e020bfd)

![image](https://github.com/user-attachments/assets/9a933ae1-1412-4978-a0cb-4a944e390276)


## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
