### PR TITLE
Removes sizing objects from model

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>fa7b33c1-3d99-4f78-980e-4644d6e5db8d</version_id>
-  <version_modified>2026-02-25T17:01:14Z</version_modified>
+  <version_id>cae35be2-713c-49cf-84f5-05f6382d8574</version_id>
+  <version_modified>2026-02-26T20:28:49Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -475,7 +475,7 @@
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>0A27A2C8</checksum>
+      <checksum>E7E79C68</checksum>
     </file>
     <file>
       <filename>minitest_helper.rb</filename>

--- a/HPXMLtoOpenStudio/resources/meta_measure.rb
+++ b/HPXMLtoOpenStudio/resources/meta_measure.rb
@@ -70,6 +70,14 @@ def run_hpxml_workflow(rundir, measures, measures_dir, debug: false, run_measure
     end
   end
 
+  # Remove sizing objects that we don't use
+  # Remove this case when https://github.com/NatLabRockies/OpenStudio/issues/5601 is addressed
+  ['Sizing:Parameters', 'Sizing:System'].each do |sizing_type|
+    workspace.getObjectsByType(sizing_type.to_IddObjectType).each do |sizing_obj|
+      sizing_obj.remove
+    end
+  end
+
   if not success
     print "Creating input unsuccessful.\n"
     print "See #{File.join(rundir, 'run.log')} for details.\n"


### PR DESCRIPTION
## Pull Request Description

Removes the sizing objects from the model since we don't use them and it is confusing to have them in the model. Currently only removing them when using `run_simulation.rb` since [the OS SDK does not support their removal](https://github.com/NatLabRockies/OpenStudio/issues/5601).

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
