### PR TITLE
Save release zip as CI artifact

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -144,6 +144,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           path: OpenStudio-HPXML-*.zip
+          archive: false
 
   run-windows-tests:
     runs-on: windows-latest

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -140,6 +140,11 @@ jobs:
           path: workflow/tests/test_results
           name: results-workflow2-tests
 
+      - name: Store release package
+        uses: actions/upload-artifact@v7
+        with:
+          path: OpenStudio-HPXML-*.zip
+
   run-windows-tests:
     runs-on: windows-latest
     steps:

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -537,7 +537,9 @@ class WorkflowOtherTest < Minitest::Test
       system(command)
       assert(File.exist? 'OpenStudio-HPXML/workflow/sample_files/run/results_annual.csv')
 
-      File.delete(zip_path)
+      if not ENV['CI'] # Keep on CI to store as an artifact
+        File.delete(zip_path)
+      end
       rm_path('OpenStudio-HPXML')
     end
   end


### PR DESCRIPTION
## Pull Request Description

Adds the package release zip as a CI artifact.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
