### PR TITLE
Refactor BuildResidentialScheduleFile measure to use the HPXML class, take 3

### DIFF
--- a/BuildResidentialScheduleFile/measure.rb
+++ b/BuildResidentialScheduleFile/measure.rb
@@ -137,8 +137,8 @@ class BuildResidentialScheduleFile < OpenStudio::Measure::ModelMeasure
       # Check if HPXML data will be dropped when we write the new HPXML file.
       # This can happen if the original HPXML file was not written by OS-HPXML.
       # If this will occur, we will save a backup of the original HPXML file.
-      orig_hpxml_contents = hpxml.contents.delete("\r")
-      new_hpxml_contents = XMLHelper.finalize_doc_string(hpxml.to_doc())
+      orig_hpxml_contents = hpxml.contents.delete("\r").gsub(" dataSource='software'", '')
+      new_hpxml_contents = XMLHelper.finalize_doc_string(hpxml.to_doc()).gsub(" dataSource='software'", '')
       if orig_hpxml_contents != new_hpxml_contents
         create_backup = true
       end

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>fa83c237-7f60-4e33-9a7b-533353a7306a</version_id>
-  <version_modified>2025-04-28T23:49:34Z</version_modified>
+  <version_id>41a51ac7-f6a5-4e3c-8d7d-15e546034f01</version_id>
+  <version_modified>2025-04-29T21:16:21Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -133,7 +133,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>D52EEF10</checksum>
+      <checksum>C75F5224</checksum>
     </file>
     <file>
       <filename>README.md</filename>
@@ -427,7 +427,7 @@
       <filename>test_build_residential_schedule_file.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>E41BA855</checksum>
+      <checksum>DC417F90</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Fixes the situation where a defaulted HPXML file is used (as in the case of ResStock).

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
