### PR TITLE
Changes to support E+ 26.1

### DIFF
--- a/HPXMLtoOpenStudio/resources/airflow.rb
+++ b/HPXMLtoOpenStudio/resources/airflow.rb
@@ -2325,6 +2325,14 @@ module Airflow
     )
     infil_flow.additionalProperties.setFeature('ObjectType', Constants::ObjectTypeInfiltration)
 
+    # Warmup workaround, see https://github.com/NatLabRockies/EnergyPlus/pull/11409
+    ['Qducts', 'Qexhaust', 'Qsupply'].each do |var|
+      Model.add_ems_global_var(
+        model,
+        var_name: var
+      )
+    end
+
     # Average in-unit CFMs (include recirculation from in unit CFMs for shared systems)
     sup_cfm_tot = vent_fans[:mech_supply].map { |vent_mech| vent_mech.average_unit_flow_rate }.sum(0.0)
     exh_cfm_tot = vent_fans[:mech_exhaust].map { |vent_mech| vent_mech.average_unit_flow_rate }.sum(0.0)

--- a/HPXMLtoOpenStudio/resources/output.rb
+++ b/HPXMLtoOpenStudio/resources/output.rb
@@ -799,6 +799,8 @@ module Outputs
         end
       end
 
+      unit_multiplier = hpxml_bldg.building_construction.number_of_units
+
       # EMS program: Internal Gains, Lighting, Infiltration, Natural Ventilation, Mechanical Ventilation, Ducts
       { 'intgains' => intgains_sensors,
         'lighting' => lightings_sensors,
@@ -824,7 +826,7 @@ module Outputs
       end
       intgains_dhw_sensors.each do |sensor, vals|
         off_loss, on_loss, rtf_sensor = vals
-        program.addLine("Set hr_intgains = hr_intgains + #{sensor.name} * (#{off_loss}*(1-#{rtf_sensor.name}) + #{on_loss}*#{rtf_sensor.name})") # Water heater tank losses to zone
+        program.addLine("Set hr_intgains = hr_intgains + (#{sensor.name} * (#{off_loss}*(1-#{rtf_sensor.name}) + #{on_loss}*#{rtf_sensor.name})) / #{unit_multiplier}") # Water heater tank losses to zone
       end
       if (not ducts_mix_loss_sensor.nil?) && (not ducts_mix_gain_sensor.nil?)
         program.addLine("Set hr_ducts = hr_ducts + (#{ducts_mix_loss_sensor.name} - #{ducts_mix_gain_sensor.name})")
@@ -900,7 +902,6 @@ module Outputs
       program.addLine('  EndIf')
       program.addLine('EndIf')
 
-      unit_multiplier = hpxml_bldg.building_construction.number_of_units
       [:htg, :clg].each do |mode|
         if mode == :htg
           sign = ''

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -838,8 +838,8 @@ module Waterheater
     storage_tank.setHeaterThermalEfficiency(1)
     storage_tank.ambientTemperatureSchedule.get.remove
     apply_ambient_temperature(loc_space, loc_schedule, storage_tank)
-    storage_tank.setSkinLossFractiontoZone(1.0 / unit_multiplier) # Tank losses are multiplied by E+ zone multiplier, so need to compensate here
-    storage_tank.setOffCycleFlueLossFractiontoZone(1.0 / unit_multiplier)
+    storage_tank.setSkinLossFractiontoZone(1.0)
+    storage_tank.setOffCycleFlueLossFractiontoZone(1.0)
     storage_tank.setUseSideEffectiveness(1)
     storage_tank.setUseSideInletHeight(0)
     storage_tank.setSourceSideOutletHeight(0)
@@ -1111,8 +1111,8 @@ module Waterheater
     tank.setSourceSideFlowControlMode('')
     tank.setSourceSideInletHeight(0)
     tank.setSourceSideOutletHeight(0)
-    tank.setSkinLossFractiontoZone(1.0 / unit_multiplier) # Tank losses are multiplied by E+ zone multiplier, so need to compensate here
-    tank.setOffCycleFlueLossFractiontoZone(1.0 / unit_multiplier)
+    tank.setSkinLossFractiontoZone(1.0)
+    tank.setOffCycleFlueLossFractiontoZone(1.0)
     apply_stratified_tank_losses(tank, tank_u, unit_multiplier)
     tank.additionalProperties.setFeature('HPXML_ID', water_heating_system.id) # Used by reporting measure
 
@@ -1990,8 +1990,8 @@ module Waterheater
       water_heater.setSourceSideFlowControlMode('')
       water_heater.setSourceSideInletHeight((1.0 - (1 - 0.5) / 15) * h_tank) # in the 1st node of a 15-node tank (counting from top)
       water_heater.setSourceSideOutletHeight((1.0 - (15 - 0.5) / 15) * h_tank) # in the 15th node of a 15-node tank (counting from top)
-      water_heater.setSkinLossFractiontoZone(1.0 / unit_multiplier) # Tank losses are multiplied by E+ zone multiplier, so need to compensate here
-      water_heater.setOffCycleFlueLossFractiontoZone(1.0 / unit_multiplier)
+      water_heater.setSkinLossFractiontoZone(1.0)
+      water_heater.setOffCycleFlueLossFractiontoZone(1.0)
       apply_stratified_tank_losses(water_heater, tank_u, unit_multiplier)
     else
       water_heater = OpenStudio::Model::WaterHeaterMixed.new(model)
@@ -2028,8 +2028,8 @@ module Waterheater
           skinlossfrac = 0.96 # Condensing
         end
       end
-      water_heater.setOffCycleLossFractiontoThermalZone(skinlossfrac / unit_multiplier) # Tank losses are multiplied by E+ zone multiplier, so need to compensate here
-      water_heater.setOnCycleLossFractiontoThermalZone(1.0 / unit_multiplier) # Tank losses are multiplied by E+ zone multiplier, so need to compensate here
+      water_heater.setOffCycleLossFractiontoThermalZone(skinlossfrac)
+      water_heater.setOnCycleLossFractiontoThermalZone(1.0)
 
       water_heater.setOnCycleLossCoefficienttoAmbientTemperature(UnitConversions.convert(tank_ua, 'Btu/(hr*F)', 'W/K'))
       water_heater.setOffCycleLossCoefficienttoAmbientTemperature(UnitConversions.convert(tank_ua, 'Btu/(hr*F)', 'W/K'))


### PR DESCRIPTION
## Pull Request Description

Most of the changes are related to [this](https://github.com/NatLabRockies/EnergyPlus/issues/10168). Also added [this workaround](https://github.com/NatLabRockies/EnergyPlus/pull/11409/changes#diff-21a1f1bade3add7748eef82d530722574d8c37d36a9bfad98f8f714fde7b8992) for EMS, but there might be better solutions we should use instead.

Very minor diffs seen compared to E+ 25.2.

This PR will still open for a while (until the next OpenStudio release).

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
