### PR TITLE
Account for condenser loop pump in electric panel defaults

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>eefa4851-17a5-4128-8dc7-92d666238ae7</version_id>
-  <version_modified>2025-07-18T21:55:38Z</version_modified>
+  <version_id>8236fe34-b875-445e-aca9-33261309cd73</version_id>
+  <version_modified>2025-07-28T22:46:25Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -348,7 +348,7 @@
       <filename>defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D8D92CF4</checksum>
+      <checksum>86CF4CA8</checksum>
     </file>
     <file>
       <filename>electric_panel.rb</filename>
@@ -414,7 +414,7 @@
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>52163224</checksum>
+      <checksum>A5526423</checksum>
     </file>
     <file>
       <filename>hvac_sizing.rb</filename>
@@ -738,7 +738,7 @@
       <filename>test_electric_panel.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>487C84D2</checksum>
+      <checksum>7FA8BC56</checksum>
     </file>
     <file>
       <filename>test_enclosure.rb</filename>

--- a/HPXMLtoOpenStudio/resources/defaults.rb
+++ b/HPXMLtoOpenStudio/resources/defaults.rb
@@ -6836,7 +6836,7 @@ module Defaults
         end
 
         watts += HVAC.get_blower_fan_power_watts(heating_system.fan_watts_per_cfm, heating_system.additional_properties.heating_actual_airflow_cfm)
-        watts += HVAC.get_pump_power_watts(heating_system.electric_auxiliary_energy)
+        watts += HVAC.get_pump_power_watts(heating_system)
 
         if branch_circuit.occupied_spaces.nil?
           branch_circuit.occupied_spaces = get_breaker_spaces_from_power_watts_voltage_amps(watts, branch_circuit.voltage, branch_circuit.max_current_rating)
@@ -6852,6 +6852,7 @@ module Defaults
         branch_circuit_ahu = get_or_add_branch_circuit(electric_panel, heat_pump, unit_num, true)
 
         watts_ahu = HVAC.get_blower_fan_power_watts(heat_pump.fan_watts_per_cfm, heat_pump.additional_properties.heating_actual_airflow_cfm)
+        watts_ahu += HVAC.get_pump_power_watts(heat_pump)
         watts_odu = HVAC.get_dx_coil_power_watts_from_capacity(UnitConversions.convert(heat_pump.heating_capacity, 'btu/hr', 'kbtu/hr'), branch_circuit_odu.voltage)
 
         if heat_pump.backup_type == HPXML::HeatPumpBackupTypeIntegrated
@@ -6928,6 +6929,7 @@ module Defaults
         next if heat_pump.fraction_cool_load_served == 0
 
         watts_ahu = HVAC.get_blower_fan_power_watts(heat_pump.fan_watts_per_cfm, heat_pump.additional_properties.cooling_actual_airflow_cfm)
+        watts_ahu += HVAC.get_pump_power_watts(heat_pump)
         watts_odu = HVAC.get_dx_coil_power_watts_from_capacity(UnitConversions.convert(heat_pump.cooling_capacity, 'btu/hr', 'kbtu/hr'), HPXML::ElectricPanelVoltage240)
 
         if heat_pump.fraction_heat_load_served == 0

--- a/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/HPXMLtoOpenStudio/resources/hvac.rb
@@ -844,11 +844,7 @@ module HVAC
     setpoint_mgr_follow_ground_temp.addToNode(plant_loop.supplyOutletNode)
 
     # Pump
-    if heat_pump.cooling_capacity > 1.0
-      pump_w = heat_pump.pump_watts_per_ton * UnitConversions.convert(heat_pump.cooling_capacity, 'Btu/hr', 'ton')
-    else
-      pump_w = heat_pump.pump_watts_per_ton * UnitConversions.convert(heat_pump.heating_capacity, 'Btu/hr', 'ton')
-    end
+    pump_w = get_pump_power_watts(heat_pump)
     pump_w = [pump_w, 1.0].max # prevent error if zero
     pump = Model.add_pump_variable_speed(
       model,
@@ -998,14 +994,21 @@ module HVAC
     return fan_watts_per_cfm * airflow_cfm
   end
 
-  # Get the boiler pump power (W).
+  # Get the boiler or GHP pump power (W).
   #
-  # @param electric_auxiliary_energy [Double] Boiler electric auxiliary energy [kWh/yr]
-  # @return [Double] Boiler pump power [W]
-  def self.get_pump_power_watts(electric_auxiliary_energy)
-    return 0.0 if electric_auxiliary_energy.nil?
+  # @param hvac_system [HPXML::HeatingSystem or HPXML::HeatPump] The HPXML HVAC system of interest
+  def self.get_pump_power_watts(hvac_system)
+    if hvac_system.is_a?(HPXML::HeatingSystem) && (not hvac_system.electric_auxiliary_energy.nil?)
+      return hvac_system.electric_auxiliary_energy / 2.08
+    elsif hvac_system.is_a?(HPXML::HeatPump) && (not hvac_system.pump_watts_per_ton.nil?)
+      if hvac_system.cooling_capacity > 1.0
+        return hvac_system.pump_watts_per_ton * UnitConversions.convert(hvac_system.cooling_capacity, 'Btu/hr', 'ton')
+      else
+        return hvac_system.pump_watts_per_ton * UnitConversions.convert(hvac_system.heating_capacity, 'Btu/hr', 'ton')
+      end
+    end
 
-    return electric_auxiliary_energy / 2.08
+    return 0.0
   end
 
   # Returns the heating input capacity, calculated as the heating rated (output) capacity divided by the rated efficiency.
@@ -1062,7 +1065,7 @@ module HVAC
     loop_sizing.setLoopDesignTemperatureDifference(UnitConversions.convert(20.0, 'deltaF', 'deltaC'))
 
     # Pump
-    pump_w = get_pump_power_watts(heating_system.electric_auxiliary_energy)
+    pump_w = get_pump_power_watts(heating_system)
     pump_w = [pump_w, 1.0].max # prevent error if zero
     pump = Model.add_pump_variable_speed(
       model,

--- a/HPXMLtoOpenStudio/tests/test_electric_panel.rb
+++ b/HPXMLtoOpenStudio/tests/test_electric_panel.rb
@@ -501,6 +501,19 @@ class HPXMLtoOpenStudioElectricPanelTest < Minitest::Test
     _test_occupied_spaces(hpxml_bldg, [HPXML::ElectricPanelLoadTypeHeating, HPXML::ElectricPanelLoadTypeCooling], 4)
   end
 
+  def test_hvac_gshp_without_backup
+    args_hash = { 'hpxml_path' => File.absolute_path(@tmp_hpxml_path),
+                  'skip_validation' => true }
+
+    hpxml, _hpxml_bldg = _create_hpxml('base-hvac-ground-to-air-heat-pump-1-speed.xml')
+    XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
+    _model, _hpxml, hpxml_bldg = _test_measure(args_hash)
+
+    _test_service_feeder_power(hpxml_bldg, HPXML::ElectricPanelLoadTypeHeating, 6679)
+    _test_service_feeder_power(hpxml_bldg, HPXML::ElectricPanelLoadTypeCooling, 6679)
+    _test_occupied_spaces(hpxml_bldg, [HPXML::ElectricPanelLoadTypeHeating, HPXML::ElectricPanelLoadTypeCooling], 4)
+  end
+
   def test_hvac_ducted_mshp_without_backup
     args_hash = { 'hpxml_path' => File.absolute_path(@tmp_hpxml_path),
                   'skip_validation' => true }

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -4946,7 +4946,7 @@ Loads with power ratings of "auto" are calculated based on estimates for:
 
 - input capacities (using regressions involving rated output capacities and efficiencies if direct expansion)
 - blower fans (using fan W/cfm multiplied by airflow cfm)
-- hydronic pumps (using electric auxiliary energy kWh/yr divided by 2.08)
+- hydronic pumps (using either electric auxiliary energy kWh/yr divided by 2.08 for boilers, or pump power W/ton and cooling/heating capacity tons for ground-to-air heat pumps)
 
 Loads with occupied breaker spaces of "auto" vary based on calculated power ratings.
 Room air conditioners connected to a 120V branch circuit are assumed to occupy 0 breaker spaces.


### PR DESCRIPTION
## Pull Request Description

Assume the condenser loop pump for GHPs is wired with the AHU (i.e., blower fan).

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
