### PR TITLE
Fix registered error message for EPW file not found

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -4252,7 +4252,8 @@ module HPXMLFile
   # @param existing_hpxml_path [String] Path to the existing HPXML file
   # @return [Oga::XML::Element] Root XML element of the updated HPXML document
   def self.create(runner, model, args, hpxml_path, existing_hpxml_path)
-    weather = get_weather_if_needed(args)
+    weather = get_weather_if_needed(runner, args)
+    return false if !weather.nil? && !weather
 
     success = create_geometry_envelope(runner, model, args)
     return false if not success
@@ -4357,7 +4358,7 @@ module HPXMLFile
   #
   # @param args [Hash] Map of :argument_name => value
   # @return [WeatherFile] Weather object containing EPW information
-  def self.get_weather_if_needed(args)
+  def self.get_weather_if_needed(runner, args)
     if (args[:hvac_control_heating_season_period].to_s == Constants::BuildingAmerica) ||
        (args[:hvac_control_cooling_season_period].to_s == Constants::BuildingAmerica) ||
        (args[:solar_thermal_system_type] != Constants::None && args[:solar_thermal_collector_tilt].start_with?('latitude')) ||

--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -4356,6 +4356,7 @@ module HPXMLFile
 
   # Returns the WeatherFile object if we determine we need it for subsequent processing.
   #
+  # @param runner [OpenStudio::Measure::OSRunner] Object typically used to display warnings
   # @param args [Hash] Map of :argument_name => value
   # @return [WeatherFile] Weather object containing EPW information
   def self.get_weather_if_needed(runner, args)

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>de751122-45f6-4751-8b61-1fd5a2bdc43a</version_id>
-  <version_modified>2025-06-30T17:13:19Z</version_modified>
+  <version_id>d0b82c09-e294-4979-ae43-4d41fb56dbca</version_id>
+  <version_modified>2025-07-09T15:37:25Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -8413,7 +8413,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>5283A0AB</checksum>
+      <checksum>1EF74BAC</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>
@@ -8437,7 +8437,7 @@
       <filename>test_build_residential_hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>1AB5834A</checksum>
+      <checksum>FFAF9279</checksum>
     </file>
   </files>
 </measure>

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>d0b82c09-e294-4979-ae43-4d41fb56dbca</version_id>
-  <version_modified>2025-07-09T15:37:25Z</version_modified>
+  <version_id>62ccd4ea-0b97-425c-bacc-87b3e7b39dce</version_id>
+  <version_modified>2025-07-14T15:40:53Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -8413,7 +8413,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>1EF74BAC</checksum>
+      <checksum>AE050C39</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>

--- a/BuildResidentialHPXML/tests/test_build_residential_hpxml.rb
+++ b/BuildResidentialHPXML/tests/test_build_residential_hpxml.rb
@@ -214,6 +214,7 @@ class BuildResidentialHPXMLTest < Minitest::Test
       'error-different-simulation-control.xml' => 'base-sfd-header.xml',
       'error-same-emissions-scenario-name.xml' => 'base-sfd-header.xml',
       'error-same-utility-bill-scenario-name.xml' => 'base-sfd-header.xml',
+      'error-could-not-find-epw-file.xml' => 'base-sfd.xml',
 
       'warning-non-electric-heat-pump-water-heater.xml' => 'base-sfd.xml',
       'warning-sfd-slab-non-zero-foundation-height.xml' => 'base-sfd.xml',
@@ -281,7 +282,8 @@ class BuildResidentialHPXMLTest < Minitest::Test
                                                    "'Simulation Control: Run Period Calendar Year' cannot vary across dwelling units.",
                                                    "'Simulation Control: Temperature Capacitance Multiplier' cannot vary across dwelling units."],
       'error-same-emissions-scenario-name.xml' => ["HPXML header already includes an emissions scenario named 'Emissions' with type 'CO2e'."],
-      'error-same-utility-bill-scenario-name.xml' => ["HPXML header already includes a utility bill scenario named 'Bills'."]
+      'error-same-utility-bill-scenario-name.xml' => ["HPXML header already includes a utility bill scenario named 'Bills'."],
+      'error-could-not-find-epw-file.xml' => ['Could not find EPW file at']
     }
 
     expected_warnings = {
@@ -1282,6 +1284,8 @@ class BuildResidentialHPXMLTest < Minitest::Test
     when 'error-same-utility-bill-scenario-name.xml'
       args['existing_hpxml_path'] = File.join(File.dirname(__FILE__), 'extra_files/base-sfd-header.xml')
       args['utility_bill_electricity_fixed_charges'] = '13.0'
+    when 'error-could-not-find-epw-file.xml'
+      args['weather_station_epw_filepath'] = 'foo.epw'
     end
 
     # Warning


### PR DESCRIPTION
## Pull Request Description

Pass `runner` into BuildResidentialHPXML's `get_weather_if_needed` method. Handle returned `false` appropriately. Add a test for registered error message "Could not find EPW file at ...".

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
