### PR TITLE
Refactor BuildResidentialScheduleFile measure to use the HPXML class

### DIFF
--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -107,7 +107,8 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
       hpxml_path = File.expand_path(hpxml_path)
     end
     unless File.exist?(hpxml_path) && hpxml_path.downcase.end_with?('.xml')
-      fail "'#{hpxml_path}' does not exist or is not an .xml file."
+      runner.registerError("'#{hpxml_path}' does not exist or is not an .xml file.")
+      return false
     end
 
     hpxml_output_path = args[:hpxml_output_path]
@@ -129,27 +130,28 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
 
     output_csv_basename, _ = args[:output_csv_path].split('.csv')
 
-    doc = XMLHelper.parse_file(hpxml_path)
-    hpxml_doc = XMLHelper.get_element(doc, '/HPXML')
-    doc_buildings = XMLHelper.get_elements(hpxml_doc, 'Building')
-    doc_buildings.each_with_index do |building, i|
-      doc_building_id = XMLHelper.get_attribute_value(XMLHelper.get_element(building, 'BuildingID'), 'id')
+    hpxml = HPXML.new(hpxml_path: hpxml_path)
 
-      next if doc_buildings.size > 1 && args[:building_id] != 'ALL' && args[:building_id] != doc_building_id
+    # Since we modify the HPXML object (apply defaults), use a copy of the
+    # original HPXML object so that the HPXML object we write does not include
+    # any such modifications.
+    orig_hpxml = Marshal.load(Marshal.dump(hpxml))
 
-      hpxml = HPXML.new(hpxml_path: hpxml_path, building_id: doc_building_id)
-      hpxml_bldg = hpxml.buildings[0]
+    hpxml.buildings.each_with_index do |hpxml_bldg, i|
+      next if hpxml.buildings.size > 1 && args[:building_id] != 'ALL' && args[:building_id] != hpxml_bldg.building_id
 
+      # Only need to do this once
       if epw_path.nil?
         epw_path = Location.get_epw_path(hpxml_bldg, hpxml_path)
         weather = WeatherFile.new(epw_path: epw_path, runner: runner)
       end
+
       # deterministically vary schedules across building units
       args[:random_seed] *= (i + 1)
 
       # exit if number of occupants is zero
       if hpxml_bldg.building_occupancy.number_of_residents == 0
-        runner.registerInfo("#{doc_building_id}: Number of occupants set to zero; skipping generation of stochastic schedules.")
+        runner.registerInfo("#{hpxml_bldg.building_id}: Number of occupants set to zero; skipping generation of stochastic schedules.")
         next
       end
 
@@ -159,34 +161,23 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
 
       # create the schedules
       success = create_schedules(runner, hpxml, hpxml_bldg, weather, args)
-      return false if not success
+      return false unless success
 
       # modify the hpxml with the schedules path
-      extension = XMLHelper.create_elements_as_needed(building, ['BuildingDetails', 'BuildingSummary', 'extension'])
-      schedules_filepaths = XMLHelper.get_values(extension, 'SchedulesFilePath', :string)
-      if !schedules_filepaths.include?(args[:output_csv_path])
-        XMLHelper.add_element(extension, 'SchedulesFilePath', args[:output_csv_path], :string)
+      if !orig_hpxml.buildings[i].header.schedules_filepaths.include?(args[:output_csv_path])
+        orig_hpxml.buildings[i].header.schedules_filepaths << args[:output_csv_path]
       end
-      write_modified_hpxml(runner, doc, hpxml_path, hpxml_output_path, schedules_filepaths, args)
     end
+
+    if hpxml_path == hpxml_output_path
+      # Create a backup of the original HPXML file
+      runner.registerWarning('HPXML Output File Path is same as HPXML File Path, creating backup.')
+      File.rename(hpxml_path, hpxml_path.gsub('.xml', '_bak.xml'))
+    end
+
+    XMLHelper.write_file(orig_hpxml.to_doc(), hpxml_output_path)
 
     return true
-  end
-
-  # Write out the HPXML file with the output CSV path containing occupancy schedules.
-  #
-  # @param runner [OpenStudio::Measure::OSRunner] Object typically used to display warnings
-  # @param doc [Oga::XML::Document] Oga XML Document object
-  # @param hpxml_path [String] Path to the HPXML file
-  # @param hpxml_output_path [String] Path to the output HPXML file
-  # @param schedules_filepaths [Array<String>] array of SchedulesFilePath strings in the input HPXML file
-  # @param args [Hash] Map of :argument_name => value
-  def write_modified_hpxml(runner, doc, hpxml_path, hpxml_output_path, schedules_filepaths, args)
-    # write out the modified hpxml
-    if (hpxml_path != hpxml_output_path) || !schedules_filepaths.include?(args[:output_csv_path])
-      XMLHelper.write_file(doc, hpxml_output_path)
-      runner.registerInfo("Wrote file: #{hpxml_output_path}")
-    end
   end
 
   # Create and export the occupancy schedules.

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>89690a76-2554-419f-a46f-355884fae6e5</version_id>
-  <version_modified>2025-04-21T16:48:50Z</version_modified>
+  <version_id>eba2cc3b-e887-499e-9064-77b96b40dc50</version_id>
+  <version_modified>2025-04-21T17:02:49Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -427,7 +427,7 @@
       <filename>test_build_residential_schedule_file.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>D0894053</checksum>
+      <checksum>B08AB8DB</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>547aff6f-ced8-41de-91c6-35b5dc5ad4cd</version_id>
-  <version_modified>2025-03-12T01:27:36Z</version_modified>
+  <version_id>89690a76-2554-419f-a46f-355884fae6e5</version_id>
+  <version_modified>2025-04-21T16:48:50Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -133,7 +133,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>5EB9E0D7</checksum>
+      <checksum>0F8CD14D</checksum>
     </file>
     <file>
       <filename>README.md</filename>
@@ -427,7 +427,7 @@
       <filename>test_build_residential_schedule_file.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>AF58D77B</checksum>
+      <checksum>D0894053</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialScheduleFile/tests/test_build_residential_schedule_file.rb
+++ b/BuildResidentialScheduleFile/tests/test_build_residential_schedule_file.rb
@@ -4,7 +4,6 @@ require_relative '../../HPXMLtoOpenStudio/resources/minitest_helper'
 require 'openstudio'
 require 'openstudio/measure/ShowRunnerOutput'
 require 'fileutils'
-# require 'csv'
 require_relative '../measure.rb'
 
 class BuildResidentialScheduleFileTest < Minitest::Test

--- a/BuildResidentialScheduleFile/tests/test_build_residential_schedule_file.rb
+++ b/BuildResidentialScheduleFile/tests/test_build_residential_schedule_file.rb
@@ -17,8 +17,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     FileUtils.mkdir_p(@tmp_output_path)
 
     @args_hash = {}
-    @args_hash['hpxml_path'] = File.absolute_path(@tmp_hpxml_path)
-    @args_hash['hpxml_output_path'] = @args_hash['hpxml_path']
+    @args_hash['hpxml_output_path'] = File.join(@tmp_output_path, 'stochastic_schedules.xml')
     @year = 2007
     @tol = 0.005
   end
@@ -30,9 +29,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
   end
 
   def test_stochastic
-    hpxml = _create_hpxml('base.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
-
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base.xml')
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     hpxml, result = _test_measure()
 
@@ -69,9 +66,6 @@ class BuildResidentialScheduleFileTest < Minitest::Test
   end
 
   def test_stochastic_subset_of_columns
-    hpxml = _create_hpxml('base.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
-
     columns = [SchedulesFile::Columns[:CookingRange].name,
                SchedulesFile::Columns[:Dishwasher].name,
                SchedulesFile::Columns[:HotWaterDishwasher].name,
@@ -80,6 +74,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
                SchedulesFile::Columns[:ClothesDryer].name,
                SchedulesFile::Columns[:HotWaterFixtures].name]
 
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base.xml')
     @args_hash['schedules_type'] = 'stochastic'
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     @args_hash['schedules_column_names'] = columns.join(', ')
@@ -101,9 +96,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
   end
 
   def test_stochastic_subset_of_columns_invalid_name
-    hpxml = _create_hpxml('base.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
-
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base.xml')
     @args_hash['schedules_type'] = 'stochastic'
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     @args_hash['schedules_column_names'] = "foobar, #{SchedulesFile::Columns[:CookingRange].name}, foobar2"
@@ -115,9 +108,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
   end
 
   def test_stochastic_location_detailed
-    hpxml = _create_hpxml('base-location-detailed.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
-
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base-location-detailed.xml')
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     hpxml, result = _test_measure()
 
@@ -154,9 +145,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
   end
 
   def test_stochastic_debug
-    hpxml = _create_hpxml('base.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
-
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base.xml')
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     @args_hash['debug'] = true
     hpxml, result = _test_measure()
@@ -194,9 +183,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
   end
 
   def test_random_seed
-    hpxml = _create_hpxml('base-location-baltimore-md.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
-
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base-location-baltimore-md.xml')
     @args_hash['schedules_random_seed'] = 1
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     hpxml, result = _test_measure()
@@ -267,9 +254,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
   end
 
   def test_10_min_timestep
-    hpxml = _create_hpxml('base-simcontrol-timestep-10-mins.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
-
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base-simcontrol-timestep-10-mins.xml')
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     hpxml, result = _test_measure()
 
@@ -312,6 +297,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     hpxml.buildings[0].building_occupancy.number_of_residents = num_occupants
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
 
+    @args_hash['hpxml_path'] = File.absolute_path(@tmp_hpxml_path)
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     _hpxml, result = _test_measure()
 
@@ -326,6 +312,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     hpxml.buildings[0].building_occupancy.number_of_residents = num_occupants
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
 
+    @args_hash['hpxml_path'] = File.absolute_path(@tmp_hpxml_path)
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     _hpxml, result = _test_measure()
 
@@ -343,6 +330,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     hpxml.buildings[0].building_occupancy.number_of_residents = num_occupants
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
 
+    @args_hash['hpxml_path'] = File.absolute_path(@tmp_hpxml_path)
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     hpxml, _result = _test_measure()
     sf = SchedulesFile.new(schedules_paths: hpxml.buildings[0].header.schedules_filepaths,
@@ -359,6 +347,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     end
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
 
+    @args_hash['hpxml_path'] = File.absolute_path(@tmp_hpxml_path)
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic.csv'))
     @args_hash['building_id'] = 'ALL'
     hpxml, result = _test_measure()
@@ -438,6 +427,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     end
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
 
+    @args_hash['hpxml_path'] = File.absolute_path(@tmp_hpxml_path)
     @args_hash['output_csv_path'] = File.absolute_path(File.join(@tmp_output_path, 'occupancy-stochastic_2.csv'))
     @args_hash['building_id'] = 'MyBuilding_2'
     hpxml, result = _test_measure()
@@ -488,8 +478,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     orig_cols = File.readlines(existing_csv_path)[0].strip.split(',')
 
     # Test w/ append_output=false
-    hpxml = _create_hpxml('base.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base.xml')
     FileUtils.cp(existing_csv_path, @tmp_schedule_file_path)
     @args_hash['output_csv_path'] = @tmp_schedule_file_path
     @args_hash['append_output'] = false
@@ -500,8 +489,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
     assert((outdata[0].strip.split(',').to_set - expected_cols.to_set).empty?)
 
     # Test w/ append_output=true
-    hpxml = _create_hpxml('base.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base.xml')
     FileUtils.cp(existing_csv_path, @tmp_schedule_file_path)
     @args_hash['output_csv_path'] = @tmp_schedule_file_path
     @args_hash['append_output'] = true
@@ -514,8 +502,7 @@ class BuildResidentialScheduleFileTest < Minitest::Test
 
     # Test w/ append_output=true and inconsistent data
     existing_csv_path = File.join(File.dirname(__FILE__), '..', '..', 'HPXMLtoOpenStudio', 'resources', 'schedule_files', 'setpoints-10-mins.csv')
-    hpxml = _create_hpxml('base.xml')
-    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
+    @args_hash['hpxml_path'] = File.join(@sample_files_path, 'base.xml')
     FileUtils.cp(existing_csv_path, @tmp_schedule_file_path)
     @args_hash['output_csv_path'] = @tmp_schedule_file_path
     @args_hash['append_output'] = true
@@ -523,6 +510,25 @@ class BuildResidentialScheduleFileTest < Minitest::Test
 
     error_msgs = result.errors.map { |x| x.logMessage }
     assert(error_msgs.any? { |error_msg| error_msg.include?('Invalid number of rows (52561) in file.csv. Expected 8761 rows (including the header row).') })
+  end
+
+  def test_output_hpxml_path_same_as_input_hpxml_path
+    hpxml_path = File.join(@sample_files_path, 'base.xml')
+    @args_hash['hpxml_path'] = hpxml_path
+    @args_hash['hpxml_output_path'] = @args_hash['hpxml_path']
+    @args_hash['output_csv_path'] = @tmp_schedule_file_path
+    _hpxml, result = _test_measure()
+
+    # Check that original HPXML file was backed up
+    hpxml_backup_path = @args_hash['hpxml_path'].gsub('.xml', '_bak.xml')
+    assert(File.exist? hpxml_backup_path)
+
+    warn_msgs = result.warnings.map { |x| x.logMessage }
+    assert(warn_msgs.any? { |warn_msg| warn_msg.include?('HPXML Output File Path is same as HPXML File Path, creating backup.') })
+
+    # Revert to original
+    File.delete(hpxml_path)
+    File.rename(hpxml_backup_path, hpxml_path)
   end
 
   private
@@ -560,7 +566,9 @@ class BuildResidentialScheduleFileTest < Minitest::Test
       assert_equal('Success', result.value.valueName)
     end
 
-    hpxml = HPXML.new(hpxml_path: @tmp_hpxml_path)
+    if File.exist? @args_hash['hpxml_output_path']
+      hpxml = HPXML.new(hpxml_path: @args_hash['hpxml_output_path'])
+    end
 
     return hpxml, result
   end

--- a/tasks.rb
+++ b/tasks.rb
@@ -153,6 +153,11 @@ def create_hpxmls
 
   puts "\n"
 
+  # Delete stochastic schedule backup file
+  dirs.each do |dir|
+    Dir.glob("#{workflow_dir}/#{dir}/*_bak.xml").each { |file| File.delete(file) }
+  end
+
   # Print warnings about extra files
   dirs.each do |dir|
     Dir["#{workflow_dir}/#{dir}/*.xml"].each do |hpxml|

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -28,6 +28,7 @@ def run_workflow(basedir, rundir, hpxml, debug, skip_validation, add_comp_loads,
     measure_subdir = 'BuildResidentialScheduleFile'
     args = {}
     args['hpxml_path'] = hpxml
+    hpxml = File.join(rundir, File.basename(hpxml).gsub('.xml', 'stochastic_schedules.xml'))
     args['hpxml_output_path'] = hpxml
     args['output_csv_path'] = File.join(rundir, 'stochastic.csv')
     args['debug'] = debug


### PR DESCRIPTION
## Pull Request Description

It's always bothered me that we are doing direct XML manipulation rather than using the HPXML class. The latter is much cleaner/simpler. The original reason we went the direct XML manipulation path was in case we got an HPXML from a third-party software tool, we wanted to make sure that we don't lose any information not supported by the HPXML class when we write the updated HPXML. To address that, I now:
1. Create a backup of the original HPXML and give a warning message if the user has provided an output HPXML path that is the same as the input HPXML path.
2. Change the `run_simulation.rb` default so that it writes a new HPXML file rather than updating the original. (The template OSWs already did this. So unless someone uses their own OSWs where they deviate from our templates, they will not encounter the situation where the original HPXML is overwritten.)

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
