### PR TITLE
Fixes CFIS w/ zero outdoor air

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ __Bugfixes__
 - Fixes ground-source heat pump plant loop fluid type (workaround for OpenStudio bug).
 - Fixes default hours driven per week for electric vehicles (8.88 -> 9.5).
 - Fixes empty TimeDST/TimeUTC columns in JSON timeseries data.
+- Fixes zero mech vent fan energy when CFIS system w/ `AdditionalRuntimeOperatingMode="air handler fan"` has the airflow rate set to zero.
+- Fixes requested EnergyPlus timeseries output variables/meters not displayed in DView if they don't have units.
 
 ## OpenStudio-HPXML v1.10.0
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3b2aed8f-5d99-47e7-aaad-8f906f096ede</version_id>
-  <version_modified>2025-09-09T22:21:57Z</version_modified>
+  <version_id>ecd4769e-cf61-49cf-92ae-6b36231e4404</version_id>
+  <version_modified>2025-09-11T23:38:51Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -198,7 +198,7 @@
       <filename>airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>842E4D55</checksum>
+      <checksum>A9DCF216</checksum>
     </file>
     <file>
       <filename>battery.rb</filename>

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -1270,7 +1270,7 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
     @output_variables = {}
     @output_variables_requests.each do |output_variable_name|
       key_values, units = get_output_variable_key_values_and_units(output_variable_name)
-      if key_values.empty?
+      if units.nil?
         runner.registerWarning("Request for output variable '#{output_variable_name}' returned no results.")
         next
       end
@@ -1935,6 +1935,11 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
         data.delete_at(1) # Remove units, added to header data above
         data.delete_at(0) # Remove series name, added to header data above
 
+        # DView requires a units string to display a variable, but some EnergyPlus output
+        # variables (like Runtime Fractions) don't have units. So we specify them as
+        # unitless for DView.
+        header_data[-1].map! { |units| units.empty? ? 'unitless' : units }
+
         # Apply daylight savings
         if args[:timeseries_frequency] == EPlus::TimeseriesFrequencyTimestep || args[:timeseries_frequency] == EPlus::TimeseriesFrequencyHourly
           if @hpxml_bldgs[0].dst_observed
@@ -2203,10 +2208,10 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
   # @param var_name [Name] Name of the EnergyPlus output variable
   # @return [Array<String, String>] The key value and units for the output variable
   def get_output_variable_key_values_and_units(var_name)
-    keys = []
-    units = ''
-    return keys, units if @msgpackDataTimeseries.nil?
+    return if @msgpackDataTimeseries.nil?
 
+    keys = []
+    units = nil
     @msgpackDataTimeseries['Cols'].each do |col|
       next unless col['Variable'].end_with? ":#{var_name}"
 

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>d2815bb5-3851-437a-84ad-0747dfd93113</version_id>
-  <version_modified>2025-08-25T16:51:58Z</version_modified>
+  <version_id>de7bc8ae-deb0-4629-a271-afa09c218aa0</version_id>
+  <version_modified>2025-09-12T00:04:34Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1991,7 +1991,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0B89F7D1</checksum>
+      <checksum>644C7D4C</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>


### PR DESCRIPTION
## Pull Request Description

Closes #2072. Ensure we calculate additional air handler fan energy for CFIS systems even when the outdoor air cfm is zero. 

Also fixes a bug where an EnergyPlus timeseries output was not displayed in DView if it didn't have units. Found while debugging the issue.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
