### PR TITLE
BuildResidentialHPXML: Prevent garage slab insulation

### DIFF
--- a/BuildResidentialHPXML/measure.rb
+++ b/BuildResidentialHPXML/measure.rb
@@ -2054,10 +2054,23 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
         exposed_perimeter -= Geometry.get_unexposed_garage_perimeter(**args)
       end
 
-      if args[:enclosure_slab_under_slab_insulation_width].to_f >= 999
-        under_slab_insulation_spans_entire_slab = true
+      if interior_adjacent_to == HPXML::LocationGarage
+        perimeter_insulation_r_value = 0
+        perimeter_insulation_depth = 0
+        under_slab_insulation_width = 0
+        under_slab_insulation_r_value = 0
       else
-        under_slab_insulation_width = args[:enclosure_slab_under_slab_insulation_width]
+        perimeter_insulation_r_value = args[:enclosure_slab_perimeter_insulation_nominal_r_value]
+        perimeter_insulation_depth = args[:enclosure_slab_perimeter_insulation_depth]
+        exterior_horizontal_insulation_r_value = args[:enclosure_slab_exterior_horizontal_insulation_nominal_r_value]
+        exterior_horizontal_insulation_width = args[:enclosure_slab_exterior_horizontal_insulation_width]
+        exterior_horizontal_insulation_depth_below_grade = args[:enclosure_slab_exterior_horizontal_insulation_depth_below_grade]
+        if args[:enclosure_slab_under_slab_insulation_width].to_f >= 999
+          under_slab_insulation_spans_entire_slab = true
+        else
+          under_slab_insulation_width = args[:enclosure_slab_under_slab_insulation_width]
+        end
+        under_slab_insulation_r_value = args[:enclosure_slab_under_slab_insulation_nominal_r_value]
       end
 
       hpxml_bldg.slabs.add(id: "Slab#{hpxml_bldg.slabs.size + 1}",
@@ -2065,13 +2078,13 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
                            area: UnitConversions.convert(surface.grossArea, 'm^2', 'ft^2'),
                            thickness: args[:enclosure_slab_thickness],
                            exposed_perimeter: exposed_perimeter,
-                           perimeter_insulation_r_value: args[:enclosure_slab_perimeter_insulation_nominal_r_value],
-                           perimeter_insulation_depth: args[:enclosure_slab_perimeter_insulation_depth],
-                           exterior_horizontal_insulation_r_value: args[:enclosure_slab_exterior_horizontal_insulation_nominal_r_value],
-                           exterior_horizontal_insulation_width: args[:enclosure_slab_exterior_horizontal_insulation_width],
-                           exterior_horizontal_insulation_depth_below_grade: args[:enclosure_slab_exterior_horizontal_insulation_depth_below_grade],
+                           perimeter_insulation_r_value: perimeter_insulation_r_value,
+                           perimeter_insulation_depth: perimeter_insulation_depth,
+                           exterior_horizontal_insulation_r_value: exterior_horizontal_insulation_r_value,
+                           exterior_horizontal_insulation_width: exterior_horizontal_insulation_width,
+                           exterior_horizontal_insulation_depth_below_grade: exterior_horizontal_insulation_depth_below_grade,
                            under_slab_insulation_width: under_slab_insulation_width,
-                           under_slab_insulation_r_value: args[:enclosure_slab_under_slab_insulation_nominal_r_value],
+                           under_slab_insulation_r_value: under_slab_insulation_r_value,
                            under_slab_insulation_spans_entire_slab: under_slab_insulation_spans_entire_slab)
       hpxml_slab = hpxml_bldg.slabs[-1]
       @surface_ids[surface.name.to_s] = hpxml_slab.id

--- a/BuildResidentialHPXML/measure.xml
+++ b/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>9022988f-a451-492c-b27a-b74b1d356df1</version_id>
-  <version_modified>2025-12-12T16:41:46Z</version_modified>
+  <version_id>61837c09-279b-4399-bf6f-d773ecedf820</version_id>
+  <version_modified>2025-12-12T23:29:45Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -11302,7 +11302,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>8B19EBA5</checksum>
+      <checksum>23C369CC</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>


### PR DESCRIPTION
## Pull Request Description

Don't apply slab insulation inputs to the garage slab. Noticed while looking at a ResStock HPXML. The impact on results is very small since the garage is not conditioned, it just looks weird.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
