### PR TITLE
Fixes `PanHeaterControlType="heat pump mode"` for mini-split HPs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ __New Features__
 __Bugfixes__
 - Fixes a misleading warning about adjusting inverted setpoints when heating setpoint is greater than cooling setpoint during non-overlapping heating/cooling seasons.
 - Fixes possible incorrect unmet hours outputs for unavailable periods with no space heating only (or no space cooling only).
+- Fixes PanHeaterControlType="heat pump mode" incorrectly disallowed for mini-split heat pumps.
 
 ## OpenStudio-HPXML v1.11.0
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>6f3658e4-715f-4ef2-aa75-2e82ec6dcbef</version_id>
-  <version_modified>2026-01-26T16:58:29Z</version_modified>
+  <version_id>1b5ed401-6cf9-43e9-b51d-ddc412d3dbf1</version_id>
+  <version_modified>2026-01-27T20:50:02Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -402,7 +402,7 @@
       <filename>hpxml_schematron/EPvalidator.sch</filename>
       <filetype>sch</filetype>
       <usage_type>resource</usage_type>
-      <checksum>60805C44</checksum>
+      <checksum>71EC385E</checksum>
     </file>
     <file>
       <filename>hpxml_schematron/iso-schematron.xsd</filename>

--- a/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.sch
+++ b/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.sch
@@ -1633,7 +1633,7 @@
       <sch:assert role='ERROR' test='count(h:extension/h:PanHeaterPowerWatts) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/PanHeaterPowerWatts</sch:assert>
       <sch:assert role='ERROR' test='number(h:extension/h:PanHeaterPowerWatts) &gt;= 0.0 or not(h:extension/h:PanHeaterPowerWatts)'>Expected extension/PanHeaterPowerWatts to be greater than or equal to 0.0.</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:PanHeaterControlType) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/PanHeaterControlType</sch:assert>
-      <sch:assert role='ERROR' test='h:extension/h:PanHeaterControlType[text()="continuous" or text()="defrost mode"] or not(h:extension/h:PanHeaterControlType)'>Expected extension/PanHeaterControlType to be 'continuous' or 'defrost mode'</sch:assert>
+      <sch:assert role='ERROR' test='h:extension/h:PanHeaterControlType[text()="continuous" or text()="heat pump mode" or text()="defrost mode"] or not(h:extension/h:PanHeaterControlType)'>Expected extension/PanHeaterControlType to be 'continuous' or 'heat pump mode' or 'defrost mode'</sch:assert>
       <sch:assert role='ERROR' test='count(h:extension/h:BackupHeatingActiveDuringDefrost) &lt;= 1'>Expected 0 or 1 element(s) for xpath: extension/BackupHeatingActiveDuringDefrost</sch:assert>
       <sch:assert role='ERROR' test='h:extension/h:BackupHeatingActiveDuringDefrost[text()="true" or text()="false"] or not(h:extension/h:BackupHeatingActiveDuringDefrost)'>Expected extension/BackupHeatingActiveDuringDefrost to be 'true' or 'false'</sch:assert>
       <!-- Warnings -->


### PR DESCRIPTION
## Pull Request Description

Fixes #2154.

## Checklist

Not all may apply:

- [x] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
