### PR TITLE
Fix measure.xml name typo

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <measure>
   <schema_version>3.1</schema_version>
-  <name>hpxm_lto_openstudio</name>
+  <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
   <version_id>b2ce30a3-be8a-4659-85ec-2e133724ef4e</version_id>
   <version_modified>2026-04-22T17:51:13Z</version_modified>


### PR DESCRIPTION
## Pull Request Description

The HPXML to OpenStudio measure name was set to hpxm_lto_openstudio in the measure.xml file. Assuming this was a typo, I changed it to hpxml_to_openstudio.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
