### PR TITLE
Handle empty row in deep ground temperature lookup

### DIFF
--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b984686c-af33-46d9-bb49-a6b0b1bac73e</version_id>
-  <version_modified>2026-06-25T19:40:15Z</version_modified>
+  <version_id>f7860089-0482-40a8-b2e3-9608c7b89791</version_id>
+  <version_modified>2026-06-29T17:48:35Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -338,6 +338,12 @@
       <filetype>json</filetype>
       <usage_type>resource</usage_type>
       <checksum>B1AC362A</checksum>
+    </file>
+    <file>
+      <filename>data/g_functions/g-function_library_1.0/zoned_rectangle_5m_v1.0.json</filename>
+      <filetype>json</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6A4C47AD</checksum>
     </file>
     <file>
       <filename>data/g_functions/rectangle_5m_v1.0.json</filename>
@@ -721,7 +727,7 @@
       <filename>weather.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>05F5C947</checksum>
+      <checksum>C95C27B2</checksum>
     </file>
     <file>
       <filename>xmlhelper.rb</filename>
@@ -847,7 +853,7 @@
       <filename>test_weather.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>9177CC7A</checksum>
+      <checksum>016A5CCA</checksum>
     </file>
     <file>
       <filename>util.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f7860089-0482-40a8-b2e3-9608c7b89791</version_id>
-  <version_modified>2026-06-29T17:48:35Z</version_modified>
+  <version_id>b904324c-c003-426c-b14b-e21e92d726d7</version_id>
+  <version_modified>2026-06-29T17:58:33Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -338,12 +338,6 @@
       <filetype>json</filetype>
       <usage_type>resource</usage_type>
       <checksum>B1AC362A</checksum>
-    </file>
-    <file>
-      <filename>data/g_functions/g-function_library_1.0/zoned_rectangle_5m_v1.0.json</filename>
-      <filetype>json</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6A4C47AD</checksum>
     </file>
     <file>
       <filename>data/g_functions/rectangle_5m_v1.0.json</filename>
@@ -727,7 +721,7 @@
       <filename>weather.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>C95C27B2</checksum>
+      <checksum>030BF66B</checksum>
     </file>
     <file>
       <filename>xmlhelper.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>b904324c-c003-426c-b14b-e21e92d726d7</version_id>
-  <version_modified>2026-06-29T17:58:33Z</version_modified>
+  <version_id>1758c9b2-66d0-4ff3-b33b-aeccb8170254</version_id>
+  <version_modified>2026-06-29T18:04:23Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -721,7 +721,7 @@
       <filename>weather.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>030BF66B</checksum>
+      <checksum>EA2A55AF</checksum>
     </file>
     <file>
       <filename>xmlhelper.rb</filename>

--- a/HPXMLtoOpenStudio/resources/weather.rb
+++ b/HPXMLtoOpenStudio/resources/weather.rb
@@ -424,10 +424,14 @@ class WeatherFile
       row = row.split(',')
       v2 = Vector[row[3].to_f, row[4].to_f]
       new_dist = (v1 - v2).magnitude
-      if new_dist < dist
-        temperatures_amplitudes = row[5..9].map(&:to_f)
-        dist = new_dist
-      end
+      next unless new_dist < dist
+
+      row_values = row[5..9].map(&:to_f)
+      next unless not row_values.empty?
+
+      temperatures_amplitudes = row_values
+
+      dist = new_dist
     end
 
     data.DeepGroundAnnualTemp = UnitConversions.convert(temperatures_amplitudes[0], 'C', 'F')

--- a/HPXMLtoOpenStudio/resources/weather.rb
+++ b/HPXMLtoOpenStudio/resources/weather.rb
@@ -426,10 +426,10 @@ class WeatherFile
       new_dist = (v1 - v2).magnitude
       next unless new_dist < dist
 
-      raw_values = row[5..9]
-      next if raw_values.nil? || raw_values.any? { |v| v.nil? || v.strip.empty? }
+      row_values = row[5..9].map(&:to_f)
+      next unless not row_values.empty?
 
-      temperatures_amplitudes = raw_values.map(&:to_f)
+      temperatures_amplitudes = row_values
       dist = new_dist
     end
 

--- a/HPXMLtoOpenStudio/resources/weather.rb
+++ b/HPXMLtoOpenStudio/resources/weather.rb
@@ -426,11 +426,10 @@ class WeatherFile
       new_dist = (v1 - v2).magnitude
       next unless new_dist < dist
 
-      row_values = row[5..9].map(&:to_f)
-      next unless not row_values.empty?
+      raw_values = row[5..9]
+      next if raw_values.nil? || raw_values.any? { |v| v.nil? || v.strip.empty? }
 
-      temperatures_amplitudes = row_values
-
+      temperatures_amplitudes = raw_values.map(&:to_f)
       dist = new_dist
     end
 

--- a/HPXMLtoOpenStudio/tests/test_weather.rb
+++ b/HPXMLtoOpenStudio/tests/test_weather.rb
@@ -298,4 +298,25 @@ class HPXMLtoOpenStudioWeatherTest < Minitest::Test
     assert_equal(0, runner.result.stepErrors.size)
     assert_equal(0, runner.result.stepWarnings.size)
   end
+
+  def test_missing_deep_ground_temperatures
+    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    weather = WeatherFile.new(epw_path: File.join(weather_dir, 'USA_CO_Denver.Intl.AP.725650_TMY3.epw'), runner: runner)
+
+    # For epw w/ LOCATION,Hydaburg Seaplane Base,AK,USA,TMY3,703884,55.20250,-132.8230,-9.0,0.0,
+    # row in the lookup file is mostly blank
+    header = weather.header
+    header.Latitude = 55.2025
+    header.Longitude = -132.823
+
+    weather.send(:calc_deep_ground_temperatures) # access private method
+
+    # Check ground temps
+    # Corresponds to Station=Ketchikan Intl AP, i.e., next closest
+    assert_in_delta(45.32, weather.data.DeepGroundAnnualTemp, 0.1)
+    assert_in_delta(14.76, weather.data.DeepGroundSurfTempAmp1, 0.1)
+    assert_in_delta(-0.9, weather.data.DeepGroundSurfTempAmp2, 0.1)
+    assert_equal(29, weather.data.DeepGroundPhaseShiftTempAmp1)
+    assert_equal(10, weather.data.DeepGroundPhaseShiftTempAmp2)
+  end
 end


### PR DESCRIPTION
## Pull Request Description

Found this through resstock for newly sampled AK.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
