### PR TITLE
Prevent possible error for HPWH in confined space

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 __Features__
 
 __Bugfixes__
+- **Breaking change**: Prevent possible error if HPWH in confined space with very small containment volume; minimum allowed volume now 32 ft3.
 
 ## OpenStudio-HPXML v1.12.0
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>e474d894-1b03-4f94-8692-4f2d5743eb7d</version_id>
-  <version_modified>2026-05-22T19:09:39Z</version_modified>
+  <version_id>3604f093-f1b9-4916-a126-9bfd0a83dee6</version_id>
+  <version_modified>2026-05-22T20:13:25Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -841,7 +841,7 @@
       <filename>test_water_heater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>76D9632D</checksum>
+      <checksum>F216022C</checksum>
     </file>
     <file>
       <filename>test_weather.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>8f77287f-a46a-417c-a8fb-70899b1cfe6d</version_id>
-  <version_modified>2026-05-20T18:28:50Z</version_modified>
+  <version_id>94ad2f51-12f8-47f7-bfb9-2903a0b04e7a</version_id>
+  <version_modified>2026-05-22T16:55:22Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -421,7 +421,7 @@
       <filename>hpxml_schematron/EPvalidator.sch</filename>
       <filetype>sch</filetype>
       <usage_type>resource</usage_type>
-      <checksum>0D042BF0</checksum>
+      <checksum>F2DB1072</checksum>
     </file>
     <file>
       <filename>hpxml_schematron/iso-schematron.xsd</filename>
@@ -715,7 +715,7 @@
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>C9FBD6FB</checksum>
+      <checksum>C428F4AB</checksum>
     </file>
     <file>
       <filename>weather.rb</filename>
@@ -829,7 +829,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>08D1113A</checksum>
+      <checksum>1B4BF5AF</checksum>
     </file>
     <file>
       <filename>test_vehicle.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>94ad2f51-12f8-47f7-bfb9-2903a0b04e7a</version_id>
-  <version_modified>2026-05-22T16:55:22Z</version_modified>
+  <version_id>e474d894-1b03-4f94-8692-4f2d5743eb7d</version_id>
+  <version_modified>2026-05-22T19:09:39Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -841,7 +841,7 @@
       <filename>test_water_heater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>8DBA3BD3</checksum>
+      <checksum>76D9632D</checksum>
     </file>
     <file>
       <filename>test_weather.rb</filename>

--- a/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.sch
+++ b/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.sch
@@ -2155,7 +2155,7 @@
     <sch:title>[WaterHeatingSystemType=HPWHInConfinedSpaceWithoutMitigation]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:WaterHeating/h:WaterHeatingSystem/h:extension[h:HPWHInConfinedSpaceWithoutMitigation="true"]'>
       <sch:assert role='ERROR' test='count(h:HPWHContainmentVolume) = 1'>Expected HPWHContainmentVolume if HPWHInConfinedSpaceWithoutMitigation="true"</sch:assert>
-      <sch:assert role='ERROR' test='number(h:HPWHContainmentVolume) &gt; 0 or not(h:HPWHContainmentVolume)'>Expected HPWHContainmentVolume to be greater than 0.</sch:assert>
+      <sch:assert role='ERROR' test='number(h:HPWHContainmentVolume) &gt;= 32 or not(h:HPWHContainmentVolume)'>Expected HPWHContainmentVolume to be greater than or equal to 32.</sch:assert>
       <!-- Warnings -->
       <sch:report role='WARN' test='number(h:HPWHContainmentVolume) &gt; 1500'>HPWHContainmentVolume should typically be less than 1500 cuft when the HPWH is in confined space.</sch:report>
     </sch:rule>

--- a/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -990,17 +990,32 @@ module Waterheater
     cop = water_heating_system.additional_properties.cop
 
     # Adjust COP based on RESNET HERS Addendum 77
-    if not water_heating_system.hpwh_containment_volume.nil?
+    cv = water_heating_system.hpwh_containment_volume
+    if not cv.nil?
+      # Very small containment volume and low COP can result in E+ error (Rated total cooling capacity is zero or less)
+      # Prevent that by setting a minimum CV value that avoids the error
+      # Equation determined empirically by running different combinations of CV & UEF using base-dhw-tank-heat-pump-confined-space.xml
+      #   UEF  | COP  | Min CV
+      #   ---  | ---  | ------
+      #   2.00 | 2.09 | 105
+      #   2.25 | 2.37 | 85
+      #   2.50 | 2.64 | 70
+      #   2.75 | 2.91 | 60
+      #   3.00 | 3.19 | 55
+      #   3.25 | 3.46 | 45
+      min_cv = 347.57 * cop**-1.631
+      cv = [cv, min_cv].max
+
       if not water_heating_system.hpwh_confined_space_without_mitigation
-        if water_heating_system.hpwh_containment_volume < 1000.0
+        if cv < 1000.0
           runner.registerWarning("HPWH COP adjustment based on HPWHContainmentVolume will not be applied to #{water_heating_system.id} because HPWHInConfinedSpaceWithoutMitigation is not 'true'.")
         end
       else
         # FUTURE: apply for 120V HPWH and other system types that the correction may not be accurate for
-        if water_heating_system.hpwh_containment_volume < 450.0 && (water_heating_system.backup_heating_capacity == 0.0)
+        if cv < 450.0 && (water_heating_system.backup_heating_capacity == 0.0)
           runner.registerWarning("Heat pump water heater: #{water_heating_system.id} has no backup electric resistance element, COP adjustment for confined space may not be accurate when the containment space volume is below 450 cubic feet.")
         end
-        rv = [water_heating_system.hpwh_containment_volume / 1500.0, 1.0].min
+        rv = [cv / 1500.0, 1.0].min
         cop = (cop - 0.92) * (1 - (1.009 * Math.exp(-5.492 * rv))) + 0.92
       end
     end

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -242,6 +242,7 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
                             'invalid-window-height' => ['Expected DistanceToBottomOfWindow to be greater than DistanceToTopOfWindow [context: /HPXML/Building/BuildingDetails/Enclosure/Windows/Window/Overhangs[number(Depth) > 0], id: "Window2"]'],
                             'leakiness-description-missing-year-built' => ['Expected BuildingSummary/BuildingConstruction/YearBuilt'],
                             'lighting-fractions' => ['Expected sum(LightingGroup/FractionofUnitsInLocation) for Location="interior" to be less than or equal to 1 [context: /HPXML/Building/BuildingDetails/Lighting, id: "MyBuilding"]'],
+                            'low-hpwh-containment-volume' => ['Expected HPWHContainmentVolume to be greater than or equal to 32.'],
                             'manufactured-home-reference-duct' => ['There are references to "manufactured home belly" or "manufactured home underbelly" but ResidentialFacilityType is not "manufactured home".',
                                                                    'A location is specified as "manufactured home belly" but no surfaces were found adjacent to the "manufactured home underbelly" space type.'],
                             'manufactured-home-reference-water-heater' => ['There are references to "manufactured home belly" or "manufactured home underbelly" but ResidentialFacilityType is not "manufactured home".',
@@ -278,7 +279,6 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
                             'negative-autosizing-factors' => ['Expected CoolingAutosizingFactor to be greater than 0',
                                                               'Expected HeatingAutosizingFactor to be greater than 0',
                                                               'Expected BackupHeatingAutosizingFactor to be greater than 0'],
-                            'negative-hpwh-containment-volume' => ['Expected HPWHContainmentVolume to be greater than 0.'],
                             'panel-zero-total-breaker-spaces' => ["Element 'RatedTotalSpaces': [facet 'minExclusive'] The value '0' must be greater than '0'."],
                             'panel-without-required-system' => ['Expected AttachedToComponent'],
                             'panel-with-unrequired-system' => ['Expected no AttachedToComponent'],
@@ -804,6 +804,9 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
         hpxml, hpxml_bldg = _create_hpxml('base.xml')
         int_cfl = hpxml_bldg.lighting_groups.find { |lg| lg.location == HPXML::LocationInterior && lg.lighting_type == HPXML::LightingTypeCFL }
         int_cfl.fraction_of_units_in_location = 0.8
+      when 'low-hpwh-containment-volume'
+        hpxml, hpxml_bldg = _create_hpxml('base-dhw-tank-heat-pump-confined-space.xml')
+        hpxml_bldg.water_heating_systems[0].hpwh_containment_volume = 30
       when 'manufactured-home-reference-duct'
         hpxml, hpxml_bldg = _create_hpxml('base.xml')
         hpxml_bldg.hvac_distributions[0].ducts[1].duct_location = HPXML::LocationManufacturedHomeBelly
@@ -888,9 +891,6 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
         hpxml_bldg.heat_pumps[0].heating_autosizing_factor = -0.5
         hpxml_bldg.heat_pumps[0].cooling_autosizing_factor = -1.2
         hpxml_bldg.heat_pumps[0].backup_heating_autosizing_factor = -0.1
-      when 'negative-hpwh-containment-volume'
-        hpxml, hpxml_bldg = _create_hpxml('base-dhw-tank-heat-pump-confined-space.xml')
-        hpxml_bldg.water_heating_systems[0].hpwh_containment_volume = -10.0
       when 'panel-zero-total-breaker-spaces'
         hpxml, hpxml_bldg = _create_hpxml('base.xml')
         hpxml_bldg.electric_panels.add(id: 'ElectricPanel1',

--- a/HPXMLtoOpenStudio/tests/test_water_heater.rb
+++ b/HPXMLtoOpenStudio/tests/test_water_heater.rb
@@ -1059,36 +1059,30 @@ class HPXMLtoOpenStudioWaterHeaterTest < Minitest::Test
 
   def test_tank_heat_pump_containment_volume_adjustment
     # Volumes are based on RESNET spreadsheet: https://github.com/user-attachments/files/23135608/ConstrainedHPWH_04xlsx.xlsx,
-    containment_volumes = [3000, 1500, 960, 707, 453, 200, 83.5]
-    # Replaced the COP in the spreadsheet to 3.73135, and the expected COP are calculated as below:
-    expected_cop = [3.720, 3.720, 3.647, 3.518, 3.191, 2.367, 1.642]
-    expected_cap = 500.0 * 3.73135 # not adjusted
+    # Replaced the COP in the spreadsheet to 3.73135, and the expected COP as a function of CV are calculated as below:
+    expected_cops = {
+      3000 => 3.720,
+      1500 => 3.720,
+      960 => 3.647,
+      707 => 3.518,
+      453 => 3.191,
+      200 => 2.367,
+      83.5 => 1.642,
+      32 => 1.286 # COP floor set per https://github.com/NatLabRockies/OpenStudio-HPXML/pull/2223
+    }
     args_hash = {}
     args_hash['hpxml_path'] = @tmp_hpxml_path
-    containment_volumes.each_with_index do |v, i|
+    expected_cops.each do |cv, expected_cop|
       hpxml, hpxml_bldg = _create_hpxml('base-dhw-tank-heat-pump-confined-space.xml')
-      hpxml_bldg.water_heating_systems[0].hpwh_containment_volume = v
+      hpxml_bldg.water_heating_systems[0].hpwh_containment_volume = cv
       XMLHelper.write_file(hpxml.to_doc, @tmp_hpxml_path)
-      model, _hpxml, hpxml_bldg = _test_measure(args_hash)
-      # Get HPXML values
-      water_heating_system = hpxml_bldg.water_heating_systems[0]
+      model, _hpxml, _hpxml_bldg = _test_measure(args_hash)
+
       # Check EnergyPlus inputs
       assert_equal(1, model.getWaterHeaterHeatPumpWrappedCondensers.size)
-      assert_equal(1, model.getWaterHeaterStratifieds.size)
       hpwh = model.getWaterHeaterHeatPumpWrappedCondensers[0]
-      wh = hpwh.tank.to_WaterHeaterStratified.get
       coil = hpwh.dXCoil.to_CoilWaterHeatingAirToWaterHeatPumpWrapped.get
-      assert_equal(EPlus.fuel_type(water_heating_system.fuel_type), wh.heaterFuelType)
-      assert_equal('Schedule', wh.ambientTemperatureIndicator)
-      assert_in_epsilon(UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3'), wh.tankVolume.get, 0.01)
-      assert_in_epsilon(1.3343, wh.tankHeight.get, 0.01)
-      assert_in_epsilon(UnitConversions.convert(water_heating_system.backup_heating_capacity, 'Btu/hr', 'W'), wh.heater1Capacity.get, 0.01)
-      assert_in_epsilon(UnitConversions.convert(water_heating_system.backup_heating_capacity, 'Btu/hr', 'W'), wh.heater2Capacity, 0.01)
-      assert_in_epsilon(0.926, wh.uniformSkinLossCoefficientperUnitAreatoAmbientTemperature.get, 0.01)
-      assert_in_epsilon(1.0, wh.heaterThermalEfficiency, 0.01)
-      # Check heat pump cooling coil cop being adjusted
-      assert_in_epsilon(expected_cop[i], coil.ratedCOP, 0.01)
-      assert_in_epsilon(expected_cap, coil.ratedHeatingCapacity, 0.01)
+      assert_in_epsilon(expected_cop, coil.ratedCOP, 0.01)
     end
   end
 

--- a/HPXMLtoOpenStudio/tests/test_water_heater.rb
+++ b/HPXMLtoOpenStudio/tests/test_water_heater.rb
@@ -1059,7 +1059,7 @@ class HPXMLtoOpenStudioWaterHeaterTest < Minitest::Test
 
   def test_tank_heat_pump_containment_volume_adjustment
     # Volumes are based on RESNET spreadsheet: https://github.com/user-attachments/files/23135608/ConstrainedHPWH_04xlsx.xlsx,
-    # Replaced the COP in the spreadsheet to 3.73135, and the expected COP as a function of CV are calculated as below:
+    # Replaced the COP in the spreadsheet to 3.73135, and the expected COPs as a function of CV are calculated as below:
     expected_cops = {
       3000 => 3.720,
       1500 => 3.720,

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -4261,7 +4261,7 @@ Each heat pump water heater is entered as a ``/HPXML/Building/BuildingDetails/Sy
   ``UsesDesuperheater``                                boolean                                                  No        false           Presence of desuperheater? [#]_
   ``extension/NumberofBedroomsServed``                 integer                          > NumberofBedrooms      See [#]_                  Number of bedrooms served directly or indirectly
   ``extension/HPWHInConfinedSpaceWithoutMitigation``   boolean                                                  No        false           Whether HPWH is installed in confined space without mitigation [#]_
-  ``extension/HPWHContainmentVolume``                  double            ft3            > 0                     See [#]_                  Containment volume of the space where HPWH is installed
+  ``extension/HPWHContainmentVolume``                  double            ft3            >= 32                   See [#]_                  Containment volume of the space where HPWH is installed
   ===================================================  ================  =============  ======================  ========  ==============  =============================================
 
   .. [#] Location choices are "conditioned space", "basement - unconditioned", "basement - conditioned", "attic - unvented", "attic - vented", "garage", "crawlspace - unvented", "crawlspace - vented", "crawlspace - conditioned", "other exterior", "other housing unit", "other heated space", "other multifamily buffer space", or "other non-freezing space".


### PR DESCRIPTION
## Pull Request Description

Closes #2220.

The containment volume (CV) must now be >= 32 ft3 (2' x 2' x 8'), previously > 0.

For older HPWH with low efficiencies, that is still not sufficient to prevent E+ errors, so we set a minimum CV as a function of COP. In other words, we cap the COP derate that gets applied in these situations.

## Checklist

Not all may apply:

- [x] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
