### PR TITLE
Updates simple utility rate task to use SEDS bulk download

### DIFF
--- a/tasks.rb
+++ b/tasks.rb
@@ -3584,42 +3584,23 @@ def download_g_functions
 end
 
 def download_simple_utility_rates
-  require 'net/http'
-  require 'uri'
+  require_relative 'HPXMLtoOpenStudio/resources/util'
+  require 'tempfile'
   require 'json'
   require 'csv'
-  require 'openssl'
 
-  # Load .env file if it exists
-  env_path = File.join(File.dirname(__FILE__), '.env')
-  if File.exist?(env_path)
-    File.foreach(env_path) do |line|
-      line.strip!
-      next if line.empty? || line.start_with?('#')
+  seds_path = File.join(File.dirname(__FILE__), 'SEDS.txt')
 
-      key, value = line.split('=', 2)
-      ENV[key.strip] = value.strip if key && value
+  if !File.exist? seds_path
+    tmpfile = Tempfile.new('rates')
+    UrlResolver.fetch('https://www.eia.gov/opendata/bulk/SEDS.zip', tmpfile)
+    zf = OpenStudio::UnzipFile.new(tmpfile.path.to_s)
+    zf.extractAllFiles('.')
+
+    if !File.exist? seds_path
+      fail "#{File.basename(seds_path)} not successfully retrieved."
     end
   end
-
-  # EIA API v2 SEDS endpoint. Register for a free key at:
-  # https://www.eia.gov/opendata/register.php
-  api_key = ENV['EIA_API_KEY']
-  if api_key.nil? || api_key.empty?
-    puts 'ERROR: EIA_API_KEY is not set.'
-    puts 'Options:'
-    puts '  1. Create a .env file in the project root with: EIA_API_KEY=<your_key_here>'
-    puts '  2. Set the environment variable: export EIA_API_KEY=<your_key_here>'
-    puts 'Register for a free key at https://www.eia.gov/opendata/register.php'
-    exit!
-  end
-
-  simple_rates_dir = File.join(File.dirname(__FILE__), 'ReportUtilityBills', 'resources', 'simple_rates')
-  FileUtils.mkdir_p(simple_rates_dir) unless File.exist?(simple_rates_dir)
-  filepath = File.join(simple_rates_dir, 'eia_fuel_rates_by_state.csv')
-
-  base_url = 'https://api.eia.gov/v2/seds/data/'
-  page_length = 5000
 
   # Residential fuel price series (MSN codes)
   msn_codes = {
@@ -3632,76 +3613,26 @@ def download_simple_utility_rates
 
   latest_rates = Hash.new { |h, k| h[k] = {} }
 
-  msn_codes.each do |msn, fuel|
-    puts "  Fetching SEDS series: #{msn} (#{fuel})..."
+  File.readlines(seds_path).each do |seds_line|
+    json = JSON.parse(seds_line)
+    msn_codes.each do |msn, fuel|
+      next if json['series_id'].nil?
+      next unless json['series_id'].start_with? "SEDS.#{msn}"
 
-    offset = 0
-    loop do
-      query_parts = [
-        "api_key=#{URI.encode_www_form_component(api_key)}",
-        'frequency=annual',
-        'data[0]=value',
-        "facets[seriesId][0]=#{URI.encode_www_form_component(msn)}",
-        'sort[0][column]=period',
-        'sort[0][direction]=asc',
-        "offset=#{offset}",
-        "length=#{page_length}"
-      ]
-      url = "#{base_url}?#{query_parts.join('&')}"
+      state = json['geography'].gsub('USA-', '').gsub('USA', 'US')
+      json['data'].each do |data|
+        next if data[1].to_f <= 0
 
-      parsed = nil
-      begin
-        uri = URI(url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-        request = Net::HTTP::Get.new(uri)
-        request['Accept'] = 'application/json'
-
-        response = http.request(request)
-
-        if response.is_a?(Net::HTTPSuccess)
-          parsed = JSON.parse(response.body)
-        else
-          puts "API Error: #{response.code}"
-        end
-      rescue JSON::ParserError => e
-        puts "JSON Parsing Error: #{e.message}"
-      rescue StandardError => e
-        puts "Network Error: #{e.message}"
+        latest_rates[state][fuel] = [data[0], Float(data[1])]
+        break # Found a non-zero value
       end
-
-      if parsed.nil? || parsed['response'].nil? || parsed['response']['data'].nil?
-        puts "Error: Unexpected API response for #{msn}: #{parsed.inspect}"
-        exit!
-      end
-
-      data  = parsed['response']['data']
-      total = parsed['response']['total'].to_i
-
-      data.each do |row|
-        state  = row['stateId']
-        period = row['period'].to_i
-        value  = row['value']
-
-        next if value.nil? || value.to_f == 0.0
-
-        existing = latest_rates[state][fuel]
-
-        next unless existing.nil? || period > existing[:period]
-
-        latest_rates[state][fuel] = {
-          period: period,
-          value: value.to_f
-        }
-      end
-
-      offset += data.size
-      break if offset >= total || data.empty?
     end
   end
 
+  FileUtils.rm(seds_path)
+
+  simple_rates_dir = File.join(File.dirname(__FILE__), 'ReportUtilityBills', 'resources', 'simple_rates')
+  filepath = File.join(simple_rates_dir, 'eia_fuel_rates_by_state.csv')
   puts "Writing to #{filepath}..."
 
   CSV.open(filepath, 'w') do |csv|
@@ -3713,10 +3644,10 @@ def download_simple_utility_rates
         next if entry.nil?
 
         csv << [
-          entry[:period],
+          entry[0],
           state,
           fuel,
-          entry[:value].round(4)
+          entry[1].round(4)
         ]
       end
     end


### PR DESCRIPTION
## Pull Request Description

Addresses part of #2218. Replaces SEDS API with simpler SEDS bulk download; no API key is needed anymore. Values are unchanged (2025 data is not yet available).

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results of sample files
