### PR TITLE
A couple more zipcode based defaults

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,8 +4,9 @@ __New Features__
 - Updates to HPXML v4.2-rc3.
 - Allows optional `UsageMultiplier` for electric vehicles described using `Vehicles`.
 - Improves water heater tank losses when using `EnergyFactor` as the metric; now consistent with how `UniformEnergyFactor` is handled.
-- `TimeZone/DSTObserved` now defaults to false if `Address/StateCode` is 'AZ' or 'HI'.
-- `Address/StateCode`, `GeoLocation/Latitude`, and `GeoLocation/Longitude` now default based on zip code if available, otherwise falls back to EPW weather file header as before.
+- Updated site defaults:
+  - `Address/CityMunicipality`, `Address/StateCode`, `GeoLocation/Latitude`, `GeoLocation/Longitude`, and `TimeZone/UTCOffset` now default based on zip code if available.
+  - `TimeZone/DSTObserved` now defaults to false if `Address/StateCode` is 'AZ' or 'HI'.
 
 __Bugfixes__
 - Fixes ground-source heat pump plant loop fluid type (workaround for OpenStudio bug).

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>7c595853-9d55-4dd3-b13b-e5e0dde0bcf3</version_id>
-  <version_modified>2025-08-14T18:35:46Z</version_modified>
+  <version_id>d1c4ccbf-8687-4df9-a186-a1a5fb3d7836</version_id>
+  <version_modified>2025-08-15T05:06:44Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -342,13 +342,13 @@
       <filename>data/zipcode_weather_stations.csv</filename>
       <filetype>csv</filetype>
       <usage_type>resource</usage_type>
-      <checksum>2B7E2F0F</checksum>
+      <checksum>2138BE14</checksum>
     </file>
     <file>
       <filename>defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>496C635D</checksum>
+      <checksum>E4DAF77C</checksum>
     </file>
     <file>
       <filename>electric_panel.rb</filename>
@@ -732,7 +732,7 @@
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>CC87C5D6</checksum>
+      <checksum>F2EB9AE4</checksum>
     </file>
     <file>
       <filename>test_electric_panel.rb</filename>

--- a/HPXMLtoOpenStudio/resources/defaults.rb
+++ b/HPXMLtoOpenStudio/resources/defaults.rb
@@ -732,12 +732,12 @@ module Defaults
     end
 
     if hpxml_bldg.city.nil?
-      hpxml_bldg.city = weather.header.City
+      hpxml_bldg.city = get_city(hpxml_bldg.city, weather, hpxml_bldg.zip_code)
       hpxml_bldg.city_isdefaulted = true
     end
 
     if hpxml_bldg.time_zone_utc_offset.nil?
-      hpxml_bldg.time_zone_utc_offset = get_time_zone(hpxml_bldg.time_zone_utc_offset, weather)
+      hpxml_bldg.time_zone_utc_offset = get_time_zone(hpxml_bldg.time_zone_utc_offset, weather, hpxml_bldg.zip_code)
       hpxml_bldg.time_zone_utc_offset_isdefaulted = true
     end
 
@@ -5249,11 +5249,16 @@ module Defaults
   #
   # @param time_zone [Double] Time zone (UTC offset) from the HPXML file
   # @param weather [WeatherFile] Weather object containing EPW information
+  # @param zipcode [String] Zipcode of interest
   # @return [Double] Default value for time zone (UTC offset)
-  def self.get_time_zone(time_zone, weather)
+  def self.get_time_zone(time_zone, weather, zipcode)
     return time_zone unless time_zone.nil?
 
-    # FUTURE: Add time zone to zipcode_weather_stations.csv and use here first.
+    if not zipcode.nil?
+      weather_data = lookup_weather_data_from_zipcode(zipcode)
+      return Float(weather_data[:zipcode_utc_offset]) unless weather_data[:zipcode_utc_offset].nil?
+    end
+
     return weather.header.TimeZone
   end
 
@@ -5273,6 +5278,24 @@ module Defaults
     end
 
     return weather.header.StateProvinceRegion.upcase
+  end
+
+  # Gets the default city from the HPXML file, or as backup from the
+  # zip code, or as backup from the weather file.
+  #
+  # @param city [String] city from the HPXML file
+  # @param weather [WeatherFile] Weather object containing EPW information
+  # @param zipcode [String] Zipcode of interest
+  # @return [String] City
+  def self.get_city(city, weather, zipcode)
+    return city unless city.nil?
+
+    if not zipcode.nil?
+      weather_data = lookup_weather_data_from_zipcode(zipcode)
+      return weather_data[:zipcode_city] unless weather_data[:zipcode_city].nil?
+    end
+
+    return weather.header.City
   end
 
   # Gets the default weekday/weekend schedule fractions and monthly multipliers for each end use.

--- a/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -335,9 +335,11 @@ class HPXMLtoOpenStudioDefaultsTest < Minitest::Test
     hpxml_bldg.climate_and_risk_zones.weather_station_epw_filepath = 'USA_NV_Las.Vegas-McCarran.Intl.AP.723860_TMY3.epw'
     XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
     _default_hpxml, default_hpxml_bldg = _test_measure()
+    assert_equal('Dolan Springs', default_hpxml_bldg.city)
     assert_equal('AZ', default_hpxml_bldg.state_code)
     assert_equal(35.8897, default_hpxml_bldg.latitude)
     assert_equal(-114.599, default_hpxml_bldg.longitude)
+    assert_equal(-7.0, default_hpxml_bldg.time_zone_utc_offset)
 
     # Test defaults w/ NumberOfResidents provided and less than Nbr+1
     hpxml_bldg.building_occupancy.number_of_residents = 1

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -489,14 +489,14 @@ Building site information can be entered in ``/HPXML/Building/Site``.
   ``TimeZone/DSTObserved``                 boolean                           No        See [#]_  Daylight saving time observed?
   =======================================  ========  =====  ===============  ========  ========  ===============
 
-  .. [#] If CityMunicipality not provided, defaults according to the EPW weather file header.
-  .. [#] If StateCode not provided, defaults to using the ZipCode mapping found at ``HPXMLtoOpenStudio/resources/data/zipcode_weather_stations.csv``, or defaults to the EPW weather file header if ZipCode not provided or not in the CSV lookup file.
+  .. [#] If CityMunicipality not provided, defaults to using the ZipCode mapping found at ``HPXMLtoOpenStudio/resources/data/zipcode_weather_stations.csv``, or defaults to the EPW weather file header.
+  .. [#] If StateCode not provided, defaults to using the ZipCode mapping found at ``HPXMLtoOpenStudio/resources/data/zipcode_weather_stations.csv``, or defaults to the EPW weather file header.
   .. [#] ZipCode can be defined as the standard 5 number postal code, or it can have the additional 4 number code separated by a hyphen.
   .. [#] Either ZipCode or WeatherStation/extension/EPWFilePath (see :ref:`weather_station`) must be provided.
-  .. [#] If Latitude not provided, defaults to using the ZipCode mapping found at ``HPXMLtoOpenStudio/resources/data/zipcode_weather_stations.csv``, or defaults to the EPW weather file header if ZipCode not provided or not in the CSV lookup file.
-  .. [#] If Longitude not provided, defaults to using the ZipCode mapping found at ``HPXMLtoOpenStudio/resources/data/zipcode_weather_stations.csv``, or defaults to the EPW weather file header if ZipCode not provided or not in the CSV lookup file.
+  .. [#] If Latitude not provided, defaults to using the ZipCode mapping found at ``HPXMLtoOpenStudio/resources/data/zipcode_weather_stations.csv``, or defaults to the EPW weather file header.
+  .. [#] If Longitude not provided, defaults to using the ZipCode mapping found at ``HPXMLtoOpenStudio/resources/data/zipcode_weather_stations.csv``, or defaults to the EPW weather file header.
   .. [#] If Elevation not provided, defaults according to the EPW weather file header.
-  .. [#] If UTCOffset not provided, defaults according to the EPW weather file header.
+  .. [#] If UTCOffset not provided, defaults to using the ZipCode mapping found at ``HPXMLtoOpenStudio/resources/data/zipcode_weather_stations.csv``, or defaults to the EPW weather file header.
   .. [#] If DSTObserved not provided, defaults to false if StateCode is 'AZ' or 'HI', otherwise true.
 
 If daylight saving time is observed, additional information can be specified in ``/HPXML/Building/Site/TimeZone/extension``.


### PR DESCRIPTION
## Pull Request Description

`TimeZone/UTCOffset` and `Address/CityMunicipality` also now default based on zip code if available, otherwise falls back to EPW weather file header as before.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
