### PR TITLE
Some cleanup/refactor of output.rb, try 2

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>1650c5b8-4859-4a8f-b2ef-3ed9d8e7e178</version_id>
-  <version_modified>2025-12-04T18:00:16Z</version_modified>
+  <version_id>60c375b5-525b-4a1b-8344-08185cbf8892</version_id>
+  <version_modified>2025-12-04T18:35:03Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -480,7 +480,7 @@
       <filename>output.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>9AD6DDEB</checksum>
+      <checksum>8A1049F9</checksum>
     </file>
     <file>
       <filename>psychrometrics.rb</filename>
@@ -738,7 +738,7 @@
       <filename>test_electric_panel.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1556FAD</checksum>
+      <checksum>8D28B720</checksum>
     </file>
     <file>
       <filename>test_enclosure.rb</filename>

--- a/HPXMLtoOpenStudio/resources/output.rb
+++ b/HPXMLtoOpenStudio/resources/output.rb
@@ -1048,7 +1048,16 @@ module Outputs
             # So we don't double-count, e.g., heat pump breaker spaces since it is shared across two service feeder types
             next unless component.service_feeders.select { |sf| sf.type == HPXML::ElectricPanelLoadTypeHeating }.empty?
           end
-          component.branch_circuits.each do |branch_circuit|
+          if [HPXML::ElectricPanelLoadTypePoolHeater,
+              HPXML::ElectricPanelLoadTypePermanentSpaHeater].include? service_feeder.type
+            branch_circuits = component.heater_branch_circuits
+          elsif [HPXML::ElectricPanelLoadTypePoolPump,
+                 HPXML::ElectricPanelLoadTypePermanentSpaPump].include? service_feeder.type
+            branch_circuits = component.pump_branch_circuits
+          else
+            branch_circuits = component.branch_circuits
+          end
+          branch_circuits.each do |branch_circuit|
             breaker_spaces[service_feeder.type] += branch_circuit.occupied_spaces * unit_multiplier
           end
         end

--- a/HPXMLtoOpenStudio/tests/test_electric_panel.rb
+++ b/HPXMLtoOpenStudio/tests/test_electric_panel.rb
@@ -926,6 +926,7 @@ class HPXMLtoOpenStudioElectricPanelTest < Minitest::Test
                         is_new_load: true,
                         component_idrefs: [hpxml_bldg.plug_loads[-1].id])
     hpxml_bldg.pools.add(id: "Pool#{hpxml_bldg.pools.size + 1}",
+                         type: HPXML::TypeUnknown,
                          pump_id: "Pool#{hpxml_bldg.pools.size + 1}Pump",
                          pump_type: HPXML::TypeUnknown,
                          heater_id: "Pool#{hpxml_bldg.pools.size + 1}Heater",
@@ -951,12 +952,12 @@ class HPXMLtoOpenStudioElectricPanelTest < Minitest::Test
     assert_equal(27, json['Electric Panel Breaker Spaces']['Total Count'])
     assert_equal(27, json['Electric Panel Breaker Spaces']['Occupied Count'])
     assert_equal(0, json['Electric Panel Breaker Spaces']['Headroom Count'])
-    assert_equal(34827.2, json['Electric Panel Load']['2023 Existing Dwelling Load-Based: Total Load (W)'])
-    assert_equal(145.1, json['Electric Panel Load']['2023 Existing Dwelling Load-Based: Total Capacity (A)'])
-    assert_in_epsilon(100.0 - 145.1, json['Electric Panel Load']['2023 Existing Dwelling Load-Based: Headroom Capacity (A)'], 0.01)
-    assert_equal(46477.0, json['Electric Panel Load']['2023 Existing Dwelling Meter-Based: Total Load (W)'])
-    assert_equal(193.7, json['Electric Panel Load']['2023 Existing Dwelling Meter-Based: Total Capacity (A)'])
-    assert_in_epsilon(100.0 - 193.7, json['Electric Panel Load']['2023 Existing Dwelling Meter-Based: Headroom Capacity (A)'], 0.01)
+    assert_equal(37463.6, json['Electric Panel Load']['2023 Existing Dwelling Load-Based: Total Load (W)'])
+    assert_equal(156.1, json['Electric Panel Load']['2023 Existing Dwelling Load-Based: Total Capacity (A)'])
+    assert_in_epsilon(100.0 - 156.1, json['Electric Panel Load']['2023 Existing Dwelling Load-Based: Headroom Capacity (A)'], 0.01)
+    assert_equal(53068.0, json['Electric Panel Load']['2023 Existing Dwelling Meter-Based: Total Load (W)'])
+    assert_equal(221.1, json['Electric Panel Load']['2023 Existing Dwelling Meter-Based: Total Capacity (A)'])
+    assert_in_epsilon(100.0 - 221.1, json['Electric Panel Load']['2023 Existing Dwelling Meter-Based: Headroom Capacity (A)'], 0.01)
   end
 
   private


### PR DESCRIPTION
## Pull Request Description

Fixes bug introduced in https://github.com/NREL/OpenStudio-HPXML/pull/2106.

Add test for electric panel with pool.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
