### PR TITLE
pandas bugfixes for compare.py

### DIFF
--- a/workflow/tests/compare.py
+++ b/workflow/tests/compare.py
@@ -85,11 +85,11 @@ class BaseCompare:
                     feature_df = group_df.merge(feature_df, 'outer', left_index=True, right_index=True)\
                                          .groupby(aggregate_columns)
                     if aggregate_function == 'sum':
-                        base_df = base_df.sum(min_count=1).stack(dropna=False)
-                        feature_df = feature_df.sum(min_count=1).stack(dropna=False)
+                        base_df = base_df.sum(min_count=1).stack()
+                        feature_df = feature_df.sum(min_count=1).stack()
                     elif aggregate_function == 'mean':
-                        base_df = base_df.mean(numeric_only=True).stack(dropna=False)
-                        feature_df = feature_df.mean(numeric_only=True).stack(dropna=False)
+                        base_df = base_df.mean(numeric_only=True).stack()
+                        feature_df = feature_df.mean(numeric_only=True).stack()
                 else:
                     if aggregate_function == 'sum':
                         base_df = base_df.sum(min_count=1)
@@ -112,6 +112,7 @@ class BaseCompare:
         deltas = deltas.round(2)
         deltas.reset_index(level=aggregate_columns, inplace=True)
         deltas.index.name = 'enduse'
+        deltas[deltas.columns] = deltas[deltas.columns].astype('object')
         deltas.fillna('n/a', inplace=True)
         sims_df = pd.DataFrame({'base': sim_ct_base,
                                 'feature': sim_ct_feature,


### PR DESCRIPTION
## Pull Request Description

Update compare.py to address newer pandas changes. Backported from https://github.com/NatLabRockies/resstock/pull/1556

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
