### PR TITLE
Refactor BuildResidentialScheduleFile measure to use the HPXML class, take 2

### DIFF
--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -138,7 +138,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
       # This can happen if the original HPXML file was not written by OS-HPXML.
       # If this will occur, we will save a backup of the original HPXML file.
       orig_hpxml_contents = hpxml.contents.delete("\r")
-      new_hpxml_contents = XMLHelper.write_file(hpxml.to_doc(), nil)
+      new_hpxml_contents = XMLHelper.finalize_doc_string(hpxml.to_doc())
       if orig_hpxml_contents != new_hpxml_contents
         create_backup = true
       end

--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -132,6 +132,18 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
 
     hpxml = HPXML.new(hpxml_path: hpxml_path)
 
+    create_backup = false
+    if hpxml_path == hpxml_output_path
+      # Check if HPXML data will be dropped when we write the new HPXML file.
+      # This can happen if the original HPXML file was not written by OS-HPXML.
+      # If this will occur, we will save a backup of the original HPXML file.
+      orig_hpxml_contents = hpxml.contents.delete("\r")
+      new_hpxml_contents = XMLHelper.write_file(hpxml.to_doc(), nil)
+      if orig_hpxml_contents != new_hpxml_contents
+        create_backup = true
+      end
+    end
+
     # Since we modify the HPXML object (apply defaults), use a copy of the
     # original HPXML object so that the HPXML object we write does not include
     # any such modifications.
@@ -169,7 +181,7 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
       end
     end
 
-    if hpxml_path == hpxml_output_path
+    if create_backup
       # Create a backup of the original HPXML file
       runner.registerWarning('HPXML Output File Path is same as HPXML File Path, creating backup.')
       File.rename(hpxml_path, hpxml_path.gsub('.xml', '_bak.xml'))

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>eba2cc3b-e887-499e-9064-77b96b40dc50</version_id>
-  <version_modified>2025-04-21T17:02:49Z</version_modified>
+  <version_id>10c7a324-c8ed-48dc-bbe2-55393aae37af</version_id>
+  <version_modified>2025-04-28T23:42:12Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -133,7 +133,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0F8CD14D</checksum>
+      <checksum>3A426F10</checksum>
     </file>
     <file>
       <filename>README.md</filename>
@@ -427,7 +427,7 @@
       <filename>test_build_residential_schedule_file.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>B08AB8DB</checksum>
+      <checksum>E41BA855</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>10c7a324-c8ed-48dc-bbe2-55393aae37af</version_id>
-  <version_modified>2025-04-28T23:42:12Z</version_modified>
+  <version_id>fa83c237-7f60-4e33-9a7b-533353a7306a</version_id>
+  <version_modified>2025-04-28T23:49:34Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -133,7 +133,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3A426F10</checksum>
+      <checksum>D52EEF10</checksum>
     </file>
     <file>
       <filename>README.md</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f0a3a0b6-2dd6-48de-9a1c-d843bfa3b91f</version_id>
-  <version_modified>2025-04-28T23:17:56Z</version_modified>
+  <version_id>ed686a1b-c64c-4bba-951b-e35c6ec61ad1</version_id>
+  <version_modified>2025-04-28T23:49:38Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -687,7 +687,7 @@
       <filename>xmlhelper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>EA684F62</checksum>
+      <checksum>3424CF52</checksum>
     </file>
     <file>
       <filename>xmlvalidator.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>aadbff36-6fed-4ea3-beb0-59c4dcc9b92a</version_id>
-  <version_modified>2025-04-25T21:52:46Z</version_modified>
+  <version_id>f0a3a0b6-2dd6-48de-9a1c-d843bfa3b91f</version_id>
+  <version_modified>2025-04-28T23:17:56Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -363,7 +363,7 @@
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>F5FEDDD2</checksum>
+      <checksum>0592752B</checksum>
     </file>
     <file>
       <filename>hpxml_schema/HPXML.xsd</filename>
@@ -687,19 +687,13 @@
       <filename>xmlhelper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B18A6A72</checksum>
+      <checksum>EA684F62</checksum>
     </file>
     <file>
       <filename>xmlvalidator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>93120E27</checksum>
-    </file>
-    <file>
-      <filename>results_design_load_details.json</filename>
-      <filetype>json</filetype>
-      <usage_type>test</usage_type>
-      <checksum>4578819C</checksum>
     </file>
     <file>
       <filename>test_airflow.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -557,6 +557,8 @@ class HPXML < Object
                     cdl_lat_vent: 'Ventilation',
                     cdl_lat_intgains: 'InternalLoads' }
 
+  attr_accessor(:contents)
+
   def initialize(hpxml_path: nil, schema_validator: nil, schematron_validator: nil, building_id: nil)
     @hpxml_path = hpxml_path
     @errors = []
@@ -565,7 +567,8 @@ class HPXML < Object
 
     hpxml_element = nil
     if not hpxml_path.nil?
-      doc = XMLHelper.parse_file(hpxml_path)
+      @contents = File.read(hpxml_path)
+      doc = XMLHelper.parse_file(hpxml_path, hpxml_contents: @contents)
 
       # Validate against XSD schema
       if not schema_validator.nil?

--- a/HPXMLtoOpenStudio/resources/xmlhelper.rb
+++ b/HPXMLtoOpenStudio/resources/xmlhelper.rb
@@ -263,12 +263,12 @@ module XMLHelper
     return hpxml_doc
   end
 
-  # Writes the XML file for the given XML document.
+  # Creates the final string representation of the XML document -- i.e., one that is
+  # ready to be written to a file.
   #
   # @param doc [Oga::XML::Document] Oga XML Document object
-  # @param hpxml_path [String] Path to the HPXML file
-  # @return [String] The written XML file as a string
-  def self.write_file(doc, hpxml_path)
+  # @return [String] The final string representation
+  def self.finalize_doc_string(doc)
     doc_s = doc.to_xml.delete("\r")
 
     # Manually apply pretty-printing (indentation and newlines)
@@ -309,17 +309,24 @@ module XMLHelper
     doc_s.gsub!(' ?>', '?>')
     doc_s.gsub!('&quot;', '"')
 
-    if not hpxml_path.nil?
-      # Write XML file
-      if not Dir.exist? File.dirname(hpxml_path)
-        FileUtils.mkdir_p(File.dirname(hpxml_path))
-      end
-      File.open(hpxml_path, 'w', newline: :crlf) do |f|
-        f << doc_s
-      end
-    end
-
     return doc_s
+  end
+
+  # Writes the XML file for the given XML document.
+  #
+  # @param doc [Oga::XML::Document] Oga XML Document object
+  # @param hpxml_path [String] Path to the HPXML file
+  # @return [nil]
+  def self.write_file(doc, hpxml_path)
+    doc_s = finalize_doc_string(doc)
+
+    # Write XML file
+    if not Dir.exist? File.dirname(hpxml_path)
+      FileUtils.mkdir_p(File.dirname(hpxml_path))
+    end
+    File.open(hpxml_path, 'w', newline: :crlf) do |f|
+      f << doc_s
+    end
   end
 end
 

--- a/HPXMLtoOpenStudio/resources/xmlhelper.rb
+++ b/HPXMLtoOpenStudio/resources/xmlhelper.rb
@@ -253,10 +253,13 @@ module XMLHelper
   # Obtains the XML document for the XML file at the specified path.
   #
   # @param hpxml_path [String] Path to the HPXML file
+  # @param hpxml_path [String] Contents of the HPXML file if already available
   # @return [Oga::XML::Document] The XML document
-  def self.parse_file(hpxml_path)
-    file_read = File.read(hpxml_path)
-    hpxml_doc = Oga.parse_xml(file_read)
+  def self.parse_file(hpxml_path, hpxml_contents: nil)
+    if hpxml_contents.nil?
+      hpxml_contents = File.read(hpxml_path)
+    end
+    hpxml_doc = Oga.parse_xml(hpxml_contents)
     return hpxml_doc
   end
 
@@ -306,12 +309,14 @@ module XMLHelper
     doc_s.gsub!(' ?>', '?>')
     doc_s.gsub!('&quot;', '"')
 
-    # Write XML file
-    if not Dir.exist? File.dirname(hpxml_path)
-      FileUtils.mkdir_p(File.dirname(hpxml_path))
-    end
-    File.open(hpxml_path, 'w', newline: :crlf) do |f|
-      f << doc_s
+    if not hpxml_path.nil?
+      # Write XML file
+      if not Dir.exist? File.dirname(hpxml_path)
+        FileUtils.mkdir_p(File.dirname(hpxml_path))
+      end
+      File.open(hpxml_path, 'w', newline: :crlf) do |f|
+        f << doc_s
+      end
     end
 
     return doc_s

--- a/tasks.rb
+++ b/tasks.rb
@@ -153,11 +153,6 @@ def create_hpxmls
 
   puts "\n"
 
-  # Delete stochastic schedule backup file
-  dirs.each do |dir|
-    Dir.glob("#{workflow_dir}/#{dir}/*_bak.xml").each { |file| File.delete(file) }
-  end
-
   # Print warnings about extra files
   dirs.each do |dir|
     Dir["#{workflow_dir}/#{dir}/*.xml"].each do |hpxml|

--- a/workflow/run_simulation.rb
+++ b/workflow/run_simulation.rb
@@ -28,7 +28,6 @@ def run_workflow(basedir, rundir, hpxml, debug, skip_validation, add_comp_loads,
     measure_subdir = 'BuildResidentialScheduleFile'
     args = {}
     args['hpxml_path'] = hpxml
-    hpxml = File.join(rundir, File.basename(hpxml).gsub('.xml', 'stochastic_schedules.xml'))
     args['hpxml_output_path'] = hpxml
     args['output_csv_path'] = File.join(rundir, 'stochastic.csv')
     args['debug'] = debug

--- a/workflow/template-build-and-run-hpxml-with-stochastic-occupancy.osw
+++ b/workflow/template-build-and-run-hpxml-with-stochastic-occupancy.osw
@@ -84,13 +84,13 @@
       "arguments": {
         "hpxml_path": "../built.xml",
         "output_csv_path": "stochastic.csv",
-        "hpxml_output_path": "../built-stochastic-schedules.xml"
+        "hpxml_output_path": "../built.xml"
       },
       "measure_dir_name": "BuildResidentialScheduleFile"
     },
     {
       "arguments": {
-        "hpxml_path": "../built-stochastic-schedules.xml",
+        "hpxml_path": "../built.xml",
         "output_dir": "..",
         "debug": false,
         "add_component_loads": false,


### PR DESCRIPTION
## Pull Request Description

In the BuildResidentialScheduleFile measure, we now smartly avoid creating a backup file when it's not needed (i.e., when the HPXML file we are updating was written by the HPXML class). This means that the ResStock workflow, for example, will not produce the backup file.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
