### PR TITLE
DST imrovements, take 2

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7cd55bc4-3a35-4922-81be-75b4003c7627</version_id>
-  <version_modified>2025-08-13T05:34:29Z</version_modified>
+  <version_id>0cd1fddd-76a0-4541-a92d-e243012f1e09</version_id>
+  <version_modified>2025-08-13T20:46:03Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -348,7 +348,7 @@
       <filename>defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>1F520F06</checksum>
+      <checksum>F7FF55E6</checksum>
     </file>
     <file>
       <filename>electric_panel.rb</filename>
@@ -438,7 +438,7 @@
       <filename>location.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>6137EE13</checksum>
+      <checksum>7DB56BD8</checksum>
     </file>
     <file>
       <filename>materials.rb</filename>
@@ -732,7 +732,7 @@
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>1BA607EF</checksum>
+      <checksum>0DD3B09A</checksum>
     </file>
     <file>
       <filename>test_electric_panel.rb</filename>

--- a/HPXMLtoOpenStudio/resources/defaults.rb
+++ b/HPXMLtoOpenStudio/resources/defaults.rb
@@ -420,20 +420,18 @@ module Defaults
     end
 
     if hpxml_bldg.header.shading_summer_begin_month.nil? || hpxml_bldg.header.shading_summer_begin_day.nil? || hpxml_bldg.header.shading_summer_end_month.nil? || hpxml_bldg.header.shading_summer_end_day.nil?
-      if not weather.nil?
-        # Default based on Building America seasons
-        _, default_cooling_months = HVAC.get_building_america_hvac_seasons(weather, hpxml_bldg.latitude)
-        begin_month, begin_day, end_month, end_day = Calendar.get_begin_and_end_dates_from_monthly_array(default_cooling_months, hpxml_header.sim_calendar_year)
-        if not begin_month.nil? # Check if no summer
-          hpxml_bldg.header.shading_summer_begin_month = begin_month
-          hpxml_bldg.header.shading_summer_begin_day = begin_day
-          hpxml_bldg.header.shading_summer_end_month = end_month
-          hpxml_bldg.header.shading_summer_end_day = end_day
-          hpxml_bldg.header.shading_summer_begin_month_isdefaulted = true
-          hpxml_bldg.header.shading_summer_begin_day_isdefaulted = true
-          hpxml_bldg.header.shading_summer_end_month_isdefaulted = true
-          hpxml_bldg.header.shading_summer_end_day_isdefaulted = true
-        end
+      # Default based on Building America seasons
+      _, default_cooling_months = HVAC.get_building_america_hvac_seasons(weather, hpxml_bldg.latitude)
+      begin_month, begin_day, end_month, end_day = Calendar.get_begin_and_end_dates_from_monthly_array(default_cooling_months, hpxml_header.sim_calendar_year)
+      if not begin_month.nil? # Check if no summer
+        hpxml_bldg.header.shading_summer_begin_month = begin_month
+        hpxml_bldg.header.shading_summer_begin_day = begin_day
+        hpxml_bldg.header.shading_summer_end_month = end_month
+        hpxml_bldg.header.shading_summer_end_day = end_day
+        hpxml_bldg.header.shading_summer_begin_month_isdefaulted = true
+        hpxml_bldg.header.shading_summer_begin_day_isdefaulted = true
+        hpxml_bldg.header.shading_summer_end_month_isdefaulted = true
+        hpxml_bldg.header.shading_summer_end_day_isdefaulted = true
       end
     end
   end
@@ -719,6 +717,11 @@ module Defaults
       hpxml_bldg.site.ground_diffusivity_isdefaulted = true
     end
 
+    if hpxml_bldg.state_code.nil?
+      hpxml_bldg.state_code = get_state_code(hpxml_bldg.state_code, weather)
+      hpxml_bldg.state_code_isdefaulted = true
+    end
+
     if hpxml_bldg.dst_observed.nil?
       if ['AZ', 'HI'].include? hpxml_bldg.state_code
         hpxml_bldg.dst_observed = false
@@ -728,61 +731,53 @@ module Defaults
       hpxml_bldg.dst_observed_isdefaulted = true
     end
 
-    if not weather.nil?
+    if hpxml_bldg.city.nil?
+      hpxml_bldg.city = weather.header.City
+      hpxml_bldg.city_isdefaulted = true
+    end
 
-      if hpxml_bldg.state_code.nil?
-        hpxml_bldg.state_code = get_state_code(hpxml_bldg.state_code, weather)
-        hpxml_bldg.state_code_isdefaulted = true
-      end
+    if hpxml_bldg.time_zone_utc_offset.nil?
+      hpxml_bldg.time_zone_utc_offset = get_time_zone(hpxml_bldg.time_zone_utc_offset, weather)
+      hpxml_bldg.time_zone_utc_offset_isdefaulted = true
+    end
 
-      if hpxml_bldg.city.nil?
-        hpxml_bldg.city = weather.header.City
-        hpxml_bldg.city_isdefaulted = true
-      end
-
-      if hpxml_bldg.time_zone_utc_offset.nil?
-        hpxml_bldg.time_zone_utc_offset = get_time_zone(hpxml_bldg.time_zone_utc_offset, weather)
-        hpxml_bldg.time_zone_utc_offset_isdefaulted = true
-      end
-
-      if hpxml_bldg.dst_observed
-        if hpxml_bldg.dst_begin_month.nil? || hpxml_bldg.dst_begin_day.nil? || hpxml_bldg.dst_end_month.nil? || hpxml_bldg.dst_end_day.nil?
-          if (not weather.header.DSTStartDate.nil?) && (not weather.header.DSTEndDate.nil?)
-            # Use weather file DST dates if available
-            dst_start_date = weather.header.DSTStartDate
-            dst_end_date = weather.header.DSTEndDate
-            hpxml_bldg.dst_begin_month = dst_start_date.monthOfYear.value
-            hpxml_bldg.dst_begin_day = dst_start_date.dayOfMonth
-            hpxml_bldg.dst_end_month = dst_end_date.monthOfYear.value
-            hpxml_bldg.dst_end_day = dst_end_date.dayOfMonth
-          else
-            # Roughly average US dates according to https://en.wikipedia.org/wiki/Daylight_saving_time_in_the_United_States
-            hpxml_bldg.dst_begin_month = 3
-            hpxml_bldg.dst_begin_day = 12
-            hpxml_bldg.dst_end_month = 11
-            hpxml_bldg.dst_end_day = 5
-          end
-          hpxml_bldg.dst_begin_month_isdefaulted = true
-          hpxml_bldg.dst_begin_day_isdefaulted = true
-          hpxml_bldg.dst_end_month_isdefaulted = true
-          hpxml_bldg.dst_end_day_isdefaulted = true
+    if hpxml_bldg.dst_observed
+      if hpxml_bldg.dst_begin_month.nil? || hpxml_bldg.dst_begin_day.nil? || hpxml_bldg.dst_end_month.nil? || hpxml_bldg.dst_end_day.nil?
+        if (not weather.header.DSTStartDate.nil?) && (not weather.header.DSTEndDate.nil?)
+          # Use weather file DST dates if available
+          dst_start_date = weather.header.DSTStartDate
+          dst_end_date = weather.header.DSTEndDate
+          hpxml_bldg.dst_begin_month = dst_start_date.monthOfYear.value
+          hpxml_bldg.dst_begin_day = dst_start_date.dayOfMonth
+          hpxml_bldg.dst_end_month = dst_end_date.monthOfYear.value
+          hpxml_bldg.dst_end_day = dst_end_date.dayOfMonth
+        else
+          # Roughly average US dates according to https://en.wikipedia.org/wiki/Daylight_saving_time_in_the_United_States
+          hpxml_bldg.dst_begin_month = 3
+          hpxml_bldg.dst_begin_day = 12
+          hpxml_bldg.dst_end_month = 11
+          hpxml_bldg.dst_end_day = 5
         end
+        hpxml_bldg.dst_begin_month_isdefaulted = true
+        hpxml_bldg.dst_begin_day_isdefaulted = true
+        hpxml_bldg.dst_end_month_isdefaulted = true
+        hpxml_bldg.dst_end_day_isdefaulted = true
       end
+    end
 
-      if hpxml_bldg.elevation.nil?
-        hpxml_bldg.elevation = weather.header.Elevation.round(1)
-        hpxml_bldg.elevation_isdefaulted = true
-      end
+    if hpxml_bldg.elevation.nil?
+      hpxml_bldg.elevation = weather.header.Elevation.round(1)
+      hpxml_bldg.elevation_isdefaulted = true
+    end
 
-      if hpxml_bldg.latitude.nil?
-        hpxml_bldg.latitude = get_latitude(hpxml_bldg.latitude, weather)
-        hpxml_bldg.latitude_isdefaulted = true
-      end
+    if hpxml_bldg.latitude.nil?
+      hpxml_bldg.latitude = get_latitude(hpxml_bldg.latitude, weather)
+      hpxml_bldg.latitude_isdefaulted = true
+    end
 
-      if hpxml_bldg.longitude.nil?
-        hpxml_bldg.longitude = get_longitude(hpxml_bldg.longitude, weather)
-        hpxml_bldg.longitude_isdefaulted = true
-      end
+    if hpxml_bldg.longitude.nil?
+      hpxml_bldg.longitude = get_longitude(hpxml_bldg.longitude, weather)
+      hpxml_bldg.longitude_isdefaulted = true
     end
   end
 
@@ -949,7 +944,7 @@ module Defaults
   # @param unit_num [Integer] Dwelling unit number
   # @return [nil]
   def self.apply_climate_and_risk_zones(hpxml_bldg, weather, unit_num)
-    if (not weather.nil?) && hpxml_bldg.climate_and_risk_zones.climate_zone_ieccs.empty?
+    if hpxml_bldg.climate_and_risk_zones.climate_zone_ieccs.empty?
       weather_data = lookup_weather_data_from_wmo(weather.header.WMONumber)
       if not weather_data.empty?
         hpxml_bldg.climate_and_risk_zones.climate_zone_ieccs.add(zone: weather_data[:zipcode_iecc_zone],

--- a/HPXMLtoOpenStudio/resources/location.rb
+++ b/HPXMLtoOpenStudio/resources/location.rb
@@ -146,7 +146,7 @@ module Location
   # @param weather [WeatherFile] Weather object containing EPW information
   # @return [Integer] the simulation calendar year
   def self.get_sim_calendar_year(sim_calendar_year, weather)
-    if (not weather.nil?) && (not weather.header.ActualYear.nil?) # AMY
+    if not weather.header.ActualYear.nil? # AMY
       sim_calendar_year = weather.header.ActualYear
     end
     if sim_calendar_year.nil?

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -321,10 +321,14 @@ class HPXMLtoOpenStudioDefaultsTest < Minitest::Test
                                   5, 1, 10, 31, 6.8, 91.76, HPXML::ManualJDailyTempRangeHigh, 70.0, 75.0, 0.45, -28.8, 2400.0, 0.0, 4, HPXML::HeatPumpBackupSizingEmergency, HPXML::ManualJInfiltrationMethodBlowerDoor, 4)
 
     # Test defaults w/ StateCode=AZ
-    hpxml_bldg.state_code = 'AZ'
+    hpxml_bldg.climate_and_risk_zones.weather_station_epw_filepath = 'USA_AZ_Phoenix-Sky.Harbor.Intl.AP.722780_TMY3.epw'
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
     _default_hpxml, default_hpxml_bldg = _test_measure()
     assert_equal(false, default_hpxml_bldg.dst_observed)
+    assert_nil(default_hpxml_bldg.dst_begin_month)
+    assert_nil(default_hpxml_bldg.dst_begin_day)
+    assert_nil(default_hpxml_bldg.dst_end_month)
+    assert_nil(default_hpxml_bldg.dst_end_day)
 
     # Test defaults w/ NumberOfResidents provided and less than Nbr+1
     hpxml_bldg.building_occupancy.number_of_residents = 1

--- a/ReportUtilityBills/measure.xml
+++ b/ReportUtilityBills/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_utility_bills</name>
   <uid>ca88a425-e59a-4bc4-af51-c7e7d1e960fe</uid>
-  <version_id>7dab5e5c-e497-4a3c-9875-3eb35c7132de</version_id>
-  <version_modified>2025-07-28T17:26:25Z</version_modified>
+  <version_id>b1e56095-9d01-4e9f-aadd-da5470339b1e</version_id>
+  <version_modified>2025-08-13T22:10:11Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>ReportUtilityBills</class_name>
   <display_name>Utility Bills Report</display_name>
@@ -360,7 +360,7 @@
       <filename>test_report_utility_bills.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>DF07C895</checksum>
+      <checksum>94348A13</checksum>
     </file>
   </files>
 </measure>

--- a/ReportUtilityBills/tests/test_report_utility_bills.rb
+++ b/ReportUtilityBills/tests/test_report_utility_bills.rb
@@ -6,12 +6,15 @@ require_relative '../../HPXMLtoOpenStudio/resources/constants'
 require_relative '../../HPXMLtoOpenStudio/resources/energyplus'
 require_relative '../../HPXMLtoOpenStudio/resources/hpxml'
 require_relative '../../HPXMLtoOpenStudio/resources/defaults'
+require_relative '../../HPXMLtoOpenStudio/resources/materials'
 require_relative '../../HPXMLtoOpenStudio/resources/minitest_helper'
+require_relative '../../HPXMLtoOpenStudio/resources/psychrometrics'
 require_relative '../../HPXMLtoOpenStudio/resources/schedules'
 require_relative '../../HPXMLtoOpenStudio/resources/unit_conversions'
 require_relative '../../HPXMLtoOpenStudio/resources/utility_bills'
-require_relative '../../HPXMLtoOpenStudio/resources/xmlhelper'
 require_relative '../../HPXMLtoOpenStudio/resources/version'
+require_relative '../../HPXMLtoOpenStudio/resources/weather'
+require_relative '../../HPXMLtoOpenStudio/resources/xmlhelper'
 require_relative '../resources/util.rb'
 require 'openstudio'
 require 'openstudio/measure/ShowRunnerOutput'
@@ -83,8 +86,12 @@ class ReportUtilityBillsTest < Minitest::Test
     HPXML::fossil_fuels.each do |fuel|
       @has_fuel[fuel] = true
     end
-    Defaults.apply_header(@hpxml_header, @hpxml_bldg, nil)
-    Defaults.apply_utility_bill_scenarios(nil, @hpxml_header, @hpxml_bldg, @has_fuel)
+
+    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    weather_dir = File.join(File.dirname(__FILE__), '..', '..', 'weather')
+    weather = WeatherFile.new(epw_path: File.join(weather_dir, 'USA_CO_Denver.Intl.AP.725650_TMY3.epw'), runner: runner)
+    Defaults.apply_header(@hpxml_header, @hpxml_bldg, weather)
+    Defaults.apply_utility_bill_scenarios(runner, @hpxml_header, @hpxml_bldg, @has_fuel)
 
     @root_path = File.absolute_path(File.join(File.dirname(__FILE__), '..', '..'))
     @sample_files_path = File.join(@root_path, 'workflow', 'sample_files')


### PR DESCRIPTION
## Pull Request Description

Related to #2060. Fixes DST defaulting when `Address/StateCode` is also defaulted.

Also removes various `weather.nil?` handling; we should always be providing a weather object for these methods.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
