### PR TITLE
Fix JSON timeseries columns

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ __New Features__
 __Bugfixes__
 - Fixes ground-source heat pump plant loop fluid type (workaround for OpenStudio bug).
 - Fixes default hours driven per week for electric vehicles (8.88 -> 9.5).
+- Fixes empty TimeDST/TimeUTC columns in JSON timeseries data.
 
 ## OpenStudio-HPXML v1.10.0
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>47893c21-41de-46d7-a790-605a202e52c5</version_id>
-  <version_modified>2025-08-04T22:50:31Z</version_modified>
+  <version_id>93ead307-0c70-4b82-b92d-12c0682335a9</version_id>
+  <version_modified>2025-08-08T19:09:42Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -474,7 +474,7 @@
       <filename>model.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>625DB094</checksum>
+      <checksum>E01BEB72</checksum>
     </file>
     <file>
       <filename>output.rb</filename>

--- a/HPXMLtoOpenStudio/resources/model.rb
+++ b/HPXMLtoOpenStudio/resources/model.rb
@@ -1054,7 +1054,7 @@ module Model
       handles << obj.handle
     end
     if !handles.empty?
-      runner.registerWarning('The model contains existing objects and is being reset.')
+      runner.registerInfo('The model contains existing objects and is being reset.')
       model.removeObjects(handles)
     end
   end

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -1960,8 +1960,8 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
       # Assemble data
       h = {}
       h['Time'] = data[2..-1]
-      h['TimeDST'] = timestamps2[2..-1] if @timestamps_dst
-      h['TimeUTC'] = timestamps3[2..-1] if @timestamps_utc
+      h['TimeDST'] = timestamps2[0][2..-1] unless @timestamps_dst.nil?
+      h['TimeUTC'] = timestamps3[0][2..-1] unless @timestamps_utc.nil?
 
       [total_energy_data, fuel_data, end_use_data, system_use_data, emissions_data, emission_fuel_data,
        emission_end_use_data, hot_water_use_data, total_loads_data, comp_loads_data, unmet_hours_data,

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>d3ac5a9d-8471-4bdb-9d74-ed180340e4cb</version_id>
-  <version_modified>2025-06-06T21:50:10Z</version_modified>
+  <version_id>f8c7e8ee-fbe0-4147-b1b5-7c85ecaba45a</version_id>
+  <version_modified>2025-08-08T19:09:48Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1991,13 +1991,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>41995180</checksum>
+      <checksum>6CB47F37</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>6395C30B</checksum>
+      <checksum>E2E6370B</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Fixes empty `TimeDST`/`TimeUTC` columns in JSON timeseries outputs. And downgrades model reset warning to info statement.
Closes #2053 and closes #2052.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
