### PR TITLE
Fix timeseries heating/cooling setpoints when using on/off thermostat deadband model

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,9 @@ __Bugfixes__
   - Fixes lighting and plug/fuel load energy use to not be zeroed out when a kWh/year or therm/year value is provided.
   - Fixes pool/spa energy use to be zeroed out when a kWh/year or therm/year value is not provided, or when there is a "Vacancy" unavailable period.
 - Fixes incorrect hot water (gallons) output for solar thermal systems using `SolarFraction`.
+- Small bugfixes when using the on/off thermostat deadband advanced research feature:
+  - Fixes unmet hours outputs, which could be missing some periods of unmet hours.
+  - Fixes timeseries outputs for heating/cooling setpoints.
 
 ## OpenStudio-HPXML v1.11.1
 

--- a/ReportSimulationOutput/measure.rb
+++ b/ReportSimulationOutput/measure.rb
@@ -549,11 +549,17 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
       end
 
       # Also report thermostat setpoints
+      # Note that we use the schedule value, rather than the Zone Thermostat Heating (or Cooling) Setpoint Temperature output variable,
+      # because the latter is adjusted when the on-off thermostat deadband model is used.
       heated_zones.each do |heated_zone|
-        Model.add_output_variable(model, key_value: heated_zone.upcase, variable_name: 'Zone Thermostat Heating Setpoint Temperature', reporting_frequency: args[:timeseries_frequency])
+        thermal_zone = model.getThermalZones.find { |z| z.name.to_s == heated_zone }
+        sched_name = thermal_zone.thermostatSetpointDualSetpoint.get.heatingSetpointTemperatureSchedule.get.name.to_s.upcase
+        Model.add_output_variable(model, key_value: sched_name, variable_name: 'Schedule Value', reporting_frequency: args[:timeseries_frequency])
       end
       cooled_zones.each do |cooled_zone|
-        Model.add_output_variable(model, key_value: cooled_zone.upcase, variable_name: 'Zone Thermostat Cooling Setpoint Temperature', reporting_frequency: args[:timeseries_frequency])
+        thermal_zone = model.getThermalZones.find { |z| z.name.to_s == cooled_zone }
+        sched_name = thermal_zone.thermostatSetpointDualSetpoint.get.coolingSetpointTemperatureSchedule.get.name.to_s.upcase
+        Model.add_output_variable(model, key_value: sched_name, variable_name: 'Schedule Value', reporting_frequency: args[:timeseries_frequency])
       end
     end
 
@@ -1185,28 +1191,32 @@ class ReportSimulationOutput < OpenStudio::Measure::ReportingMeasure
       heated_zones = eval(@model.getBuilding.additionalProperties.getFeatureAsString('heated_zones').get)
       heated_zones.each do |heated_zone|
         var_name = 'Temperature: Heating Setpoint'
+        thermal_zone = @model.getThermalZones.find { |z| z.name.to_s == heated_zone }
         if @hpxml_bldgs.size > 1
-          building_id = @model.getThermalZones.find { |z| z.name.to_s == heated_zone }.additionalProperties.getFeatureAsString('BuildingID').get
+          building_id = thermal_zone.additionalProperties.getFeatureAsString('BuildingID').get
           var_name = "Temperature: #{building_id} Heating Setpoint"
         end
         @zone_temps["#{heated_zone} Heating Setpoint"] = ZoneTemp.new
         @zone_temps["#{heated_zone} Heating Setpoint"].name = var_name
         @zone_temps["#{heated_zone} Heating Setpoint"].timeseries_units = 'F'
-        @zone_temps["#{heated_zone} Heating Setpoint"].timeseries_output = get_report_variable_data_timeseries([heated_zone.upcase], ['Zone Thermostat Heating Setpoint Temperature'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
+        sched_name = thermal_zone.thermostatSetpointDualSetpoint.get.heatingSetpointTemperatureSchedule.get.name.to_s.upcase
+        @zone_temps["#{heated_zone} Heating Setpoint"].timeseries_output = get_report_variable_data_timeseries([sched_name], ['Schedule Value'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
       end
 
       # Cooling Setpoints
       cooled_zones = eval(@model.getBuilding.additionalProperties.getFeatureAsString('cooled_zones').get)
       cooled_zones.each do |cooled_zone|
         var_name = 'Temperature: Cooling Setpoint'
+        thermal_zone = @model.getThermalZones.find { |z| z.name.to_s == cooled_zone }
         if @hpxml_bldgs.size > 1
-          building_id = @model.getThermalZones.find { |z| z.name.to_s == cooled_zone }.additionalProperties.getFeatureAsString('BuildingID').get
+          building_id = thermal_zone.additionalProperties.getFeatureAsString('BuildingID').get
           var_name = "Temperature: #{building_id} Cooling Setpoint"
         end
         @zone_temps["#{cooled_zone} Cooling Setpoint"] = ZoneTemp.new
         @zone_temps["#{cooled_zone} Cooling Setpoint"].name = var_name
         @zone_temps["#{cooled_zone} Cooling Setpoint"].timeseries_units = 'F'
-        @zone_temps["#{cooled_zone} Cooling Setpoint"].timeseries_output = get_report_variable_data_timeseries([cooled_zone.upcase], ['Zone Thermostat Cooling Setpoint Temperature'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
+        sched_name = thermal_zone.thermostatSetpointDualSetpoint.get.coolingSetpointTemperatureSchedule.get.name.to_s.upcase
+        @zone_temps["#{cooled_zone} Cooling Setpoint"].timeseries_output = get_report_variable_data_timeseries([sched_name], ['Schedule Value'], 9.0 / 5.0, 32.0, args[:timeseries_frequency])
       end
     end
 

--- a/ReportSimulationOutput/measure.xml
+++ b/ReportSimulationOutput/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>report_simulation_output</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>1079d5e6-b3cf-4cfe-9edb-25648c7cfe5f</version_id>
-  <version_modified>2026-03-31T20:30:18Z</version_modified>
+  <version_id>c918e8fa-1faf-4f04-8fa0-b8bc22a4a06a</version_id>
+  <version_modified>2026-04-13T22:34:52Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ReportSimulationOutput</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -2029,7 +2029,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>58B64AA8</checksum>
+      <checksum>267ED60A</checksum>
     </file>
     <file>
       <filename>test_report_sim_output.rb</filename>

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -658,7 +658,7 @@ Depending on the outputs requested, the file may include:
   Total Loads                         ``loads``            Heating, cooling, and hot water loads (in kBtu).
   Component Loads                     ``componentloads``   Heating and cooling loads (in kBtu) disaggregated by component (e.g., Walls, Windows, Infiltration, Ducts, etc.).
   Unmet Hours                         ``unmethours``       Heating, cooling, and EV driving unmet hours.
-  Zone Temperatures                   ``temperatures``     Zone temperatures (in deg-F) for each space (e.g., conditioned space, attic, garage, basement, crawlspace, etc.) plus heating/cooling setpoints. [#]_
+  Zone Temperatures                   ``temperatures``     Zone temperatures for each space (e.g., conditioned space [#]_, attic, garage, basement, crawlspace, etc.) plus heating/cooling setpoints [#]_ (in deg-F).
   Zone Conditions                     ``conditions``       Zone conditions (humidity ratio and relative humidity and dewpoint, radiant, and operative temperatures).
   Airflows                            ``airflows``         Airflow rates (in cfm) for infiltration, mechanical ventilation (including clothes dryer exhaust), natural ventilation, whole house fans.
   Weather                             ``weather``          Weather file data including outdoor temperatures, relative humidity, wind speed, and solar.
@@ -668,6 +668,7 @@ Depending on the outputs requested, the file may include:
   ==================================  ===================  ==================================================================================================================================
 
   .. [#] This is the argument provided to ``run_simulation.rb`` as described in the :ref:`basic_run` usage instructions.
+  .. [#] If the home is not fully conditioned (e.g., a room air conditioner that only meets 30% of the cooling load), the reported zone temperature for the conditioned space will reflect a fully conditioned home due to the way these systems are modeled in EnergyPlus.
   .. [#] When an On-Off Thermostat Deadband Temperature (see :ref:`hpxml_simulation_control`) is used, heating and cooling setpoints reflect the *cut-in* temperature for HVAC operation, not the middle of the deadband.
 
 Timeseries outputs can be one of the following frequencies: hourly, daily, monthly, or timestep (i.e., equal to the simulation timestep, which defaults to an hour but can be sub-hourly).
@@ -675,8 +676,6 @@ Timeseries outputs can be one of the following frequencies: hourly, daily, month
 Timestamps in the output use the start-of-period convention unless you have requested the end-of-period timestamp convention.
 Additional timestamp columns can be optionally requested that reflect daylight saving time (DST) and/or coordinated universal time (UTC).
 Most outputs will be summed over the hour (e.g., energy) but some will be averaged over the hour (e.g., temperatures, airflows).
-
-Note that if the home is not fully conditioned (e.g., a room air conditioner that only meets 30% of the cooling load), the reported zone temperature for the conditioned space will reflect a fully conditioned home due to the way these systems are modeled in EnergyPlus.
 
 .. _bill_outputs:
 

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -658,7 +658,7 @@ Depending on the outputs requested, the file may include:
   Total Loads                         ``loads``            Heating, cooling, and hot water loads (in kBtu).
   Component Loads                     ``componentloads``   Heating and cooling loads (in kBtu) disaggregated by component (e.g., Walls, Windows, Infiltration, Ducts, etc.).
   Unmet Hours                         ``unmethours``       Heating, cooling, and EV driving unmet hours.
-  Zone Temperatures                   ``temperatures``     Zone temperatures (in deg-F) for each space (e.g., conditioned space, attic, garage, basement, crawlspace, etc.) plus heating/cooling setpoints.
+  Zone Temperatures                   ``temperatures``     Zone temperatures (in deg-F) for each space (e.g., conditioned space, attic, garage, basement, crawlspace, etc.) plus heating/cooling setpoints. [#]_
   Zone Conditions                     ``conditions``       Zone conditions (humidity ratio and relative humidity and dewpoint, radiant, and operative temperatures).
   Airflows                            ``airflows``         Airflow rates (in cfm) for infiltration, mechanical ventilation (including clothes dryer exhaust), natural ventilation, whole house fans.
   Weather                             ``weather``          Weather file data including outdoor temperatures, relative humidity, wind speed, and solar.
@@ -668,6 +668,7 @@ Depending on the outputs requested, the file may include:
   ==================================  ===================  ==================================================================================================================================
 
   .. [#] This is the argument provided to ``run_simulation.rb`` as described in the :ref:`basic_run` usage instructions.
+  .. [#] When an On-Off Thermostat Deadband Temperature (see :ref:`hpxml_simulation_control`) is used, heating and cooling setpoints reflect the *cut-in* temperature for HVAC operation, not the middle of the deadband.
 
 Timeseries outputs can be one of the following frequencies: hourly, daily, monthly, or timestep (i.e., equal to the simulation timestep, which defaults to an hour but can be sub-hourly).
 


### PR DESCRIPTION
## Pull Request Description

We now use the heating/cooling setpoint schedules ("Schedule Value") rather than the zone output variables (e.g., "Zone Thermostat Heating Setpoint Temperature"), since E+ will automatically adjust the latter as part of the model.

Results for `base-hvac-air-to-air-heat-pump-1-speed-research-features.xml`:

<img width="1919" height="1016" alt="image" src="https://github.com/user-attachments/assets/aa376a91-2cdc-4dca-93f0-b41612f2fa0c" />

The blue/orange data is before this change and the red/black is after. The latter no longer shows the E+ adjustments that are being made. However, they may still be confusing to a user because the HPXML inputs are 78F for cooling and 64-70F for heating, with a 2F deadband, while the timeseries results show the _edges_ of the deadband. Maybe we just need to document this?


## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
