### PR TITLE
Improve reporting measure sum check

### DIFF
--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>1a03c52f-33c2-4d29-b571-5a25b9c7c755</version_id>
-  <version_modified>2025-05-03T16:54:19Z</version_modified>
+  <version_id>647c4828-f3b6-4dab-9fa3-f09e819b3887</version_id>
+  <version_modified>2025-05-14T23:13:16Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1991,7 +1991,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>645A80FD</checksum>
+      <checksum>AC40B63F</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>


### PR DESCRIPTION
## Pull Request Description

Use a percentage check rather than an absolute value (since different outputs have different units - MBtu, kWh, lb, etc.). Prevents the possibility of a "Timeseries outputs ... do not sum to annual output" error.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
