### PR TITLE
Refactor 1-based arrays

### DIFF
--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>70d685cb-16a7-4c52-90a1-bfba48675ebb</version_id>
-  <version_modified>2026-04-24T02:55:46Z</version_modified>
+  <version_id>b32e378c-d611-44a6-9e46-9204efecef5a</version_id>
+  <version_modified>2026-04-24T03:16:09Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -229,7 +229,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>0BE63889</checksum>
+      <checksum>97FAE82D</checksum>
     </file>
     <file>
       <filename>shower_cluster_size_probability.csv</filename>

--- a/BuildResidentialScheduleFile/measure.xml
+++ b/BuildResidentialScheduleFile/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_schedule_file</name>
   <uid>f770b2db-1a9f-4e99-99a7-7f3161a594b1</uid>
-  <version_id>a794739a-f354-4670-8457-1d52216ff5dd</version_id>
-  <version_modified>2026-02-12T20:36:49Z</version_modified>
+  <version_id>70d685cb-16a7-4c52-90a1-bfba48675ebb</version_id>
+  <version_modified>2026-04-24T02:55:46Z</version_modified>
   <xml_checksum>03F02484</xml_checksum>
   <class_name>BuildResidentialScheduleFile</class_name>
   <display_name>Schedule File Builder</display_name>
@@ -229,7 +229,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D5735F4A</checksum>
+      <checksum>0BE63889</checksum>
     </file>
     <file>
       <filename>shower_cluster_size_probability.csv</filename>

--- a/BuildResidentialScheduleFile/resources/schedules.rb
+++ b/BuildResidentialScheduleFile/resources/schedules.rb
@@ -702,7 +702,7 @@ class ScheduleGenerator
     sunrise_hour = []
     sunset_hour = []
     std_long = -time_zone_utc_offset * 15
-    normalized_hourly_lighting = [[1..24]] * 12
+    normalized_hourly_lighting = [[1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24]]
     for month in 0..11
       if latitude < 51.49
         m_num = month + 1
@@ -797,7 +797,7 @@ class ScheduleGenerator
     end
 
     # Calculate schedule values
-    lighting_sch = [[]] * 12
+    lighting_sch = [[], [], [], [], [], [], [], [], [], [], [], []]
     for month in 0..11
       for hour in 0..23
         lighting_sch[month][hour] = normalized_monthly_lighting[month] * normalized_hourly_lighting[month][hour] / days_m[month]

--- a/BuildResidentialScheduleFile/resources/schedules.rb
+++ b/BuildResidentialScheduleFile/resources/schedules.rb
@@ -702,7 +702,7 @@ class ScheduleGenerator
     sunrise_hour = []
     sunset_hour = []
     std_long = -time_zone_utc_offset * 15
-    normalized_hourly_lighting = [[1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24], [1..24]]
+    normalized_hourly_lighting = [[1..24]] * 12
     for month in 0..11
       if latitude < 51.49
         m_num = month + 1
@@ -738,37 +738,37 @@ class ScheduleGenerator
     monthly_kwh_per_day = []
     days_m = Calendar.num_days_in_months(1999) # Intentionally excluding leap year designation
     wtd_avg_monthly_kwh_per_day = 0
-    for monthNum in 1..12
-      month = monthNum - 1
+    for month_num in 1..12
+      month = month_num - 1
       monthHalfHourKWHs = [0]
-      for hourNum in 0..9
-        monthHalfHourKWHs[hourNum] = june_kws[hourNum]
+      for hour_num in 0..9
+        monthHalfHourKWHs[hour_num] = june_kws[hour_num]
       end
-      for hourNum in 9..17
-        hour = (hourNum + 1.0) * 0.5
-        monthHalfHourKWHs[hourNum] = (monthHalfHourKWHs[8] - (0.15 / (2 * Math::PI)) * Math.sin((2 * Math::PI) * (hour - 4.5) / 3.5) + (0.15 / 3.5) * (hour - 4.5)) * lighting_seasonal_multiplier[month]
+      for hour_num in 9..17
+        hour = (hour_num + 1.0) * 0.5
+        monthHalfHourKWHs[hour_num] = (monthHalfHourKWHs[8] - (0.15 / (2 * Math::PI)) * Math.sin((2 * Math::PI) * (hour - 4.5) / 3.5) + (0.15 / 3.5) * (hour - 4.5)) * lighting_seasonal_multiplier[month]
       end
-      for hourNum in 17..29
-        hour = (hourNum + 1.0) * 0.5
-        monthHalfHourKWHs[hourNum] = (monthHalfHourKWHs[16] - (-0.02 / (2 * Math::PI)) * Math.sin((2 * Math::PI) * (hour - 8.5) / 5.5) + (-0.02 / 5.5) * (hour - 8.5)) * lighting_seasonal_multiplier[month]
+      for hour_num in 17..29
+        hour = (hour_num + 1.0) * 0.5
+        monthHalfHourKWHs[hour_num] = (monthHalfHourKWHs[16] - (-0.02 / (2 * Math::PI)) * Math.sin((2 * Math::PI) * (hour - 8.5) / 5.5) + (-0.02 / 5.5) * (hour - 8.5)) * lighting_seasonal_multiplier[month]
       end
-      for hourNum in 29..45
-        hour = (hourNum + 1.0) * 0.5
-        monthHalfHourKWHs[hourNum] = (monthHalfHourKWHs[28] + amplConst1 * Math.exp((-1.0 * (hour - (sunset_hour[month] + sunsetLag1))**2) / (2.0 * ((25.5 / ((6.5 - monthNum).abs + 20.0)) * stdDevCons1)**2)) / ((25.5 / ((6.5 - monthNum).abs + 20.0)) * stdDevCons1 * (2.0 * Math::PI)**0.5))
+      for hour_num in 29..45
+        hour = (hour_num + 1.0) * 0.5
+        monthHalfHourKWHs[hour_num] = (monthHalfHourKWHs[28] + amplConst1 * Math.exp((-1.0 * (hour - (sunset_hour[month] + sunsetLag1))**2) / (2.0 * ((25.5 / ((6.5 - month_num).abs + 20.0)) * stdDevCons1)**2)) / ((25.5 / ((6.5 - month_num).abs + 20.0)) * stdDevCons1 * (2.0 * Math::PI)**0.5))
       end
-      for hourNum in 45..46
-        hour = (hourNum + 1.0) * 0.5
-        temp1 = (monthHalfHourKWHs[44] + amplConst1 * Math.exp((-1.0 * (hour - (sunset_hour[month] + sunsetLag1))**2) / (2.0 * ((25.5 / ((6.5 - monthNum).abs + 20.0)) * stdDevCons1)**2)) / ((25.5 / ((6.5 - monthNum).abs + 20.0)) * stdDevCons1 * (2.0 * Math::PI)**0.5))
+      for hour_num in 45..46
+        hour = (hour_num + 1.0) * 0.5
+        temp1 = (monthHalfHourKWHs[44] + amplConst1 * Math.exp((-1.0 * (hour - (sunset_hour[month] + sunsetLag1))**2) / (2.0 * ((25.5 / ((6.5 - month_num).abs + 20.0)) * stdDevCons1)**2)) / ((25.5 / ((6.5 - month_num).abs + 20.0)) * stdDevCons1 * (2.0 * Math::PI)**0.5))
         temp2 = (0.04 + amplConst2 * Math.exp((-1.0 * (hour - sunsetLag2)**2) / (2.0 * stdDevCons2**2)) / (stdDevCons2 * (2.0 * Math::PI)**0.5))
         if sunsetLag2 < sunset_hour[month] + sunsetLag1
-          monthHalfHourKWHs[hourNum] = [temp1, temp2].min
+          monthHalfHourKWHs[hour_num] = [temp1, temp2].min
         else
-          monthHalfHourKWHs[hourNum] = [temp1, temp2].max
+          monthHalfHourKWHs[hour_num] = [temp1, temp2].max
         end
       end
-      for hourNum in 46..47
-        hour = (hourNum + 1) * 0.5
-        monthHalfHourKWHs[hourNum] = (0.04 + amplConst2 * Math.exp((-1.0 * (hour - sunsetLag2)**2) / (2.0 * stdDevCons2**2)) / (stdDevCons2 * (2.0 * Math::PI)**0.5))
+      for hour_num in 46..47
+        hour = (hour_num + 1) * 0.5
+        monthHalfHourKWHs[hour_num] = (0.04 + amplConst2 * Math.exp((-1.0 * (hour - sunsetLag2)**2) / (2.0 * stdDevCons2**2)) / (stdDevCons2 * (2.0 * Math::PI)**0.5))
       end
 
       sum_kWh = 0.0
@@ -797,7 +797,7 @@ class ScheduleGenerator
     end
 
     # Calculate schedule values
-    lighting_sch = [[], [], [], [], [], [], [], [], [], [], [], []]
+    lighting_sch = [[]] * 12
     for month in 0..11
       for hour in 0..23
         lighting_sch[month][hour] = normalized_monthly_lighting[month] * normalized_hourly_lighting[month][hour] / days_m[month]

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>1f048814-4b0d-42cb-b598-60b7975bd808</version_id>
-  <version_modified>2026-04-23T23:27:18Z</version_modified>
+  <version_id>3fbd03a7-2588-4857-bfac-6ced25e2a6c3</version_id>
+  <version_modified>2026-04-24T02:56:02Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -673,7 +673,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>33634078</checksum>
+      <checksum>DF514BC5</checksum>
     </file>
     <file>
       <filename>simcontrols.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>ef525d75-2679-4a4e-96b0-e9497149a56c</version_id>
-  <version_modified>2026-04-23T16:29:11Z</version_modified>
+  <version_id>1f048814-4b0d-42cb-b598-60b7975bd808</version_id>
+  <version_modified>2026-04-23T23:27:18Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -493,7 +493,7 @@
       <filename>model.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>A41E8C73</checksum>
+      <checksum>D71FCAF6</checksum>
     </file>
     <file>
       <filename>output.rb</filename>
@@ -673,7 +673,7 @@
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>BB29BCCF</checksum>
+      <checksum>33634078</checksum>
     </file>
     <file>
       <filename>simcontrols.rb</filename>

--- a/HPXMLtoOpenStudio/resources/model.rb
+++ b/HPXMLtoOpenStudio/resources/model.rb
@@ -653,17 +653,11 @@ module Model
     rule = OpenStudio::Model::ScheduleRule.new(schedule)
 
     if (not apply_to_days.is_a? Array) || (apply_to_days.size != 7)
-      fail 'Unexpected apply_to_days.'
+      fail "Unexpected apply_to_days for #{schedule.name}."
     end
 
-    # Allow for either 0-based or 1-based array for now
-    # FUTURE: Restrict to 0-based
-    if (not hourly_values.is_a? Array) || (hourly_values.size != 24 && hourly_values.size != 25)
-      fail 'Unexpected hourly_values.'
-    end
-
-    if hourly_values.size == 24
-      hourly_values = [nil] + hourly_values
+    if (not hourly_values.is_a? Array) || (hourly_values.size != 24)
+      fail "Unexpected hourly_values for #{schedule.name}."
     end
 
     if apply_to_days == [1, 1, 1, 1, 1, 1, 1]
@@ -688,12 +682,10 @@ module Model
     day_sch = rule.daySchedule
     day_sch.setName("#{schedule.name} day")
 
-    previous_value = hourly_values[1]
-    for h in 1..24
-      next if (h != 24) && (hourly_values[h + 1] == previous_value)
+    for h in 0..23
+      next if (h != 23) && (hourly_values[h] == hourly_values[h + 1]) # skip if same as next value
 
-      day_sch.addValue(OpenStudio::Time.new(0, h, 0, 0), previous_value)
-      previous_value = hourly_values[h + 1]
+      day_sch.addValue(OpenStudio::Time.new(0, h + 1, 0, 0), hourly_values[h])
     end
 
     return rule

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -142,14 +142,14 @@ class HourlyByMonthSchedule
 
     prev_wkdy_vals, prev_wkdy_rule = nil, nil
     prev_wknd_vals, prev_wknd_rule = nil, nil
-    for m in 1..12
-      date_s = OpenStudio::Date::fromDayOfYear(day_startm[m - 1], year)
-      date_e = OpenStudio::Date::fromDayOfYear(day_endm[m - 1], year)
+    for m in 0..11
+      date_s = OpenStudio::Date::fromDayOfYear(day_startm[m], year)
+      date_e = OpenStudio::Date::fromDayOfYear(day_endm[m], year)
 
       wkdy_vals, wknd_vals = [], []
-      for h in 1..24
-        wkdy_vals[h] = (@weekday_month_by_hour_values[m - 1][h - 1]) / @maxval
-        wknd_vals[h] = (@weekend_month_by_hour_values[m - 1][h - 1]) / @maxval
+      for h in 0..23
+        wkdy_vals[h] = (@weekday_month_by_hour_values[m][h]) / @maxval
+        wknd_vals[h] = (@weekend_month_by_hour_values[m][h]) / @maxval
       end
 
       if (wkdy_vals == prev_wkdy_vals) && (wknd_vals == prev_wknd_vals)

--- a/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/HPXMLtoOpenStudio/resources/schedules.rb
@@ -277,14 +277,14 @@ class HourlyByDaySchedule
 
     prev_wkdy_vals, prev_wkdy_rule = nil, nil
     prev_wknd_vals, prev_wknd_rule = nil, nil
-    for d in 1..num_days
-      date_s = OpenStudio::Date::fromDayOfYear(d, year)
-      date_e = OpenStudio::Date::fromDayOfYear(d, year)
+    for d in 0..num_days - 1
+      date_s = OpenStudio::Date::fromDayOfYear(d + 1, year)
+      date_e = OpenStudio::Date::fromDayOfYear(d + 1, year)
 
       wkdy_vals, wknd_vals = [], []
-      for h in 1..24
-        wkdy_vals[h] = (@weekday_day_by_hour_values[d - 1][h - 1]) / @maxval
-        wknd_vals[h] = (@weekend_day_by_hour_values[d - 1][h - 1]) / @maxval
+      for h in 0..23
+        wkdy_vals[h] = (@weekday_day_by_hour_values[d][h]) / @maxval
+        wknd_vals[h] = (@weekend_day_by_hour_values[d][h]) / @maxval
       end
 
       if (wkdy_vals == prev_wkdy_vals) && (wknd_vals == prev_wknd_vals)
@@ -482,21 +482,21 @@ class MonthWeekdayWeekendSchedule
 
     periods = []
     if begin_month <= end_month # contiguous period
-      periods << [begin_month, end_month]
+      periods << [begin_month - 1, end_month - 1]
     else # non-contiguous period
-      periods << [1, end_month]
-      periods << [begin_month, 12]
+      periods << [0, end_month - 1]
+      periods << [begin_month - 1, 11]
     end
 
     periods.each do |period|
       for m in period[0]..period[1]
-        date_s = OpenStudio::Date::fromDayOfYear(day_startm[m - 1], year)
-        date_e = OpenStudio::Date::fromDayOfYear(day_endm[m - 1], year)
+        date_s = OpenStudio::Date::fromDayOfYear(day_startm[m], year)
+        date_e = OpenStudio::Date::fromDayOfYear(day_endm[m], year)
 
         wkdy_vals, wknd_vals = [], []
-        for h in 1..24
-          wkdy_vals[h] = (@monthly_values[m - 1] * @weekday_hourly_values[h - 1]) / @maxval
-          wknd_vals[h] = (@monthly_values[m - 1] * @weekend_hourly_values[h - 1]) / @maxval
+        for h in 0..23
+          wkdy_vals[h] = (@monthly_values[m] * @weekday_hourly_values[h]) / @maxval
+          wknd_vals[h] = (@monthly_values[m] * @weekend_hourly_values[h]) / @maxval
         end
 
         if (wkdy_vals == prev_wkdy_vals) && (wknd_vals == prev_wknd_vals)


### PR DESCRIPTION
## Pull Request Description

Replace final (?) set of 1-based arrays in the code with 0-based arrays. Now our schedule method no longer has to handle both situations. No diffs expected.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
