### PR TITLE
BuildResidentialScheduleFile: Remove simple schedules

### DIFF
--- a/BuildResidentialScheduleFile/README.md
+++ b/BuildResidentialScheduleFile/README.md
@@ -24,7 +24,7 @@ Absolute/relative path of the HPXML file.
 
 **Schedules: Column Names**
 
-A comma-separated list of the column names to generate. If not provided, defaults to all columns. Possible column names are: occupants, lighting_interior, lighting_garage, cooking_range, dishwasher, clothes_washer, clothes_dryer, ceiling_fan, plug_loads_other, plug_loads_tv, hot_water_dishwasher, hot_water_clothes_washer, hot_water_fixtures.
+A comma-separated list of the column names to generate. If not provided, defaults to all columns. Possible column names are: occupants, lighting_interior, lighting_garage, cooking_range, dishwasher, clothes_washer, clothes_dryer, ceiling_fan, plug_loads_other, plug_loads_tv, hot_water_dishwasher, hot_water_clothes_washer, hot_water_fixtures, electric_vehicle.
 
 - **Name:** ``schedules_column_names``
 - **Type:** ``String``

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>41a51ac7-f6a5-4e3c-8d7d-15e546034f01</version_id>
-  <version_modified>2025-04-29T21:16:21Z</version_modified>
+  <version_id>c0f472e7-27da-4f8f-ab01-0a70aba24696</version_id>
+  <version_modified>2025-05-12T16:37:24Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -22,7 +22,7 @@
     <argument>
       <name>schedules_column_names</name>
       <display_name>Schedules: Column Names</display_name>
-      <description>A comma-separated list of the column names to generate. If not provided, defaults to all columns. Possible column names are: occupants, lighting_interior, lighting_garage, cooking_range, dishwasher, clothes_washer, clothes_dryer, ceiling_fan, plug_loads_other, plug_loads_tv, hot_water_dishwasher, hot_water_clothes_washer, hot_water_fixtures.</description>
+      <description>A comma-separated list of the column names to generate. If not provided, defaults to all columns. Possible column names are: occupants, lighting_interior, lighting_garage, cooking_range, dishwasher, clothes_washer, clothes_dryer, ceiling_fan, plug_loads_other, plug_loads_tv, hot_water_dishwasher, hot_water_clothes_washer, hot_water_fixtures, electric_vehicle.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -116,7 +116,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>EB56CA85</checksum>
+      <checksum>04BFD8B8</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -133,7 +133,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>C75F5224</checksum>
+      <checksum>76EC0401</checksum>
     </file>
     <file>
       <filename>README.md</filename>
@@ -229,7 +229,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>BA9C5FE8</checksum>
+      <checksum>7402E4B2</checksum>
     </file>
     <file>
       <filename>shower_cluster_size_probability.csv</filename>

--- a/BuildResidentialScheduleFile/resources/schedules.rb
+++ b/BuildResidentialScheduleFile/resources/schedules.rb
@@ -66,11 +66,7 @@ class ScheduleGenerator
              weather:)
     @schedules = {}
 
-    if @column_names.nil?
-      @column_names = SchedulesFile::Columns.values.map { |c| c.name }
-    end
-
-    invalid_columns = (@column_names - SchedulesFile::Columns.values.map { |c| c.name })
+    invalid_columns = (@column_names - ScheduleGenerator.export_columns)
     invalid_columns.each do |invalid_column|
       @runner.registerError("Invalid column name specified: '#{invalid_column}'.")
     end
@@ -87,7 +83,7 @@ class ScheduleGenerator
   # @param schedules_path [String] Path to write the schedules CSV file to
   # @return [Boolean] Returns true if successful, false if there was an error
   def export(schedules_path:)
-    (SchedulesFile::Columns.values.map { |c| c.name } - @column_names).each do |col_to_remove|
+    (ScheduleGenerator.export_columns - @column_names).each do |col_to_remove|
       @schedules.delete(col_to_remove)
     end
     schedule_keys = @schedules.keys

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>0592bc1d-12fb-4c44-b4ca-540dc6a3251c</version_id>
-  <version_modified>2025-05-08T03:09:04Z</version_modified>
+  <version_id>517bbc06-553e-4eca-a94d-e8f647b5c364</version_id>
+  <version_modified>2025-05-12T16:31:13Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -357,7 +357,7 @@
       <filename>hotwater_appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>92742F16</checksum>
+      <checksum>C3937CAA</checksum>
     </file>
     <file>
       <filename>hpxml.rb</filename>
@@ -393,7 +393,7 @@
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>F427C27A</checksum>
+      <checksum>76C750DE</checksum>
     </file>
     <file>
       <filename>hvac_sizing.rb</filename>
@@ -405,13 +405,13 @@
       <filename>internal_gains.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>A9CC95F5</checksum>
+      <checksum>8F87DB21</checksum>
     </file>
     <file>
       <filename>lighting.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>74899E6B</checksum>
+      <checksum>4D031B7F</checksum>
     </file>
     <file>
       <filename>location.rb</filename>
@@ -447,7 +447,7 @@
       <filename>misc_loads.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>78E80650</checksum>
+      <checksum>EF41C807</checksum>
     </file>
     <file>
       <filename>model.rb</filename>
@@ -633,7 +633,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>BA4E17C6</checksum>
+      <checksum>A53AFCEB</checksum>
     </file>
     <file>
       <filename>simcontrols.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
+++ b/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
@@ -60,10 +60,7 @@ module HotWaterAndAppliances
       end
       if cw_power_schedule.nil?
         cw_unavailable_periods = Schedule.get_unavailable_periods(runner, cw_col_name, hpxml_header.unavailable_periods)
-        cw_weekday_sch = clothes_washer.weekday_fractions
-        cw_weekend_sch = clothes_washer.weekend_fractions
-        cw_monthly_sch = clothes_washer.monthly_multipliers
-        cw_schedule_obj = MonthWeekdayWeekendSchedule.new(model, cw_object_name + ' schedule', cw_weekday_sch, cw_weekend_sch, cw_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: cw_unavailable_periods)
+        cw_schedule_obj = MonthWeekdayWeekendSchedule.new(model, cw_object_name + ' schedule', clothes_washer.weekday_fractions, clothes_washer.weekend_fractions, clothes_washer.monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: cw_unavailable_periods)
         cw_design_level_w = cw_schedule_obj.calc_design_level_from_daily_kwh(cw_annual_kwh / 365.0)
         cw_power_schedule = cw_schedule_obj.schedule
       else
@@ -103,10 +100,7 @@ module HotWaterAndAppliances
       end
       if cd_schedule.nil?
         cd_unavailable_periods = Schedule.get_unavailable_periods(runner, cd_col_name, hpxml_header.unavailable_periods)
-        cd_weekday_sch = clothes_dryer.weekday_fractions
-        cd_weekend_sch = clothes_dryer.weekend_fractions
-        cd_monthly_sch = clothes_dryer.monthly_multipliers
-        cd_schedule_obj = MonthWeekdayWeekendSchedule.new(model, cd_obj_name + ' schedule', cd_weekday_sch, cd_weekend_sch, cd_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: cd_unavailable_periods)
+        cd_schedule_obj = MonthWeekdayWeekendSchedule.new(model, cd_obj_name + ' schedule', clothes_dryer.weekday_fractions, clothes_dryer.weekend_fractions, clothes_dryer.monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: cd_unavailable_periods)
         cd_design_level_e = cd_schedule_obj.calc_design_level_from_daily_kwh(cd_annual_kwh / 365.0)
         cd_design_level_f = cd_schedule_obj.calc_design_level_from_daily_therm(cd_annual_therm / 365.0)
         cd_schedule = cd_schedule_obj.schedule
@@ -158,10 +152,7 @@ module HotWaterAndAppliances
       end
       if dw_power_schedule.nil?
         dw_unavailable_periods = Schedule.get_unavailable_periods(runner, dw_col_name, hpxml_header.unavailable_periods)
-        dw_weekday_sch = dishwasher.weekday_fractions
-        dw_weekend_sch = dishwasher.weekend_fractions
-        dw_monthly_sch = dishwasher.monthly_multipliers
-        dw_schedule_obj = MonthWeekdayWeekendSchedule.new(model, dw_obj_name + ' schedule', dw_weekday_sch, dw_weekend_sch, dw_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: dw_unavailable_periods)
+        dw_schedule_obj = MonthWeekdayWeekendSchedule.new(model, dw_obj_name + ' schedule', dishwasher.weekday_fractions, dishwasher.weekend_fractions, dishwasher.monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: dw_unavailable_periods)
         dw_design_level_w = dw_schedule_obj.calc_design_level_from_daily_kwh(dw_annual_kwh / 365.0)
         dw_power_schedule = dw_schedule_obj.schedule
       else
@@ -206,11 +197,7 @@ module HotWaterAndAppliances
           rf_design_level = UnitConversions.convert(rf_annual_kwh / 8760.0, 'kW', 'W')
           rf_schedule = get_fridge_or_freezer_coefficients_schedule(model, rf_col_name, rf_obj_name, refrigerator, rf_space, rf_loc_schedule, rf_unavailable_periods)
         elsif !refrigerator.weekday_fractions.nil? && !refrigerator.weekend_fractions.nil? && !refrigerator.monthly_multipliers.nil?
-          rf_weekday_sch = refrigerator.weekday_fractions
-          rf_weekend_sch = refrigerator.weekend_fractions
-          rf_monthly_sch = refrigerator.monthly_multipliers
-
-          rf_schedule_obj = MonthWeekdayWeekendSchedule.new(model, rf_obj_name + ' schedule', rf_weekday_sch, rf_weekend_sch, rf_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: rf_unavailable_periods)
+          rf_schedule_obj = MonthWeekdayWeekendSchedule.new(model, rf_obj_name + ' schedule', refrigerator.weekday_fractions, refrigerator.weekend_fractions, refrigerator.monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: rf_unavailable_periods)
           rf_design_level = rf_schedule_obj.calc_design_level_from_daily_kwh(rf_annual_kwh / 365.0)
           rf_schedule = rf_schedule_obj.schedule
         end
@@ -258,11 +245,7 @@ module HotWaterAndAppliances
           fz_design_level = UnitConversions.convert(fz_annual_kwh / 8760.0, 'kW', 'W')
           fz_schedule = get_fridge_or_freezer_coefficients_schedule(model, fz_col_name, fz_obj_name, freezer, fz_space, fz_loc_schedule, fz_unavailable_periods)
         elsif !freezer.weekday_fractions.nil? && !freezer.weekend_fractions.nil? && !freezer.monthly_multipliers.nil?
-          fz_weekday_sch = freezer.weekday_fractions
-          fz_weekend_sch = freezer.weekend_fractions
-          fz_monthly_sch = freezer.monthly_multipliers
-
-          fz_schedule_obj = MonthWeekdayWeekendSchedule.new(model, fz_obj_name + ' schedule', fz_weekday_sch, fz_weekend_sch, fz_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: fz_unavailable_periods)
+          fz_schedule_obj = MonthWeekdayWeekendSchedule.new(model, fz_obj_name + ' schedule', freezer.weekday_fractions, freezer.weekend_fractions, freezer.monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: fz_unavailable_periods)
           fz_design_level = fz_schedule_obj.calc_design_level_from_daily_kwh(fz_annual_kwh / 365.0)
           fz_schedule = fz_schedule_obj.schedule
         end
@@ -305,10 +288,7 @@ module HotWaterAndAppliances
       end
       if cook_schedule.nil?
         cook_unavailable_periods = Schedule.get_unavailable_periods(runner, cook_col_name, hpxml_header.unavailable_periods)
-        cook_weekday_sch = cooking_range.weekday_fractions
-        cook_weekend_sch = cooking_range.weekend_fractions
-        cook_monthly_sch = cooking_range.monthly_multipliers
-        cook_schedule_obj = MonthWeekdayWeekendSchedule.new(model, cook_obj_name + ' schedule', cook_weekday_sch, cook_weekend_sch, cook_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: cook_unavailable_periods)
+        cook_schedule_obj = MonthWeekdayWeekendSchedule.new(model, cook_obj_name + ' schedule', cooking_range.weekday_fractions, cooking_range.weekend_fractions, cooking_range.monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: cook_unavailable_periods)
         cook_design_level_e = cook_schedule_obj.calc_design_level_from_daily_kwh(cook_annual_kwh / 365.0)
         cook_design_level_f = cook_schedule_obj.calc_design_level_from_daily_therm(cook_annual_therm / 365.0)
         cook_schedule = cook_schedule_obj.schedule
@@ -377,6 +357,8 @@ module HotWaterAndAppliances
         limits: EPlus::ScheduleTypeLimitsTemperature
       )
 
+      water_heating = hpxml_bldg.water_heating
+
       # Create schedule
       fixtures_schedule = nil
       fixtures_col_name = SchedulesFile::Columns[:HotWaterFixtures].name
@@ -386,15 +368,12 @@ module HotWaterAndAppliances
       end
       if fixtures_schedule.nil?
         fixtures_unavailable_periods = Schedule.get_unavailable_periods(runner, fixtures_col_name, hpxml_header.unavailable_periods)
-        fixtures_weekday_sch = hpxml_bldg.water_heating.water_fixtures_weekday_fractions
-        fixtures_weekend_sch = hpxml_bldg.water_heating.water_fixtures_weekend_fractions
-        fixtures_monthly_sch = hpxml_bldg.water_heating.water_fixtures_monthly_multipliers
-        fixtures_schedule_obj = MonthWeekdayWeekendSchedule.new(model, fixtures_obj_name + ' schedule', fixtures_weekday_sch, fixtures_weekend_sch, fixtures_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: fixtures_unavailable_periods)
+        fixtures_schedule_obj = MonthWeekdayWeekendSchedule.new(model, fixtures_obj_name + ' schedule', water_heating.water_fixtures_weekday_fractions, water_heating.water_fixtures_weekend_fractions, water_heating.water_fixtures_monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: fixtures_unavailable_periods)
         fixtures_schedule = fixtures_schedule_obj.schedule
       else
-        runner.registerWarning("Both '#{fixtures_col_name}' schedule file and weekday fractions provided; the latter will be ignored.") if !hpxml_bldg.water_heating.water_fixtures_weekday_fractions.nil?
-        runner.registerWarning("Both '#{fixtures_col_name}' schedule file and weekend fractions provided; the latter will be ignored.") if !hpxml_bldg.water_heating.water_fixtures_weekend_fractions.nil?
-        runner.registerWarning("Both '#{fixtures_col_name}' schedule file and monthly multipliers provided; the latter will be ignored.") if !hpxml_bldg.water_heating.water_fixtures_monthly_multipliers.nil?
+        runner.registerWarning("Both '#{fixtures_col_name}' schedule file and weekday fractions provided; the latter will be ignored.") if !water_heating.water_fixtures_weekday_fractions.nil?
+        runner.registerWarning("Both '#{fixtures_col_name}' schedule file and weekend fractions provided; the latter will be ignored.") if !water_heating.water_fixtures_weekend_fractions.nil?
+        runner.registerWarning("Both '#{fixtures_col_name}' schedule file and monthly multipliers provided; the latter will be ignored.") if !water_heating.water_fixtures_monthly_multipliers.nil?
       end
     end
 
@@ -453,10 +432,7 @@ module HotWaterAndAppliances
           end
           if recirc_pump_sch.nil?
             recirc_pump_unavailable_periods = Schedule.get_unavailable_periods(runner, recirc_pump_col_name, hpxml_header.unavailable_periods)
-            recirc_pump_weekday_sch = hot_water_distribution.recirculation_pump_weekday_fractions
-            recirc_pump_weekend_sch = hot_water_distribution.recirculation_pump_weekend_fractions
-            recirc_pump_monthly_sch = hot_water_distribution.recirculation_pump_monthly_multipliers
-            recirc_pump_sch = MonthWeekdayWeekendSchedule.new(model, recirc_pump_obj_name + ' schedule', recirc_pump_weekday_sch, recirc_pump_weekend_sch, recirc_pump_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: recirc_pump_unavailable_periods)
+            recirc_pump_sch = MonthWeekdayWeekendSchedule.new(model, recirc_pump_obj_name + ' schedule', hot_water_distribution.recirculation_pump_weekday_fractions, hot_water_distribution.recirculation_pump_weekend_fractions, hot_water_distribution.recirculation_pump_monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: recirc_pump_unavailable_periods)
             recirc_pump_design_level = recirc_pump_sch.calc_design_level_from_daily_kwh(recirc_pump_annual_kwh / 365.0)
             recirc_pump_sch = recirc_pump_sch.schedule
           else

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -1490,10 +1490,7 @@ module HVAC
     if ceiling_fan_sch.nil?
       ceiling_fan_unavailable_periods = Schedule.get_unavailable_periods(runner, ceiling_fan_col_name, hpxml_header.unavailable_periods)
       annual_kwh *= ceiling_fan.monthly_multipliers.split(',').map(&:to_f).sum(0.0) / 12.0
-      weekday_sch = ceiling_fan.weekday_fractions
-      weekend_sch = ceiling_fan.weekend_fractions
-      monthly_sch = ceiling_fan.monthly_multipliers
-      ceiling_fan_sch_obj = MonthWeekdayWeekendSchedule.new(model, obj_name + ' schedule', weekday_sch, weekend_sch, monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: ceiling_fan_unavailable_periods)
+      ceiling_fan_sch_obj = MonthWeekdayWeekendSchedule.new(model, obj_name + ' schedule', ceiling_fan.weekday_fractions, ceiling_fan.weekend_fractions, ceiling_fan.monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: ceiling_fan_unavailable_periods)
       ceiling_fan_design_level = ceiling_fan_sch_obj.calc_design_level_from_daily_kwh(annual_kwh / 365.0)
       ceiling_fan_sch = ceiling_fan_sch_obj.schedule
     else

--- a/HPXMLtoOpenStudio/resources/internal_gains.rb
+++ b/HPXMLtoOpenStudio/resources/internal_gains.rb
@@ -12,10 +12,11 @@ module InternalGains
   # @param schedules_file [SchedulesFile] SchedulesFile wrapper class instance of detailed schedule files
   # @return [nil]
   def self.apply_building_occupants(runner, model, hpxml_bldg, hpxml_header, spaces, schedules_file)
-    if hpxml_bldg.building_occupancy.number_of_residents.nil? # Asset calculation
+    building_occupancy = hpxml_bldg.building_occupancy
+    if building_occupancy.number_of_residents.nil? # Asset calculation
       n_occ = Geometry.get_occupancy_default_num(hpxml_bldg.building_construction.number_of_bedrooms)
     else # Operational calculation
-      n_occ = hpxml_bldg.building_occupancy.number_of_residents
+      n_occ = building_occupancy.number_of_residents
     end
     return if n_occ <= 0
 
@@ -34,17 +35,17 @@ module InternalGains
     end
     if people_sch.nil?
       people_unavailable_periods = Schedule.get_unavailable_periods(runner, people_col_name, hpxml_header.unavailable_periods)
-      weekday_sch = hpxml_bldg.building_occupancy.weekday_fractions.split(',').map(&:to_f)
+      weekday_sch = building_occupancy.weekday_fractions.split(',').map(&:to_f)
       weekday_sch = weekday_sch.map { |v| v / weekday_sch.max }.join(',')
-      weekend_sch = hpxml_bldg.building_occupancy.weekend_fractions.split(',').map(&:to_f)
+      weekend_sch = building_occupancy.weekend_fractions.split(',').map(&:to_f)
       weekend_sch = weekend_sch.map { |v| v / weekend_sch.max }.join(',')
-      monthly_sch = hpxml_bldg.building_occupancy.monthly_multipliers
+      monthly_sch = building_occupancy.monthly_multipliers
       people_sch = MonthWeekdayWeekendSchedule.new(model, Constants::ObjectTypeOccupants + ' schedule', weekday_sch, weekend_sch, monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: people_unavailable_periods)
       people_sch = people_sch.schedule
     else
-      runner.registerWarning("Both '#{people_col_name}' schedule file and weekday fractions provided; the latter will be ignored.") if !hpxml_bldg.building_occupancy.weekday_fractions.nil?
-      runner.registerWarning("Both '#{people_col_name}' schedule file and weekend fractions provided; the latter will be ignored.") if !hpxml_bldg.building_occupancy.weekend_fractions.nil?
-      runner.registerWarning("Both '#{people_col_name}' schedule file and monthly multipliers provided; the latter will be ignored.") if !hpxml_bldg.building_occupancy.monthly_multipliers.nil?
+      runner.registerWarning("Both '#{people_col_name}' schedule file and weekday fractions provided; the latter will be ignored.") if !building_occupancy.weekday_fractions.nil?
+      runner.registerWarning("Both '#{people_col_name}' schedule file and weekend fractions provided; the latter will be ignored.") if !building_occupancy.weekend_fractions.nil?
+      runner.registerWarning("Both '#{people_col_name}' schedule file and monthly multipliers provided; the latter will be ignored.") if !building_occupancy.monthly_multipliers.nil?
     end
 
     # Create schedule
@@ -82,12 +83,13 @@ module InternalGains
   # @return [nil]
   def self.apply_general_water_use(runner, model, hpxml_bldg, hpxml_header, spaces, schedules_file)
     nbeds = hpxml_bldg.building_construction.number_of_bedrooms
-    n_occ = hpxml_bldg.building_occupancy.number_of_residents
     unit_type = hpxml_bldg.building_construction.residential_facility_type
-    general_water_use_usage_multiplier = hpxml_bldg.building_occupancy.general_water_use_usage_multiplier
+
+    building_occupancy = hpxml_bldg.building_occupancy
+    n_occ = hpxml_bldg.building_occupancy.number_of_residents
 
     if not hpxml_header.apply_ashrae140_assumptions
-      water_sens_btu, water_lat_btu = Defaults.get_water_use_internal_gains(nbeds, n_occ, unit_type, general_water_use_usage_multiplier)
+      water_sens_btu, water_lat_btu = Defaults.get_water_use_internal_gains(nbeds, n_occ, unit_type, building_occupancy.general_water_use_usage_multiplier)
 
       # Create schedule
       water_schedule = nil
@@ -100,17 +102,14 @@ module InternalGains
       end
       if water_schedule.nil?
         water_unavailable_periods = Schedule.get_unavailable_periods(runner, water_col_name, hpxml_header.unavailable_periods)
-        water_weekday_sch = hpxml_bldg.building_occupancy.general_water_use_weekday_fractions
-        water_weekend_sch = hpxml_bldg.building_occupancy.general_water_use_weekend_fractions
-        water_monthly_sch = hpxml_bldg.building_occupancy.general_water_use_monthly_multipliers
-        water_schedule_obj = MonthWeekdayWeekendSchedule.new(model, water_obj_name + ' schedule', water_weekday_sch, water_weekend_sch, water_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: water_unavailable_periods)
+        water_schedule_obj = MonthWeekdayWeekendSchedule.new(model, water_obj_name + ' schedule', building_occupancy.general_water_use_weekday_fractions, building_occupancy.general_water_use_weekend_fractions, building_occupancy.general_water_use_monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: water_unavailable_periods)
         water_design_level_sens = water_schedule_obj.calc_design_level_from_daily_kwh(UnitConversions.convert(water_sens_btu, 'Btu', 'kWh') / 365.0)
         water_design_level_lat = water_schedule_obj.calc_design_level_from_daily_kwh(UnitConversions.convert(water_lat_btu, 'Btu', 'kWh') / 365.0)
         water_schedule = water_schedule_obj.schedule
       else
-        runner.registerWarning("Both '#{water_col_name}' schedule file and weekday fractions provided; the latter will be ignored.") if !hpxml_bldg.building_occupancy.general_water_use_weekday_fractions.nil?
-        runner.registerWarning("Both '#{water_col_name}' schedule file and weekend fractions provided; the latter will be ignored.") if !hpxml_bldg.building_occupancy.general_water_use_weekend_fractions.nil?
-        runner.registerWarning("Both '#{water_col_name}' schedule file and monthly multipliers provided; the latter will be ignored.") if !hpxml_bldg.building_occupancy.general_water_use_monthly_multipliers.nil?
+        runner.registerWarning("Both '#{water_col_name}' schedule file and weekday fractions provided; the latter will be ignored.") if !building_occupancy.general_water_use_weekday_fractions.nil?
+        runner.registerWarning("Both '#{water_col_name}' schedule file and weekend fractions provided; the latter will be ignored.") if !building_occupancy.general_water_use_weekend_fractions.nil?
+        runner.registerWarning("Both '#{water_col_name}' schedule file and monthly multipliers provided; the latter will be ignored.") if !building_occupancy.general_water_use_monthly_multipliers.nil?
       end
 
       Model.add_other_equipment(

--- a/HPXMLtoOpenStudio/resources/lighting.rb
+++ b/HPXMLtoOpenStudio/resources/lighting.rb
@@ -86,10 +86,7 @@ module Lighting
       end
       if interior_sch.nil?
         interior_unavailable_periods = Schedule.get_unavailable_periods(runner, interior_col_name, hpxml_header.unavailable_periods)
-        interior_weekday_sch = lighting.interior_weekday_fractions
-        interior_weekend_sch = lighting.interior_weekend_fractions
-        interior_monthly_sch = lighting.interior_monthly_multipliers
-        interior_sch = MonthWeekdayWeekendSchedule.new(model, interior_obj_name + ' schedule', interior_weekday_sch, interior_weekend_sch, interior_monthly_sch, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: interior_unavailable_periods)
+        interior_sch = MonthWeekdayWeekendSchedule.new(model, interior_obj_name + ' schedule', lighting.interior_weekday_fractions, lighting.interior_weekend_fractions, lighting.interior_monthly_multipliers, EPlus::ScheduleTypeLimitsFraction, unavailable_periods: interior_unavailable_periods)
         design_level = interior_sch.calc_design_level_from_daily_kwh(int_kwh / 365.0)
         interior_sch = interior_sch.schedule
       else

--- a/HPXMLtoOpenStudio/resources/misc_loads.rb
+++ b/HPXMLtoOpenStudio/resources/misc_loads.rb
@@ -249,10 +249,10 @@ module MiscLoads
     heater_sch = nil
     if pool_or_spa.is_a? HPXML::Pool
       obj_name = Constants::ObjectTypeMiscPoolHeater
-      col_name = 'pool_heater'
+      col_name = SchedulesFile::Columns[:PoolHeater].name
     else
       obj_name = Constants::ObjectTypeMiscPermanentSpaHeater
-      col_name = 'permanent_spa_heater'
+      col_name = SchedulesFile::Columns[:PermanentSpaHeater].name
     end
     if not schedules_file.nil?
       heater_sch = schedules_file.create_schedule_file(model, col_name: col_name)
@@ -334,10 +334,10 @@ module MiscLoads
     pump_sch = nil
     if pool_or_spa.is_a? HPXML::Pool
       obj_name = Constants::ObjectTypeMiscPoolPump
-      col_name = 'pool_pump'
+      col_name = SchedulesFile::Columns[:PoolPump].name
     else
       obj_name = Constants::ObjectTypeMiscPermanentSpaPump
-      col_name = 'permanent_spa_pump'
+      col_name = SchedulesFile::Columns[:PermanentSpaPump].name
     end
     if not schedules_file.nil?
       pump_sch = schedules_file.create_schedule_file(model, col_name: col_name)

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1017,7 +1017,7 @@ class SchedulesFile
     Battery: Column.new('battery', false, false, :neg_one_to_one),
     BatteryCharging: Column.new('battery_charging', true, false, nil),
     BatteryDischarging: Column.new('battery_discharging', true, false, nil),
-    ElectricVehicle: Column.new('electric_vehicle', false, false, :neg_one_to_one),
+    ElectricVehicle: Column.new('electric_vehicle', false, true, :neg_one_to_one),
     ElectricVehicleCharging: Column.new('electric_vehicle_charging', true, false, nil),
     ElectricVehicleDischarging: Column.new('electric_vehicle_discharging', true, false, nil),
     SpaceHeating: Column.new('space_heating', true, false, nil),

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -98,42 +98,54 @@ class WorkflowOtherTest < Minitest::Test
     assert_equal(0, component_loads.size)
   end
 
-  def test_run_simulation_detailed_occupancy_schedules
-    [false, true].each do |debug|
-      # Check that the simulation produces stochastic schedules if requested
-      sample_files_path = File.join(File.dirname(__FILE__), '..', 'sample_files')
-      tmp_hpxml_path = File.join(sample_files_path, 'tmp.xml')
-      hpxml = HPXML.new(hpxml_path: File.join(sample_files_path, 'base.xml'))
-      XMLHelper.write_file(hpxml.to_doc, tmp_hpxml_path)
+  def test_run_simulation_stochastic_occupancy_schedules
+    hpxml_names = ['base-schedules-simple.xml',
+                   'base-misc-loads-large-uncommon.xml',
+                   'base-misc-loads-large-uncommon2.xml',
+                   'base-lighting-ceiling-fans.xml']
 
-      rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
-      xml = File.absolute_path(tmp_hpxml_path)
-      command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --add-stochastic-schedules"
-      command += ' -d' if debug
-      system(command, err: File::NULL)
+    hpxml_names.each do |hpxml_name|
+      [false, true].each do |debug|
+        # Check that the simulation produces stochastic schedules if requested
+        sample_files_path = File.join(File.dirname(__FILE__), '..', 'sample_files')
+        tmp_hpxml_path = File.join(sample_files_path, 'tmp.xml')
+        hpxml = HPXML.new(hpxml_path: File.join(sample_files_path, hpxml_name))
+        XMLHelper.write_file(hpxml.to_doc, tmp_hpxml_path)
 
-      # Check for output files
-      assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
-      assert(File.exist? File.join(File.dirname(xml), 'run', 'in.schedules.csv'))
-      assert(File.exist? File.join(File.dirname(xml), 'run', 'stochastic.csv'))
+        rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
+        xml = File.absolute_path(tmp_hpxml_path)
+        command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{xml}\" --add-stochastic-schedules"
+        command += ' -d' if debug
+        system(command, err: File::NULL)
 
-      # Check for E+ msgpack files
-      if debug
-        assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
-      else
-        refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+        # Check for output files
+        assert(File.exist? File.join(File.dirname(xml), 'run', 'results_annual.csv'))
+        assert(File.exist? File.join(File.dirname(xml), 'run', 'in.schedules.csv'))
+        assert(File.exist? File.join(File.dirname(xml), 'run', 'stochastic.csv'))
+
+        # Check for E+ msgpack files
+        if debug
+          assert(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+        else
+          refute(File.exist? File.join(File.dirname(xml), 'run', 'eplusout.msgpack'))
+        end
+
+        # Check stochastic.csv headers
+        schedules = CSV.read(File.join(File.dirname(xml), 'run', 'stochastic.csv'), headers: true)
+        if debug
+          assert(schedules.headers.include?(SchedulesFile::Columns[:Sleeping].name))
+        else
+          refute(schedules.headers.include?(SchedulesFile::Columns[:Sleeping].name))
+        end
+
+        # Check run.log has no warnings about both simple and detailed schedules
+        assert(File.exist? File.join(File.dirname(xml), 'run', 'run.log'))
+        log_lines = File.readlines(File.join(File.dirname(xml), 'run', 'run.log')).map(&:strip)
+        refute(log_lines.any? { |log_line| log_line.include?('provided; the latter will be ignored') })
+
+        # Cleanup
+        File.delete(tmp_hpxml_path) if File.exist? tmp_hpxml_path
       end
-
-      # Check stochastic.csv headers
-      schedules = CSV.read(File.join(File.dirname(xml), 'run', 'stochastic.csv'), headers: true)
-      if debug
-        assert(schedules.headers.include?(SchedulesFile::Columns[:Sleeping].name))
-      else
-        refute(schedules.headers.include?(SchedulesFile::Columns[:Sleeping].name))
-      end
-
-      # Cleanup
-      File.delete(tmp_hpxml_path) if File.exist? tmp_hpxml_path
     end
   end
 


### PR DESCRIPTION
## Pull Request Description

Removes any simple schedules in the HPXML file when we produce stochastic schedules to be used instead. Prevents warnings.

Also fixes a bug where `electric_vehicles` was not an option for the column names argument.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.xml`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
